### PR TITLE
wrapper script argument passthrough

### DIFF
--- a/retropie_setup.sh
+++ b/retropie_setup.sh
@@ -1347,7 +1347,7 @@ if [ \$nb_lock_files -ne 0 ]; then
     exit 1
 fi
 
-\$es_bin \$@
+\$es_bin "\$@"
 _EOF_
     chmod +x /usr/bin/emulationstation
 }


### PR DESCRIPTION
Pass arguments to the wrapper script on to emulationstation - this way I can do _--help_ or _--debug_ as expected.

...also skipped moving in the directory stack as emulationstation already supports execution from arbitrary locations - it's just missing from PATH.
