### PR TITLE
Make the user for whom we install variable and automatically determine the user

### DIFF
--- a/retropie_setup.sh
+++ b/retropie_setup.sh
@@ -30,9 +30,6 @@
 #  Raspberry Pi is a trademark of the Raspberry Pi Foundation.
 # 
 
-user=pi
-
-rootdir=/home/$user/RetroPie
 if [ $(id -u) -ne 0 ]; then
   printf "Script must be run as root. Try 'sudo ./retropie_setup'\n"
   exit 1
@@ -521,12 +518,27 @@ main_options()
 
 # here starts the main loop
 
-if [ $# -ne 1 ]
+#determine $username, standard is the second paramameter from the command-line, if there wasn't one we use the user who called
+#sudo, if the programm was directly launched (without sudo) we use the 'whoami' command to determine the user who launched the
+#script
+if [ $# -lt 2 ]
+then
+    user=$SUDO_USER
+    if [ -z "$user" ]
+    then
+      user=$(whoami)
+    fi
+else
+    user=$2
+fi
+
+if [ $# -lt 1 ]
 then
     rootdir=/home/$user/RetroPie
 else
     rootdir=$1
 fi
+
 # printMsg "Installing all RetroPie-packages into the directory $rootdir"
 if [[ ! -d $rootdir ]]; then
     mkdir "$rootdir"


### PR DESCRIPTION
There are images (for example the old raspbian pisces images) that don't use 'pi' as standard user, and some people may have changed the default user or have added others. So I think it would be better to not hardcode the user, but determine automatically the user that launched the installation. The patches give the user also the possibility to pass a commandline argument to override the automatic detection.
