### PR TITLE
Added libsdl1.2-dev dependency for mame4all

### DIFF
--- a/scriptmodules/emulators/mame4all.sh
+++ b/scriptmodules/emulators/mame4all.sh
@@ -3,7 +3,7 @@ rp_module_desc="MAME emulator MAME4All-Pi"
 rp_module_menus="2+"
 
 function depends_mame4all() {
-	rps_checkNeededPackages libasound2-dev
+	rps_checkNeededPackages libasound2-dev libsdl1.2-dev
 }
 
 function sources_mame4all() {


### PR DESCRIPTION
Fixes #504 for mame4all. A similar patch should work for gpsp, but I have not attempted it. 
