### PR TITLE
ES-config: Write to dummy files

### DIFF
--- a/supplementary/settings.xml
+++ b/supplementary/settings.xml
@@ -1,3 +1,3 @@
-<changeConfigPath from="retroarch.cfg" to="/home/pi/RetroPie/configs/all/retroarch.cfg" />
-<changeConfigPath from="dgen.cfg" to="/home/pi/RetroPie/configs/all/dgenrc" />
-<changeConfigPath from="gngeo.rc" to="/home/pi/.gngeo/gngeorc" />
+<changeConfigPath from="retroarch.cfg" to="/home/pi/RetroPie/configs/all/retroarchinput.cfg" />
+<changeConfigPath from="dgen.cfg" to="/home/pi/RetroPie/configs/all/dgenrcinput" />
+<changeConfigPath from="gngeo.rc" to="/home/pi/.gngeo/gngeorcinput" />


### PR DESCRIPTION
Don't overwrite existing files. Write dummy files. Start.py merges dummy files with main config files.
