### PR TITLE
add warning to kill emulationstation before using sselph's scraper

### DIFF
--- a/scriptmodules/supplementary/scraper.sh
+++ b/scriptmodules/supplementary/scraper.sh
@@ -87,6 +87,7 @@ function scrape_chosen_scraper() {
 }
 
 function configure_scraper() {
+    printMsgs "dialog" "Before running this scraper, make sure all EmulationStation processes are killed  with \"sudo killall emulationstation\" so that the gamelist.xml is written properly, otherwise the scraper changes may not be saved."
     if [[ ! -d "$md_inst" ]]; then
         rp_callModule "$md_id" install
     fi


### PR DESCRIPTION
from http://blog.petrockblock.com/forums/topic/scraper-little-details-to-solve/#post-110776

Unless you feel there is a better programmatic way to automate killing of processes when people start the setup script from within emulationstation