### PR TITLE
rework of runcommand.sh

### DIFF
--- a/supplementary/runcommand.sh
+++ b/supplementary/runcommand.sh
@@ -63,7 +63,7 @@ function choose_mode() {
         2 "Select default video mode for rom"
         3 "Remove default video mode for rom"
     )
-    cmd=(dialog --menu "Choose which video mode option to set"  22 76 16 )
+    cmd=(dialog --menu "Video output configuration"  22 76 16 )
     choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
 
     case $choice in


### PR DESCRIPTION
- now takes into account current aspect ratio of video mode to avoid choosing the wrong aspect ratio on 4:3 monitors
- removed unused video mode selections - users can specify an exact mode should they wish to
- short 1 second delay before resetting framebuffer, to avoid screen being left in unusable state
- only changes the video mode if the new screenmode differs from the current mode
- allows configuration of video mode for emulators & individual roms by pressing x or m on launch

```
runcommand is called with two parameters - reqmode, and command. reqmode can be:

reqmode==0: run command
reqmode==1: set video mode to 640x480 (4:3) or 720x480 (16:9) @60hz, and run command
reqmode==4: set video mode to 1024x768 (4:3) or 1280x720 (16:9) @60hz, and run command

reqmode=="CEA-#": set video mode to CEA mode #
reqmode=="DMT-#": set video mode to DMT mode #
reqmode=="PAL/NTSC-RATIO": set mode to SD output with RATIO of 4:3 / 16:10 or 16:9

note that mode switching only happens if the monitor reports the modes as available (via tvservice)
and the requested mode differs from the currently active mode
```
