### PR TITLE
Auto-detect HDMI for runcommand.sh

### DIFF
--- a/supplementary/runcommand.sh
+++ b/supplementary/runcommand.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 
-# starttype==1: set video mode to VGA and run command
+# starttype==1: set video mode to VGA ONLY IF tvservice is in HDMI mode, and run command
 # starttype==2: keep existing video mode and run command
+# starttype==3: set video mode to VGA and run command
 starttype=$1
 shift
 
-if [[ $starttype -eq 1 ]]; then
-   	tvservice -e "CEA 1"
-   	fbset -depth 8 && fbset -depth 16
-    eval $@
-    tvservice -p
-    fbset -depth 8 && fbset -depth 16
+if [[ $starttype -eq 1 && `tvservice --status` == *HDMI* || $starttype -eq 3 ]]; then
+	tvservice -e "CEA 1"
+	fbset -depth 8 && fbset -depth 16
+	eval $@
+	tvservice -p
+	fbset -depth 8 && fbset -depth 16
 elif [[ $starttype -eq 2 ]]; then
-    eval $@
+	eval $@
 fi


### PR DESCRIPTION
You might want to test this on a non-HDMI setup - I don't have one, but it should work...
Arguments are now 1 = auto, 2 = off, 3 = force on.
