### PR TITLE
Add mupen64plus libretto core.

### DIFF
--- a/scriptmodules/libretrocores/mupen64libretro.sh
+++ b/scriptmodules/libretrocores/mupen64libretro.sh
@@ -25,7 +25,7 @@ function configure_mupen64plus() {
 
     ensureSystemretroconfig "n64"
 
-    ensureKeyValue "mupen64-gfxplugin" "gln64" "$rootdir/configs/all/retroarch-core-options.cfg"
+    ensureKeyValue "mupen64-gfxplugin" "rice" "$rootdir/configs/all/retroarch-core-options.cfg"
     ensureKeyValue "mupen64-gfxplugin-accuracy" "low" "$rootdir/configs/all/retroarch-core-options.cfg"
     ensureKeyValue "mupen64-screensize" "320x240" "$rootdir/configs/all/retroarch-core-options.cfg"
 


### PR DESCRIPTION
Mario 64 needs at least 1GHz OC to be playable.
