### PR TITLE
pisnes: Try to fix compilation issue

### DIFF
--- a/scriptmodules/emulators/pisnes.sh
+++ b/scriptmodules/emulators/pisnes.sh
@@ -8,7 +8,8 @@ function sources_pisnes() {
 
 function build_pisnes() {
     pushd "$rootdir/emulators/pisnes"
-    sed -i -e "s|-lglib-2.0|-lglib-2.0 -lbcm_host|g" Makefile
+    sed -i -e "s|-lglib-2.0|-lglib-2.0 -lbcm_host -lrt -lasound -lm|g" Makefile
+    sed -i 's|armv6|armv6j|g' Makefile
     make clean
     make
     if [[ ! -f "$rootdir/emulators/pisnes/snes9x" ]]; then


### PR DESCRIPTION
Just add the missing libs (https://github.com/petrockblog/RetroPie-Setup/issues/509) and use the same -march CFLAG as RetroPie-Setup.
