### PR TITLE
Platform flags

### DIFF
--- a/scriptmodules/emulators/advmame.sh
+++ b/scriptmodules/emulators/advmame.sh
@@ -139,7 +139,7 @@ function configure_advmame() {
         iniSet "device_keyboard" "raw"
         iniSet "device_sound" "alsa"
         iniSet "display_vsync" "no"
-        if isPlatform "rpi1"; then
+        if isPlatform "armv6"; then
             iniSet "sound_samplerate" "22050"
         else
             iniSet "sound_samplerate" "44100"

--- a/scriptmodules/emulators/advmame.sh
+++ b/scriptmodules/emulators/advmame.sh
@@ -12,7 +12,7 @@
 rp_module_id="advmame"
 rp_module_desc="AdvanceMAME"
 rp_module_menus="2+"
-rp_module_flags="!x86 !odroid"
+rp_module_flags="!x86 !mali"
 
 function depends_advmame() {
     getDepends libsdl1.2-dev

--- a/scriptmodules/emulators/ags.sh
+++ b/scriptmodules/emulators/ags.sh
@@ -12,7 +12,7 @@
 rp_module_id="ags"
 rp_module_desc="Adventure Game Studio - Adventure game engine"
 rp_module_menus="4+"
-rp_module_flags="!x86 !odroid"
+rp_module_flags="!x86 !mali"
 
 function depends_ags() {
     getDepends pkg-config liballegro4.2-dev libaldmb1-dev libfreetype6-dev libtheora-dev libvorbis-dev libogg-dev

--- a/scriptmodules/emulators/atari800.sh
+++ b/scriptmodules/emulators/atari800.sh
@@ -12,7 +12,7 @@
 rp_module_id="atari800"
 rp_module_desc="Atari 8-bit/800/5200 emulator"
 rp_module_menus="2+"
-rp_module_flags="!x86 !odroid"
+rp_module_flags="!x86 !mali"
 
 function depends_atari800() {
     getDepends libsdl1.2-dev autoconf libraspberrypi-dev zlib1g-dev libpng12-dev

--- a/scriptmodules/emulators/basilisk.sh
+++ b/scriptmodules/emulators/basilisk.sh
@@ -12,7 +12,7 @@
 rp_module_id="basilisk"
 rp_module_desc="Macintosh emulator"
 rp_module_menus="2+"
-rp_module_flags="dispmanx !x86 !odroid"
+rp_module_flags="dispmanx !x86 !mali"
 
 function depends_basilisk() {
     getDepends libsdl1.2-dev autoconf automake

--- a/scriptmodules/emulators/capricerpi.sh
+++ b/scriptmodules/emulators/capricerpi.sh
@@ -12,7 +12,7 @@
 rp_module_id="capricerpi"
 rp_module_desc="Amstrad CPC emulator - port of Caprice32 for the RPI"
 rp_module_menus="2+"
-rp_module_flags="dispmanx !x86 !odroid"
+rp_module_flags="dispmanx !x86 !mali"
 
 function depends_capricerpi() {
     getDepends libsdl1.2-dev zlib1g-dev

--- a/scriptmodules/emulators/dgen.sh
+++ b/scriptmodules/emulators/dgen.sh
@@ -12,7 +12,7 @@
 rp_module_id="dgen"
 rp_module_desc="Megadrive/Genesis emulat. DGEN"
 rp_module_menus="2+"
-rp_module_flags="dispmanx !x86 !odroid"
+rp_module_flags="dispmanx !x86 !mali"
 
 function depends_dgen() {
     getDepends libsdl1.2-dev libarchive-dev

--- a/scriptmodules/emulators/dosbox.sh
+++ b/scriptmodules/emulators/dosbox.sh
@@ -12,7 +12,7 @@
 rp_module_id="dosbox"
 rp_module_desc="DOS emulator"
 rp_module_menus="2+"
-rp_module_flags="dispmanx !x86 !odroid"
+rp_module_flags="dispmanx !x86 !mali"
 
 function depends_dosbox() {
     getDepends libsdl1.2-dev libsdl-net1.2-dev libsdl-sound1.2-dev libasound2-dev libpng12-dev automake autoconf zlib1g-dev

--- a/scriptmodules/emulators/fbzx.sh
+++ b/scriptmodules/emulators/fbzx.sh
@@ -12,7 +12,7 @@
 rp_module_id="fbzx"
 rp_module_desc="ZXSpectrum emulator FBZX"
 rp_module_menus="2+"
-rp_module_flags="dispmanx !x86 !odroid"
+rp_module_flags="dispmanx !x86 !mali"
 
 function depends_fbzx() {
     getDepends libasound2-dev libsdl1.2-dev

--- a/scriptmodules/emulators/frotz.sh
+++ b/scriptmodules/emulators/frotz.sh
@@ -12,7 +12,7 @@
 rp_module_id="frotz"
 rp_module_desc="Z-Machine Interpreter for Infocom games"
 rp_module_menus="2+"
-rp_module_flags="nobin !x86 !odroid"
+rp_module_flags="nobin !x86 !mali"
 
 function install_frotz() {
     aptInstall frotz

--- a/scriptmodules/emulators/fuse.sh
+++ b/scriptmodules/emulators/fuse.sh
@@ -12,7 +12,7 @@
 rp_module_id="fuse"
 rp_module_desc="ZX Spectrum emulator Fuse"
 rp_module_menus="2+"
-rp_module_flags="dispmanx !x86 !odroid"
+rp_module_flags="dispmanx !x86 !mali"
 
 function depends_fuse() {
     getDepends libsdl1.2-dev libpng12-dev zlib1g-dev libbz2-dev libaudiofile-dev bison flex 

--- a/scriptmodules/emulators/gngeopi.sh
+++ b/scriptmodules/emulators/gngeopi.sh
@@ -12,7 +12,7 @@
 rp_module_id="gngeopi"
 rp_module_desc="NeoGeo emulator GnGeoPi"
 rp_module_menus="2+"
-rp_module_flags="!x86 !odroid"
+rp_module_flags="!x86 !mali"
 
 function depends_gngeopi() {
     getDepends libsdl1.2-dev

--- a/scriptmodules/emulators/gpsp.sh
+++ b/scriptmodules/emulators/gpsp.sh
@@ -12,7 +12,7 @@
 rp_module_id="gpsp"
 rp_module_desc="GameBoy Advance emulator"
 rp_module_menus="2+"
-rp_module_flags="!x86 !odroid"
+rp_module_flags="!x86 !mali"
 
 function depends_gpsp() {
     getDepends libsdl1.2-dev libraspberrypi-dev

--- a/scriptmodules/emulators/hatari.sh
+++ b/scriptmodules/emulators/hatari.sh
@@ -12,7 +12,7 @@
 rp_module_id="hatari"
 rp_module_desc="Atari emulator Hatari"
 rp_module_menus="2+"
-rp_module_flags="!x86 !odroid"
+rp_module_flags="!x86 !mali"
 
 function depends_hatari() {
     getDepends libsdl2-dev zlib1g-dev libpng12-dev cmake libreadline-dev portaudio19-dev

--- a/scriptmodules/emulators/jzintv.sh
+++ b/scriptmodules/emulators/jzintv.sh
@@ -12,7 +12,7 @@
 rp_module_id="jzintv"
 rp_module_desc="Intellivision emulator"
 rp_module_menus="2+"
-rp_module_flags="dispmanx !x86 !odroid"
+rp_module_flags="dispmanx !x86 !mali"
 
 function depends_jzintv() {
     getDepends libsdl1.2-dev

--- a/scriptmodules/emulators/linapple.sh
+++ b/scriptmodules/emulators/linapple.sh
@@ -12,7 +12,7 @@
 rp_module_id="linapple"
 rp_module_desc="Apple 2 emulator LinApple"
 rp_module_menus="2+"
-rp_module_flags="dispmanx !x86 !odroid"
+rp_module_flags="dispmanx !x86 !mali"
 
 function depends_linapple() {
     getDepends libzip2 libzip-dev libsdl1.2-dev libcurl4-openssl-dev

--- a/scriptmodules/emulators/mame4all.sh
+++ b/scriptmodules/emulators/mame4all.sh
@@ -12,7 +12,7 @@
 rp_module_id="mame4all"
 rp_module_desc="MAME emulator MAME4All-Pi"
 rp_module_menus="2+"
-rp_module_flags="!x86 !odroid"
+rp_module_flags="!x86 !mali"
 
 function depends_mame4all() {
     getDepends libasound2-dev libsdl1.2-dev libraspberrypi-dev

--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -12,7 +12,7 @@
 rp_module_id="mupen64plus"
 rp_module_desc="N64 emulator MUPEN64Plus"
 rp_module_menus="2+"
-rp_module_flags="!odroid"
+rp_module_flags="!mali"
 
 function depends_mupen64plus() {
     getDepends cmake libgl1-mesa-dev libsamplerate0-dev libspeexdsp-dev libsdl2-dev

--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -28,20 +28,17 @@ function sources_mupen64plus() {
         'mupen64plus input-sdl'
         'mupen64plus rsp-hle'
     )
-    case "$__platform" in
-        rpi1|rpi2)
-            repos+=(
-                'gizmo98 audio-omx'
-                'ricrpi video-gles2rice pandora-backport'
-                'ricrpi video-gles2n64'
-            )
-            ;;
-        x86)
-            repos+=(
-                'mupen64plus video-glide64mk2'
-            )
-            ;;
-    esac
+    if isPlatform "rpi"; then
+        repos+=(
+            'gizmo98 audio-omx'
+            'ricrpi video-gles2rice pandora-backport'
+            'ricrpi video-gles2n64'
+        )
+    else
+        repos+=(
+            'mupen64plus video-glide64mk2'
+        )
+    fi
     local repo
     local dir
     for repo in "${repos[@]}"; do
@@ -51,7 +48,7 @@ function sources_mupen64plus() {
     done
     gitPullOrClone "$md_build/GLideN64" https://github.com/gonetz/GLideN64.git
     # fix for static x86_64 libs found in repo which are not usefull if target is i686 
-    isPlatform "x86" && sed -i "s/BCMHOST/UNIX/g" GLideN64/src/GLideNHQ/CMakeLists.txt
+    ! isPlatform "rpi" && sed -i "s/BCMHOST/UNIX/g" GLideN64/src/GLideNHQ/CMakeLists.txt
 }
 
 function build_mupen64plus() {
@@ -92,20 +89,17 @@ function build_mupen64plus() {
         'mupen64plus-rsp-hle/projects/unix/mupen64plus-rsp-hle.so'
         'GLideN64/projects/cmake/plugin/release/mupen64plus-video-GLideN64.so'
     )
-    case "$__platform" in
-        rpi1|rpi2)
-            md_ret_require+=(
-                'mupen64plus-video-gles2rice/projects/unix/mupen64plus-video-rice.so'
-                'mupen64plus-video-gles2n64/projects/unix/mupen64plus-video-n64.so'
-                'mupen64plus-audio-omx/projects/unix/mupen64plus-audio-omx.so'
-            )
-            ;;
-        x86)
-            md_ret_require+=(
-                'mupen64plus-video-glide64mk2/projects/unix/mupen64plus-video-glide64mk2.so'
-            )
-            ;;
-    esac
+    if isPlatform "rpi"; then
+        md_ret_require+=(
+            'mupen64plus-video-gles2rice/projects/unix/mupen64plus-video-rice.so'
+            'mupen64plus-video-gles2n64/projects/unix/mupen64plus-video-n64.so'
+            'mupen64plus-audio-omx/projects/unix/mupen64plus-audio-omx.so'
+        )
+    else
+        md_ret_require+=(
+            'mupen64plus-video-glide64mk2/projects/unix/mupen64plus-video-glide64mk2.so'
+        )
+    fi
 }
 
 function install_mupen64plus() {
@@ -146,15 +140,12 @@ function configure_mupen64plus() {
 
     delSystem "$md_id" "n64-mupen64plus"
     addSystem 0 "${md_id}-GLideN64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM%"
-    case "$__platform" in
-        rpi1|rpi2)
-            addSystem 1 "${md_id}-gles2rice" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-rice %ROM%"
-            addSystem 0 "${md_id}-gles2n64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-n64 %ROM%"
-            ;;
-        x86)
-            addSystem 1 "${md_id}-glide64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-glide64mk2 %ROM%"
-            ;;
-    esac
+    if isPlatform "rpi"; then
+        addSystem 1 "${md_id}-gles2rice" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-rice %ROM%"
+        addSystem 0 "${md_id}-gles2n64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-n64 %ROM%"
+    else
+        addSystem 1 "${md_id}-glide64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-glide64mk2 %ROM%"
+    fi
 
     addAutoConf mupen64plus_audio 1
     addAutoConf mupen64plus_hotkeys 1

--- a/scriptmodules/emulators/openmsx.sh
+++ b/scriptmodules/emulators/openmsx.sh
@@ -12,7 +12,7 @@
 rp_module_id="openmsx"
 rp_module_desc="MSX emulator OpenMSX"
 rp_module_menus="4+"
-rp_module_flags="!x86 !odroid"
+rp_module_flags="!x86 !mali"
 
 function depends_openmsx() {
     getDepends libsdl1.2-dev libsdl-ttf2.0-dev libglew-dev libao-dev libogg-dev libtheora-dev libxml2-dev libvorbis-dev tcl-dev

--- a/scriptmodules/emulators/osmose.sh
+++ b/scriptmodules/emulators/osmose.sh
@@ -12,7 +12,7 @@
 rp_module_id="osmose"
 rp_module_desc="Gamegear emulator Osmose"
 rp_module_menus="2+"
-rp_module_flags="!x86 !odroid"
+rp_module_flags="!x86 !mali"
 
 function depends_osmose() {
     getDepends libsdl1.2-dev

--- a/scriptmodules/emulators/pcsx-rearmed.sh
+++ b/scriptmodules/emulators/pcsx-rearmed.sh
@@ -12,7 +12,7 @@
 rp_module_id="pcsx-rearmed"
 rp_module_desc="Playstation emulator - PCSX (arm optimised)"
 rp_module_menus="4+"
-rp_module_flags="dispmanx !x86 !odroid"
+rp_module_flags="dispmanx !x86 !mali"
 
 function depends_pcsx-rearmed() {
     getDepends libsdl1.2-dev libasound2-dev libpng12-dev libx11-dev

--- a/scriptmodules/emulators/pifba.sh
+++ b/scriptmodules/emulators/pifba.sh
@@ -12,7 +12,7 @@
 rp_module_id="pifba"
 rp_module_desc="FBA emulator PiFBA"
 rp_module_menus="2+"
-rp_module_flags="!x86 !odroid"
+rp_module_flags="!x86 !mali"
 
 function depends_pifba() {
     getDepends libasound2-dev libsdl1.2-dev libraspberrypi-dev

--- a/scriptmodules/emulators/pisnes.sh
+++ b/scriptmodules/emulators/pisnes.sh
@@ -12,7 +12,7 @@
 rp_module_id="pisnes"
 rp_module_desc="SNES emulator PiSNES"
 rp_module_menus="2+"
-rp_module_flags="!x86 !odroid"
+rp_module_flags="!x86 !mali"
 
 function depends_pisnes() {
     getDepends libasound2-dev libsdl1.2-dev libraspberrypi-dev

--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -12,7 +12,7 @@
 rp_module_id="ppsspp"
 rp_module_desc="PlayStation Portable emulator PPSSPP"
 rp_module_menus="2+"
-rp_module_flags="!rpi1 !x86 !odroid"
+rp_module_flags="!armv6 !x86 !mali"
 
 function depends_ppsspp() {
     getDepends cmake libraspberrypi-dev libsdl2-dev

--- a/scriptmodules/emulators/px68k.sh
+++ b/scriptmodules/emulators/px68k.sh
@@ -12,7 +12,7 @@
 rp_module_id="px68k"
 rp_module_desc="SHARP X68000 Emulator"
 rp_module_menus="4+"
-rp_module_flags="!x86 !odroid"
+rp_module_flags="!x86 !mali"
 
 function depends_px68k() {
     getDepends libsdl1.2-dev libsdl-gfx1.2-dev

--- a/scriptmodules/emulators/reicast.sh
+++ b/scriptmodules/emulators/reicast.sh
@@ -12,7 +12,7 @@
 rp_module_id="reicast"
 rp_module_desc="Dreamcast emulator Reicast"
 rp_module_menus="2+"
-rp_module_flags="!rpi1 !odroid"
+rp_module_flags="!armv6 !mali"
 
 function depends_reicast() {
     getDepends libsdl1.2-dev python-dev python-pip alsa-oss

--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -16,7 +16,7 @@ rp_module_menus="2+"
 function depends_retroarch() {
     local depends=(libudev-dev libxkbcommon-dev libsdl2-dev)
     isPlatform "rpi" && depends+=(libraspberrypi-dev)
-    isPlatform "odroid" && depends+=(mali-fbdev)
+    isPlatform "mali" && depends+=(mali-fbdev)
     isPlatform "x86" && depends+=(nvidia-cg-toolkit)
     [[ "$__raspbian_ver" -ge "8" ]] && depends+=(libusb-1.0-0-dev)
 
@@ -37,7 +37,7 @@ function sources_retroarch() {
     isPlatform "x86" && gitPullOrClone "$md_build/shader" https://github.com/libretro/common-shaders.git
     # disable the search dialog
     sed -i 's|menu_input_ctl(MENU_INPUT_CTL_SEARCH_START|//menu_input_ctl(MENU_INPUT_CTL_SEARCH_START|g' menu/menu_entry.c
-    if isPlatform "odroid"; then
+    if isPlatform "mali"; then
         sed -i 's|struct mali_native_window native_window|fbdev_window native_window|' gfx/drivers_context/mali_fbdev_ctx.c
     fi
 }
@@ -46,7 +46,7 @@ function build_retroarch() {
     local params=(--disable-x11 --disable-ffmpeg --disable-sdl --disable-oss --disable-pulse --disable-al --disable-jack --enable-floathard)
     isPlatform "rpi" && params+=(--enable-dispmanx --enable-sdl2)
     isPlatform "rpi2" && params+=(--enable-neon)
-    isPlatform "odroid" && params+=(--enable-mali_fbdev --enable-gles --enable-sdl2 --enable-neon)
+    isPlatform "mali" && params+=(--enable-mali_fbdev --enable-gles --enable-sdl2 --enable-neon)
     isPlatform "x86" && params=(--enable-sdl2)
     ./configure --prefix="$md_inst" "${params[@]}"
     make clean

--- a/scriptmodules/emulators/rpix86.sh
+++ b/scriptmodules/emulators/rpix86.sh
@@ -12,7 +12,7 @@
 rp_module_id="rpix86"
 rp_module_desc="DOS Emulator rpix86"
 rp_module_menus="2+"
-rp_module_flags="nobin !x86 !odroid"
+rp_module_flags="nobin !x86 !mali"
 
 function install_rpix86() {
     wget -O- -q $__archive_url/rpix86.tar.gz | tar -xvz -C "$md_inst"

--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -12,7 +12,7 @@
 rp_module_id="scummvm"
 rp_module_desc="ScummVM"
 rp_module_menus="2+"
-rp_module_flags="dispmanx !x86 !odroid"
+rp_module_flags="dispmanx !x86 !mali"
 
 function depends_scummvm() {
     getDepends libsdl1.2-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng12-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev

--- a/scriptmodules/emulators/snes9x.sh
+++ b/scriptmodules/emulators/snes9x.sh
@@ -12,7 +12,7 @@
 rp_module_id="snes9x"
 rp_module_desc="SNES emulator SNES9X-RPi"
 rp_module_menus="2+"
-rp_module_flags="dispmanx !x86 !odroid"
+rp_module_flags="dispmanx !x86 !mali"
 
 function depends_snes9x() {
     getDepends libsdl1.2-dev libboost-thread-dev libboost-system-dev libsdl-ttf2.0-dev libasound2-dev

--- a/scriptmodules/emulators/stella.sh
+++ b/scriptmodules/emulators/stella.sh
@@ -12,7 +12,7 @@
 rp_module_id="stella"
 rp_module_desc="Atari2600 emulator STELLA"
 rp_module_menus="2+"
-rp_module_flags="dispmanx nobin !x86 !odroid"
+rp_module_flags="dispmanx nobin !x86 !mali"
 
 function install_stella() {
     aptInstall stella

--- a/scriptmodules/emulators/uae4all.sh
+++ b/scriptmodules/emulators/uae4all.sh
@@ -12,7 +12,7 @@
 rp_module_id="uae4all"
 rp_module_desc="Amiga emulator UAE4All"
 rp_module_menus="2+"
-rp_module_flags="dispmanx !x86 !odroid"
+rp_module_flags="dispmanx !x86 !mali"
 
 function depends_uae4all() {
     getDepends libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev libsdl-gfx1.2-dev libsdl-ttf2.0-dev

--- a/scriptmodules/emulators/uae4arm.sh
+++ b/scriptmodules/emulators/uae4arm.sh
@@ -12,7 +12,7 @@
 rp_module_id="uae4arm"
 rp_module_desc="Amiga emulator with JIT support"
 rp_module_menus="2+"
-rp_module_flags="!x86 !odroid"
+rp_module_flags="!x86 !mali"
 
 function depends_uae4arm() {
     getDepends libsdl1.2-dev libsdl-gfx1.2-dev libsdl-ttf2.0-dev libguichan-dev

--- a/scriptmodules/emulators/vice.sh
+++ b/scriptmodules/emulators/vice.sh
@@ -12,7 +12,7 @@
 rp_module_id="vice"
 rp_module_desc="C64 emulator VICE"
 rp_module_menus="2+"
-rp_module_flags="dispmanx !x86 !odroid"
+rp_module_flags="dispmanx !x86 !mali"
 
 function depends_vice() {
     if hasPackage vice; then

--- a/scriptmodules/emulators/xroar.sh
+++ b/scriptmodules/emulators/xroar.sh
@@ -12,7 +12,7 @@
 rp_module_id="xroar"
 rp_module_desc="Dragon / CoCo emulator XRoar"
 rp_module_menus="2+"
-rp_module_flags="!x86 !odroid"
+rp_module_flags="!x86 !mali"
 
 function depends_xroar() {
     getDepends libsdl1.2-dev libraspberrypi-dev

--- a/scriptmodules/emulators/zesarux.sh
+++ b/scriptmodules/emulators/zesarux.sh
@@ -12,7 +12,7 @@
 rp_module_id="zesarux"
 rp_module_desc="ZX Spectrum emulator ZEsarUX"
 rp_module_menus="4+"
-rp_module_flags="dispmanx !x86 !odroid"
+rp_module_flags="dispmanx !x86 !mali"
 
 function depends_zesarux() {
     getDepends libssl-dev libpthread-stubs0-dev libsdl1.2-dev libasound2-dev

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -54,21 +54,9 @@ function hasFlag() {
 }
 
 function isPlatform() {
-
-    # isPlatform "rpi" matches both rpi1 and rpi2
-    if [[ "$1" == "rpi" ]] && [[ "$__platform" == "rpi1" || "$__platform" == "rpi2" ]]; then
+    local flag="$1"
+    if hasFlag "$__platform $__platform_flags" "$flag"; then
         return 0
-    fi
-
-    # isPlatform "odroid" matches any odroid platform
-    if [[ "$1" == "odroid" ]] && [[ "$__platform" == odroid* ]]; then
-        return 0
-    fi
-
-    if [[ "$__platform" == "$1" ]]; then
-        return 0
-    else
-        return 1
     fi
 }
 

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -58,6 +58,7 @@ function isPlatform() {
     if hasFlag "$__platform $__platform_flags" "$flag"; then
         return 0
     fi
+    return 1
 }
 
 function addLineToFile() {

--- a/scriptmodules/libretrocores/lr-beetle-vb.sh
+++ b/scriptmodules/libretrocores/lr-beetle-vb.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-beetle-vb"
 rp_module_desc="Virtual Boy emulator - Mednafen VB (optimised) port for libretro"
 rp_module_menus="4+"
-rp_module_flags="!rpi1 !x86"
+rp_module_flags="!armv6 !x86"
 
 function sources_lr-beetle-vb() {
     gitPullOrClone "$md_build" https://github.com/libretro/beetle-vb-libretro.git

--- a/scriptmodules/libretrocores/lr-fba-next.sh
+++ b/scriptmodules/libretrocores/lr-fba-next.sh
@@ -49,7 +49,7 @@ function configure_lr-fba-next() {
     ensureSystemretroconfig "neogeo"
 
     local def=1
-    isPlatform "rpi1" && def=0
+    isPlatform "armv6" && def=0
     addSystem $def "$md_id" "neogeo" "$md_inst/fba_libretro.so"
     addSystem $def "$md_id" "fba arcade" "$md_inst/fba_libretro.so"
 }

--- a/scriptmodules/libretrocores/lr-mgba.sh
+++ b/scriptmodules/libretrocores/lr-mgba.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-mgba"
 rp_module_desc="GBA emulator - MGBA (optimised) port for libretro"
 rp_module_menus="2+"
-rp_module_flags="!rpi1"
+rp_module_flags="!armv6"
 
 function sources_lr-mgba() {
     gitPullOrClone "$md_build" https://github.com/libretro/mgba.git

--- a/scriptmodules/libretrocores/lr-mupen64plus.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus.sh
@@ -21,14 +21,11 @@ function sources_lr-mupen64plus() {
 function build_lr-mupen64plus() {
     rpSwap on 750
     make clean
-    case "$__platform" in
-        rpi|rpi2)
-            make platform="$__platform"
-            ;;
-        *)
-            make
-            ;;
-    esac
+    if isPlatform "rpi"; then
+        make platform="$__platform"
+    else
+        make
+    fi
     rpSwap off
     md_ret_require="$md_build/mupen64plus_libretro.so"
 }

--- a/scriptmodules/libretrocores/lr-picodrive.sh
+++ b/scriptmodules/libretrocores/lr-picodrive.sh
@@ -22,14 +22,11 @@ function sources_lr-picodrive() {
 
 function build_lr-picodrive() {
     make clean
-    case "$__platform" in
-        rpi|rpi2)
-            make -f Makefile.libretro platform=raspberrypi
-            ;;
-        *)
-            make -f Makefile.libretro
-            ;;
-    esac
+    if isPlatform "arm"; then
+        make -f Makefile.libretro platform=raspberrypi
+    else
+        make -f Makefile.libretro
+    fi
     md_ret_require="$md_build/picodrive_libretro.so"
 }
 

--- a/scriptmodules/libretrocores/lr-pocketsnes.sh
+++ b/scriptmodules/libretrocores/lr-pocketsnes.sh
@@ -41,6 +41,6 @@ function configure_lr-pocketsnes() {
     ensureSystemretroconfig "snes" "snes_phosphor.glslp"
 
     local def=0
-    isPlatform "rpi1" && def=1
+    isPlatform "armv6" && def=1
     addSystem $def "$md_id" "snes" "$md_inst/pocketsnes_libretro.so"
 }

--- a/scriptmodules/libretrocores/lr-ppsspp.sh
+++ b/scriptmodules/libretrocores/lr-ppsspp.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-ppsspp"
 rp_module_desc="PlayStation Portable emu - PPSSPP port for libretro"
 rp_module_menus="2+"
-rp_module_flags="!rpi1"
+rp_module_flags="!armv6"
 
 function depends_lr-ppsspp() {
     isPlatform "rpi2" && getDepends libraspberrypi-dev

--- a/scriptmodules/libretrocores/lr-snes9x-next.sh
+++ b/scriptmodules/libretrocores/lr-snes9x-next.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-snes9x-next"
 rp_module_desc="SNES emulator - Snes9x 1.52+ (optimised) port for libretro"
 rp_module_menus="2+"
-rp_module_flags="!rpi1"
+rp_module_flags="!armv6"
 
 function sources_lr-snes9x-next() {
     gitPullOrClone "$md_build" https://github.com/libretro/snes9x-next

--- a/scriptmodules/libretrocores/lr-vba-next.sh
+++ b/scriptmodules/libretrocores/lr-vba-next.sh
@@ -20,14 +20,11 @@ function sources_lr-vba-next() {
 
 function build_lr-vba-next() {
     make -f Makefile.libretro clean
-    case "$__platform" in
-        rpi2)
-            make -f Makefile.libretro platform=armvhardfloatunix TILED_RENDERING=1 HAVE_NEON=1
-            ;;
-        *)
-            make -f Makefile.libretro
-            ;;
-    esac
+    if isPlatform "armv7"; then
+        make -f Makefile.libretro platform=armvhardfloatunix TILED_RENDERING=1 HAVE_NEON=1
+    else
+        make -f Makefile.libretro
+    fi
     md_ret_require="$md_build/vba_next_libretro.so"
 }
 

--- a/scriptmodules/libretrocores/lr-vba-next.sh
+++ b/scriptmodules/libretrocores/lr-vba-next.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-vba-next"
 rp_module_desc="GBA emulator - VBA-M (optimised) port for libretro"
 rp_module_menus="2+"
-rp_module_flags="!rpi1"
+rp_module_flags="!armv6"
 
 function sources_lr-vba-next() {
     gitPullOrClone "$md_build" https://github.com/libretro/vba-next.git

--- a/scriptmodules/libretrocores/lr-virtualjaguar.sh
+++ b/scriptmodules/libretrocores/lr-virtualjaguar.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-virtualjaguar"
 rp_module_desc="Atari Jaguar emu - Virtual Jaguar (optimised) port for libretro"
 rp_module_menus="4+"
-rp_module_flags="!rpi1"
+rp_module_flags="!armv6"
 
 function sources_lr-virtualjaguar() {
     gitPullOrClone "$md_build" https://github.com/libretro/virtualjaguar-libretro.git

--- a/scriptmodules/libretrocores/lr-yabause.sh
+++ b/scriptmodules/libretrocores/lr-yabause.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-yabause"
 rp_module_desc="Sega Saturn emu - Yabause (optimised) port for libretro"
 rp_module_menus="4+"
-rp_module_flags="!rpi1"
+rp_module_flags="!armv6"
 
 function sources_lr-yabause() {
     gitPullOrClone "$md_build" https://github.com/libretro/yabause.git

--- a/scriptmodules/libretrocores/lr-yabause.sh
+++ b/scriptmodules/libretrocores/lr-yabause.sh
@@ -21,14 +21,11 @@ function sources_lr-yabause() {
 function build_lr-yabause() {
     cd libretro
     make clean
-    case "$__platform" in
-        rpi2)
-            make platform=armvneonhardfloat
-            ;;
-        *)
-            make
-            ;;
-    esac
+    if isPlatform "armv7"; then
+        make platform=armvneonhardfloat
+    else
+        make
+    fi
     md_ret_require="$md_build/libretro/yabause_libretro.so"
 }
 

--- a/scriptmodules/ports/dxx-rebirth.sh
+++ b/scriptmodules/ports/dxx-rebirth.sh
@@ -12,7 +12,7 @@
 rp_module_id="dxx-rebirth"
 rp_module_desc="DXX-Rebirth (Descent & Descent 2) build from source"
 rp_module_menus="4+"
-rp_module_flags="!odroid"
+rp_module_flags="!mali"
 
 function depends_dxx-rebirth() {
     getDepends libphysfs1 libphysfs-dev libsdl1.2-dev libsdl-mixer1.2-dev scons

--- a/scriptmodules/ports/eduke32.sh
+++ b/scriptmodules/ports/eduke32.sh
@@ -12,7 +12,7 @@
 rp_module_id="eduke32"
 rp_module_desc="Duke3D Port"
 rp_module_menus="2+"
-rp_module_flags="dispmanx !odroid"
+rp_module_flags="dispmanx !mali"
 
 function depends_eduke32() {
     getDepends libsdl1.2-dev libsdl-mixer1.2-dev libflac-dev libvorbis-dev libpng12-dev libvpx-dev freepats

--- a/scriptmodules/ports/kodi.sh
+++ b/scriptmodules/ports/kodi.sh
@@ -12,7 +12,7 @@
 rp_module_id="kodi"
 rp_module_desc="Kodi - Open source home theatre software"
 rp_module_menus="4+"
-rp_module_flags="nobin !odroid"
+rp_module_flags="nobin !mali"
 
 function install_kodi() {
     # remove old repository - we will use Kodi from the Raspbian repositories

--- a/scriptmodules/ports/minecraft.sh
+++ b/scriptmodules/ports/minecraft.sh
@@ -12,7 +12,7 @@
 rp_module_id="minecraft"
 rp_module_desc="Minecraft"
 rp_module_menus="4+"
-rp_module_flags="nobin !odroid"
+rp_module_flags="nobin !mali"
 
 function depends_minecraft() {
     getDepends matchbox

--- a/scriptmodules/ports/openttd.sh
+++ b/scriptmodules/ports/openttd.sh
@@ -12,7 +12,7 @@
 rp_module_id="openttd"
 rp_module_desc="Open Source Simulator Based On Transport Tycoon Deluxe"
 rp_module_menus="4+"
-rp_module_flags="nobin !odroid"
+rp_module_flags="nobin !mali"
  
 function install_openttd() {
     aptInstall openttd

--- a/scriptmodules/ports/opentyrian.sh
+++ b/scriptmodules/ports/opentyrian.sh
@@ -12,7 +12,7 @@
 rp_module_id="opentyrian"
 rp_module_desc="Open Tyrian - port of the DOS shoot-em-up Tyrian"
 rp_module_menus="4+"
-rp_module_flags="dispmanx !odroid"
+rp_module_flags="dispmanx !mali"
 
 function depends_opentyrian() {
     getDepends libsdl1.2-dev libsdl-net1.2-dev mercurial

--- a/scriptmodules/ports/quake3.sh
+++ b/scriptmodules/ports/quake3.sh
@@ -12,7 +12,7 @@
 rp_module_id="quake3"
 rp_module_desc="Quake 3"
 rp_module_menus="2+"
-rp_module_flags="!x86 !odroid"
+rp_module_flags="!x86 !mali"
 
 function depends_quake3() {
     getDepends libsdl1.2-dev

--- a/scriptmodules/ports/smw.sh
+++ b/scriptmodules/ports/smw.sh
@@ -11,7 +11,8 @@
 
 rp_module_id="smw"
 rp_module_desc="Super Mario War"
-rp_module_menus="2+ !odroid"
+rp_module_menus="2+"
+rp_module_flags="!mali"
 
 function depends_smw() {
     getDepends libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev

--- a/scriptmodules/ports/supertux.sh
+++ b/scriptmodules/ports/supertux.sh
@@ -12,7 +12,7 @@
 rp_module_id="supertux"
 rp_module_desc="SuperTux 2d scrolling platform"
 rp_module_menus="4+"
-rp_module_flags="nobin !odroid"
+rp_module_flags="nobin !mali"
  
 function install_supertux() {
     aptInstall supertux

--- a/scriptmodules/ports/wolf4sdl.sh
+++ b/scriptmodules/ports/wolf4sdl.sh
@@ -12,7 +12,7 @@
 rp_module_id="wolf4sdl"
 rp_module_desc="Wolf4SDL - port of Wolfenstein 3D / Spear of Destiny engine"
 rp_module_menus="4+"
-rp_module_flags="dispmanx !odroid"
+rp_module_flags="dispmanx !mali"
 
 function depends_wolf4sdl() {
     getDepends libsdl1.2-dev libsdl-mixer1.2-dev

--- a/scriptmodules/ports/zdoom.sh
+++ b/scriptmodules/ports/zdoom.sh
@@ -12,7 +12,7 @@
 rp_module_id="zdoom"
 rp_module_desc="ZDoom - Enhanced port of the official DOOM source"
 rp_module_menus="4+"
-rp_module_flags="dispmanx !odroid"
+rp_module_flags="dispmanx !mali"
 
 function depends_zdoom() {
     getDepends libev-dev libsdl2-dev libmpg123-dev libsndfile1-dev zlib1g-dev libbz2-dev timidity cmake

--- a/scriptmodules/supplementary/audiosettings.sh
+++ b/scriptmodules/supplementary/audiosettings.sh
@@ -12,7 +12,7 @@
 rp_module_id="audiosettings"
 rp_module_desc="Configure audio settings"
 rp_module_menus="3+"
-rp_module_flags="nobin !x86 !odroid"
+rp_module_flags="nobin !x86 !mali"
 
 function depends_audiosettings() {
     getDepends alsa-utils

--- a/scriptmodules/supplementary/autostart.sh
+++ b/scriptmodules/supplementary/autostart.sh
@@ -15,7 +15,7 @@ rp_module_menus="3+"
 rp_module_flags="nobin"
 
 function enable_autostart() {
-    if [[ "$__platform" == *rpi* ]]; then
+    if isPlatform "rpi" || isPlatform "mali"; then
         if [[ "$__raspbian_ver" -lt "8" ]]; then
             sed -i "s|^1:2345:.*|1:2345:respawn:/bin/login -f $user tty1 </dev/tty1 >/dev/tty1 2>\&1|g" /etc/inittab
             update-rc.d lightdm disable 2 # taken from /usr/bin/raspi-config
@@ -39,7 +39,7 @@ _EOF_
 }
 
 function disable_autostart() {
-    if [[ "$__platform" == *rpi* ]]; then
+    if isPlatform "rpi" || isPlatform "mali"; then
         if [[ "$__raspbian_ver" -lt "8" ]]; then
             sed -i "s|^1:2345:.*|1:2345:respawn:/sbin/getty --noclear 38400 tty1|g" /etc/inittab
             sed -i "/emulationstation/d" /etc/profile

--- a/scriptmodules/supplementary/dispmanx.sh
+++ b/scriptmodules/supplementary/dispmanx.sh
@@ -12,7 +12,7 @@
 rp_module_id="dispmanx"
 rp_module_desc="Configure emulators to use dispmanx SDL"
 rp_module_menus="3+"
-rp_module_flags="nobin !odroid !x86"
+rp_module_flags="nobin !mali !x86"
 
 function configure_dispmanx() {
     iniConfig "=" "\"" "$configdir/all/dispmanx.cfg"

--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -24,7 +24,7 @@ function depends_emulationstation() {
 function sources_emulationstation() {
     gitPullOrClone "$md_build" "https://github.com/retropie/EmulationStation"
     # make sure libMali.so can be found so we use OpenGL ES
-    if isPlatform "odroid"; then
+    if isPlatform "mali"; then
         sed -i 's|/usr/lib/libMali.so|/usr/lib/arm-linux-gnueabihf/libMali.so|g' CMakeLists.txt
     fi
 }

--- a/scriptmodules/supplementary/raspbiantools.sh
+++ b/scriptmodules/supplementary/raspbiantools.sh
@@ -12,7 +12,7 @@
 rp_module_id="raspbiantools"
 rp_module_desc="Raspbian related tools"
 rp_module_menus="3+"
-rp_module_flags="nobin !x86 !odroid"
+rp_module_flags="nobin !x86 !mali"
 
 function apt_upgrade_raspbiantools() {
     aptUpdate

--- a/scriptmodules/supplementary/sdl1.sh
+++ b/scriptmodules/supplementary/sdl1.sh
@@ -12,7 +12,7 @@
 rp_module_id="sdl1"
 rp_module_desc="SDL 1.2.15 with rpi fixes and dispmanx"
 rp_module_menus=""
-rp_module_flags="!odroid nobin !x86"
+rp_module_flags="!mali nobin !x86"
 
 function get_ver_sdl1() {
     if [[ "$__raspbian_ver" -lt "8" ]]; then

--- a/scriptmodules/supplementary/sdl2.sh
+++ b/scriptmodules/supplementary/sdl2.sh
@@ -17,7 +17,7 @@ rp_module_flags="nobin !x86"
 function get_ver_sdl2() {
     local ver="2.0.3+1"
     isPlatform "rpi" && ver+="rpi"
-    isPlatform "odroid" && ver+="mali"
+    isPlatform "mali" && ver+="mali"
     echo "$ver"
 }
 
@@ -26,13 +26,13 @@ function depends_sdl2() {
     # already covered by the build-essential package retropie relies on.
     local depends=(devscripts debhelper dh-autoreconf libasound2-dev libudev-dev libdbus-1-dev libx11-dev libxcursor-dev libxext-dev libxi-dev libxinerama-dev libxrandr-dev libxss-dev libxt-dev libxxf86vm-dev)
     isPlatform "rpi" && depends+=(libraspberrypi-dev)
-    isPlatform "odroid" && depends+=(mali-fbdev)
+    isPlatform "mali" && depends+=(mali-fbdev)
     getDepends "${depends[@]}"
 }
 
 function sources_sdl2() {
     local branch="retropie-2.0.3"
-    isPlatform "odroid" && branch="mali-2.0.3"
+    isPlatform "mali" && branch="mali-2.0.3"
     gitPullOrClone "$md_build/$(get_ver_sdl2)" https://github.com/RetroPie/SDL-mirror.git "$branch"
     cd $(get_ver_sdl2)
     DEBEMAIL="Jools Wills <buzz@exotica.org.uk>" dch -v $(get_ver_sdl2) "SDL 2.0.3 configured for the $__platform"

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -169,6 +169,7 @@ function platform_rpi1() {
     __default_cflags="-O2 -mfpu=vfp -march=armv6j -mfloat-abi=hard"
     __default_asflags=""
     __default_makeflags=""
+    __platform_flags="arm armv6 rpi"
     # if building in a chroot, what cpu should be set by qemu
     # make chroot identify as arm6l
     __qemu_cpu=arm1176
@@ -180,6 +181,7 @@ function platform_rpi2() {
     __default_cflags="-O2 -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard"
     __default_asflags=""
     __default_makeflags="-j2"
+    __platform_flags="arm armv7 rpi"
     # there is no support in qemu for cortex-a7 it seems, but it does have cortex-a15 which is architecturally
     # aligned with the a7, and allows the a7 targetted code to be run in a chroot/emulated environment
     __qemu_cpu=cortex-a15
@@ -190,6 +192,7 @@ function platform_odroid-c1() {
     __default_cflags="-O2 -mcpu=cortex-a5 -mfpu=neon-vfpv4 -mfloat-abi=hard"
     __default_asflags=""
     __default_makeflags="-j2"
+    __platform_flags="arm armv7 mali"
     __qemu_cpu=cortex-a5
     __has_binaries=0
 }
@@ -198,5 +201,6 @@ function platform_x86() {
     __default_cflags="-O2 -march=native"
     __default_asflags=""
     __default_makeflags="-j$(nproc)"
+    __platform_flags="x11"
     __has_binaries=0
 }

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -204,3 +204,19 @@ function platform_x86() {
     __platform_flags="x11"
     __has_binaries=0
 }
+
+function platform_x11() {
+    __default_cflags="-O2"
+    __default_asflags=""
+    __default_makeflags="-j$(nproc)"
+    __platform_flags="x11"
+    __has_binaries=0
+}
+
+function platform_armv7-mali() {
+    __default_cflags="-O2 -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard"
+    __default_asflags=""
+    __default_makeflags="-j$(nproc)"
+    __platform_flags="arm armv7 mali"
+    __has_binaries=0
+}

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -42,7 +42,7 @@ function setup_env() {
     if fn_exists "platform_${__platform}"; then
         platform_${__platform}
     else
-        fatalError "Unknown platform - please manually set the __platform variable to rpi1 or rpi2"
+        fatalError "Unknown platform - please manually set the __platform variable to one of the following: $(compgen -A function platform_ | cut -b10- | paste -s -d' ')"
     fi
 
     get_os_version


### PR DESCRIPTION
This allows more flexibility in modules - so instead of checking specifically for a platform you can check for something in common with a platform. in the same way isPlatform "rpi" matches rpi1 and rpi2, now you can do isPlatform "mali" to check if the current platform has a mali gpu.

the addtional flags are set in the system.sh

thi makes it easier to add new platforms (I have included a generic X11 and armv7+mali platform), without additional work in modules. Or for example you can do isPlatform "armv7" to decide whether to enable armv7 optimisations.

not for merging yet as I need to do some more testing.