### PR TITLE
retroarch fixes

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -111,5 +111,11 @@ function configure_retroarch() {
     iniSet "joypad_autoconfig_dir" "$configdir/all/retroarch-joypads/"
     iniSet "auto_remaps_enable" "true"
 
+    # use analog sticks as dpads
+    local i
+    for i in {1..8}; do
+        iniSet "input_player${i}_analog_dpad_mode" "1"
+    done 
+
     chown $user:$user "$config"
 }

--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -26,9 +26,6 @@ function sources_retroarch() {
     gitPullOrClone "$md_build" https://github.com/libretro/RetroArch.git
     gitPullOrClone "$md_build/overlays" https://github.com/libretro/common-overlays.git
     gitPullOrClone "$md_build/shader" https://github.com/gizmo98/common-shaders.git
-    # disable the search dialog which doesn't work - https://github.com/libretro/RetroArch/issues/1432
-    sed -i 's|menu_input_search_start|//menu_input_search_start|g' $md_build/menu/menu_entry.c
-
 }
 
 function build_retroarch() {


### PR DESCRIPTION
-remove old search box fix because it does not work and is not necessary anymore
-default use analog sticks as dpads