### PR TITLE
RetroArch: minor improvements

### DIFF
--- a/scriptmodules/emulators.shinc
+++ b/scriptmodules/emulators.shinc
@@ -717,6 +717,9 @@ function em_configureRetroArch()
     ensureKeyValue "rewind_granularity" "2" "$rootdir/configs/all/retroarch.cfg"
     ensureKeyValue "input_rewind" "r" "$rootdir/configs/all/retroarch.cfg"
 
+    # enable gpu screenshots
+    ensureKeyValue "video_gpu_screenshot" "true" "$rootdir/configs/all/retroarch.cfg"
+
     # enable and configure shaders
     if [[ ! -d "$rootdir/emulators/RetroArch/shader" ]]; then
         mkdir -p "$rootdir/emulators/RetroArch/shader"
@@ -758,6 +761,10 @@ function em_configureRetroArch()
     # system-specific shaders, Gameboy Color
     ensureKeyValue "video_shader" "\"$rootdir/emulators/RetroArch/shader/hq4x.glslp\"" "$rootdir/configs/gbc/retroarch.cfg"
     ensureKeyValue "video_shader_enable" "true" "$rootdir/configs/gbc/retroarch.cfg"
+
+    # system-specific, PSX
+    ensureKeyValue "rewind_enable" "false" "$rootdir/configs/psx/retroarch.cfg"
+    
 
     # configure keyboard mappings
     ensureKeyValue "input_player1_a" "x" "$rootdir/configs/all/retroarch.cfg"


### PR DESCRIPTION
-GPU screenshots are possible now:
https://github.com/libretro/RetroArch/commit/28d1e77a36884e0ac036f73132f116fe56ad8e55
-PSX: Extreme slowdown if rewind is enabled. If there is no keybinding, rewind should be always disabled.
