### PR TITLE
Add Miroof's Virtual Gamepad

### DIFF
--- a/scriptmodules/supplementary/virtualgamepad.sh
+++ b/scriptmodules/supplementary/virtualgamepad.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# This file is part of RetroPie.
+# 
+# (c) Copyright 2012-2015  Florian Müller (contact@petrockblock.com)
+# 
+# See the LICENSE.md file at the top-level directory of this distribution and 
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="virtualgamepad"
+rp_module_desc="Virtual Gamepad for Smartphone"
+rp_module_menus="4+"
+
+function install_virtualgamepad() {
+    wget http://node-arm.herokuapp.com/node_latest_armhf.deb
+    dpkg -i node_latest_armhf.deb
+    rm node_latest_armhf.deb
+    gitPullOrClone $md_inst https://github.com/miroof/node-virtual-gamepads.git
+    cd $md_inst
+    npm install --unsafe-perm
+    npm install --unsafe-perm pm2 -g
+    pm2 start main.js
+    pm2 startup
+    pm2 save
+}


### PR DESCRIPTION
script that installs a virtual gamepad from Miroof (https://github.com/miroof/node-virtual-gamepads) with node.js that enables people to use their smartphone as a gamepad. The code is probably not the most standardised but it was the only way I was able to figure out how to get it to work. if you have any suggestions for improvement I'm all ears.