### PR TITLE
Fixing mame4all-pi permissions to allow config changes to be saved

### DIFF
--- a/scriptmodules/emulators.shinc
+++ b/scriptmodules/emulators.shinc
@@ -579,7 +579,11 @@ function configure_mame4all() {
     mkdir -p "$rootdir/emulators/mame4all-pi/hi"
     mkdir -p "$rootdir/emulators/mame4all-pi/sta"
     mkdir -p "$rootdir/emulators/mame4all-pi/roms"
-    chmod 777 "$rootdir/emulators/mame4all-pi/mame.cfg"
+    chmod a+w "$rootdir/emulators/mame4all-pi/cfg"
+    chmod a+w "$rootdir/emulators/mame4all-pi/hi"
+    chmod a+w "$rootdir/emulators/mame4all-pi/sta"
+    chmod a+w "$rootdir/emulators/mame4all-pi/roms"
+    chmod a+w "$rootdir/emulators/mame4all-pi/mame.cfg"
     ensureKeyValueShort "samplerate" "22050" "$rootdir/emulators/mame4all-pi/mame.cfg"
     ensureKeyValueShort "rompath" "$romdir/mame" "$rootdir/emulators/mame4all-pi/mame.cfg"    
 }


### PR DESCRIPTION
This is needed to allow mame4all-pi to save configuration changes made from within MAME itself at runtime. Without this change, you can customize the inputs (via the MAME menu), but the changes will be lost upon exiting the game.
