### PR TITLE
rework and speed up processing of the input configuration

### DIFF
--- a/scriptmodules/supplementary/emulationstation/configscripts/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/emulationstation.sh
@@ -8,153 +8,83 @@
 # at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
 #
 
-#### input type: Joystick ###
+function onstart_emulationstation_joystick() {
+    local device_type=$1
+    local device_name=$2
 
-function onstart_inputconfig_emulationstation_joystick() {
-    local deviceType=$1
-    local deviceName=$2
-    local confFile="$home/.emulationstation/es_input.cfg"
+    local es_conf="$home/.emulationstation/es_input.cfg"
+
     mkdir -p "$home/.emulationstation"
-    if [[ ! -f "$confFile" ]]; then
-        echo "<inputList />" >"$confFile"
+
+    if [[ ! -f "$conf" ]]; then
+        echo "<inputList />" >"$es_conf"
     fi
 
-    cp "$confFile" "$confFile.bak"
+    cp "$es_conf" "$es_conf.bak"
 
     # make sure that device exists
-    deviceNameString=\'$deviceName\'
-    if [[ $(xmlstarlet sel -t -v "count(/inputList/inputConfig[@deviceName=$deviceNameString])" "$confFile") -eq 0 ]]; then
+    if [[ $(xmlstarlet sel -t -v "count(/inputList/inputConfig[@deviceName='$device_name'])" "$es_conf") -eq 0 ]]; then
         xmlstarlet ed -L -s "/inputList" -t elem -n newInputConfig -v "" \
-            -i //newInputConfig -t attr -n "type" -v "$deviceType" \
-            -i //newInputConfig -t attr -n "deviceName" -v "$deviceName" \
+            -i //newInputConfig -t attr -n "type" -v "$device_type" \
+            -i //newInputConfig -t attr -n "deviceName" -v "$device_name" \
             -r //newInputConfig -v inputConfig \
-            "$confFile"
+            "$es_conf"
     else
         xmlstarlet ed -L \
-            -u "/inputList/inputConfig[@deviceName=$deviceNameString]/@deviceType" -v "$deviceType" \
-            -d "/inputList/inputConfig[@deviceName=$deviceNameString]/@deviceGUID" \
-            "$confFile"
+            -u "/inputList/inputConfig[@deviceName='$device_name']/@device_type" -v "$device_type" \
+            -d "/inputList/inputConfig[@deviceName='$device_name']/@deviceGUID" \
+            "$es_conf"
     fi
-
 }
 
-function up_inputconfig_emulationstation_joystick() {
-    setESInputConfig_inputconfig_emulationstation "$1" "$2" "up" "$4" "$5" "$6"
-}
+function map_emulationstation_joystick() {
+    local device_type="$1"
+    local device_name="$2"
+    local input_name="$3"
+    local input_type="$4"
+    local input_id="$5"
+    local input_value="$6"
 
-function right_inputconfig_emulationstation_joystick() {
-    setESInputConfig_inputconfig_emulationstation "$1" "$2" "right" "$4" "$5" "$6"
-}
+    local key
+    case "$input_name" in
+        leftbottom)
+            key="pageup"
+            ;;
+        rightbottom)
+            key="pagedown"
+            ;;
+        up|right|down|left|a|b|start|select)
+            key="$input_name"
+            ;;
+        *)
+            return
+            ;;
+    esac
 
