### PR TITLE
"make clean" is no longer necessary for EmulationStation.

### DIFF
--- a/retropie_setup.sh
+++ b/retropie_setup.sh
@@ -744,7 +744,6 @@ function install_emulationstation()
 {
     printMsg "Installing EmulationStation as graphical front end"
     gitPullOrClone "$rootdir/supplementary/EmulationStation" git://github.com/Aloshi/EmulationStation.git
-    make clean
     make
     install_esscript
     if [[ ! -f "$rootdir/supplementary/EmulationStation/emulationstation" ]]; then


### PR DESCRIPTION
Pending acceptance of Aloshi/EmulationStation#26, `make clean` should no longer be necessary. And sorry for the silly typos in the last commit. I should have spotted that.
