### PR TITLE
gpsp doesn't save menu options

### DIFF
--- a/scriptmodules/emulators.shinc
+++ b/scriptmodules/emulators.shinc
@@ -514,6 +514,9 @@ function build_gpsp() {
 function configure_gpsp() {
     printMsg "Configuring GPSP"
     mkdir "$romdir/gba"
+    chmod -R 777 "$rootdir/emulators/gpsp/raspberrypi/"
+    # gpsp.cfg seems to exist after first start/quit of emulator
+    # chmod 777 "$rootdir/emulators/gpsp/raspberrypi/gpsp.cfg"
 }
 
 function sources_gngeopi() {


### PR DESCRIPTION
the file gpsp.cfg contains menu settings but this file is created only after leaving the emulator if pi user has rights to make it
