### PR TITLE
Add dependency for unzip in OpenTyrian port

### DIFF
--- a/scriptmodules/ports/opentyrian.sh
+++ b/scriptmodules/ports/opentyrian.sh
@@ -15,7 +15,7 @@ rp_module_menus="4+"
 rp_module_flags="dispmanx !odroid"
 
 function depends_opentyrian() {
-    getDepends libsdl1.2-dev libsdl-net1.2-dev mercurial
+    getDepends libsdl1.2-dev libsdl-net1.2-dev mercurial unzip
 }
 
 function sources_opentyrian() {


### PR DESCRIPTION
This will force the installation script to use proper version of unzip on systems using other implementations (e.g. busybox unzip).