-function down_inputconfig_emulationstation_joystick() {
-    setESInputConfig_inputconfig_emulationstation "$1" "$2" "down" "$4" "$5" "$6"
-}
-
-function left_inputconfig_emulationstation_joystick() {
-    setESInputConfig_inputconfig_emulationstation "$1" "$2" "left" "$4" "$5" "$6"
-}
-
-function a_inputconfig_emulationstation_joystick() {
-    setESInputConfig_inputconfig_emulationstation "$1" "$2" "a" "$4" "$5" "$6"
-}
-
-function b_inputconfig_emulationstation_joystick() {
-    setESInputConfig_inputconfig_emulationstation "$1" "$2" "b" "$4" "$5" "$6"
-}
-
-function leftbottom_inputconfig_emulationstation_joystick() {
-    setESInputConfig_inputconfig_emulationstation "$1" "$2" "pageup" "$4" "$5" "$6"
-}
-
-function rightbottom_inputconfig_emulationstation_joystick() {
-    setESInputConfig_inputconfig_emulationstation "$1" "$2" "pagedown" "$4" "$5" "$6"
-}
-
-function start_inputconfig_emulationstation_joystick() {
-    setESInputConfig_inputconfig_emulationstation "$1" "$2" "start" "$4" "$5" "$6"
-}
-
-function select_inputconfig_emulationstation_joystick() {
-    setESInputConfig_inputconfig_emulationstation "$1" "$2" "select" "$4" "$5" "$6"
-}
-
-
-#### input type: Keyboard ###
-
-function onstart_inputconfig_emulationstation_keyboard() {
-    onstart_inputconfig_emulationstation_joystick "$1" "$2"
-}
-
-function up_inputconfig_emulationstation_keyboard() {
-    setESInputConfig_inputconfig_emulationstation "$1" "$2" "up" "$4" "$5" "$6"
-}
-
-function right_inputconfig_emulationstation_keyboard() {
-    setESInputConfig_inputconfig_emulationstation "$1" "$2" "right" "$4" "$5" "$6"
-}
-
-function down_inputconfig_emulationstation_keyboard() {
-    setESInputConfig_inputconfig_emulationstation "$1" "$2" "down" "$4" "$5" "$6"
-}
-
-function left_inputconfig_emulationstation_keyboard() {
-    setESInputConfig_inputconfig_emulationstation "$1" "$2" "left" "$4" "$5" "$6"
-}
-
-function a_inputconfig_emulationstation_keyboard() {
-    setESInputConfig_inputconfig_emulationstation "$1" "$2" "a" "$4" "$5" "$6"
-}
-
-function b_inputconfig_emulationstation_keyboard() {
-    setESInputConfig_inputconfig_emulationstation "$1" "$2" "b" "$4" "$5" "$6"
-}
-
-function leftbottom_inputconfig_emulationstation_keyboard() {
-    setESInputConfig_inputconfig_emulationstation "$1" "$2" "pageup" "$4" "$5" "$6"
-}
-
-function rightbottom_inputconfig_emulationstation_keyboard() {
-    setESInputConfig_inputconfig_emulationstation "$1" "$2" "pagedown" "$4" "$5" "$6"
-}
-
-function start_inputconfig_emulationstation_keyboard() {
-    setESInputConfig_inputconfig_emulationstation "$1" "$2" "start" "$4" "$5" "$6"
-}
-
-function select_inputconfig_emulationstation_keyboard() {
-    setESInputConfig_inputconfig_emulationstation "$1" "$2" "select" "$4" "$5" "$6"
-}
-
-
-###### helper functions ######
-# to circumvent name collisions we use quite long function names in the following
-
-# add or update input configuration for a given device and input
-function setESInputConfig_inputconfig_emulationstation() {
-    local deviceType=$1
-    local deviceName=$2
-    local inputName=$3
-    local inputType=$4
-    local inputID=$5
-    local inputValue=$6
-
-    local confFile="$home/.emulationstation/es_input.cfg"
+    local es_conf="$home/.emulationstation/es_input.cfg"
 
     # add or update element
-    inputNameString=\'$inputName\'
-    if [[ $(xmlstarlet sel -t -v "count(/inputList/inputConfig[@deviceName=$deviceNameString]/input[@name=$inputNameString])" "$confFile") -eq 0 ]]; then
-        xmlstarlet ed -L -s "/inputList/inputConfig[@deviceName=$deviceNameString]" -t elem -n newinput -v "" \
-            -i //newinput -t attr -n "name" -v "$inputName" \
-            -i //newinput -t attr -n "type" -v "$inputType" \
-            -i //newinput -t attr -n "id" -v "$inputID" \
-            -i //newinput -t attr -n "value" -v "$inputValue" \
+    if [[ $(xmlstarlet sel -t -v "count(/inputList/inputConfig[@deviceName='$device_name']/input[@name='$key'])" "$es_conf") -eq 0 ]]; then
+        xmlstarlet ed -L -s "/inputList/inputConfig[@deviceName='$device_name']" -t elem -n newinput -v "" \
+            -i //newinput -t attr -n "name" -v "$key" \
+            -i //newinput -t attr -n "type" -v "$input_type" \
+            -i //newinput -t attr -n "id" -v "$input_id" \
+            -i //newinput -t attr -n "value" -v "$input_value" \
             -r //newinput -v input \
-            "$confFile"
+            "$es_conf"
     else  # if device already exists, update it
         xmlstarlet ed -L \
-            -u "/inputList/inputConfig[@deviceName=$deviceNameString]/input[@name=$inputNameString]/@type" -v "$inputType" \
-            -u "/inputList/inputConfig[@deviceName=$deviceNameString]/input[@name=$inputNameString]/@id" -v "$inputID" \
-            -u "/inputList/inputConfig[@deviceName=$deviceNameString]/input[@name=$inputNameString]/@value" -v "$inputValue" \
-            "$confFile"
+            -u "/inputList/inputConfig[@deviceName='$device_name']/input[@name='$key']/@type" -v "$input_type" \
+            -u "/inputList/inputConfig[@deviceName='$device_name']/input[@name='$key']/@id" -v "$input_id" \
+            -u "/inputList/inputConfig[@deviceName='$device_name']/input[@name='$key']/@value" -v "$input_value" \
+            "$es_conf"
     fi
+}
+
+function onstart_emulationstation_keyboard() {
+    onstart_emulationstation_joystick "$@"
+}
+
+function map_emulationstation_keyboard() {
+    map_emulationstation_joystick "$@"
 }

