### PR TITLE
Recognize .gen ROMs in Sega MegaDrive as well.

### DIFF
--- a/scriptmodules/supplementary.shinc
+++ b/scriptmodules/supplementary.shinc
@@ -642,7 +642,7 @@ PLATFORMID=35
 DESCNAME=Sega Mega Drive / Genesis
 NAME=megadrive
 PATH=$rootdir/roms/megadrive
-EXTENSION=.smd .SMD .bin .BIN
+EXTENSION=.smd .SMD .bin .BIN .gen .GEN
 COMMAND=$rootdir/supplementary/runcommand/runcommand.sh 4 "$rootdir/emulators/RetroArch/installdir/bin/retroarch -L `find $rootdir/emulatorcores/picodrive/ -name "*libretro*.so" | head -1` --config $rootdir/configs/all/retroarch.cfg --appendconfig $rootdir/configs/megadrive/retroarch.cfg $__tmpnetplaymode$__tmpnetplayhostip_cfile$__tmpnetplayport$__tmpnetplayframes %ROM%"
 # alternatively: COMMAND=$rootdir/supplementary/runcommand/runcommand.sh 1 "$rootdir/emulators/dgen-sdl/dgen -f -r $rootdir/configs/all/dgenrc %ROM%"
 # alternatively: COMMAND=export LD_LIBRARY_PATH="$rootdir/supplementary/dispmanx/SDL12-kms-dispmanx/build/.libs"; $rootdir/emulators/dgen-sdl/dgen %ROM%


### PR DESCRIPTION
GoodTools ends up renaming roms to .gen, but they're just regular .bin files.
The users could simply rename them back to .bin, but why not accept them
as is anyway? DGen doesn't complain.
