### PR TITLE
mupen64plus: raspbian jessie compatibility

### DIFF
--- a/scriptmodules/emulators/mupen64plus-testing.sh
+++ b/scriptmodules/emulators/mupen64plus-testing.sh
@@ -14,7 +14,8 @@ rp_module_menus="4+"
 rp_module_flags="!odroid"
 
 function depends_mupen64plus-testing() {
-    getDepends libsamplerate0-dev libspeexdsp-dev libsdl2-dev gcc-4.8
+    getDepends libsamplerate0-dev libspeexdsp-dev libsdl2-dev
+    [[ "$__default_gcc_version" == "4.7" ]] && getDepends gcc-4.8 g++-4.8
 }
 
 function sources_mupen64plus-testing() {
@@ -74,7 +75,11 @@ function build_mupen64plus-testing() {
     $md_build/GLideN64/src/getRevision.sh
     pushd $md_build/GLideN64/projects/cmake
     # this plugin needs at least gcc-4.8
-    cmake -DCMAKE_C_COMPILER=gcc-4.8 -DCMAKE_CXX_COMPILER=g++-4.8 -DMUPENPLUSAPI=On ../../src/
+    if [[ "$__default_gcc_version" == "4.7" ]]; then
+        cmake -DCMAKE_C_COMPILER=gcc-4.8 -DCMAKE_CXX_COMPILER=g++-4.8 -DMUPENPLUSAPI=On ../../src/
+    else
+        cmake -DMUPENPLUSAPI=On ../../src/
+    fi
     make
     popd
     

--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -14,7 +14,8 @@ rp_module_menus="2+"
 rp_module_flags="!odroid"
 
 function depends_mupen64plus() {
-    getDepends libsamplerate0-dev libspeexdsp-dev libsdl2-dev gcc-4.8
+    getDepends libsamplerate0-dev libspeexdsp-dev libsdl2-dev
+    [[ "$__default_gcc_version" == "4.7" ]] && getDepends gcc-4.8 g++-4.8
 }
 
 function sources_mupen64plus() {
@@ -70,12 +71,16 @@ function build_mupen64plus() {
         fi
     done
 
-# build GLideN64
+    # build GLideN64
     chmod +x $md_build/GLideN64/src/getRevision.sh
     $md_build/GLideN64/src/getRevision.sh
     pushd $md_build/GLideN64/projects/cmake
     # this plugin needs at least gcc-4.8
-    cmake -DCMAKE_C_COMPILER=gcc-4.8 -DCMAKE_CXX_COMPILER=g++-4.8 -DMUPENPLUSAPI=On ../../src/
+    if [[ "$__default_gcc_version" == "4.7" ]]; then
+        cmake -DCMAKE_C_COMPILER=gcc-4.8 -DCMAKE_CXX_COMPILER=g++-4.8 -DMUPENPLUSAPI=On ../../src/
+    else
+        cmake -DMUPENPLUSAPI=On ../../src/
+    fi
     make
     popd
 


### PR DESCRIPTION
Add default gcc version check. If default version is 4.7 (whezzy)
install and use gcc-4.8. Else use default gcc version (jessie=4.9).