### PR TITLE
Add SuperTux to ports

### DIFF
--- a/scriptmodules/ports/supertux.sh
+++ b/scriptmodules/ports/supertux.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+ 
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+ 
+rp_module_id="supertux"
+rp_module_desc="SuperTux 2d scrolling platform"
+rp_module_menus="4+"
+ 
+function install_supertux() {
+    aptInstall supertux
+}
+ 
+function configure_supertux() {
+    mkRomDir "ports"
+
+    addPort "SuperTux" << _EOF_
+#!/bin/bash
+supertux
+_EOF_
+}

--- a/scriptmodules/ports/supertux.sh
+++ b/scriptmodules/ports/supertux.sh
@@ -12,6 +12,7 @@
 rp_module_id="supertux"
 rp_module_desc="SuperTux 2d scrolling platform"
 rp_module_menus="4+"
+rp_module_flags="nobin"
  
 function install_supertux() {
     aptInstall supertux


### PR DESCRIPTION
So I was thinking, there are quite a few games that can be installed directly with apt-get from the raspbian repositories- would there be any merit to a dynamic menu/script of sorts that builds the games based solely on the repo name as most games scripts will look virtually identical to this one?

That is of course unless you want them to be built from source/ want to be more picky  about what we include with retropie (as some games only work with an x server, some just aren't worth playing, some only require a keyboard etc.)

Just some thoughts anyhow, if you want supertux compiled from source instead of a repo/ don't think its up to snuff then feel free to reject it- just posted it as an option just in case people were interested. 