### PR TITLE
wrong variable name - copy n paste fail. fixed

### DIFF
--- a/scriptmodules/retropiesetup.shinc
+++ b/scriptmodules/retropiesetup.shinc
@@ -142,7 +142,7 @@ function rps_main_options()
         touch $logfilename
         for choice in $choices
         do
-            source $scriptdir/retropie_packages.sh $choice ${command[$choices]} 2>&1 > >(tee >(gzip --stdout >$logfilename))
+            source $scriptdir/retropie_packages.sh $choice ${command[$choice]} 2>&1 > >(tee >(gzip --stdout >$logfilename))
         done
 
         if [[ ! -z $__ERRMSGS ]]; then


### PR DESCRIPTION
sorry. copy and paste bug that broke building from source.
