### PR TITLE
change location of retroarch joypad configurations to /opt/retropie/c…

### DIFF
--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -142,7 +142,6 @@ function binaries_setup()
 
         # required supplementary modules 
         rp_callModule esthemesimple
-        rp_callModule retroarchautoconf
         rp_callModule runcommand install
 
         # some additional supplementary modules

--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -108,7 +108,7 @@ function configure_retroarch() {
 
     # input settings
     iniSet "input_autodetect_enable" "true"
-    iniSet "joypad_autoconfig_dir" "$md_inst/configs/"
+    iniSet "joypad_autoconfig_dir" "$configdir/all/retroarch-joypads/"
 
     chown $user:$user "$config"
 }

--- a/scriptmodules/supplementary/retroarchautoconf.sh
+++ b/scriptmodules/supplementary/retroarchautoconf.sh
@@ -9,8 +9,8 @@
 #
 
 rp_module_id="retroarchautoconf"
-rp_module_desc="RetroArch-AutoConfigs"
-rp_module_menus="2+"
+rp_module_desc="Install RetroArch joypad autoconfigs"
+rp_module_menus="3+"
 rp_module_flags="nobin"
 
 function sources_retroarchautoconf() {
@@ -18,13 +18,13 @@ function sources_retroarchautoconf() {
 }
 
 function install_retroarchautoconf() {
-    mkdir -p "$emudir/retroarch/configs/"
+    mkUserDir "$configdir/all/retroarch-joypads"
     # strip CR's from the files
     cd "$md_build/udev/"
     for file in *; do
-        tr -d '\015' <"$file" >"$emudir/retroarch/configs/$file"
-        chown $user:$user "$emudir/retroarch/configs/$file"
+        tr -d '\015' <"$file" >"$configdir/all/retroarch-joypads/$file"
     done
+    chown -R $user:$user "$configdir/all/retroarch-joypads"
 }
 
 function remap_hotkeys_retroarchautoconf() {

--- a/scriptmodules/supplementary/retroarchinput.sh
+++ b/scriptmodules/supplementary/retroarchinput.sh
@@ -22,15 +22,15 @@ function joystick_retroarchinput() {
     # todo Find number of first joystick device in /dev/input
     numJoypads=$(ls -1 /dev/input/js* | head -n 1)
     if [[ -n "$numJoypads" ]]; then
-        "$emudir/retroarch/retroarch-joyconfig" --autoconfig "$emudir/retroarch/configs/tempconfig.cfg" --timeout 4 --joypad ${numJoypads:13}
-        configfname=$(grep "input_device = \"" "$emudir/retroarch/configs/tempconfig.cfg")
+        "$emudir/retroarch/retroarch-joyconfig" --autoconfig "$__tmpdir/tempconfig.cfg" --timeout 4 --joypad ${numJoypads:13}
+        configfname=$(grep "input_device = \"" "$__tmpdir/tempconfig.cfg")
         configfname=$(echo ${configfname:16:-1} | tr -d ' ')
-        mv "$emudir/retroarch/configs/tempconfig.cfg" "$emudir/retroarch/configs/$configfname.cfg"
+        mv "$__tmpdir/tempconfig.cfg" "$configdir/all/retroarch-joypads/$configfname.cfg"
 
         # Add hotkeys
-        rp_callModule retroarchautoconf remap_hotkeys "$emudir/retroarch/configs/$configfname.cfg"
+        rp_callModule retroarchautoconf remap_hotkeys "$configdir/all/retroarch-joypads/$configfname.cfg"
 
-        chown $user:$user "$emudir/retroarch/configs/$configfname.cfg"
+        chown $user:$user "$configdir/all/retroarch-joypads/$configfname.cfg"
 
         printMsgs "dialog" "The configuration file has been saved as $configfname.cfg and will be used by RetroArch from now on whenever that controller is connected."
     else

--- a/supplementary/moduledata/supplementary/emulationstation/configscripts/retroarch.sh
+++ b/supplementary/moduledata/supplementary/emulationstation/configscripts/retroarch.sh
@@ -10,7 +10,7 @@
 
 function onstart_inputconfig_retroarch_joystick() {
     local deviceName=$2
-    iniConfig " = " "\"" "./tempconfig.cfg"
+    iniConfig " = " "\"" "/tmp/tempconfig.cfg"
     iniSet "input_device" "$deviceName"
     iniSet "input_driver" "udev"
 }
@@ -143,12 +143,11 @@ function onend_inputconfig_retroarch_joystick() {
     local deviceType=$1
     local deviceName=$2
     newFilename=$(echo "$deviceName" | sed -e 's/ /_/g')".cfg"
-    mv "./tempconfig.cfg" "$newFilename"
-    if [[ -f "/opt/retropie/emulators/retroarch/configs/$newFilename" ]]; then
-        mv "/opt/retropie/emulators/retroarch/configs/$newFilename" "/opt/retropie/emulators/retroarch/configs/$newFilename.bak"
+    if [[ -f "/opt/retropie/configs/all/retroarch-joypads/$newFilename" ]]; then
+        mv "/opt/retropie/configs/all/retroarch-joypads/$newFilename" "/opt/retropie/configs/all/retroarch-joypads/$newFilename.bak"
     fi
-    mv "$newFilename" "/opt/retropie/emulators/retroarch/configs/$newFilename"
-    chown $user:$user "/opt/retropie/emulators/retroarch/configs/$newFilename"
+    mv "/tmp/tempconfig.cfg" "/opt/retropie/configs/all/retroarch-joypads/$newFilename"
+    chown $user:$user "/opt/retropie/configs/all/retroarch-joypads/$newFilename"
 }
 
 


### PR DESCRIPTION
…onfigs/all/retroarch-joypads/

don't install the retroarch-joypad-autoconfig files by default - they can be confusing and collide with our generated configs
minor tweaks to temp file used in retrorch inputconfiguration