### PR TITLE
Makes `rps_downloadBinaries` more disk efficient

### DIFF
--- a/scriptmodules/retropiesetup.sh
+++ b/scriptmodules/retropiesetup.sh
@@ -38,7 +38,7 @@ function rps_downloadBinaries()
     wget -O binariesDownload.tar.bz2 http://blog.petrockblock.com/?wpdmdl=7113
     tar -jxvf binariesDownload.tar.bz2 -C $rootdir
     pushd $rootdir/retropie
-    cp -r * ../
+    rsync --remove-source-files -av . ../
     popd
     rm -rf $rootdir/retropie
     rm binariesDownload.tar.bz2


### PR DESCRIPTION
This should delete files as it goes and prevent the disk usage from temporarily ballooning
