### PR TITLE
Add wolf4sdl to ports

### DIFF
--- a/scriptmodules/ports/wolf4sdl.sh
+++ b/scriptmodules/ports/wolf4sdl.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+# 
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# 
+# See the LICENSE.md file at the top-level directory of this distribution and 
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="wolf4sdl"
+rp_module_desc="Wolf4SDL, port of Wolfenstein 3D Shareware 1.4 version"
+rp_module_menus="4+"
+rp_module_flags="dispmanx"
+
+function depends_wolf4sdl() {
+    getDepends libsdl1.2-dev
+}
+
+function sources_wolf4sdl() {
+    gitPullOrClone "$md_build" https://github.com/mozzwald/wolf4sdl.git
+    # Define Shareware version
+    sed -i 's|#define GOODTIMES|//#define GOODTIMES|g' version.h
+    
+    # Define Steam version
+    # sed -i 's|#define UPLOAD|//#define UPLOAD|g' version.h
+    
+    # Define 3D Realms version
+    # sed -i 's|#define GOODTIMES|//#define GOODTIMES|g' version.h
+    # sed -i 's|#define UPLOAD|//#define UPLOAD|g' version.h
+}
+
+function build_wolf4sdl() {
+    make clean
+    make DATADIR="$romdir/ports/wolf3d/"
+    md_ret_require="$md_build"
+}
+
+function install_wolf4sdl() {
+     mkdir -p "$md_inst/share/man/man6"
+     make install PREFIX="$md_inst" MANPREFIX="$md_inst/share/man"
+}
+
+function configure_wolf4sdl() {
+    mkRomDir "ports"
+    mkRomDir "ports/wolf3d"
+
+    # Get shareware game data
+    wget -q -O wolf3d14.zip http://maniacsvault.net/ecwolf/files/shareware/wolf3d14.zip
+    unzip -j -o -LL wolf3d14.zip -d "$romdir/ports/wolf3d"
+    rm -f wolf3d14.zip
+
+    setDispmanx "$md_id" 1
+
+    addPort "$md_id" "wolf4sdl" "Wolfenstein 3D" "$md_inst/bin/wolf3d"
+}


### PR DESCRIPTION
I have written a script module to install wolf4sdl. The wolf4sdl source code builds a distinct binary, wolf3d, on the Pi depending upon the game data to be used. Binaries are not compatible with different versions of the game. For example, the shareware binary will not work with the 3D Realms game data.

The script module will first present a menu to let a user select which game data they wish to use. The script currently supports the following versions:

* Shareware version v1.4
* 3D Realms retail version (Apogee v1.4)
* Steam retail version (GT/ID/Activision)

Depending on the user selection, the script module (lines 29 to 40) will then clone the source code and delete the appropriate line(s) in [version.h](https://github.com/mozzwald/wolf4sdl/blob/master/version.h). I'm not sure whether this is best practice and commenting the necessary lines may be better. I could not find (at least get my head around) the command to do this so I went ahead with deleting option. Maybe this could be improved?

I have successfully tested the script for all three versions of the game data. There is a minor error, though, during the install process as below:
````
===> INSTALL
install: cannot create regular file `/opt/retropie/ports/wolf4sdl/share/man//man6': No such file or directory
Makefile:117: recipe for target 'install' failed
make: *** [install] Error 1
````
The wolf3d binary is installed to the correct location (/opt/retropie/ports/wolf4sdl/bin) and the game launches fine.

Users will need to put their game data in /home/pi/RetroPie/ports/wolf3d folder. File names need to be lower case. To make things easier, the scriptmodule will create a bash script, lower-script.sh, located in the wolf3d folder that can change the file names from the command line.

It may be also be worthwhile checking the CFlags in [Makefile](https://github.com/mozzwald/wolf4sdl/blob/master/Makefile) and [config.default](https://github.com/mozzwald/wolf4sdl/blob/master/config.default) file.