### PR TITLE
The Kodi installer adds a new Tab for Kodi to EmulationStation

### DIFF
--- a/scriptmodules/ports/kodi.sh
+++ b/scriptmodules/ports/kodi.sh
@@ -26,14 +26,34 @@ function install_kodi() {
 function configure_kodi() {
     echo 'SUBSYSTEM=="input", GROUP="input", MODE="0660"' > /etc/udev/rules.d/99-input.rules
 
-    mkRomDir "ports"
+    mkRomDir "kodi"
 
-    cat > "$romdir/ports/Kodi.sh" << _EOF_
+
+    # Install kodi simple theme
+    mkdir -p /etc/emulationstation/themes/simple/kodi/art
+    cd /etc/emulationstation/themes/simple/kodi
+
+    wget https://github.com/cschlonsok/retropie-kodi-installer/archive/1.0.zip
+
+    unzip 1.0.zip
+
+    cd retropie-kodi-installer-1.0/
+    cp -v theme.xml ../
+    cp -v kodi_background.jpg ../art/
+    cp -v kodi_icon.png ../art/
+
+    cd ..
+    rm 1.0.zip
+
+
+
+    cat > "$romdir/kodi/Kodi.sh" << _EOF_
 #!/bin/bash
 /opt/retropie/supplementary/runcommand/runcommand.sh 0 "kodi-standalone" "kodi"
 _EOF_
 
-    chmod +x "$romdir/ports/Kodi.sh"
+    chmod +x "$romdir/kodi/Kodi.sh"
 
-    setESSystem 'Ports' 'ports' '~/RetroPie/roms/ports' '.sh .SH' '%ROM%' 'pc' 'ports'
+    # Add System to es_system.cfg
+    setESSystem 'Kodi' 'kodi' '~/RetroPie/roms/kodi' '.sh .SH' '%ROM%' 'pc' 'kodi'
 }


### PR DESCRIPTION
Most users want to use Retropie and Kodi. If they want to install Kodi out of RetroPie, it would be nice to give Kodi a separated Tab.