### PR TITLE
callFunction changes

### DIFF
--- a/retropie_packages.sh
+++ b/retropie_packages.sh
@@ -332,7 +332,7 @@ import "scriptmodules/emulators"
 import "scriptmodules/libretrocores"
 import "scriptmodules/supplementary"
 
-rps_checkNeededPackages git dialog gcc-4.7
+rps_checkNeededPackages git dialog gcc-4.7 g++-4.7
 
 # set default gcc version
 gcc_version $__default_gcc_version


### PR DESCRIPTION
re-add local scope for __desc
correct parameter order for call to rp_callFunction

I was assuming the local scope of __desc was removed by accident - It's not too important, but I assumed it wasn't needed outside of the function. perhaps we should have a document btw to lock down some styles/naming - like with __ in variable names. should we use for all, or just global or ?

Other fix is the one I mentioned in the code comment, with parameter ordering being changed, this call needed switching round.

Cheers.
