### PR TITLE
retroarch: use sdl2 as input_joypad_driver

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -113,6 +113,7 @@ function configure_retroarch() {
     iniSet "input_autodetect_enable" "true"
     iniSet "joypad_autoconfig_dir" "$configdir/all/retroarch-joypads/"
     iniSet "auto_remaps_enable" "true"
+    iniSet "input_joypad_driver" "sdl2"
 
     chown $user:$user "$config"
 }


### PR DESCRIPTION
Contrary to retroarch's wiki retroarch's sdl2 joypad driver supports hotplugging as well.
https://github.com/libretro/RetroArch/wiki/Input-drivers-in-Linux-withou
t-Xorg#joypads

Switch to sdl2 so there is no button mismatch between emulationstation
generated controller configs and retroarch’s udev driver.