### PR TITLE
Add logs and tmp folders in the root to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ Icon?
 ehthumbs.db
 Thumbs.db
 
+# Generated files
+logs/
+tmp/
+


### PR DESCRIPTION
Both the tmp and logs folders located in the root are generated, and should be ignored.