### PR TITLE
revert permissions back to user pi to enable savestates in GPSP

### DIFF
--- a/scriptmodules/emulators/gpsp.sh
+++ b/scriptmodules/emulators/gpsp.sh
@@ -42,6 +42,7 @@ function install_gpsp() {
 
 function configure_gpsp() {
     mkRomDir "gba"
+    chown $user:$user -R "$md_inst"
 
     mkUserDir "$configdir/gba"
 


### PR DESCRIPTION
I couldnt figure out how to get gpsp to not overwrite the romdir.txt
created so for the time being this PR just enables savestates but they
are all currently saved in /opt/retropie/emulators/gpsp. If people wish
for their configs to be saved they need to exit from the F10 menu rather
than pressing escape.