### PR TITLE
retroarchinput.sh: remove retroarch-joyconfig

### DIFF
--- a/scriptmodules/supplementary/retroarchinput.sh
+++ b/scriptmodules/supplementary/retroarchinput.sh
@@ -14,32 +14,6 @@ rp_module_desc="Configure input devices for RetroArch"
 rp_module_menus="3+configure"
 rp_module_flags="nobin"
 
-function joystick_retroarchinput() {
-    local configfname
-    local numJoypads
-
-    printMsgs "dialog" "Connect ONLY the controller to be registered for RetroArch to the Raspberry Pi."
-    clear
-    local dest="$configdir/all/retroarch-joypads"
-    # todo Find number of first joystick device in /dev/input
-    numJoypads=$(ls -1 /dev/input/js* | head -n 1)
-    if [[ -n "$numJoypads" ]]; then
-        "$emudir/retroarch/bin/retroarch-joyconfig" --autoconfig "/tmp/tempconfig.cfg" --timeout 4 --joypad ${numJoypads:13}
-        configfname=$(grep "input_device = \"" "/tmp/tempconfig.cfg")
-        configfname=$(echo ${configfname:16:-1} | tr -d ' ')
-        mv "/tmp/tempconfig.cfg" "$dest/$configfname.cfg"
-
-        # Add hotkeys
-        rp_callModule retroarchautoconf remap_hotkeys "$dest/$configfname.cfg"
-
-        chown $user:$user "$dest/$configfname.cfg"
-
-        printMsgs "dialog" "The configuration file has been saved as '$dest/$configfname.cfg' and will be used by RetroArch from now on whenever that controller is connected."
-    else
-        printMsgs "dialog" "Sorry, no joystick detected."
-    fi
-}
-
 function keyboard_retroarchinput() {
     if [[ ! -f "$configdir/all/retroarch.cfg" ]]; then
         printMsgs "dialog" "No RetroArch configuration file found at $configdir/all/retroarch.cfg"
@@ -101,20 +75,16 @@ function hotkey_retroarchinput() {
 function configure_retroarchinput() {
     local cmd=(dialog --backtitle "$__backtitle" --menu "Choose an option." 22 76 16)
     local options=(
-        1 "Configure joystick/controller for use with RetroArch"
-        2 "Configure keyboard for use with RetroArch"
-        3 "Configure keyboard hotkey behaviour for RetroArch"
+        1 "Configure keyboard for use with RetroArch"
+        2 "Configure keyboard hotkey behaviour for RetroArch"
     )
     local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
     if [[ -n "$choice" ]]; then
         case $choice in
             1)
-                joystick_retroarchinput
-                ;;
-            2)
                 keyboard_retroarchinput
                 ;;
-            3)
+            2)
                 hotkey_retroarchinput
                 ;;
         esac


### PR DESCRIPTION
retroarch-joyconfig is deprecated and no longer part of retroarch
https://github.com/libretro/RetroArch/issues/2388