### PR TITLE
emulationstation: swap a/b buttons

### DIFF
--- a/scriptmodules/supplementary/emulationstation/configscripts/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/emulationstation.sh
@@ -54,8 +54,14 @@ function map_emulationstation_joystick() {
         rightbottom)
             key="pagedown"
             ;;
-        up|right|down|left|a|b|start|select)
+        up|right|down|left|start|select)
             key="$input_name"
+            ;;
+        a)
+            key="b"
+            ;;
+        b)
+            key="a"
             ;;
         *)
             return


### PR DESCRIPTION
Swap a/b buttons for modern controllers:
a = ok = X (Playstation) = A (XBOX)
b = abort = O (Playstation) = B (XBOX)

Old mapping is:
a = ok = O (Playstation) = B (XBOX)
b = abort = X (Playstation) = A (XBOX)