### PR TITLE
ps3controller: fix two controller issue

### DIFF
--- a/scriptmodules/supplementary/ps3controller.sh
+++ b/scriptmodules/supplementary/ps3controller.sh
@@ -173,8 +173,7 @@ function pair_ps3controller() {
         done
     fi
 
-    printMsgs "dialog" "Please make sure that your Bluetooth dongle is connected to the Raspberry Pi and press ENTER."
-    printMsgs "dialog" "The driver and configuration tools for connecting PS3 controllers have been installed. \n\nPlease disconnect your PS3 controller from its USB connection, and press the PS button to connect via Bluetooth."
+    printMsgs "dialog" "The driver and configuration tools for connecting PS3 controllers have been installed. \n\nPlease connect your PS3 controller anytime to its USB connection, to setup Bluetooth connection. \n\nAfterwards disconnect your PS3 controller from its USB connection, and press the PS button to connect via Bluetooth."
 }
 
 function configure_ps3controller() {

--- a/scriptmodules/supplementary/ps3controller.sh
+++ b/scriptmodules/supplementary/ps3controller.sh
@@ -69,8 +69,9 @@ _EOF_
     chmod +x "$md_inst/bluetooth.sh"
 
     # If a PS3 controller is connected over usb check if bluetooth dongle exits and start sixpair
-    cat > "$md_inst/ps3pair.sh" << _EOF_
+    cat > "$md_inst/ps3helper.sh" << _EOF_
 #!/bin/bash
+params="\$1"
 if hcitool dev | grep -q "hci0"; then
     # Check if sixad is running
     if service sixad status | grep -q "sixad is running"; then
@@ -82,29 +83,9 @@ if hcitool dev | grep -q "hci0"; then
         if !(hciconfig | grep -q "PSCAN"); then
             hciconfig hci0 pscan
         fi
-        # Write bt dongle's mac address into controller
-        $md_inst/sixpair
-    else
-        echo "sixad is not running!"
-    fi
-fi
-_EOF_
-
-    chmod +x "$md_inst/ps3pair.sh"
-
-    # If a PS3 controller is paired for the first time pscan will be disabled. Enable again.
-    cat > "$md_inst/ps3helper.sh" << _EOF_
-#!/bin/bash
-if hcitool dev | grep -q "hci0"; then
-    # Check if sixad is running
-    if service sixad status | grep -q "sixad is running"; then
-        # activate bt dongle if necessary
-        if !(hciconfig | grep -q "RUNNING"); then
-            hciconfig hci0 up
-        fi
-        # make bt dongle discoverable if necessary
-        if !(hciconfig | grep -q "PSCAN"); then
-            hciconfig hci0 pscan
+        if [[ "\$params" == "config" ]]; then
+            # Write bt dongle's mac address into controller
+            $md_inst/sixpair
         fi
     else
         echo "sixad is not running!"
@@ -123,8 +104,8 @@ _EOF_
     # udev rule for ps3 controller usb connection
     cat > "/etc/udev/rules.d/99-sixpair.rules" << _EOF_
 # Pair if PS3 controller is connected
-DRIVER=="usb", SUBSYSTEM=="usb", ATTR{idVendor}=="054c", ATTR{idProduct}=="0268", RUN+="$md_inst/ps3pair.sh"
-SUBSYSTEM=="input", ATTR{name}=="PLAYSTATION(R)3 Controller", RUN+="/opt/retropie/supplementary/ps3controller/ps3helper.sh"
+DRIVER=="usb", SUBSYSTEM=="usb", ATTR{idVendor}=="054c", ATTR{idProduct}=="0268", RUN+="$md_inst/ps3helper.sh config"
+SUBSYSTEM=="input", ATTR{name}=="PLAYSTATION(R)3 Controller", RUN+="$md_inst/ps3helper.sh"
 _EOF_
 
     # add default sixad settings


### PR DESCRIPTION
@joolswills please take a look if everything is fine. I tested these changes on a fresh RP3.1 installation and with two controllers. Rebooted five times. Disabled and enabled controllers at runtime. Controllers always paired. Issue https://github.com/RetroPie/RetroPie-Setup/issues/654 should be solved now.

ps3helper.sh and ps3pair.sh could be merged somehow because they share 90% code.

1. Workaround second controller pairing issue. Bluetooth dongle is no
longer discoverable after first controller is paired. Reenable pscan
with a udev rule (if virtual input device bt controller shows up
reenable pscan).

2. Cleanup module from old stuff which is no longer necessary because
udev rules manage everything.

3. Add some checks to ps3pair.sh. Check if sixad is running and enable
bluetooth dongle or pscan if necessary.