### PR TITLE
Initial "platform x86" PR

### DIFF
--- a/scriptmodules/emulators/advmame.sh
+++ b/scriptmodules/emulators/advmame.sh
@@ -12,6 +12,7 @@
 rp_module_id="advmame"
 rp_module_desc="AdvanceMAME"
 rp_module_menus="2+"
+rp_module_flags="!x86"
 
 function depends_advmame() {
     getDepends libsdl1.2-dev

--- a/scriptmodules/emulators/ags.sh
+++ b/scriptmodules/emulators/ags.sh
@@ -12,6 +12,7 @@
 rp_module_id="ags"
 rp_module_desc="Adventure Game Studio - Adventure game engine"
 rp_module_menus="4+"
+rp_module_flags="!x86"
 
 function depends_ags() {
     getDepends pkg-config liballegro4.2-dev libaldmb1-dev libfreetype6-dev libtheora-dev libvorbis-dev libogg-dev

--- a/scriptmodules/emulators/atari800.sh
+++ b/scriptmodules/emulators/atari800.sh
@@ -12,6 +12,7 @@
 rp_module_id="atari800"
 rp_module_desc="Atari 8-bit/800/5200 emulator"
 rp_module_menus="2+"
+rp_module_flags="!x86"
 
 function depends_atari800() {
     getDepends libsdl1.2-dev autoconf libraspberrypi-dev zlib1g-dev libpng12-dev

--- a/scriptmodules/emulators/basilisk.sh
+++ b/scriptmodules/emulators/basilisk.sh
@@ -12,7 +12,7 @@
 rp_module_id="basilisk"
 rp_module_desc="Macintosh emulator"
 rp_module_menus="2+"
-rp_module_flags="dispmanx"
+rp_module_flags="dispmanx !x86"
 
 function depends_basilisk() {
     getDepends libsdl1.2-dev autoconf automake

--- a/scriptmodules/emulators/capricerpi.sh
+++ b/scriptmodules/emulators/capricerpi.sh
@@ -12,7 +12,7 @@
 rp_module_id="capricerpi"
 rp_module_desc="Amstrad CPC emulator - port of Caprice32 for the RPI"
 rp_module_menus="2+"
-rp_module_flags="dispmanx"
+rp_module_flags="dispmanx !x86"
 
 function depends_capricerpi() {
     getDepends libsdl1.2-dev zlib1g-dev

--- a/scriptmodules/emulators/dgen.sh
+++ b/scriptmodules/emulators/dgen.sh
@@ -12,7 +12,7 @@
 rp_module_id="dgen"
 rp_module_desc="Megadrive/Genesis emulat. DGEN"
 rp_module_menus="2+"
-rp_module_flags="dispmanx"
+rp_module_flags="dispmanx !x86"
 
 function depends_dgen() {
     getDepends libsdl1.2-dev libarchive-dev

--- a/scriptmodules/emulators/dosbox.sh
+++ b/scriptmodules/emulators/dosbox.sh
@@ -12,7 +12,7 @@
 rp_module_id="dosbox"
 rp_module_desc="DOS emulator"
 rp_module_menus="2+"
-rp_module_flags="dispmanx"
+rp_module_flags="dispmanx !x86"
 
 function depends_dosbox() {
     getDepends libsdl1.2-dev libsdl-net1.2-dev libsdl-sound1.2-dev libasound2-dev libpng12-dev automake autoconf zlib1g-dev

--- a/scriptmodules/emulators/fbzx.sh
+++ b/scriptmodules/emulators/fbzx.sh
@@ -12,7 +12,7 @@
 rp_module_id="fbzx"
 rp_module_desc="ZXSpectrum emulator FBZX"
 rp_module_menus="2+"
-rp_module_flags="dispmanx"
+rp_module_flags="dispmanx !x86"
 
 function depends_fbzx() {
     getDepends libasound2-dev libsdl1.2-dev

--- a/scriptmodules/emulators/frotz.sh
+++ b/scriptmodules/emulators/frotz.sh
@@ -12,7 +12,7 @@
 rp_module_id="frotz"
 rp_module_desc="Z-Machine Interpreter for Infocom games"
 rp_module_menus="2+"
-rp_module_flags="nobin"
+rp_module_flags="nobin !x86"
 
 function install_frotz() {
     aptInstall frotz

--- a/scriptmodules/emulators/fuse.sh
+++ b/scriptmodules/emulators/fuse.sh
@@ -12,7 +12,7 @@
 rp_module_id="fuse"
 rp_module_desc="ZX Spectrum emulator Fuse"
 rp_module_menus="2+"
-rp_module_flags="dispmanx"
+rp_module_flags="dispmanx !x86"
 
 function depends_fuse() {
     getDepends libsdl1.2-dev libpng12-dev zlib1g-dev libbz2-dev libaudiofile-dev bison flex 

--- a/scriptmodules/emulators/gngeopi.sh
+++ b/scriptmodules/emulators/gngeopi.sh
@@ -12,7 +12,7 @@
 rp_module_id="gngeopi"
 rp_module_desc="NeoGeo emulator GnGeoPi"
 rp_module_menus="2+"
-rp_module_flags=""
+rp_module_flags="!x86"
 
 function depends_gngeopi() {
     getDepends libsdl1.2-dev

--- a/scriptmodules/emulators/gpsp.sh
+++ b/scriptmodules/emulators/gpsp.sh
@@ -12,7 +12,7 @@
 rp_module_id="gpsp"
 rp_module_desc="GameBoy Advance emulator"
 rp_module_menus="2+"
-rp_module_flags=""
+rp_module_flags="!x86"
 
 function depends_gpsp() {
     getDepends libsdl1.2-dev libraspberrypi-dev

--- a/scriptmodules/emulators/hatari.sh
+++ b/scriptmodules/emulators/hatari.sh
@@ -12,6 +12,7 @@
 rp_module_id="hatari"
 rp_module_desc="Atari emulator Hatari"
 rp_module_menus="2+"
+rp_module_flags="!x86"
 
 function depends_hatari() {
     getDepends libsdl2-dev zlib1g-dev libpng12-dev cmake libreadline-dev portaudio19-dev

--- a/scriptmodules/emulators/jzintv.sh
+++ b/scriptmodules/emulators/jzintv.sh
@@ -12,7 +12,7 @@
 rp_module_id="jzintv"
 rp_module_desc="Intellivision emulator"
 rp_module_menus="2+"
-rp_module_flags="dispmanx"
+rp_module_flags="dispmanx !x86"
 
 function depends_jzintv() {
     getDepends libsdl1.2-dev

--- a/scriptmodules/emulators/linapple.sh
+++ b/scriptmodules/emulators/linapple.sh
@@ -12,7 +12,7 @@
 rp_module_id="linapple"
 rp_module_desc="Apple 2 emulator LinApple"
 rp_module_menus="2+"
-rp_module_flags="dispmanx"
+rp_module_flags="dispmanx !x86"
 
 function depends_linapple() {
     getDepends libzip2 libzip-dev libsdl1.2-dev libcurl4-openssl-dev

--- a/scriptmodules/emulators/mame4all.sh
+++ b/scriptmodules/emulators/mame4all.sh
@@ -12,6 +12,7 @@
 rp_module_id="mame4all"
 rp_module_desc="MAME emulator MAME4All-Pi"
 rp_module_menus="2+"
+rp_module_flags="!x86"
 
 function depends_mame4all() {
     getDepends libasound2-dev libsdl1.2-dev libraspberrypi-dev

--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -12,7 +12,7 @@
 rp_module_id="mupen64plus"
 rp_module_desc="N64 emulator MUPEN64Plus"
 rp_module_menus="2+"
-rp_module_flags="!odroid"
+rp_module_flags="!odroid !x86"
 
 function depends_mupen64plus() {
     getDepends cmake libgl1-mesa-dev libsamplerate0-dev libspeexdsp-dev libsdl2-dev

--- a/scriptmodules/emulators/openmsx.sh
+++ b/scriptmodules/emulators/openmsx.sh
@@ -12,6 +12,7 @@
 rp_module_id="openmsx"
 rp_module_desc="MSX emulator OpenMSX"
 rp_module_menus="4+"
+rp_module_flags="!x86"
 
 function depends_openmsx() {
     getDepends libsdl1.2-dev libsdl-ttf2.0-dev libglew-dev libao-dev libogg-dev libtheora-dev libxml2-dev libvorbis-dev tcl-dev

--- a/scriptmodules/emulators/osmose.sh
+++ b/scriptmodules/emulators/osmose.sh
@@ -12,6 +12,7 @@
 rp_module_id="osmose"
 rp_module_desc="Gamegear emulator Osmose"
 rp_module_menus="2+"
+rp_module_flags="!x86"
 
 function depends_osmose() {
     getDepends libsdl1.2-dev

--- a/scriptmodules/emulators/pcsx-rearmed.sh
+++ b/scriptmodules/emulators/pcsx-rearmed.sh
@@ -12,7 +12,7 @@
 rp_module_id="pcsx-rearmed"
 rp_module_desc="Playstation emulator - PCSX (arm optimised)"
 rp_module_menus="4+"
-rp_module_flags="dispmanx"
+rp_module_flags="dispmanx !x86"
 
 function depends_pcsx-rearmed() {
     getDepends libsdl1.2-dev libasound2-dev libpng12-dev libx11-dev

--- a/scriptmodules/emulators/pifba.sh
+++ b/scriptmodules/emulators/pifba.sh
@@ -12,6 +12,7 @@
 rp_module_id="pifba"
 rp_module_desc="FBA emulator PiFBA"
 rp_module_menus="2+"
+rp_module_flags="!x86"
 
 function depends_pifba() {
     getDepends libasound2-dev libsdl1.2-dev libraspberrypi-dev

--- a/scriptmodules/emulators/pisnes.sh
+++ b/scriptmodules/emulators/pisnes.sh
@@ -12,6 +12,7 @@
 rp_module_id="pisnes"
 rp_module_desc="SNES emulator PiSNES"
 rp_module_menus="2+"
+rp_module_flags="!x86"
 
 function depends_pisnes() {
     getDepends libasound2-dev libsdl1.2-dev libraspberrypi-dev

--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -12,7 +12,7 @@
 rp_module_id="ppsspp"
 rp_module_desc="PlayStation Portable emulator PPSSPP"
 rp_module_menus="2+"
-rp_module_flags="!rpi1"
+rp_module_flags="!rpi1 !x86"
 
 function depends_ppsspp() {
     getDepends cmake libraspberrypi-dev libsdl2-dev

--- a/scriptmodules/emulators/px68k.sh
+++ b/scriptmodules/emulators/px68k.sh
@@ -12,6 +12,7 @@
 rp_module_id="px68k"
 rp_module_desc="SHARP X68000 Emulator"
 rp_module_menus="4+"
+rp_module_flags="!x86"
 
 function depends_px68k() {
     getDepends libsdl1.2-dev libsdl-gfx1.2-dev

--- a/scriptmodules/emulators/reicast.sh
+++ b/scriptmodules/emulators/reicast.sh
@@ -12,7 +12,7 @@
 rp_module_id="reicast"
 rp_module_desc="Dreamcast emulator Reicast"
 rp_module_menus="2+"
-rp_module_flags="!rpi1"
+rp_module_flags="!rpi1 !x86"
 
 function depends_reicast() {
     getDepends libsdl1.2-dev python-dev python-pip alsa-oss

--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -14,7 +14,8 @@ rp_module_desc="RetroArch"
 rp_module_menus="2+"
 
 function depends_retroarch() {
-    getDepends libudev-dev libxkbcommon-dev libsdl2-dev libraspberrypi-dev
+    getDepends libudev-dev libxkbcommon-dev libsdl2-dev 
+    [[ "$__platform" == *rpi* ]] && getDepends libraspberrypi-dev
     [[ "$__raspbian_ver" -ge "8" ]] && getDepends libusb-1.0-0-dev
 
     cat > "/etc/udev/rules.d/99-evdev.rules" << _EOF_

--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -35,6 +35,7 @@ function sources_retroarch() {
 function build_retroarch() {
     local params=(--disable-x11 --enable-dispmanx --disable-oss --disable-pulse --disable-al --disable-jack --enable-sdl2 --enable-floathard)
     isPlatform "rpi2" && params+=(--enable-neon)
+    isPlatform "x86" && params=(--enable-sdl2)
     ./configure --prefix="$md_inst" "${params[@]}"
     make clean
     make

--- a/scriptmodules/emulators/rpix86.sh
+++ b/scriptmodules/emulators/rpix86.sh
@@ -12,7 +12,7 @@
 rp_module_id="rpix86"
 rp_module_desc="DOS Emulator rpix86"
 rp_module_menus="2+"
-rp_module_flags="nobin"
+rp_module_flags="nobin !x86"
 
 function install_rpix86() {
     wget -O- -q $__archive_url/rpix86.tar.gz | tar -xvz -C "$md_inst"

--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -12,7 +12,7 @@
 rp_module_id="scummvm"
 rp_module_desc="ScummVM"
 rp_module_menus="2+"
-rp_module_flags="dispmanx"
+rp_module_flags="dispmanx !x86"
 
 function depends_scummvm() {
     getDepends libsdl1.2-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng12-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev

--- a/scriptmodules/emulators/snes9x.sh
+++ b/scriptmodules/emulators/snes9x.sh
@@ -12,7 +12,7 @@
 rp_module_id="snes9x"
 rp_module_desc="SNES emulator SNES9X-RPi"
 rp_module_menus="2+"
-rp_module_flags="dispmanx"
+rp_module_flags="dispmanx !x86"
 
 function depends_snes9x() {
     getDepends libsdl1.2-dev libboost-thread-dev libboost-system-dev libsdl-ttf2.0-dev libasound2-dev

--- a/scriptmodules/emulators/stella.sh
+++ b/scriptmodules/emulators/stella.sh
@@ -12,7 +12,7 @@
 rp_module_id="stella"
 rp_module_desc="Atari2600 emulator STELLA"
 rp_module_menus="2+"
-rp_module_flags="dispmanx nobin"
+rp_module_flags="dispmanx nobin !x86"
 
 function install_stella()
 {

--- a/scriptmodules/emulators/uae4all.sh
+++ b/scriptmodules/emulators/uae4all.sh
@@ -12,7 +12,7 @@
 rp_module_id="uae4all"
 rp_module_desc="Amiga emulator UAE4All"
 rp_module_menus="2+"
-rp_module_flags="dispmanx"
+rp_module_flags="dispmanx !x86"
 
 function depends_uae4all() {
     getDepends libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev libsdl-gfx1.2-dev libsdl-ttf2.0-dev

--- a/scriptmodules/emulators/uae4arm.sh
+++ b/scriptmodules/emulators/uae4arm.sh
@@ -12,6 +12,7 @@
 rp_module_id="uae4arm"
 rp_module_desc="Amiga emulator with JIT support"
 rp_module_menus="2+"
+rp_module_flags="!x86"
 
 function depends_uae4arm() {
     getDepends libsdl1.2-dev libsdl-gfx1.2-dev libsdl-ttf2.0-dev libguichan-dev

--- a/scriptmodules/emulators/vice.sh
+++ b/scriptmodules/emulators/vice.sh
@@ -12,7 +12,7 @@
 rp_module_id="vice"
 rp_module_desc="C64 emulator VICE"
 rp_module_menus="2+"
-rp_module_flags="dispmanx"
+rp_module_flags="dispmanx !x86"
 
 function depends_vice() {
     if hasPackage vice; then

--- a/scriptmodules/emulators/xroar.sh
+++ b/scriptmodules/emulators/xroar.sh
@@ -12,6 +12,7 @@
 rp_module_id="xroar"
 rp_module_desc="Dragon / CoCo emulator XRoar"
 rp_module_menus="2+"
+rp_module_flags="!x86"
 
 function depends_xroar() {
     getDepends libsdl1.2-dev libraspberrypi-dev

--- a/scriptmodules/emulators/zesarux.sh
+++ b/scriptmodules/emulators/zesarux.sh
@@ -12,7 +12,7 @@
 rp_module_id="zesarux"
 rp_module_desc="ZX Spectrum emulator ZEsarUX"
 rp_module_menus="4+"
-rp_module_flags="dispmanx"
+rp_module_flags="dispmanx !x86"
 
 function depends_zesarux() {
     getDepends libssl-dev libpthread-stubs0-dev libsdl1.2-dev libasound2-dev

--- a/scriptmodules/libretrocores/lr-armsnes.sh
+++ b/scriptmodules/libretrocores/lr-armsnes.sh
@@ -12,6 +12,7 @@
 rp_module_id="lr-armsnes"
 rp_module_desc="SNES emu - forked from pocketsnes focused on performance"
 rp_module_menus="2+"
+rp_module_flags="!x86"
 
 function sources_lr-armsnes() {
     gitPullOrClone "$md_build" https://github.com/rmaz/ARMSNES-libretro

--- a/scriptmodules/libretrocores/lr-beetle-vb.sh
+++ b/scriptmodules/libretrocores/lr-beetle-vb.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-beetle-vb"
 rp_module_desc="Virtual Boy emulator - Mednafen VB (optimised) port for libretro"
 rp_module_menus="4+"
-rp_module_flags="!rpi1"
+rp_module_flags="!rpi1 !x86"
 
 function sources_lr-beetle-vb() {
     gitPullOrClone "$md_build" https://github.com/libretro/beetle-vb-libretro.git

--- a/scriptmodules/libretrocores/lr-desmume.sh
+++ b/scriptmodules/libretrocores/lr-desmume.sh
@@ -12,6 +12,7 @@
 rp_module_id="lr-desmume"
 rp_module_desc="NDS emu - DESMUME"
 rp_module_menus="4+"
+rp_module_flags="!x86"
 
 function sources_lr-desmume() {
     gitPullOrClone "$md_build" https://github.com/libretro/desmume.git

--- a/scriptmodules/libretrocores/lr-fba-next.sh
+++ b/scriptmodules/libretrocores/lr-fba-next.sh
@@ -12,6 +12,7 @@
 rp_module_id="lr-fba-next"
 rp_module_desc="Arcade emu - Final Burn Alpha (0.2.97.37) port for libretro"
 rp_module_menus="2+"
+rp_module_flags="!x86"
 
 function depends_lr-fba-next() {
     [[ "$__default_gcc_version" == "4.7" ]] && getDepends gcc-4.8 g++-4.8

--- a/scriptmodules/libretrocores/lr-fba.sh
+++ b/scriptmodules/libretrocores/lr-fba.sh
@@ -12,6 +12,7 @@
 rp_module_id="lr-fba"
 rp_module_desc="Arcade emu - Final Burn Alpha (0.2.97.30) port for libretro"
 rp_module_menus="2+"
+rp_module_flags="!x86"
 
 function depends_lr-fba() {
     [[ "$__default_gcc_version" == "4.7" ]] && getDepends gcc-4.8 g++-4.8

--- a/scriptmodules/libretrocores/lr-gpsp.sh
+++ b/scriptmodules/libretrocores/lr-gpsp.sh
@@ -12,6 +12,7 @@
 rp_module_id="lr-gpsp"
 rp_module_desc="GBA emu - gpSP port for libretro"
 rp_module_menus="2+"
+rp_module_flags="!x86"
 
 function sources_lr-gpsp() {
     gitPullOrClone "$md_build" https://github.com/libretro/gpsp.git

--- a/scriptmodules/libretrocores/lr-imame4all.sh
+++ b/scriptmodules/libretrocores/lr-imame4all.sh
@@ -12,6 +12,7 @@
 rp_module_id="lr-imame4all"
 rp_module_desc="Arcade emu - iMAME4all (based on MAME 0.37b5) port for libretro"
 rp_module_menus="2+"
+rp_module_flags="!x86"
 
 function sources_lr-imame4all() {
     gitPullOrClone "$md_build" https://github.com/libretro/mame2000-libretro.git

--- a/scriptmodules/libretrocores/lr-mame2010.sh
+++ b/scriptmodules/libretrocores/lr-mame2010.sh
@@ -12,6 +12,7 @@
 rp_module_id="lr-mame2010"
 rp_module_desc="Arcade emu - MAME 0.139 port for libretro"
 rp_module_menus="4+"
+rp_module_flags="!x86"
 
 function depends_lr-mame2010() {
     [[ "$__default_gcc_version" == "4.7" ]] && getDepends gcc-4.8 g++-4.8

--- a/scriptmodules/libretrocores/lr-mgba.sh
+++ b/scriptmodules/libretrocores/lr-mgba.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-mgba"
 rp_module_desc="GBA emulator - MGBA (optimised) port for libretro"
 rp_module_menus="2+"
-rp_module_flags="!rpi1"
+rp_module_flags="!rpi1 !x86"
 
 function sources_lr-mgba() {
     gitPullOrClone "$md_build" https://github.com/libretro/mgba.git

--- a/scriptmodules/libretrocores/lr-mupen64plus.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-mupen64plus"
 rp_module_desc="N64 emu - Mupen64 Plus port for libretro"
 rp_module_menus="2+"
-rp_module_flags="!x86"
+rp_module_flags=""
 
 function sources_lr-mupen64plus() {
     gitPullOrClone "$md_build" https://github.com/libretro/mupen64plus-libretro.git
@@ -21,11 +21,14 @@ function sources_lr-mupen64plus() {
 function build_lr-mupen64plus() {
     rpSwap on 750
     make clean
-    if isPlatform "rpi2"; then
-        make platform=rpi2
-    else
-        make platform=rpi
-    fi
+    case "$__platform" in
+        rpi|rpi2)
+            make platform="$__platform"
+            ;;
+        *)
+            make
+            ;;
+    esac
     rpSwap off
     md_ret_require="$md_build/mupen64plus_libretro.so"
 }

--- a/scriptmodules/libretrocores/lr-mupen64plus.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus.sh
@@ -12,6 +12,7 @@
 rp_module_id="lr-mupen64plus"
 rp_module_desc="N64 emu - Mupen64 Plus port for libretro"
 rp_module_menus="2+"
+rp_module_flags="!x86"
 
 function sources_lr-mupen64plus() {
     gitPullOrClone "$md_build" https://github.com/libretro/mupen64plus-libretro.git

--- a/scriptmodules/libretrocores/lr-picodrive.sh
+++ b/scriptmodules/libretrocores/lr-picodrive.sh
@@ -12,6 +12,7 @@
 rp_module_id="lr-picodrive"
 rp_module_desc="Sega 8/16 bit emu - picodrive arm optimised libretro core"
 rp_module_menus="2+"
+rp_module_flags="!x86"
 
 function sources_lr-picodrive() {
     gitPullOrClone "$md_build" https://github.com/libretro/picodrive.git

--- a/scriptmodules/libretrocores/lr-picodrive.sh
+++ b/scriptmodules/libretrocores/lr-picodrive.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-picodrive"
 rp_module_desc="Sega 8/16 bit emu - picodrive arm optimised libretro core"
 rp_module_menus="2+"
-rp_module_flags="!x86"
+rp_module_flags=""
 
 function sources_lr-picodrive() {
     gitPullOrClone "$md_build" https://github.com/libretro/picodrive.git

--- a/scriptmodules/libretrocores/lr-picodrive.sh
+++ b/scriptmodules/libretrocores/lr-picodrive.sh
@@ -27,7 +27,7 @@ function build_lr-picodrive() {
             make -f Makefile.libretro platform=raspberrypi
             ;;
         *)
-            make
+            make -f Makefile.libretro
             ;;
     esac
     md_ret_require="$md_build/picodrive_libretro.so"

--- a/scriptmodules/libretrocores/lr-picodrive.sh
+++ b/scriptmodules/libretrocores/lr-picodrive.sh
@@ -22,7 +22,14 @@ function sources_lr-picodrive() {
 
 function build_lr-picodrive() {
     make clean
-    make -f Makefile.libretro platform=armv6
+    case "$__platform" in
+        rpi|rpi2)
+            make -f Makefile.libretro platform=raspberrypi
+            ;;
+        *)
+            make
+            ;;
+    esac
     md_ret_require="$md_build/picodrive_libretro.so"
 }
 

--- a/scriptmodules/libretrocores/lr-pocketsnes.sh
+++ b/scriptmodules/libretrocores/lr-pocketsnes.sh
@@ -12,6 +12,7 @@
 rp_module_id="lr-pocketsnes"
 rp_module_desc="SNES emu - ARM based SNES emulator for libretro"
 rp_module_menus="2+"
+rp_module_flags="!x86"
 
 function sources_lr-pocketsnes() {
     gitPullOrClone "$md_build" https://github.com/libretro/pocketsnes-libretro.git

--- a/scriptmodules/libretrocores/lr-ppsspp.sh
+++ b/scriptmodules/libretrocores/lr-ppsspp.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-ppsspp"
 rp_module_desc="PlayStation Portable emu - PPSSPP port for libretro"
 rp_module_menus="2+"
-rp_module_flags="!rpi1"
+rp_module_flags="!rpi1 !x86"
 
 function depends_lr-ppsspp() {
     getDepends libraspberrypi-dev

--- a/scriptmodules/libretrocores/lr-snes9x-next.sh
+++ b/scriptmodules/libretrocores/lr-snes9x-next.sh
@@ -22,7 +22,11 @@ function sources_lr-snes9x-next() {
 
 function build_lr-snes9x-next() {
     make -f Makefile.libretro clean
-    make -f Makefile.libretro platform=armvneon
+    if isPlatform "x86"; then
+        make -f Makefile.libretro
+    else
+        make -f Makefile.libretro platform=armvneon
+    fi
     md_ret_require="$md_build/snes9x_next_libretro.so"
 }
 

--- a/scriptmodules/libretrocores/lr-vba-next.sh
+++ b/scriptmodules/libretrocores/lr-vba-next.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-vba-next"
 rp_module_desc="GBA emulator - VBA-M (optimised) port for libretro"
 rp_module_menus="2+"
-rp_module_flags="!rpi1"
+rp_module_flags="!rpi1 !x86"
 
 function sources_lr-vba-next() {
     gitPullOrClone "$md_build" https://github.com/libretro/vba-next.git

--- a/scriptmodules/libretrocores/lr-vba-next.sh
+++ b/scriptmodules/libretrocores/lr-vba-next.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-vba-next"
 rp_module_desc="GBA emulator - VBA-M (optimised) port for libretro"
 rp_module_menus="2+"
-rp_module_flags="!rpi1 !x86"
+rp_module_flags="!rpi1"
 
 function sources_lr-vba-next() {
     gitPullOrClone "$md_build" https://github.com/libretro/vba-next.git
@@ -20,7 +20,14 @@ function sources_lr-vba-next() {
 
 function build_lr-vba-next() {
     make -f Makefile.libretro clean
-    make -f Makefile.libretro platform=armvhardfloatunix TILED_RENDERING=1 HAVE_NEON=1
+    case "$__platform" in
+        rpi2)
+            make -f Makefile.libretro platform=armvhardfloatunix TILED_RENDERING=1 HAVE_NEON=1
+            ;;
+        *)
+            make -f Makefile.libretro
+            ;;
+    esac
     md_ret_require="$md_build/vba_next_libretro.so"
 }
 

--- a/scriptmodules/libretrocores/lr-yabause.sh
+++ b/scriptmodules/libretrocores/lr-yabause.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-yabause"
 rp_module_desc="Sega Saturn emu - Yabause (optimised) port for libretro"
 rp_module_menus="4+"
-rp_module_flags="!rpi1 !x86"
+rp_module_flags="!rpi1"
 
 function sources_lr-yabause() {
     gitPullOrClone "$md_build" https://github.com/libretro/yabause.git
@@ -21,7 +21,14 @@ function sources_lr-yabause() {
 function build_lr-yabause() {
     cd libretro
     make clean
-    make platform=armvneonhardfloat
+    case "$__platform" in
+        rpi2)
+            make platform=armvneonhardfloat
+            ;;
+        *)
+            make
+            ;;
+    esac
     md_ret_require="$md_build/libretro/yabause_libretro.so"
 }
 

--- a/scriptmodules/libretrocores/lr-yabause.sh
+++ b/scriptmodules/libretrocores/lr-yabause.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-yabause"
 rp_module_desc="Sega Saturn emu - Yabause (optimised) port for libretro"
 rp_module_menus="4+"
-rp_module_flags="!rpi1"
+rp_module_flags="!rpi1 !x86"
 
 function sources_lr-yabause() {
     gitPullOrClone "$md_build" https://github.com/libretro/yabause.git

--- a/scriptmodules/ports/quake3.sh
+++ b/scriptmodules/ports/quake3.sh
@@ -12,6 +12,7 @@
 rp_module_id="quake3"
 rp_module_desc="Quake 3"
 rp_module_menus="2+"
+rp_module_flags="!x86"
 
 function depends_quake3() {
     getDepends libsdl1.2-dev

--- a/scriptmodules/supplementary/audiosettings.sh
+++ b/scriptmodules/supplementary/audiosettings.sh
@@ -12,7 +12,7 @@
 rp_module_id="audiosettings"
 rp_module_desc="Configure audio settings"
 rp_module_menus="3+"
-rp_module_flags="nobin"
+rp_module_flags="nobin !x86"
 
 function depends_audiosettings() {
     getDepends alsa-utils

--- a/scriptmodules/supplementary/autostart.sh
+++ b/scriptmodules/supplementary/autostart.sh
@@ -12,7 +12,7 @@
 rp_module_id="autostart"
 rp_module_desc="Auto-start EmulationStation"
 rp_module_menus="3+"
-rp_module_flags="nobin"
+rp_module_flags="nobin !x86"
 
 function enable_autostart() {
     if [[ "$__raspbian_ver" -lt "8" ]]; then

--- a/scriptmodules/supplementary/autostart.sh
+++ b/scriptmodules/supplementary/autostart.sh
@@ -34,7 +34,19 @@ _EOF_
 _EOF_
     else
         mkdir "$home/.config/autostart"
-        cp "/usr/share/applications/retropie.desktop" "$home/.config/autostart/"
+        cat >"$home/.config/autostart/retropie.desktop" <<_EOF_
+[Desktop Entry]
+Type=Application
+Exec=/opt/retropie/supplementary/emulationstation/emulationstation
+Hidden=false
+NoDisplay=false
+X-GNOME-Autostart-enabled=true
+Name[de_DE]=RetroPie
+Name=rpie
+Comment[de_DE]=RetroPie
+Comment=retropie
+X-GNOME-Autostart-Delay=25
+_EOF_
     fi
 }
 

--- a/scriptmodules/supplementary/dispmanx.sh
+++ b/scriptmodules/supplementary/dispmanx.sh
@@ -12,7 +12,7 @@
 rp_module_id="dispmanx"
 rp_module_desc="Configure emulators to use dispmanx SDL"
 rp_module_menus="3+"
-rp_module_flags="nobin !odroid"
+rp_module_flags="nobin !odroid !x86"
 
 function configure_dispmanx() {
     iniConfig "=" "\"" "$configdir/all/dispmanx.cfg"

--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -71,7 +71,7 @@ if [[ \$(id -u) -eq 0 ]]; then
     exit 1
 fi
 
-if [[ "$(uname --machine)" != "x86" ]]; then
+if [[ "\$(uname --machine)" != "x86" ]]; then
     if [[ -n "\$(pidof X)" ]]; then
         echo "X is running. Please shut down X in order to mitigate problems with loosing keyboard input. For example, logout from LXDE."
         exit 1

--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -61,7 +61,10 @@ _EOF_
 }
 
 function configure_emulationstation() {
-    cat > /usr/bin/emulationstation << _EOF_
+    if isPlatform "x86"; then
+        ln -sf "$md_inst/emulationstation" "/usr/bin/emulationstation"
+    else
+        cat > /usr/bin/emulationstation << _EOF_
 #!/bin/bash
 
 es_bin="$md_inst/emulationstation"
@@ -83,14 +86,15 @@ while [[ -z "\$key" ]]; do
     IFS= read -s -t 5 -N 1 key </dev/tty
 done
 _EOF_
-    chmod +x /usr/bin/emulationstation
+        # make sure that ES has enough GPU memory
+        iniConfig "=" "" /boot/config.txt
+        iniSet "gpu_mem_256" 128
+        iniSet "gpu_mem_512" 256
+        iniSet "gpu_mem_1024" 256
+        iniSet "overscan_scale" 1
+    fi
 
-    # make sure that ES has enough GPU memory
-    iniConfig "=" "" /boot/config.txt
-    iniSet "gpu_mem_256" 128
-    iniSet "gpu_mem_512" 256
-    iniSet "gpu_mem_1024" 256
-    iniSet "overscan_scale" 1
+    chmod +x /usr/bin/emulationstation
 
     mkdir -p "/etc/emulationstation"
 

--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -12,6 +12,7 @@
 rp_module_id="emulationstation"
 rp_module_desc="EmulationStation"
 rp_module_menus="2+"
+rp_module_flags="!x86"
 
 function depends_emulationstation() {
     getDepends \
@@ -61,10 +62,7 @@ _EOF_
 }
 
 function configure_emulationstation() {
-    if isPlatform "x86"; then
-        ln -sf "$md_inst/emulationstation" "/usr/bin/emulationstation"
-    else
-        cat > /usr/bin/emulationstation << _EOF_
+    cat > /usr/bin/emulationstation << _EOF_
 #!/bin/bash
 
 es_bin="$md_inst/emulationstation"
@@ -74,9 +72,11 @@ if [[ \$(id -u) -eq 0 ]]; then
     exit 1
 fi
 
-if [[ -n "\$(pidof X)" ]]; then
-    echo "X is running. Please shut down X in order to mitigate problems with loosing keyboard input. For example, logout from LXDE."
-    exit 1
+if [[ "$(uname --machine)" != "x86" ]]; then
+    if [[ -n "\$(pidof X)" ]]; then
+        echo "X is running. Please shut down X in order to mitigate problems with loosing keyboard input. For example, logout from LXDE."
+        exit 1
+    fi
 fi
 
 key=""
@@ -86,6 +86,7 @@ while [[ -z "\$key" ]]; do
     IFS= read -s -t 5 -N 1 key </dev/tty
 done
 _EOF_
+    if [[ isPlatform "rpi1" || isPlatform "rpi2" ]]; then
         # make sure that ES has enough GPU memory
         iniConfig "=" "" /boot/config.txt
         iniSet "gpu_mem_256" 128

--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -71,7 +71,7 @@ if [[ \$(id -u) -eq 0 ]]; then
     exit 1
 fi
 
-if [[ "\$(uname --machine)" != "i686" ]]; then
+if [[ "\$(uname --machine)" != *86* ]]; then
     if [[ -n "\$(pidof X)" ]]; then
         echo "X is running. Please shut down X in order to mitigate problems with loosing keyboard input. For example, logout from LXDE."
         exit 1
@@ -92,6 +92,18 @@ _EOF_
         iniSet "gpu_mem_512" 256
         iniSet "gpu_mem_1024" 256
         iniSet "overscan_scale" 1
+    else
+        cat > /usr/share/applications/retropie.desktop << _EOF_
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=RetroPie
+Comment=RetroPie
+Path=/usr/bin
+Exec=emulationstation
+Terminal=true
+Categories=Game
+_EOF_
     fi
 
     chmod +x /usr/bin/emulationstation

--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -12,7 +12,6 @@
 rp_module_id="emulationstation"
 rp_module_desc="EmulationStation"
 rp_module_menus="2+"
-rp_module_flags="!x86"
 
 function depends_emulationstation() {
     getDepends \

--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -71,7 +71,7 @@ if [[ \$(id -u) -eq 0 ]]; then
     exit 1
 fi
 
-if [[ "\$(uname --machine)" != "x86" ]]; then
+if [[ "\$(uname --machine)" != "i686" ]]; then
     if [[ -n "\$(pidof X)" ]]; then
         echo "X is running. Please shut down X in order to mitigate problems with loosing keyboard input. For example, logout from LXDE."
         exit 1
@@ -85,7 +85,7 @@ while [[ -z "\$key" ]]; do
     IFS= read -s -t 5 -N 1 key </dev/tty
 done
 _EOF_
-    if [[ isPlatform "rpi1" || isPlatform "rpi2" ]]; then
+    if [[ "$__platform" == *rpi* ]]; then
         # make sure that ES has enough GPU memory
         iniConfig "=" "" /boot/config.txt
         iniSet "gpu_mem_256" 128

--- a/scriptmodules/supplementary/raspbiantools.sh
+++ b/scriptmodules/supplementary/raspbiantools.sh
@@ -12,7 +12,7 @@
 rp_module_id="raspbiantools"
 rp_module_desc="Raspbian related tools"
 rp_module_menus="3+"
-rp_module_flags="nobin"
+rp_module_flags="nobin !x86"
 
 function apt_upgrade_raspbiantools() {
     aptUpdate

--- a/scriptmodules/supplementary/retropiemenu.sh
+++ b/scriptmodules/supplementary/retropiemenu.sh
@@ -12,7 +12,7 @@
 rp_module_id="retropiemenu"
 rp_module_desc="RetroPie configuration menu for EmulationStation"
 rp_module_menus="3+"
-rp_module_flags="nobin !x86"
+rp_module_flags="nobin"
 
 function depends_retropiemenu() {
     getDepends mc
@@ -23,19 +23,29 @@ function configure_retropiemenu()
     local rpdir="$home/RetroPie/retropiemenu"
     mkdir -p "$rpdir"
 
-    files=(
-        'raspiconfig.rp'
-        'rpsetup.rp'
-        'configedit.rp'
-        'retroarch.rp'
-        'audiosettings.rp'
-        'dispmanx.rp'
-        'retronetplay.rp'
-        'splashscreen.rp'
-        'filemanager.rp'
-        'showip.rp'
-        'wifi.rp'
-    )
+    if [[ isPlatform "x86" ]]; then
+        files=(
+            'rpsetup.rp'
+            'configedit.rp'
+            'retroarch.rp'
+            'retronetplay.rp'
+            'filemanager.rp'
+        )
+    else
+        files=(
+            'raspiconfig.rp'
+            'rpsetup.rp'
+            'configedit.rp'
+            'retroarch.rp'
+            'audiosettings.rp'
+            'dispmanx.rp'
+            'retronetplay.rp'
+            'splashscreen.rp'
+            'filemanager.rp'
+            'showip.rp'
+            'wifi.rp'
+        )
+    fi
 
     for file in "${files[@]}"; do
         touch "$rpdir/$file"

--- a/scriptmodules/supplementary/retropiemenu.sh
+++ b/scriptmodules/supplementary/retropiemenu.sh
@@ -23,7 +23,7 @@ function configure_retropiemenu()
     local rpdir="$home/RetroPie/retropiemenu"
     mkdir -p "$rpdir"
 
-    if [[ isPlatform "x86" ]]; then
+    if isPlatform "x86"; then
         files=(
             'rpsetup.rp'
             'configedit.rp'

--- a/scriptmodules/supplementary/retropiemenu.sh
+++ b/scriptmodules/supplementary/retropiemenu.sh
@@ -12,7 +12,7 @@
 rp_module_id="retropiemenu"
 rp_module_desc="RetroPie configuration menu for EmulationStation"
 rp_module_menus="3+"
-rp_module_flags="nobin"
+rp_module_flags="nobin !x86"
 
 function depends_retropiemenu() {
     getDepends mc

--- a/scriptmodules/supplementary/sdl1.sh
+++ b/scriptmodules/supplementary/sdl1.sh
@@ -12,7 +12,7 @@
 rp_module_id="sdl1"
 rp_module_desc="SDL 1.2.15 with rpi fixes and dispmanx"
 rp_module_menus=""
-rp_module_flags="!odroid nobin"
+rp_module_flags="!odroid nobin !x86"
 
 function get_ver_sdl1() {
     if [[ "$__raspbian_ver" -lt "8" ]]; then

--- a/scriptmodules/supplementary/sdl2.sh
+++ b/scriptmodules/supplementary/sdl2.sh
@@ -12,7 +12,7 @@
 rp_module_id="sdl2"
 rp_module_desc="SDL (Simple DirectMedia Layer) v2.x"
 rp_module_menus=""
-rp_module_flags="nobin"
+rp_module_flags="nobin !x86"
 
 function get_ver_sdl2() {
     echo "2.0.3+1rpi"

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -28,7 +28,7 @@ function setup_env() {
             *)
                 local architecture=$(uname --machine)
                 case $architecture in
-                    i686 x86_64)
+                    i686|x86_64)
                         __platform="x86"
                         ;;
                 esac

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -183,6 +183,6 @@ function platform_odroid() {
 function platform_x86() {
     __default_cflags="-O2"
     __default_asflags=""
-    __default_makeflags=""
+    __default_makeflags="-j2"
     __has_binaries=0
 }

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -183,6 +183,6 @@ function platform_odroid() {
 function platform_x86() {
     __default_cflags="-O2"
     __default_asflags=""
-    __default_makeflags="-j2"
+    __default_makeflags="-j$(nproc)"
     __has_binaries=0
 }

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -31,6 +31,7 @@ function setup_env() {
                     i686)
                         __platform="x86"
                         ;;
+                esac
                 ;;
         esac
     fi

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -25,6 +25,13 @@ function setup_env() {
             BCM2709)
                 __platform="rpi2"
                 ;;
+            *)
+                local architecture=$(uname --machine)
+                case $architecture in
+                    i686)
+                        __platform="x86"
+                        ;;
+                ;;
         esac
     fi
 
@@ -167,6 +174,13 @@ function platform_rpi2() {
 
 function platform_odroid() {
     __default_cflags="-O2 -mfpu=neon -march=armv7-a -mfloat-abi=hard"
+    __default_asflags=""
+    __default_makeflags=""
+    __has_binaries=0
+}
+
+function platform_x86() {
+    __default_cflags="-O2"
     __default_asflags=""
     __default_makeflags=""
     __has_binaries=0

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -28,7 +28,7 @@ function setup_env() {
             *)
                 local architecture=$(uname --machine)
                 case $architecture in
-                    i686)
+                    i686 x86_64)
                         __platform="x86"
                         ;;
                 esac


### PR DESCRIPTION
https://github.com/RetroPie/RetroPie-Setup/issues/1148

@joolswills @HerbFargus 
I don't see any problem using this alongside with rpi platforms. Please take a look if i have missed something. Retroarch cores (vba-next, snes9x-next, gambatte, genesis-plus-gx, etc.) and emulationstation run under an emulated x86 Debian Jessie, X11 and OpenGL support. 