### PR TITLE
mupen64plus-rpi dirty fix

### DIFF
--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -270,7 +270,7 @@ function configure_emulationstation() {
         <name>n64</name>
         <path>~/RetroPie/roms/n64</path>
         <extension>.z64 .Z64 .n64 .N64 .v64 .V64</extension>
-        <command>$rootdir/supplementary/runcommand/runcommand.sh 1 "cd $rootdir/emulators/mupen64plus-rpi/test/ && ./mupen64plus %ROM%"</command>
+        <command>$rootdir/supplementary/runcommand/runcommand.sh 1 "cd $rootdir/emulators/mupen64plus-rpi/test/ && sudo ./mupen64plus %ROM%"</command>
         <platform>n64</platform>
         <theme>n64</theme>
     </system>


### PR DESCRIPTION
Run as root seems to fix startup problems. 

New problems:
-cannot exit mupen64plus with "ESCAPE". No reaction.
-emulationstation pops up if some keys are pressed (ALT+TAB??). Mupen64plus runs in background. I have never seen emulationstation pop up if a emulator is still running.
