### PR TITLE
Add libeigen3-dev for new EmulationStation update.

### DIFF
--- a/retropie_setup.sh
+++ b/retropie_setup.sh
@@ -284,7 +284,7 @@ function installAPTPackages()
                         build-essential nasm libgl1-mesa-dev libglu1-mesa-dev libsdl1.2-dev \
                         libvorbis-dev libpng12-dev libvpx-dev freepats subversion \
                         libboost-serialization-dev libboost-thread-dev libsdl-ttf2.0-dev \
-                        cmake g++-4.7 unrar-free p7zip p7zip-full
+                        cmake g++-4.7 unrar-free p7zip p7zip-full libeigen3-dev
                         # libgles2-mesa-dev
 
     # remove PulseAudio since this is slowing down the whole system significantly


### PR DESCRIPTION
The unstable branch is ready to be merged into master again (at least it should be!), and with it, I've changed ES to use the linear algebra library Eigen for vector and matrix math.
