### PR TITLE
Configuration of RetroArch shaders is not saved

### DIFF
--- a/scriptmodules/emulators.shinc
+++ b/scriptmodules/emulators.shinc
@@ -179,6 +179,8 @@ function configure_retroarch() {
     # input settings
     ensureKeyValue "input_autodetect_enable" "true" "$rootdir/configs/all/retroarch.cfg"
     ensureKeyValue "joypad_autoconfig_dir" "$rootdir/emulators/RetroArch/configs/" "$rootdir/configs/all/retroarch.cfg"
+
+    chmod -R 777 "$rootdir/emulators/RetroArch/shader/"
 }
 
 function package_retroarch() {


### PR DESCRIPTION
The user pi doesn't have rights to write in the directory of sharders config in RetroArch.
When you configure sharders in RetroArch menu, modifications are not saved.
