### PR TITLE
MAME4All: Add support for platform specific compile

### DIFF
--- a/scriptmodules/emulators/mame4all.sh
+++ b/scriptmodules/emulators/mame4all.sh
@@ -17,7 +17,7 @@ function depends_mame4all() {
 }
 
 function sources_mame4all() {
-    gitPullOrClone "$md_build" https://github.com/RetroPie/mame4all-pi.git
+    gitPullOrClone "$md_build" https://github.com/MattWatt/mame4all-pi.git "make-optimizations"
 }
 
 function build_mame4all() {

--- a/scriptmodules/emulators/mame4all.sh
+++ b/scriptmodules/emulators/mame4all.sh
@@ -22,7 +22,11 @@ function sources_mame4all() {
 
 function build_mame4all() {
     make clean
-    make -j 4
+    if isPlatform "rpi2"; then
+        make PLATFORM=rpi2 -j 4
+    else
+        make PLATFORM=rpi1
+    fi
     md_ret_require="$md_build/mame"
 }
 

--- a/scriptmodules/emulators/mame4all.sh
+++ b/scriptmodules/emulators/mame4all.sh
@@ -22,7 +22,7 @@ function sources_mame4all() {
 
 function build_mame4all() {
     make clean
-    make
+    make -j 4
     md_ret_require="$md_build/mame"
 }
 

--- a/scriptmodules/emulators/mame4all.sh
+++ b/scriptmodules/emulators/mame4all.sh
@@ -17,7 +17,7 @@ function depends_mame4all() {
 }
 
 function sources_mame4all() {
-    gitPullOrClone "$md_build" https://github.com/MattWatt/mame4all-pi.git "make-optimizations"
+    gitPullOrClone "$md_build" https://github.com/RetroPie/mame4all-pi.git
 }
 
 function build_mame4all() {


### PR DESCRIPTION
Platform specific compilation.  Use 4 cores for compiling on RPi2.  Pass platform parameter to pending modification to MAME4All Makefile.