### PR TITLE
Scrape with 4 worker threads for speed.

### DIFF
--- a/scriptmodules/supplementary/scraper.sh
+++ b/scriptmodules/supplementary/scraper.sh
@@ -46,6 +46,7 @@ function scrape_scraper() {
     params+=(-image_path "$img_path")
     params+=(-output_file "$gamelist")
     params+=(-rom_dir "$romdir/$system")
+    params+=(-workers "4")
     [[ "$system" =~ ^mame- ]] && params+=(-mame -mame_img t,m,s)
     sudo -u $user "$md_inst/scraper" ${params[@]} -thumb_only -skip_check
 }


### PR DESCRIPTION
Set the scrapper to scrape using 4 different worker threads by default, massively speeding up scraping. Perhaps add a menu allowing the user to select the number of worker threads to use in the future.