### PR TITLE
Convert <plaformid> tags to <platform> tags

### DIFF
--- a/scriptmodules/supplementary.shinc
+++ b/scriptmodules/supplementary.shinc
@@ -471,6 +471,8 @@ function sup_generate_esconfig()
          local __tmpnetplayframes=""
      fi
 
+    mkdir /etc/emulationstation
+
     cat > "/etc/emulationstation/es_systems.cfg" << _EOF_
 <systemList>  
 


### PR DESCRIPTION
Last night I changed the `<platformid>` tag to a `<platform>` tag that uses actually readable names (there was no reason to keep using numbers!).  I updated the script to use the new format.  I also added an "ignore" platform which removes the "scrape" option for games in this system and removes the system from the "scrape now" system list.  I've used this for the "Cave Story", "Doom", and "Duke Nukem" systems.

There are still a few missing platforms that I haven't added to ES yet (ScummVM, Atari 800, Atari ST/STE/Falcon).

(I also added a `mkdir /etc/emulationstation`; the "generate folder structure" might already do this, I didn't check.  I usually just run the "generate ES config file" function and nothing else.)