--- a/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh
@@ -8,151 +8,16 @@
 # at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
 #
 
-function onstart_inputconfig_retroarch_joystick() {
-    local deviceName=$2
+function onstart_retroarch_joystick() {
+    local device_type=$1
+    local device_name=$2
+
     iniConfig " = " "\"" "/tmp/tempconfig.cfg"
-    iniSet "input_device" "$deviceName"
+    iniSet "input_device" "$device_name"
     iniSet "input_driver" "udev"
 }
 
-function up_inputconfig_retroarch_joystick() {
-    local inputName=$3
-    local inputType=$4
-    local inputID=$5
-    local inputValue=$6
-
-    inputconfig_retroarch_addControl "input_up" "$inputName" "$inputType" "$inputID" "$inputValue"
-}
-
-function right_inputconfig_retroarch_joystick() {
-    local inputName=$3
-    local inputType=$4
-    local inputID=$5
-    local inputValue=$6
-
-    inputconfig_retroarch_addControl "input_right" "$inputName" "$inputType" "$inputID" "$inputValue"
-    inputconfig_retroarch_addControl "input_state_slot_increase" "$inputName" "$inputType" "$inputID" "$inputValue"
-}
-
-function down_inputconfig_retroarch_joystick() {
-    local inputName=$3
-    local inputType=$4
-    local inputID=$5
-    local inputValue=$6
-
-    inputconfig_retroarch_addControl "input_down" "$inputName" "$inputType" "$inputID" "$inputValue"
-}
-
-function left_inputconfig_retroarch_joystick() {
-    local inputName=$3
-    local inputType=$4
-    local inputID=$5
-    local inputValue=$6
-
-    inputconfig_retroarch_addControl "input_left" "$inputName" "$inputType" "$inputID" "$inputValue"
-    inputconfig_retroarch_addControl "input_state_slot_decrease" "$inputName" "$inputType" "$inputID" "$inputValue"
-}
-
-function a_inputconfig_retroarch_joystick() {
-    inputconfig_retroarch_addControl "input_a" "$3" "$4" "$5" "$6"
-}
-
-function b_inputconfig_retroarch_joystick() {
-    inputconfig_retroarch_addControl "input_b" "$3" "$4" "$5" "$6"
-    inputconfig_retroarch_addControl "input_reset" "$3" "$4" "$5" "$6"
-}
-
-function x_inputconfig_retroarch_joystick() {
-    inputconfig_retroarch_addControl "input_x" "$3" "$4" "$5" "$6"
-    inputconfig_retroarch_addControl "input_menu_toggle" "$3" "$4" "$5" "$6"
-}
-
-function y_inputconfig_retroarch_joystick() {
-    inputconfig_retroarch_addControl "input_y" "$3" "$4" "$5" "$6"
-}
-
-function leftbottom_inputconfig_retroarch_joystick() {
-    inputconfig_retroarch_addControl "input_l" "$3" "$4" "$5" "$6"
-    inputconfig_retroarch_addControl "input_load_state" "$3" "$4" "$5" "$6"
-}
-
-function rightbottom_inputconfig_retroarch_joystick() {
-    inputconfig_retroarch_addControl "input_r" "$3" "$4" "$5" "$6"
-    inputconfig_retroarch_addControl "input_save_state" "$3" "$4" "$5" "$6"
-}
-
-function lefttop_inputconfig_retroarch_joystick() {
-    inputconfig_retroarch_addControl "input_l2" "$3" "$4" "$5" "$6"
-}
-
-function righttop_inputconfig_retroarch_joystick() {
-    inputconfig_retroarch_addControl "input_r2" "$3" "$4" "$5" "$6"
-}
-
-function leftthumb_inputconfig_retroarch_joystick() {
-    inputconfig_retroarch_addControl "input_l3" "$3" "$4" "$5" "$6"
-}
-
-function rightthumb_inputconfig_retroarch_joystick() {
-    inputconfig_retroarch_addControl "input_r3" "$3" "$4" "$5" "$6"
-}
-
-function start_inputconfig_retroarch_joystick() {
-    inputconfig_retroarch_addControl "input_start" "$3" "$4" "$5" "$6"
-    inputconfig_retroarch_addControl "input_exit_emulator" "$3" "$4" "$5" "$6"
-}
-
-function select_inputconfig_retroarch_joystick() {
-    inputconfig_retroarch_addControl "input_select" "$3" "$4" "$5" "$6"
-    inputconfig_retroarch_addControl "input_enable_hotkey" "$3" "$4" "$5" "$6"
-}
-
-function leftanalogright_inputconfig_retroarch_joystick() {
-    inputconfig_retroarch_addControl "input_l_x_plus" "$3" "$4" "$5" "$6"
-}
-
-function leftanalogleft_inputconfig_retroarch_joystick() {
-    inputconfig_retroarch_addControl "input_l_x_minus" "$3" "$4" "$5" "$6"
-}
-
-function leftanalogdown_inputconfig_retroarch_joystick() {
-    inputconfig_retroarch_addControl "input_l_y_plus" "$3" "$4" "$5" "$6"
-}
-
-function leftanalogup_inputconfig_retroarch_joystick() {
-    inputconfig_retroarch_addControl "input_l_y_minus" "$3" "$4" "$5" "$6"
-}
-
-function rightanalogright_inputconfig_retroarch_joystick() {
-    inputconfig_retroarch_addControl "input_r_x_plus" "$3" "$4" "$5" "$6"
-}
-
-function rightanalogleft_inputconfig_retroarch_joystick() {
-    inputconfig_retroarch_addControl "input_r_x_minus" "$3" "$4" "$5" "$6"
-}
-
-function rightanalogdown_inputconfig_retroarch_joystick() {
-    inputconfig_retroarch_addControl "input_r_y_plus" "$3" "$4" "$5" "$6"
-}
-
-function rightanalogup_inputconfig_retroarch_joystick() {
-    inputconfig_retroarch_addControl "input_r_y_minus" "$3" "$4" "$5" "$6"
-}
-
-function onend_inputconfig_retroarch_joystick() {
-    local deviceType=$1
-    local deviceName=$2
-    newFilename="${deviceName// /}.cfg"
-    if [[ -f "/opt/retropie/configs/all/retroarch-joypads/$newFilename" ]]; then
-        mv "/opt/retropie/configs/all/retroarch-joypads/$newFilename" "/opt/retropie/configs/all/retroarch-joypads/$newFilename.bak"
-    fi
-    mv "/tmp/tempconfig.cfg" "/opt/retropie/configs/all/retroarch-joypads/$newFilename"
-}
-
-
-### input type: Keyboard ###
-
-function onstart_inputconfig_retroarch_keyboard() {
+function onstart_retroarch_keyboard() {
     iniConfig " = " "" "/opt/retropie/configs/all/retroarch.cfg"
 
     declare -Ag retroarchkeymap
@@ -263,119 +128,170 @@ function onstart_inputconfig_retroarch_keyboard() {
     retroarchkeymap["122"]="z"
 }
 
-function up_inputconfig_retroarch_keyboard() {
-    local deviceName=$2
-    local inputName=$3
-    local inputType=$4
-    local inputID=$5
-    local inputValue=$6
+function map_retroarch_joystick() {
+    local device_type="$1"
+    local device_name="$2"
+    local input_name="$3"
+    local input_type="$4"
+    local input_id="$5"
+    local input_value="$6"
 
-    iniSet "input_player1_up" "${retroarchkeymap[$inputID]}"
-}
+    local keys
+    case "$input_name" in
+        up)
+            keys=("input_up")
+            ;;
+        down)
+            keys=("input_down")
+            ;;
+        left)
+            keys=("input_left" "input_state_slot_decrease")
+            ;;
+        right)
+            keys=("input_right" "input_state_slot_increase")
+            ;;
+        a)
+            keys=("input_a")
+            ;;
+        b)
+            keys=("input_b" "input_reset")
+            ;;
+        x)
+            keys=("input_x" "input_menu_toggle")
+            ;;
+        y)
+            keys=("input_y")
+            ;;
+        leftbottom)
+            keys=("input_l" "input_load_state")
+            ;;
+        rightbottom)
+            keys=("input_r" "input_save_state")
+            ;;
+        lefttop)
+            keys=("input_l2")
+            ;;
+        righttop)
+            keys=("input_r2")
+            ;;
+        leftthumb)
+            keys=("input_l3")
+            ;;
+        rightthumb)
+            keys=("input_r3")
+            ;;
+        start)
+            keys=("input_start" "input_exit_emulator")
+            ;;
+        select)
+            keys=("input_select" "input_enable_hotkey")
+            ;;
+        leftanalogleft)
+            keys=("input_l_x_minus")
+            ;;
+        leftanalogright)
+            keys=("input_l_x_plus")
+            ;;
+        leftanalogup)
+            keys=("input_l_y_minus")
+            ;;
+        leftanalogdown)
+            keys=("input_l_y_plus")
+            ;;
+        rightanalogleft)
+            keys=("input_r_x_minus")
+            ;;
+        rightanalogright)
+            keys=("input_r_x_plus")
+            ;;
+        rightanalogup)
+            keys=("input_r_y_minus")
+            ;;
+        rightanalogdown)
+            keys=("input_r_y_plus")
+            ;;
+        *)
+            return
+            ;;
+    esac
 
