### PR TITLE
mupen64plus-libretro: add freezed working repo.

### DIFF
--- a/scriptmodules/libretrocores/mupen64libretro.sh
+++ b/scriptmodules/libretrocores/mupen64libretro.sh
@@ -4,18 +4,16 @@ rp_module_menus="4+"
 
 function sources_mupen64plus() {
     rmDirExists "$rootdir/emulatorcores/mupen64plus"
-    gitPullOrClone "$rootdir/emulatorcores/mupen64plus" git://github.com/libretro/mupen64plus-libretro.git
-    pushd "$rootdir/emulatorcores/mupen64plus"
-        # Revert to a working commit. Delete this workaround if HEAD is working again.
-        # https://github.com/libretro/mupen64plus-libretro/commit/c035cf1c7a2514aeb14adf51ad825208ff1a068d
-        sudo git revert --no-commit c035cf1..HEAD
-    popd
+    # Base repo:
+    # gitPullOrClone "$rootdir/emulatorcores/mupen64plus" git://github.com/libretro/mupen64plus-libretro.git
+    # Freezed fixed repo:
+    gitPullOrClone "$rootdir/emulatorcores/mupen64plus" git://github.com/gizmo98/mupen64plus-libretro.git
 }
 
 function build_mupen64plus() {
     pushd "$rootdir/emulatorcores/mupen64plus"
-    # Add missing path
-    sed -i 's|GL_LIB := -lGLESv2|GL_LIB := -L/opt/vc/lib -lGLESv2|g' Makefile
+    # Add missing path --> Fix already merged https://github.com/libretro/mupen64plus-libretro/commit/c035cf1c7a2514aeb14adf51ad825208ff1a068d
+    # sed -i 's|GL_LIB := -lGLESv2|GL_LIB := -L/opt/vc/lib -lGLESv2|g' Makefile
     make clean
     make platform=rpi 
     if [[ -z `find $rootdir/emulatorcores/mupen64plus/ -name "*libretro*.so"` ]]; then


### PR DESCRIPTION
Just add a freezed fixed current repo, because git revert fix from yesterday is not working today. Just wait until base mupen64plus-libreto is stable again.
