### PR TITLE
Enable hotkey button again.

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -80,8 +80,9 @@ function configure_retroarch() {
     ensureKeyValue "core_options_path" "$rootdir/configs/all/retroarch-core-options.cfg" "$rootdir/configs/all/retroarch.cfg"
 
     # enable hotkey ("select" button)
-    ensureKeyValue "input_enable_hotkey" "nul" "$rootdir/configs/all/retroarch.cfg"
-    ensureKeyValue "input_exit_emulator" "escape" "$rootdir/configs/all/retroarch.cfg"
+    ensureKeyValue "input_enable_hotkey" "escape" "$rootdir/configs/all/retroarch.cfg"
+    ensureKeyValue "input_exit_emulator" "nul" "$rootdir/configs/all/retroarch.cfg"
+    ensureKeyValue "input_menu_toggle" "escape" "$rootdir/configs/all/retroarch.cfg"
 
     # enable and configure rewind feature
     ensureKeyValue "rewind_enable" "false" "$rootdir/configs/all/retroarch.cfg"


### PR DESCRIPTION
If there is no hotkey button there is a problem with joystick autoconfig files. The joystick hotkey button will not be recognized if there is no keyboard hotkey button. Most joystick autoconfig files use start + select to exit retroarch. Without a keyboard hotkey button retroarch will exit if start is pressed.

Old solution:  Escape is hotkey and exit button. Problem --> We cannot open RGUI with F1.
New solution: Remove exit button. Open RGUI if escape is pressed. We can quit retroarch from RGUI.
