### PR TITLE
Improved rootdir handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@
 Icon?
 ehthumbs.db
 Thumbs.db
-*~
+


### PR DESCRIPTION
I had a problem when the script tried to create /home/pi/RetroPie because the directory /home/pi didn't exist and mkdir couldn't create RetroPie. The script then ran in the wrong directory and moved some files around that it shouldn't touch.
Adding the -p parameter to mkdir has the following function:
-p, --parents
              no error if existing, make parent directories as needed

The patched script also rechecks if the directory exists after mkdir, and exits if the directory isn't there.
