### PR TITLE
mame4all: Try to fix compilation issue

### DIFF
--- a/scriptmodules/emulators/mame4all.sh
+++ b/scriptmodules/emulators/mame4all.sh
@@ -13,6 +13,8 @@ function sources_mame4all() {
 
 function build_mame4all() {
     pushd "$rootdir/emulators/mame4all-pi"
+    sed -i 's|LIBS = -lm|LIBS = -lrt -lasound -lm|g' Makefile
+    sed -i 's|armv6|armv6j|g' Makefile
     make clean
     make
     if [[ ! -f "$rootdir/emulators/mame4all-pi/mame" ]]; then


### PR DESCRIPTION
Just add the missing libs (https://github.com/petrockblog/RetroPie-Setup/issues/509) and use the same -march CFLAG as RetroPie-Setup.
