### PR TITLE
shouldn't be any reason to run inputconfiguration as root - all confi…

### DIFF
--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -47,7 +47,7 @@ function configure_inputconfig_emulationstation() {
 <?xml version="1.0"?>
 <inputList>
   <inputAction type="onfinish">
-    <command>sudo /opt/retropie/supplementary/emulationstation/scripts/inputconfiguration.sh</command>
+    <command>/opt/retropie/supplementary/emulationstation/scripts/inputconfiguration.sh</command>
   </inputAction>
 </inputList>
 _EOF_

--- a/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh
@@ -147,7 +147,6 @@ function onend_inputconfig_retroarch_joystick() {
         mv "/opt/retropie/configs/all/retroarch-joypads/$newFilename" "/opt/retropie/configs/all/retroarch-joypads/$newFilename.bak"
     fi
     mv "/tmp/tempconfig.cfg" "/opt/retropie/configs/all/retroarch-joypads/$newFilename"
-    chown $user:$user "/opt/retropie/configs/all/retroarch-joypads/$newFilename"
 }
 
 

--- a/scriptmodules/supplementary/emulationstation/inputconfiguration.sh
+++ b/scriptmodules/supplementary/emulationstation/inputconfiguration.sh
@@ -201,8 +201,7 @@ function iniSet() {
 
 ###### main ######
 
-user="$SUDO_USER"
-[[ -z "$user" ]] && user=$(id -un)
+user=$(id -un)
 home="$(eval echo ~$user)"
 
 inputconfiguration


### PR DESCRIPTION
…gurations should be in $user readable places now (and if not, we need to fix that). But certainly emulationstation and retroarch are

@petrockblog - wanted to run this one by you in case there was some reasoning for this that I missed ?