### PR TITLE
Use rbp-userland-src-osmc package instead of 'hello_pi' tarball to satisfy xroar dependency

### DIFF
--- a/scriptmodules/emulators/xroar.sh
+++ b/scriptmodules/emulators/xroar.sh
@@ -15,15 +15,8 @@ rp_module_menus="2+"
 
 function depends_xroar() {
     getDepends libsdl1.2-dev libraspberrypi-dev
-    # ilclient is part of libraspberrypi-doc, but not included on all distros - eg OSMC on rpi2
-    if hasPackage rbp-bootloader-osmc; then
-        if [[ ! -d "/opt/vc/src/hello_pi" ]]; then
-            mkdir -p "/opt/vc/src"
-            wget -q -O- "http://downloads.petrockblock.com/retropiearchives/hello_pi.tar.gz" | tar -xvz -C "/opt/vc/src"
-        fi
-    else
-        getDepends libraspberrypi-doc
-    fi
+    # ilclient is part of libraspberrypi-doc, but not included on all distros
+    if hasPackage rbp-bootloader-osmc; then getDepends rbp-userland-src-osmc; else getDepends libraspberrypi-doc; fi
 }
 
 function sources_xroar() {


### PR DESCRIPTION
Further to our discussion in https://github.com/osmc/osmc/issues/219. A package is now in the official OSMC APT repository.