### PR TITLE
as we have additional package functions it would be useful to list th…

### DIFF
--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -42,10 +42,10 @@ function rp_listFunctions() {
     for idx in ${__mod_idx[@]}; do
         mod_id=${__mod_id[$idx]};
         printf "%d/%-20s: %-42s : " "$idx" "$mod_id" "${__mod_desc[$idx]}"
-        for mode in depends sources build install configure remove; do
-            func="${mode}_${mod_id}"
-            fn_exists $func && echo -e "$mode \c"
-        done
+        while read mode; do
+            mode=${mode//_$mod_id/}
+            echo -e "$mode \c"
+        done < <(compgen -A function -X \!*_$mod_id)
         echo ""
     done
     echo "==================================================================================================================================="


### PR DESCRIPTION
…em all. The changes here allow that by using compgen builtin. It does mean that functions will be listed alphabetically, but it means we can now see all the custom functions via retropie_packages.sh

Doing this one as a pull request to make sure you are happy with it @petrockblog 

it only affects the commandline output, but now for example shows:

```
sudo ./retropie_packages.sh

...

901/setup               : GUI based setup for RetroPie               : binaries configure depends experimental individual reboot source supplementary updatescript
```

previously it would only show if the module had any of a limited set of functions.