### PR TITLE
Add interpreter to emulationstation run-script

### DIFF
--- a/retropie_setup.sh
+++ b/retropie_setup.sh
@@ -332,7 +332,7 @@ install_esscript()
 {
     if [[ ! -f /usr/bin/emulationstation.sh ]]; then
         # a work around here, so that EmulationStation can be executed from arbitrary locations
-        echo -e "pushd \"$rootdir/EmulationStation\"\n./emulationstation\npopd\n" > /usr/bin/emulationstation
+        echo -e "#!/bin/bash\npushd \"$rootdir/EmulationStation\"\n./emulationstation\npopd\n" > /usr/bin/emulationstation
         sudo chmod +x /usr/bin/emulationstation
     fi
 }


### PR DESCRIPTION
I had the problem that when I tried to run /usr/bin/emulationstation I got an error that pushd and pulld couldn't be found. The problem was that the script was interpreted by /bin/sh (which doesn't support pushd and pulld) and not by bash.
