### PR TITLE
fix /usr/bin/emulationstation generation

### DIFF
--- a/retropie_setup.sh
+++ b/retropie_setup.sh
@@ -1339,8 +1339,8 @@ function install_esscript()
     cat > /usr/bin/emulationstation << _EOF_
 #!/bin/bash
 
-nb_lock_files=$(find /tmp -name ".X?-lock" | wc -l)
-if [ $nb_lock_files -ne 0 ]; then
+nb_lock_files=\$(find /tmp -name ".X?-lock" | wc -l)
+if [ \$nb_lock_files -ne 0 ]; then
     echo "X is running. Please shut down X in order to mitigate problems with loosing keyboard input. For example, logout from LXDE."
     exit 1
 fi


### PR DESCRIPTION
escape in HERE document to avoid unintended evalution during retropie_setup.sh run
