### PR TITLE
-Now asplashscreen script will parse each line of the splashscreen.list ...

### DIFF
--- a/supplementary/asplashscreen/asplashscreen
+++ b/supplementary/asplashscreen/asplashscreen
@@ -11,19 +11,22 @@
 
 do_start () {
 
-    line=$(head -n 1 /etc/splashscreen.list)
-    isMovie=$(echo $line | grep -o "*.mpg")
-    if [ -z "$isMovie" ]; then
-      /usr/bin/fbi -T 2 -once -t 20 -noverbose -a -l /etc/splashscreen.list &
-    else
-      mplayer $line &
-    fi
+    while read splashline; do
+        echo Playing splash video or image $splashline
+        isMovie=$(echo $splashline | grep -o ".mov\|.mp4\|.mkv\|.3gp\|.mpg")
+        if [ -z "$isMovie" ]; then
+            /usr/bin/fbi -T 1 -once -t 10 -noverbose -a $splashline
+            sleep 12
+        else
+            mplayer $splashline
+        fi
+    done </etc/splashscreen.list
     exit 0
 }
 
 case "$1" in
   start|"")
-    do_start
+    do_start &
     ;;
   restart|reload|force-reload)
     echo "Error: argument '$1' not supported" >&2


### PR DESCRIPTION
...instead of just looking at the first line to decide what to do.  Previously, if the first line was an image, then fbi would just be called with the list (and if there was more than one image in the list, they would all be displayed slideshow style).  If the first line was a movie, the grep did not actually detect it.  Now each line is handled separately.  This does not affect normal operation with an unmodified splashscreen.list, but if a power user wants to manually add more images and / or videos to splashscreen.list then they will now play back in the background during startup as expected.  Emulation station will interrupt the playback / display if startup finishes before the splash sequence.