### PR TITLE
emulationstation: fix shutdown/restart

### DIFF
--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -124,4 +124,8 @@ _EOF_
     mkdir -p "/etc/emulationstation"
 
     configure_inputconfig_emulationstation
+    
+    # run sudo without password so emulationstation can shutdown and restart system
+    local file="/etc/sudoers"
+    grep -q "$user" $file || echo "$user ALL=(ALL) NOPASSWD:ALL" >> $file
 }


### PR DESCRIPTION
If sudo requests a password (raspbian user !pi or debian/ubuntu) emulationstation cannot shutdown or restart a system. Sudo is hardcoded. Emulationstation expects sudo without
password request. https://github.com/Aloshi/EmulationStation/blob/646bede3d9ec0acf0ae37841
5edac136774a66c5/es-core/src/platform.cpp#L47