-function right_inputconfig_retroarch_keyboard() {
-    local inputName=$3
-    local inputType=$4
-    local inputID=$5
-    local inputValue=$6
-
-    iniSet "input_player1_right" "${retroarchkeymap[$inputID]}"
-}
-
-function down_inputconfig_retroarch_keyboard() {
-    local inputName=$3
-    local inputType=$4
-    local inputID=$5
-    local inputValue=$6
-
-    iniSet "input_player1_down" "${retroarchkeymap[$inputID]}"
-}
-
-function left_inputconfig_retroarch_keyboard() {
-    local inputName=$3
-    local inputType=$4
-    local inputID=$5
-    local inputValue=$6
-
-    iniSet "input_player1_left" "${retroarchkeymap[$inputID]}"
-}
-
-# the following functions are kept a bit shorter than above, but they still follow the the mechanism
-
-function a_inputconfig_retroarch_keyboard() {
-    iniSet "input_player1_a" "${retroarchkeymap[$5]}"
-}
-
-function b_inputconfig_retroarch_keyboard() {
-    iniSet "input_player1_b" "${retroarchkeymap[$5]}"
-}
-
-function x_inputconfig_retroarch_keyboard() {
-    iniSet "input_player1_x" "${retroarchkeymap[$5]}"
-}
-
-function y_inputconfig_retroarch_keyboard() {
-    iniSet "input_player1_y" "${retroarchkeymap[$5]}"
-}
-
-function leftbottom_inputconfig_retroarch_keyboard() {
-    iniSet "input_player1_l" "${retroarchkeymap[$5]}"
-}
-
-function rightbottom_inputconfig_retroarch_keyboard() {
-    iniSet "input_player1_r" "${retroarchkeymap[$5]}"
-}
-
-function lefttop_inputconfig_retroarch_keyboard() {
-    iniSet "input_player1_l2" "${retroarchkeymap[$5]}"
-}
-
-function righttop_inputconfig_retroarch_keyboard() {
-    iniSet "input_player1_r2" "${retroarchkeymap[$5]}"
-}
-
-function leftthumb_inputconfig_retroarch_keyboard() {
-    iniSet "input_player1_l3" "${retroarchkeymap[$5]}"
-}
-
-function rightthumb_inputconfig_retroarch_keyboard() {
-    iniSet "input_player1_r3" "${retroarchkeymap[$5]}"
-}
-
-function start_inputconfig_retroarch_keyboard() {
-    iniSet "input_player1_start" "${retroarchkeymap[$5]}"
-}
-
-function select_inputconfig_retroarch_keyboard() {
-    iniSet "input_player1_select" "${retroarchkeymap[$5]}"
-}
-
-
-###### helper functions ######
-# to circumvent name collisions we use quite long function names in the following.
-# all the following functions should have no dependencies to other shell scripts.
-
-function inputconfig_retroarch_addControl() {
-    local control=$1
-    local inputName=$2
-    local inputType=$3
-    local inputID=$4
-    local inputValue=$5
-
-    if [[ "$inputType" == "hat" ]]; then
-        control+="_btn"
-        btnString="h$inputID$inputName"
-    elif [[ "$inputType" == "axis" ]]; then
-        control+="_axis"
-        if [[ "$inputValue" == "1" ]]; then
-            btnString="+$inputID"
+    local key
+    local value
+    for key in "${keys[@]}"; do
+        if [[ "$input_type" == "hat" ]]; then
+            key+="_btn"
+            value="h$input_id$input_name"
+        elif [[ "$input_type" == "axis" ]]; then
+            key+="_axis"
+            if [[ "$input_value" == "1" ]]; then
+                value="+$input_id"
+            else
+                value="-$input_id"
+            fi
         else
-            btnString="-$inputID"
+            key+="_btn"
+            value="$input_id"
         fi
-    else
-        control+="_btn"
-        btnString=$inputID
-    fi
 
-    iniSet "$control" "$btnString"
+        iniSet "$key" "$value"
+    done
+}
+
+function onend_retroarch_joystick() {
+    local device_type=$1
+    local device_name=$2
+    local file="${device_name// /}.cfg"
+    if [[ -f "/opt/retropie/configs/all/retroarch-joypads/$file" ]]; then
+        mv "/opt/retropie/configs/all/retroarch-joypads/$file" "/opt/retropie/configs/all/retroarch-joypads/$file.bak"
+    fi
+    mv "/tmp/tempconfig.cfg" "/opt/retropie/configs/all/retroarch-joypads/$file"
+}
+
+function map_retroarch_keyboard() {
+    local device_type="$1"
+    local device_name="$2"
+    local input_name="$3"
+    local input_type="$4"
+    local input_id="$5"
+    local input_value="$6"
+
+    local key
+    case "$input_name" in
+        up|down|left|right|a|b|x|y|start|select)
+            key="input_player1_$input_name"
+            ;;
+        leftbottom)
+            key="input_player1_l"
+            ;;
+        rightbottom)
+            key="input_player1_r"
+            ;;
+        lefttop)
+            key="input_player1_l2"
+            ;;
+        righttop)
+            key="input_player1_2"
+            ;;
+        leftthumb)
+            key="input_player1_l3"
+            ;;
+        rightthumb)
+            key="input_player1_r3"
+            ;;
+        *)
+            return
+            ;;
+    esac
+
+    iniSet "$key" "${retroarchkeymap[$input_id]}"
+}
+
+function onend_retroarch_joystick() {
+    local device_type=$1
+    local device_name=$2
+    local file="${device_name// /}.cfg"
+    if [[ -f "/opt/retropie/configs/all/retroarch-joypads/$file" ]]; then
+        mv "/opt/retropie/configs/all/retroarch-joypads/$file" "/opt/retropie/configs/all/retroarch-joypads/$file.bak"
+    fi
+    mv "/tmp/tempconfig.cfg" "/opt/retropie/configs/all/retroarch-joypads/$file"
 }

