### PR TITLE
Add Opt Out autoconf functionality

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -130,4 +130,8 @@ function configure_mupen64plus() {
     addSystem 0 "${md_id}-gles2n64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-n64 %ROM%"
     addSystem 1 "${md_id}-gles2rice" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-rice %ROM%"
     addSystem 0 "${md_id}-GLideN64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM%"
+
+    addAutoConf mupen64plus_audio 1
+    addAutoConf mupen64plus_hotkeys 1
+    addAutoConf mupen64plus_compatibility_check 1
 }

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -209,7 +209,7 @@ function testCompatibility() {
     fi
 }
 
-remap
-testCompatibility
-setAudio
+getAutoConf mupen64plus_hotkeys || remap
+getAutoConf mupen64plus_compatibility_check || testCompatibility
+getAutoConf mupen64plus_audio || setAudio
 "$rootdir/emulators/mupen64plus/bin/mupen64plus" --noosd --fullscreen --gfx ${VIDEO_PLUGIN}.so --configdir "$configdir/n64" --datadir "$configdir/n64" "$ROM"

--- a/scriptmodules/emulators/reicast.sh
+++ b/scriptmodules/emulators/reicast.sh
@@ -66,5 +66,7 @@ function configure_reicast() {
     # add system
     addSystem 1 "$md_id" "dreamcast" "$md_inst/bin/reicast.sh OSS %ROM%"
 
+    addAutoConf reicast_input 1
+
     __INFMSGS+=("You need to copy the Dreamcast BIOS files (dc_boot.bin and dc_flash.bin) to the folder $biosdir to boot the Dreamcast emulator.")
 }

--- a/scriptmodules/emulators/reicast/reicast.sh
+++ b/scriptmodules/emulators/reicast/reicast.sh
@@ -59,7 +59,7 @@ function mapInput() {
 }
 
 if [[ -f "$HOME/RetroPie/BIOS/dc_boot.bin" ]]; then
-    mapInput
+    getAutoConf reicast_input || mapInput
     conf="$configdir/dreamcast/emu.cfg"
     sed -i '/audio/,/disable/d' "$conf"
     echo "[audio]" >> "$conf"

--- a/scriptmodules/inifuncs.sh
+++ b/scriptmodules/inifuncs.sh
@@ -97,3 +97,36 @@ function iniGet() {
     [[ -z "$delim_strip" ]] && delim_strip="$delim"
     ini_value=$(sed -rn "s/^[[:space:]]*$key[[:space:]]*$delim_strip[[:space:]]*$quote(.+)$quote.*/\1/p" $file)
 }
+
+# arg 1: key, arg 2: default value (optional - is 1 if not used)
+function addAutoConf() {
+    local key="$1"
+    local default="$2"
+    local file="$configdir/all/autoconf.cfg"
+
+    if [[ -z "$default" ]]; then
+       default="1"
+    fi
+
+    if [ ! -f "$file" ]; then
+        echo "# this file can be used to enable/disable retropie autoconfiguration features" >> "$file"
+    fi
+
+    iniConfig " = " "" "$file"
+    iniGet "$key"
+    ini_value="${ini_value// /}"
+    if [[ -z "$ini_value" ]]; then
+        iniSet "$key" "$default"
+    fi
+}
+
+# arg 1: key
+function getAutoConf(){
+    local key="$1"
+
+    iniConfig " = " "" "$configdir/all/autoconf.cfg"
+    iniGet "$key"
+
+    [[ "$ini_value" == "1" ]] && return 1
+    return 0
+}


### PR DESCRIPTION
-use /configs/all/autoconf.cfg to enable/disable autoconf functionality.
-add two new functions to add set read config file content.
-add functions to mupen64plus and reicast modules.
https://github.com/RetroPie/RetroPie-Setup/issues/1113