### PR TITLE
Replace GBA core with the gpSP emulator

### DIFF
--- a/retropie_setup.sh
+++ b/retropie_setup.sh
@@ -1559,7 +1559,7 @@ DESCNAME=Game Boy Advance
 NAME=gba
 PATH=$rootdir/roms/gba
 EXTENSION=.gba .GBA
-COMMAND=$rootdir/emulators/gpsp/gpsp %ROM%
+COMMAND=$rootdir/emulators/gpsp/raspberrypi/gpsp %ROM%
 PLATFORMID=5
 
 DESCNAME=Game Boy Color


### PR DESCRIPTION
Replace the horribly slow GBA RetroArch core with gpSP.

Includes sed fixes for:
- not including every necessary path in CFLAGS
- remove -O[1..3] if on a non-512mb revision Pi (it's pretty much impossible to build optimized on a 256mb Pi otherwise, no matter how little RAM is allocated to the GPU)

Ideally, these can be fixed directly at the [repository](https://github.com/DPRCZ/gpsp) level, but this will work for now.  You may also want to consider switching to the slightly more ["official" gpSP repository](https://github.com/notaz/gpsp), which has merged the RPi port changes.

You _will_ need a "gba_bios.bin" in, I believe, either the current working directory or the same directory gpSP is in (`$rootdir/emulators/gpsp/raspberrypi/`).
