### PR TITLE
Add audio options for those who want only music on boot

### DIFF
--- a/scriptmodules/supplementary/splashscreen/asplashscreen
+++ b/scriptmodules/supplementary/splashscreen/asplashscreen
@@ -14,7 +14,7 @@
 do_start () {
     local config="/etc/splashscreen.list"
     local line="$(head -1 "$config")"
-    if $(echo "$line" | grep -q ".avi\|.mov\|.mp4\|.mkv\|.3gp\|.mpg"); then
+    if $(echo "$line" | grep -q ".avi\|.mov\|.mp4\|.mkv\|.3gp\|.mpg\|.mp3\|.wav\|.m4a\|.aac\|.ogg\|.flac\|"); then
         while ! touch /tmp/writable; do
             sleep 1
         done


### PR DESCRIPTION
this should resolve https://github.com/RetroPie/RetroPie-Setup/issues/135. For those who want a splash and audio together should either just make a video for better syncing or manually sort the two files themselves with multiple instances of omxplayer or equivalent. 

Boot music can be added in the same way that one would add a custom splashscreen

https://github.com/RetroPie/RetroPie-Setup/wiki/splashscreen