### PR TITLE
ps3controller: debian jessie compatibility

### DIFF
--- a/scriptmodules/supplementary/ps3controller.sh
+++ b/scriptmodules/supplementary/ps3controller.sh
@@ -15,147 +15,47 @@ rp_module_menus="3+configure"
 rp_module_flags="nobin"
 
 function depends_ps3controller() {
-    getDepends checkinstall libusb-dev bluetooth libbluetooth-dev joystick libusb-1.0-0-dev
+    getDepends checkinstall libusb-dev bluetooth libbluetooth-dev joystick
 }
 
 function sources_ps3controller() {
-    gitPullOrClone "$md_build" https://github.com/kLeZ/SixPair.git
-    wget -O- -q http://sourceforge.net/projects/qtsixa/files/QtSixA%201.5.1/QtSixA-1.5.1-src.tar.gz | tar -xvz --strip-components=1
-    patch -p1 <<\_EOF_
---- a/sixad/shared.h	2011-10-12 03:37:38.000000000 +0300
-+++ b/sixad/shared.h	2012-08-14 19:30:12.190379004 +0300
-@@ -18,6 +18,8 @@
- #ifndef SHARED_H
- #define SHARED_H
- 
-+#include <unistd.h>
-+
- struct dev_led {
-     bool enabled;
-     bool anim;
-_EOF_
-
-    sed -i 's/strcpy(dev_name, "PLAYSTATION(R)3 Controller (");/strcpy(dev_name, "PLAYSTATION(R)3 Controller");/g' "$md_build/sixad/uinput.cpp"
-    sed -i 's/strcat(dev_name, mac);//g' "$md_build/sixad/uinput.cpp"
-    sed -i 's/strcat(dev_name, ")");//g' "$md_build/sixad/uinput.cpp"
- }
+    gitPullOrClone "$md_build/sixad" https://github.com/gizmo98/sixad.git
+    #----------------------------------------------------------------
+    # If you have a ps3 gamepad clone comment out the following line.
+    # Branch gasia does not support leds. Leds blink all the time. 
+    # Led/rumble connection animation does not work.
+    #-----------------------------------------------------------------
+    #gitPullOrClone "$md_build/sixad" https://github.com/gizmo98/sixad.git gasia
+}
 
 function build_ps3controller() {
-    g++ -o sixpair main.cpp -lusb-1.0
-    cd sixad
+    pushd $md_build/sixad
     make clean
-    make
+    make DEVICE_SHORT_NAME=1
+    popd
 }
 
 function install_ps3controller() {
-    cd sixad
+    pushd $md_build/sixad
     checkinstall -y --fstrans=no
     insserv sixad
-
-    # If a bluetooth dongle is present "at startup" set state up and enable pscan
-    sed -i 's/exit 0//g' "/etc/rc.local"
-    cat >> "/etc/rc.local" <<\_EOF_
-# PS3 PROFILE START
-if hciconfig | grep -q "hci0"; then
-    hciconfig hci0 up
-    hciconfig hci0 pscan
-fi
-# PS3 PROFILE END
-exit 0
-_EOF_
-
-    # If a bluetooth dongle is connected "at runtime" set state up and enable pscan
-    cat > "$md_inst/bluetooth.sh" << _EOF_
-#!/bin/bash
-if hciconfig | grep -q "hci0"; then
-    hciconfig hci0 up
-    hciconfig hci0 pscan
-fi
-_EOF_
-
-    chmod +x "$md_inst/bluetooth.sh"
-
-    # If a PS3 controller is connected over usb check if bluetooth dongle exits and start sixpair
-    cat > "$md_inst/ps3helper.sh" << _EOF_
-#!/bin/bash
-params="\$1"
-if hciconfig | grep -q "hci0"; then
-    # Check if sixad is running
-    if service sixad status | grep -q -e "sixad is running" -e "active (running)"; then
-        # activate bt dongle if necessary
-        if !(hciconfig | grep -q "RUNNING"); then
-            hciconfig hci0 up
-        fi
-        # Make bt dongle discoverable
-        if !(hciconfig | grep -q "PSCAN"); then
-            hciconfig hci0 pscan
-        fi
-        if [[ "\$params" == "config" ]]; then
-            # Write bt dongle's mac address into controller
-            $md_inst/sixpair
-        fi
-    else
-        echo "sixad is not running!"
-    fi
-fi
-_EOF_
-
-    chmod +x "$md_inst/ps3helper.sh"
-
-    # udev rule for bluetooth dongle
-    cat > "/etc/udev/rules.d/10-local.rules" << _EOF_  
-# Set bluetooth power up
-ACTION=="add", KERNEL=="hci0", RUN+="$md_inst/bluetooth.sh"
-_EOF_
-
-    # udev rule for ps3 controller usb connection
-    cat > "/etc/udev/rules.d/99-sixpair.rules" << _EOF_
-# Pair if PS3 controller is connected
-DRIVER=="usb", SUBSYSTEM=="usb", ATTR{idVendor}=="054c", ATTR{idProduct}=="0268", RUN+="$md_inst/ps3helper.sh config"
-SUBSYSTEM=="input", ATTR{name}=="PLAYSTATION(R)3 Controller", RUN+="$md_inst/ps3helper.sh"
-_EOF_
-
-    # add default sixad settings
-    cat > "/var/lib/sixad/profiles/default" << _EOF_
-enable_leds 1
-enable_joystick 1
-enable_input 0
-enable_remote 0
-enable_rumble 1
-enable_timeout 0
-led_n_auto 1
-led_n_number 0
-led_anim 1
-enable_buttons 1
-enable_sbuttons 0
-enable_axis 1
-enable_accel 0
-enable_accon 0
-enable_speed 0
-enable_pos 0
-_EOF_
+    popd
 
     # Start sixad daemon
     /etc/init.d/sixad start
-
-    md_ret_files=(
-        'sixpair'
-    )
 }
 
 function remove_ps3controller() {
     service sixad stop
     insserv -r sixad
     dpkg --purge sixad
-    rm -rf /var/lib/sixad/
     rm -f /etc/udev/rules.d/99-sixpair.rules
     rm -f /etc/udev/rules.d/10-local.rules
     rm -rf "$md_inst"
-    sed -i '/PS3 PROFILE START/,/PS3 PROFILE END/d' "/etc/rc.local"
 }
 
 function pair_ps3controller() {
-    if [[ ! -f "$rootdir/supplementary/ps3controller/sixpair" ]]; then
+    if [[ ! -f "/usr/sbin/sixpair" ]]; then
         local mode
         for mode in depends sources build install; do
             rp_callModule ps3controller $mode
@@ -187,5 +87,4 @@ function configure_ps3controller() {
             break
         fi
     done
-
 }


### PR DESCRIPTION
-add check for debian jessie’s „service sixad status“ return value. Jessie returns "active (running)".
-add hciconfig hci0 up/pscan to rc.local. udev rule 10-local.rules is not ready at startup if raspbian jessie is used.
https://github.com/RetroPie/RetroPie-Setup/issues/1073