### PR TITLE
n64: use mupen64plus as default emulator

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -76,7 +76,7 @@ megadrive_fullname="Sega Mega Drive / Genesis"
 msx_exts=".rom .mx1 .mx2 .col .dsk .zip"
 msx_fullname="MSX / MSX2"
 
-n64_exts=".z64 .n64 .v64 .zip"
+n64_exts=".z64 .n64 .v64"
 n64_fullname="Nintendo 64"
 
 nds_exts=".nds .zip"

--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -129,6 +129,6 @@ function configure_mupen64plus() {
 
     delSystem "$md_id" "n64-mupen64plus"
     addSystem 0 "${md_id}-gles2n64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-n64 %ROM%"
-    addSystem 0 "${md_id}-gles2rice" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-rice %ROM%"
+    addSystem 1 "${md_id}-gles2rice" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-rice %ROM%"
     addSystem 0 "${md_id}-GLideN64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM%"
 }

--- a/scriptmodules/libretrocores/lr-mupen64plus.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus.sh
@@ -153,5 +153,5 @@ target FPS=25
 _EOF_
     chown $user:$user "$biosdir/gles2n64rom.conf"
 
-    addSystem 1 "$md_id" "n64" "$md_inst/mupen64plus_libretro.so"
+    addSystem 0 "$md_id" "n64" "$md_inst/mupen64plus_libretro.so"
 }


### PR DESCRIPTION
-switch default emulator from lr-mupen64plus/rice to mupen64plus/rice.
Don’t use glesn64 or GLideN64 because glesn64 does crash with certain
roms and GLideN64 is to slow at HD resolutions.
-remove zip file extension because mupen64plus does not support zip
files.