### PR TITLE
Removed unnecessary use of sudo

### DIFF
--- a/scriptmodules/emulators.shinc
+++ b/scriptmodules/emulators.shinc
@@ -263,7 +263,7 @@ function em_install_eduke32()
         __ERRMSGS="$__ERRMSGS Could not successfully install eDuke32 core."
     else
         printMsg "Installing eDuke32"
-        sudo dpkg -i *duke*.deb
+        dpkg -i *duke*.deb
         cp /usr/share/games/eduke32/DUKE.RTS $rootdir/roms/duke3d/
         cp /usr/share/games/eduke32/duke3d.grp $rootdir/roms/duke3d/
     fi
@@ -647,7 +647,7 @@ function em_install_retroarch()
     gitPullOrClone "$rootdir/emulators/RetroArch" git://github.com/libretro/RetroArch.git
     ./configure
     make
-    sudo make install
+    make install
     cp $scriptdir/supplementary/retroarch-zip "$rootdir/emulators/RetroArch/"
     if [[ ! -f "/usr/local/bin/retroarch" ]]; then
         __ERRMSGS="$__ERRMSGS Could not successfully compile and install RetroArch."

--- a/scriptmodules/helpers.shinc
+++ b/scriptmodules/helpers.shinc
@@ -43,10 +43,10 @@ function addLineToFile()
 {
     if [[ -f "$2" ]]; then
         cp "$2" ./temp
-        sudo mv "$2" "$2.old"
+        mv "$2" "$2.old"
     fi
     echo "$1" >> ./temp
-    sudo mv ./temp "$2"
+    mv ./temp "$2"
     echo "Added $1 to file $2"
 }
 

--- a/scriptmodules/raspbianconfig.shinc
+++ b/scriptmodules/raspbianconfig.shinc
@@ -84,18 +84,18 @@ function rc_add_user_to_group()
 {
     if [ -z $(egrep -i "^$2" /etc/group) ]
     then
-      sudo addgroup $2
+      addgroup $2
     fi
-    sudo adduser $1 $2
+    adduser $1 $2
 }
 
 # make sure ALSA, uinput, and joydev modules are active
 function rc_ensure_modules()
 {
     printMsg "Enabling ALSA, uinput, and joydev modules permanently"
-    sudo modprobe snd_bcm2835
-    sudo modprobe uinput
-    sudo modprobe joydev
+    modprobe snd_bcm2835
+    modprobe uinput
+    modprobe joydev
 
     if ! grep -q "uinput" /etc/modules; then
         addLineToFile "uinput" "/etc/modules"

--- a/scriptmodules/setup.shinc
+++ b/scriptmodules/setup.shinc
@@ -41,22 +41,22 @@ function set_changeAudioOutput()
     if [ "$choices" != "" ]; then
         case $choices in
             1) amixer cset numid=3 0
-                 sudo alsactl store
+                 alsactl store
                ###set
                dialog --backtitle "PetRockBlock.com - RetroPie Setup. Installation folder: $rootdir for user $user" --msgbox "Set audio output to auto" 22 76    
                             ;;
             2) amixer cset numid=3 1
-               sudo alsactl store
+               alsactl store
                ###set
                dialog --backtitle "PetRockBlock.com - RetroPie Setup. Installation folder: $rootdir for user $user" --msgbox "Set audio output to headphones / 3.5mm jack " 22 76    
                             ;;
             3) amixer cset numid=3 2
-               sudo alsactl store
+               alsactl store
                ###set
                dialog --backtitle "PetRockBlock.com - RetroPie Setup. Installation folder: $rootdir for user $user" --msgbox "Set audio output to HDMI" 22 76    
                             ;;
-            4) sudo /etc/init.d/alsa-utils reset
-               sudo alsactl store
+            4) /etc/init.d/alsa-utils reset
+               alsactl store
                  ###set
                dialog --backtitle "PetRockBlock.com - RetroPie Setup. Installation folder: $rootdir for user $user" --msgbox "Audio settings reset to defaults" 22 76    
                             ;;


### PR DESCRIPTION
`sudo` is unnecessary since the setup script must be run as root.

On most of the raspbian images, this isn't a problem. But on a few, they remove `sudo` entirely. When you install it by from the repos, it does not permit root to `sudo` by default. This is surprisingly difficult to catch, and causes surprising errors.
