### PR TITLE
Added sane defaults for CFLAGS

### DIFF
--- a/retropie_setup.sh
+++ b/retropie_setup.sh
@@ -34,6 +34,12 @@ __ERRMSGS=""
 __INFMSGS=""
 __doReboot=0
 
+__default_cflags="-O2 -pipe -mfpu=vfp -march=armv6j -mfloat-abi=hard"
+
+[[ -z "${CFLAGS}"	]] && export CFLAGS="${__default_cflags}"
+[[ -z "${CXXFLAGS}" ]] && export CXXFLAGS="${__default_cflags}"
+[[ -z "${ASFLAGS}" 	]] && export ASFLAGS="${__default_cflags}"
+
 # HELPER FUNCTIONS ###
 
 #set -o nounset


### PR DESCRIPTION
CFLAGS and friends are currently unset by default.

Since this is designed to run on the Pi, it'd probably be a good idea to add a set of pi-centric CFLAGS. This enables the use of the fpu, as well as specifying a target architecture.

Notably absent are either mtune/mcpu. [Limited reports](http://www.raspberrypi.org/phpBB3/viewtopic.php?f=54&t=17983) say that those are slower. These also seem to be both safe, and provide [good benchmarks.](http://elinux.org/RPi_Performance)

They are still overridable, if the user wants to use softfp or something else insanely dumb like that.
