### PR TITLE
Use safer range expression in get_save_vars

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -88,7 +88,7 @@ function get_params() {
 function get_save_vars() {
     # convert emulator name / binary to a names usable as variables in our config files
     save_emu=${emulator//\//_}
-    save_emu=${save_emu//[^a-Z0-9_\-]/}
+    save_emu=${save_emu//[^a-zA-Z0-9_\-]/}
     save_emu_render="${save_emu}_render"
     fb_save_emu="${save_emu}_fb"
     save_rom=r$(echo "$command" | md5sum | cut -d" " -f1)


### PR DESCRIPTION
a-Z depends on LC_COLLATE or LC_ALL and can produce weird bugs if user
have set there something other than what we're using by default.

a-zA-Z should work just everywhere.

Fixes #1166 and mcobit/retrosmc#14