### PR TITLE
Check if a group exists (and create it if it doesn't) before adding user

### DIFF
--- a/retropie_setup.sh
+++ b/retropie_setup.sh
@@ -91,9 +91,19 @@ add_to_groups()
 {
     # add user $user to groups "video", "audio", and "input"
     printMsg "Adding user $user to groups video, audio, and input."
-    sudo usermod -a -G video $user
-    sudo usermod -a -G audio $user
-    sudo usermod -a -G input $user
+    add_user_to_group $user video
+    add_user_to_group $user audio
+    add_user_to_group $user input
+}
+
+add_user_to_group()
+{
+    # add user $1 to group $2, create the group if it doesn't exist
+    if [ -z $(egrep -i "^$2" /etc/group) ]
+    then
+      sudo addgroup $2
+    fi
+    sudo adduser $1 $2
 }
 
 ensure_modules()


### PR DESCRIPTION
Some Images (RaspBMC, Raspbian Pisces) don't have the group input. This patch checks if a group exists before adding a user to it and creates the group if it doesn't exist.

To be honest, I'm not sure if this makes sense, because surely the groups that don't exist aren't used on that system. But I think there is no harm in adding these group and if they are used, e.g. by some gamepad/joystick drivers, they are already there.
