### PR TITLE
rather than performing apt-get update multiple times which is rather slo...

### DIFF
--- a/retropie_setup.sh
+++ b/retropie_setup.sh
@@ -107,8 +107,7 @@ function initImport() {
 function rps_checkNeededPackages() {
     if [[ -z $(type -P git) || -z $(type -P dialog) ]]; then
         echo "Did not find needed packages 'git' and/or 'dialog'. I am trying to install these now."
-        apt-get update
-        apt-get install -y git dialog
+        aptInstall git dialog
         if [ $? == '0' ]; then
             echo "Successfully installed 'git' and/or 'dialog'."
         else

--- a/scriptmodules/emulators.shinc
+++ b/scriptmodules/emulators.shinc
@@ -24,7 +24,7 @@
 #
 
 function depen_retroarch() {
-    apt-get install -y libudev-dev libxkbcommon-dev
+    aptInstall libudev-dev libxkbcommon-dev
     cat > "/etc/udev/rules.d/99-evdev.rules" << _EOF_
 KERNEL=="event*", NAME="input/%k", MODE="666"
 _EOF_
@@ -182,7 +182,7 @@ function configure_retroarch() {
 
 # 101, AdvMAME
 function depen_advmame() {
-    apt-get -y install libsdl1.2-dev gcc-4.7
+    aptInstall libsdl1.2-dev gcc-4.7
 }
 
 function sources_advmame() {
@@ -295,7 +295,7 @@ function configure_cpc() {
 }
 
 function install_dosbox() {
-    apt-get install -y dosbox
+    aptInstall dosbox
 }
 
 function configure_dosbox() {
@@ -304,7 +304,7 @@ function configure_dosbox() {
 
 function install_stella()
 {
-    apt-get install -y stella
+    aptInstall stella
 }
 
 function configure_stella() {
@@ -352,8 +352,7 @@ function build_vice() {
         apt-get remove -y vice
     fi
     echo 'deb-src http://mirrordirector.raspbian.org/raspbian/ wheezy main contrib non-free rpi' >> /etc/apt/sources.list
-    apt-get update
-    apt-get install -y libxaw7-dev automake checkinstall
+    aptInstall libxaw7-dev automake checkinstall
     pushd "$rootdir/emulators/vice-2.4"
     ./configure --prefix="$rootdir/emulators/vice-2.4/installdir" --enable-sdlui --without-pulse --with-sdlsound
     make
@@ -484,7 +483,7 @@ function configure_gngeopi() {
 }
 
 function install_hatari() {
-    apt-get install -y hatari
+    aptInstall hatari
     mkdir -p $romdir/atariststefalcon
 }
 
@@ -555,7 +554,7 @@ function configure_jzint() {
 }
 
 function depen_linapple() {
-    apt-get update && apt-get install -y libzip2
+    aptInstall libzip2
 }
 
 function sources_linapple() {
@@ -609,7 +608,7 @@ function configure_mupen64rpi() {
 }
 
 function depen_snes9x() {
-    apt-get update && apt-get install -y libsdl-dev libboost-thread-dev
+    aptInstall libsdl-dev libboost-thread-dev
 }
 
 function sources_snes9x() {
@@ -721,7 +720,7 @@ _EOF_
 }
 
 function install_scummvm() {
-    apt-get install -y scummvm scummvm-data
+    aptInstall scummvm scummvm-data
     if [[ $? -gt 0 ]]; then
         __ERRMSGS="$__ERRMSGS Could not successfully install ScummVM."
     else
@@ -730,7 +729,7 @@ function install_scummvm() {
 }
 
 function install_zmachine() {
-    apt-get install -y frotz
+    aptInstall frotz
     wget -U firefox http://www.infocom-if.org/downloads/zork1.zip
     wget -U firefox http://www.infocom-if.org/downloads/zork2.zip
     wget -U firefox http://www.infocom-if.org/downloads/zork3.zip
@@ -747,7 +746,7 @@ function install_zmachine() {
 }
 
 function install_zxspectrum() {
-    apt-get install -y spectrum-roms fuse-emulator-utils fuse-emulator-common
+    aptInstall spectrum-roms fuse-emulator-utils fuse-emulator-common
 }
 
 function sources_fbzx() {
@@ -771,7 +770,7 @@ function configure_fbzx() {
 }
 
 function depen_msx() {
-    apt-get update && apt-get install -y libsdl1.2-dev libsdl-ttf2.0-dev libglew-dev libao-dev libogg-dev libtheora-dev libxml2-dev libvorbis-dev tcl-dev
+    aptInstall libsdl1.2-dev libsdl-ttf2.0-dev libglew-dev libao-dev libogg-dev libtheora-dev libxml2-dev libvorbis-dev tcl-dev
 }
 
 function sources_openmsx() {

--- a/scriptmodules/helpers.shinc
+++ b/scriptmodules/helpers.shinc
@@ -225,3 +225,18 @@ function rmDirExists()
         rm -rf "$1"
     fi
 }
+
+function aptUpdate()
+{
+    if [[ "$__apt_update" != "1" ]]; then
+        apt-get update
+        __apt_update="1"
+    fi
+}
+
+function aptInstall()
+{
+    aptUpdate
+    apt-get install -y --no-install-recommends $@
+}
+

--- a/scriptmodules/libretrocores.shinc
+++ b/scriptmodules/libretrocores.shinc
@@ -206,7 +206,7 @@ function configure_mamelibretro() {
 }
 
 function depen_fbalibretro() {
-    apt-get update && apt-get install -y --force-yes cpp-4.5 gcc-4.5 g++-4.5
+    aptInstall --force-yes cpp-4.5 gcc-4.5 g++-4.5
 }
 
 function sources_fbalibretro() {

--- a/scriptmodules/supplementary.shinc
+++ b/scriptmodules/supplementary.shinc
@@ -28,20 +28,19 @@
 # 300, APT Update
 
 function install_APTPackages() {
-    apt-get autoremove;
-    apt-get update;
-    apt-get -y upgrade;
+    apt-get autoremove
+    aptUpdate
+    apt-get -y upgrade
 }
 
 # 301, PackageRepository ---------------------
 
 function install_PackageRepository() {
     # install repository helper package
-    apt-get install -y reprepro || return 1
+    aptInstall reprepro
 
     # Create repository
-    mkdir RetroPieRepo || return 1
-    mkdir RetroPieRepo/conf || return 1
+    mkdir -p RetroPieRepo/conf
     cat >> RetroPieRepo/conf/distributions << _EOF_
 Origin: apt.petrockblock.com
 Label: apt repository
@@ -57,7 +56,7 @@ _EOF_
 # 302, SDL 2.0.1
 
 function depen_sdl() {
-    apt-get install -y libudev-dev libasound2-dev libdbus-1-dev libraspberrypi0 libraspberrypi-bin libraspberrypi-dev
+    aptInstall libudev-dev libasound2-dev libdbus-1-dev libraspberrypi0 libraspberrypi-bin libraspberrypi-dev
 }
 
 function sources_sdl() {
@@ -87,7 +86,7 @@ function install_sdl() {
 
 # 303, Emulation Station ----------------------
 function depen_emulationstation() {
-    apt-get install -y libboost-system-dev libboost-filesystem-dev libboost-date-time-dev \
+    aptInstall -y libboost-system-dev libboost-filesystem-dev libboost-date-time-dev \
                        libfreeimage-dev libfreetype6-dev libeigen3-dev libcurl4-openssl-dev \
                        libasound2-dev cmake g++-4.7
 }
@@ -488,7 +487,7 @@ chmod 755 "/etc/emulationstation/es_systems.cfg"
 function package_EmulationStation() {
     local PKGNAME
 
-    apt-get install -y reprepro
+    aptInstall reprepro
 
     printMsg "Building package of EmulationStation"
 
@@ -741,8 +740,7 @@ HDHD
 }
 
 function install_sambashares() {
-    apt-get update
-    apt-get install -y samba samba-common-bin
+    aptInstall samba samba-common-bin
 }
 
 function configure_sambashares() {
@@ -787,7 +785,7 @@ function configure_sambashares() {
 
 function install_usbromservice() {
     # install usbmount package
-    apt-get install -y usbmount
+    aptInstall usbmount
 }
 
 function configure_usbromservice() {
@@ -802,7 +800,7 @@ function set_enableSplashscreenAtStart()
     clear
     printMsg "Enabling custom splashscreen on boot."
 
-    apt-get install -y fbi
+    aptInstall fbi
 
     chmod +x "$scriptdir/supplementary/asplashscreen/asplashscreen"
     cp "$scriptdir/supplementary/asplashscreen/asplashscreen" "/etc/init.d/"
@@ -1090,8 +1088,7 @@ function configure_autostartemustat() {
 }
 
 function set_installps3controller() {
-    apt-get update
-    apt-get install -y --force-yes bluez-utils bluez-compat bluez-hcidump checkinstall libusb-dev libbluetooth-dev joystick
+    aptInstall --force-yes bluez-utils bluez-compat bluez-hcidump checkinstall libusb-dev libbluetooth-dev joystick
     apt-get remove -y cups
     apt-get autoremove -y
     dialog --backtitle "PetRockBlock.com - RetroPie Setup. Installation folder: $rootdir for user $user" --msgbox "Please make sure that your Bluetooth dongle is connected to the Raspberry Pi and press ENTER." 22 76
@@ -1127,7 +1124,7 @@ function set_installps3controller() {
 }
 
 function set_install_xboxdrv() {
-    apt-get install -y --force-yes xboxdrv
+    aptInstall --force-yes xboxdrv
     if [[ -z `cat /etc/rc.local | grep "xboxdrv"` ]]; then
         sed -i -e '13,$ s|exit 0|xboxdrv --daemon --id 0 --led 2 --deadzone 4000 --silent --trigger-as-button --next-controller --id 1 --led 3 --deadzone 4000 --silent --trigger-as-button --dbus disabled --detach-kernel-driver \&\nexit 0|g' /etc/rc.local
     fi
@@ -1152,7 +1149,7 @@ function set_RetroarchJoyconfig() {
 }
 
 function install_libsdlbinaries() {
-    apt-get install -y libudev-dev libasound2-dev libdbus-1-dev libraspberrypi0 libraspberrypi-bin libraspberrypi-dev
+    aptInstall libudev-dev libasound2-dev libdbus-1-dev libraspberrypi0 libraspberrypi-bin libraspberrypi-dev
 
     wget -O libsdlbinaries.tar.gz http://downloads.petrockblock.com/libsdl2.0.1.tar.gz
     tar xvfz libsdlbinaries.tar.gz
@@ -1282,9 +1279,8 @@ function install_gamecondriver() {
         return 0;;
     esac
 
-    #install dkms and gcc-4.7
-    apt-get update
-    apt-get install -y --force-yes dkms gcc-4.7
+    #install dkms
+    aptInstall dkms
 
     #reconfigure / install headers (takes a a while)
     if [ "$(dpkg-query -W -f='${Version}' linux-headers-$(uname -r))" = "$(uname -r)-2" ]; then


### PR DESCRIPTION
...w, use a function, set a flag, so we only apt-get update a single time

use --no-install-recommends to keep the dependencies set smaller

note - I have some more related stuff to add. But https://github.com/petrockblog/RetroPie-Setup/pull/369 needs to be pulled first. Once it is, I can de-duplicate both the retropie setup/packages script, moving some stuff to the helpers file, and rework the core dependency function to include gcc-4.7 as it is the default compiler.
