### PR TITLE
Build EmulationStation with CMake and g++-4.7

### DIFF
--- a/retropie_setup.sh
+++ b/retropie_setup.sh
@@ -1573,8 +1573,7 @@ function install_emulationstation()
     gitPullOrClone "$rootdir/supplementary/EmulationStation" git://github.com/Aloshi/EmulationStation.git
 
     #ES requires C++11 support to build, which means g++ 4.7 or later, which isn't what g++ resolves to right now
-    CXX=g++-4.7
-    cmake .
+    CXX=g++-4.7 cmake .
     make
     install_esscript    
     if [[ ! -f "$rootdir/supplementary/EmulationStation/emulationstation" ]]; then


### PR DESCRIPTION
Use the new EmulationStation build system.  After this is accepted, I'll merge the unstable branch and the old hand-written Makefile will be gone completely.
