### PR TITLE
Install gcc-4.7 along with kernel headers.

### DIFF
--- a/scriptmodules/setup.shinc
+++ b/scriptmodules/setup.shinc
@@ -329,8 +329,9 @@ function set_installGPIOpadModules()
         return 0;;
     esac
 
-    #install dkms
-    apt-get install -y dkms
+    #install dkms and gcc-4.7
+    apt-get update
+    apt-get install -y dkms gcc-4.7
 
     #reconfigure / install headers (takes a a while)
     if [ "$(dpkg-query -W -f='${Version}' linux-headers-$(uname -r))" = "$(uname -r)-2" ]; then


### PR DESCRIPTION
Sets gcc-4.7 to be installed before configuring kernel headers. Fixes the issues with gamecon/db9 drivers when built with default gcc-4.6.
