### PR TITLE
Add omxplayer video splashscreen

### DIFF
--- a/scriptmodules/supplementary/splashscreen.sh
+++ b/scriptmodules/supplementary/splashscreen.sh
@@ -14,7 +14,7 @@ rp_module_menus="3+"
 rp_module_flags="nobin"
 
 function depends_splashscreen() {
-    getDepends fbi
+    getDepends fbi omxplayer
 }
 
 function enable_splashscreen()
@@ -28,7 +28,7 @@ function enable_splashscreen()
     find $scriptdir/supplementary/splashscreens/retropie2015-blue/ -type f > /etc/splashscreen.list
 
     # This command installs the init.d script so it automatically starts on boot
-    update-rc.d asplashscreen defaults
+    update-rc.d asplashscreen start 00 S
 
     # not-so-elegant hack for later re-enabling the splashscreen
     update-rc.d asplashscreen enable

--- a/scriptmodules/supplementary/splashscreen/asplashscreen
+++ b/scriptmodules/supplementary/splashscreen/asplashscreen
@@ -1,7 +1,7 @@
 #! /bin/sh
 ### BEGIN INIT INFO
 # Provides:          asplashscreen
-# Required-Start:
+# Required-Start:    dbus
 # Required-Stop:
 # Default-Start:     S
 # Default-Stop:
@@ -11,19 +11,23 @@
 
 do_start () {
 
-    line=$(head -n 1 /etc/splashscreen.list)
-    isMovie=$(echo $line | grep -o "*.mpg")
-    if [ -z "$isMovie" ]; then
-      /usr/bin/fbi -T 2 -once -t 20 -noverbose -a -l /etc/splashscreen.list &
-    else
-      mplayer $line &
-    fi
+    while read splashline; do
+        echo Playing splash video or image $splashline
+        isMovie=$(echo $splashline | grep -o ".avi\|.mov\|.mp4\|.mkv\|.3gp\|.mpg")
+        if [ -z "$isMovie" ]; then
+            /usr/bin/fbi -T 2 -once -t 10 -noverbose -a $splashline
+            sleep 12
+        else
+           sleep 5
+           omxplayer $splashline
+        fi
+    done </etc/splashscreen.list
     exit 0
 }
 
 case "$1" in
   start|"")
-    do_start
+    do_start &
     ;;
   restart|reload|force-reload)
     echo "Error: argument '$1' not supported" >&2


### PR DESCRIPTION
and fixed the update-rc.d to match the runlevel in asplashcreen

tested it on RPi 2 and RPi 1- I had to up the sleep perameter to 5 before omxplayer for the rpi 1 because of the slower boot time, you can get away with making it a 3 for the RPi2 if you want the video to boot faster. if you want the video to play all the way through without emulationstation cutting it off you can change `do-start &` to `do-start` in asplashscreen