### PR TITLE
MAME4All save config

### DIFF
--- a/scriptmodules/emulators.shinc
+++ b/scriptmodules/emulators.shinc
@@ -574,6 +574,7 @@ function configure_mame4all() {
     mkdir -p "$rootdir/emulators/mame4all-pi/hi"
     mkdir -p "$rootdir/emulators/mame4all-pi/sta"
     mkdir -p "$rootdir/emulators/mame4all-pi/roms"
+    chmod 777 "$rootdir/emulators/mame4all-pi/mame.cfg"
     ensureKeyValueShort "samplerate" "22050" "$rootdir/emulators/mame4all-pi/mame.cfg"
     ensureKeyValueShort "rompath" "$romdir/mame" "$rootdir/emulators/mame4all-pi/mame.cfg"    
 }


### PR DESCRIPTION
When you enter in the config menu of MAME4All with TAB for remapping keys for example, when you left MAME4All and come back, the config was not update.
With chmod 777, user pi can now save this file.