--- a/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh
@@ -142,7 +142,7 @@ function rightanalogup_inputconfig_retroarch_joystick() {
 function onend_inputconfig_retroarch_joystick() {
     local deviceType=$1
     local deviceName=$2
-    newFilename=$(echo "$deviceName" | sed -e 's/ /_/g')".cfg"
+    newFilename="${deviceName// /}.cfg"
     if [[ -f "/opt/retropie/configs/all/retroarch-joypads/$newFilename" ]]; then
         mv "/opt/retropie/configs/all/retroarch-joypads/$newFilename" "/opt/retropie/configs/all/retroarch-joypads/$newFilename.bak"
     fi

--- a/scriptmodules/supplementary/emulationstation/inputconfiguration.sh
+++ b/scriptmodules/supplementary/emulationstation/inputconfiguration.sh
@@ -35,6 +35,7 @@
 #   $5 - input ID
 #   $6 - input value
 #
+# $1 - device type is currently either joystick or keyboard
 # $2 - input name is one of the following
 #   up, down, left, right
 #   a, b, x, y
@@ -43,6 +44,7 @@
 #   start, select
 #   leftanalogup, leftanalogdown, leftanalogleft, leftanalogright
 #   rightanalogup, rightanalogdown, rightanalogleft, rightanalogright
+# $3 - input type is button, axis, or hat
 #
 # Returns:
 #   None

--- a/scriptmodules/supplementary/emulationstation/inputconfiguration.sh
+++ b/scriptmodules/supplementary/emulationstation/inputconfiguration.sh
@@ -56,7 +56,7 @@
 function inputconfiguration() {
 
     local es_conf="$home/.emulationstation/es_temporaryinput.cfg"
-    declare -Ag __mapping
+    declare -A mapping
 
     # check if we have the temporary input file
     [[ ! -f "$es_conf" ]] && return
@@ -65,7 +65,7 @@ function inputconfiguration() {
     while read line; do
         if [[ -n "$line" ]]; then
             local input=($line)
-            __mapping["${input[0]}"]=${input[@]:1}
+            mapping["${input[0]}"]=${input[@]:1}
         fi
     done < <(xmlstarlet sel  -t -m "/inputList/inputConfig/input"  -v "concat(@name,' ',@type,' ',@id,' ',@value)" -n "$es_conf")
 
@@ -92,11 +92,11 @@ function inputconfiguration() {
 
         local input_name
         # loop through all buttons and use corresponding config function if it exists
-        for input_name in "${!__mapping[@]}"; do
+        for input_name in "${!mapping[@]}"; do
             funcname="map_${module_id}_${device_type}"
 
             if fn_exists "$funcname"; then
-                local params=(${__mapping[$input_name]})
+                local params=(${mapping[$input_name]})
                 local input_type=${params[0]}
                 local input_id=${params[1]}
                 local input_value=${params[2]}

--- a/scriptmodules/supplementary/emulationstation/inputconfiguration.sh
+++ b/scriptmodules/supplementary/emulationstation/inputconfiguration.sh
@@ -24,7 +24,7 @@
 # Returns:
 #   None
 #
-# function map_<filename without extension>()_<inputtype>()
+# function map_<filename without extension>_<inputtype>()
 # is run for each of the inputs - with the following arguments
 #
 # Arguments:


### PR DESCRIPTION
… xmlstarlet to parse the input xml in one go and load it into an associative array.

Previously the code run xmlstartlet 5 times for every button, for every inputconfig module.

We also skip checking whether the xml contains a button, as rather than hardcoding them, we get
them directly from the xml.

This brings processing time on a rpi1 from 27 seconds to under 5.