### PR TITLE
Add Nickname to netplay module

### DIFF
--- a/scriptmodules/supplementary/retronetplay.sh
+++ b/scriptmodules/supplementary/retronetplay.sh
@@ -21,6 +21,7 @@ __netplayport="$__netplayport"
 __netplayhostip="$__netplayhostip"
 __netplayhostip_cfile="$__netplayhostip_cfile"
 __netplayframes="$__netplayframes"
+__netplaynickname="'$__netplaynickname'"
 _EOF_
     chown $user:$user "$conf"
     printMsgs "dialog" "Configuration has been saved to $conf"
@@ -36,6 +37,7 @@ function rps_retronet_loadconfig() {
         __netplayhostip="192.168.0.1"
         __netplayhostip_cfile=""
         __netplayframes="15"
+        __netplaynickname="RetroPie"
     fi
 }
 
@@ -85,6 +87,14 @@ function rps_retronet_frames() {
     fi
 }
 
+function rps_retronet_nickname() {
+    cmd=(dialog --backtitle "$__backtitle" --inputbox "Please enter the nickname you wish to use (default: RetroPie)" 22 76 $__netplaynickname)
+    choice=$("${cmd[@]}" 2>&1 >/dev/tty)
+    if [[ -n "$choice" ]]; then
+        __netplaynickname="$choice"
+    fi
+}
+
 function configure_retronetplay() {
     rps_retronet_loadconfig
 
@@ -98,7 +108,8 @@ function configure_retronetplay() {
             2 "Set port. Currently: $__netplayport"
             3 "Set host IP address (for client mode). Currently: $__netplayhostip"
             4 "Set delay frames. Currently: $__netplayframes"
-            5 "Save configuration"
+            5 "Set netplay nickname. Currently: $__netplaynickname"
+            6 "Save configuration"
         )
         choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
         if [[ -n "$choice" ]]; then
@@ -116,6 +127,9 @@ function configure_retronetplay() {
                     rps_retronet_frames
                     ;;
                 5)
+                    rps_retronet_nickname
+                    ;;
+                6)
                     rps_retronet_saveconfig
                     ;;
             esac

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -537,7 +537,7 @@ function retroarch_append_config() {
     # append any netplay configuration
     if [[ $netplay -eq 1 ]] && [[ -f "$retronetplay_conf" ]]; then
         source "$retronetplay_conf"
-        command+=" -$__netplaymode $__netplayhostip_cfile --port $__netplayport --frames $__netplayframes"
+        command+=" -$__netplaymode $__netplayhostip_cfile --port $__netplayport --frames $__netplayframes --nick $__netplaynickname"
     fi
 }
 


### PR DESCRIPTION
Coded it so that people can have names with spaces.  The nickname is
really an optional aesthetic thing but I think it's a nice touch. 

One more setting to note is "netplay_client_swap_input" it's a simple true false perametre (default
would be true) that allows users to both use player one controls on
their respective devices even if they are player two in the game (but only for each
user which means you can't both be playing the same player one- just
using player one joypad controls) 

If it isn't already on by default, it should be- it probably isn't necessary to add to the module