### PR TITLE
[xboxdrv.sh] Added user-configurable analog deadzones and number of controllers to enable.

### DIFF
--- a/scriptmodules/supplementary/xboxdrv.sh
+++ b/scriptmodules/supplementary/xboxdrv.sh
@@ -31,7 +31,21 @@ function install_xboxdrv() {
 }
 
 function enable_xboxdrv() {
-    local config="\"$md_inst/bin/xboxdrv\" --daemon --detach --dbus disabled --detach-kernel-driver --id 0 --led 2 --deadzone 4000 --silent --trigger-as-button --next-controller --id 1 --led 3 --deadzone 4000 --silent --trigger-as-button"
+    if [[ -n "$1" ]]; then
+
+        # Because function return codes are limited to 0-255 range, we could not leave this calculation in the deadzone_xboxdrv routine or we'd get weird results.
+        local deadzone="$((($2-1) * 500))"
+
+	local config="\"$md_inst/bin/xboxdrv\" --daemon --detach --dbus disabled --detach-kernel-driver --id 0 --led 2 --deadzone $deadzone --silent --trigger-as-button"
+        local loop="1"
+
+	while [ "$loop" -lt "$1" ]
+        do
+            config+=" --next-controller --id $loop --led $(($loop+2)) --deadzone $deadzone --silent --trigger-as-button"
+            loop=$(($loop+1))
+        done
+    fi
+    
     if ! grep -q "xboxdrv" /etc/rc.local; then
         sed -i "s|^exit 0$|${config}\\nexit 0|" /etc/rc.local
         printMsgs "dialog" "xboxdrv enabled in /etc/rc.local with the following config\n\n$config\n\nIt will be started on next boot."
@@ -45,6 +59,60 @@ function disable_xboxdrv() {
     printMsgs "dialog" "xboxdrv configuration in /etc/rc.local has been removed."
 }
 
+function numcontrollers_xboxdrv() {
+    local controllers="$1"
+    local cmd=(dialog --backtitle "$__backtitle" --default-item "2" --menu "Select the number of controllers to enable" 22 86 16)
+    local options=(
+        1 "1 controller"
+        2 "2 controllers"
+        3 "3 controllers"
+        4 "4 controllers"
+    )
+
+    while true; do
+        local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
+        if [[ -n "$choice" ]]; then
+            controllers="$choice"
+            break
+        else
+            break
+        fi
+    done
+    return "$controllers"
+}
+
+function deadzone_xboxdrv() {
+    local deadzone="$1"
+    local cmd=(dialog --backtitle "$__backtitle" --default-item "9" --menu "Select range of your analog stick deadzone" 22 86 16)
+    local options=(
+        1 "No Deadzone"
+        2 "0-500"
+        3 "0-1000"
+        4 "0-1500"
+        5 "0-2000"
+        6 "0-2500"
+        7 "0-3000"
+        8 "0-3500"
+        9 "0-4000"
+       10 "0-4500"
+       11 "0-5000"
+       12 "0-5500"
+       13 "0-6000"
+    )
+
+    while true; do
+        local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
+        if [[ -n "$choice" ]]; then
+            deadzone="$choice"
+            break
+        else
+            break
+        fi
+    done
+    return "$deadzone"
+}
+
+
 function configure_xboxdrv() {
     # make sure existing configs will point to the new xboxdrv
     sed -i "s|^xboxdrv|\"$md_inst/bin/xboxdrv\"|" /etc/rc.local
@@ -57,31 +125,43 @@ function gui_xboxdrv() {
         rp_callModule "$md_id" configure
     fi
     iniConfig "=" "" "/boot/config.txt"
+    local controllers_wanted="2"
+    local deadzone_wanted="9"
 
     local cmd=(dialog --backtitle "$__backtitle" --menu "Choose an option." 22 86 16)
     local options=(
         1 "Enable xboxdrv"
         2 "Disable xboxdrv"
-        3 "Set dwc_otg.speed=1 in /boot/config.txt"
-        4 "Remove dwc_otg.speed=1 from /boot/config.txt"
+        3 "Set number of controllers to enable"
+        4 "Set analog stick deadzone"
+        5 "Set dwc_otg.speed=1 in /boot/config.txt"
+        6 "Remove dwc_otg.speed=1 from /boot/config.txt"
     )
-    iniConfig "=" "" "/boot/config.txt"
+
     while true; do
         local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
         if [[ -n "$choice" ]]; then
 
             case $choice in
                 1)
-                    enable_xboxdrv
+                    enable_xboxdrv "$controllers_wanted" "$deadzone_wanted"
                     ;;
                 2)
                     disable_xboxdrv
                     ;;
                 3)
+                    numcontrollers_xboxdrv "$controllers_wanted"
+                    controllers_wanted="$?"
+                    ;;
+                4)
+                    deadzone_xboxdrv "$deadzone_wanted"
+                    deadzone_wanted="$?"
+                    ;;
+                5)
                     iniSet "dwc_otg.speed" "1"
                     printMsgs "dialog" "dwc_otg.speed=1 has been set in /boot/config.txt"
                     ;;
-                4)
+                6)
                     iniDel "dwc_otg.speed"
                     printMsgs "dialog" "dwc_otg.speed=1 has been removed from /boot/config.txt"
                     ;;


### PR DESCRIPTION
Added new menu items to the xboxdrv.sh scriptmodule:

* Number of controllers to attempt to enable (default: 2)
* Size of analog deadzone to use for all controllers (default: 4000)