### PR TITLE
Add .prg to Commodore 64

### DIFF
--- a/supplementary/platforms.cfg
+++ b/supplementary/platforms.cfg
@@ -25,7 +25,7 @@ atarist_fullname="Atari ST/STE"
 coco_exts=".cas .wav .bas .asc .dmk .jvc .os9 .dsk .vdk .rom .ccc .sna"
 coco_fullname="TRS-80 Color Computer (CoCo)"
 
-c64_exts=".crt .d64 .g64 .t64 .tap .x64 .zip"
+c64_exts=".crt .d64 .g64 .prg .t64 .tap .x64 .zip"
 c64_fullname="Commodore 64"
 
 dragon32_exts=".cas .wav .bas .asc .dmk .jvc .os9 .dsk .vdk .rom .ccc .sna"


### PR DESCRIPTION
verified here:
http://blog.petrockblock.com/forums/topic/vice-issues-with-prg-files-and-drive-sound-emulation/