### PR TITLE
Reload Setup Script after update automatically.

### DIFF
--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -175,7 +175,8 @@ function updatescript_setup()
     fi
     popd
     rp_callModule runcommand install
-    printMsgs "dialog" "Fetched the latest version of the RetroPie Setup script. You need to restart the script."
+    printMsgs "dialog" "Fetched the latest version of the RetroPie Setup script."
+    exec "$scriptdir/retropie_setup.sh"
 }
 
 function source_setup()


### PR DESCRIPTION
These changes will make it slightly more convenient when updating the setup script so that people don't have to exit out and then go back in again each time they update the setup script.