### PR TITLE
Add CoolCV

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -28,6 +28,9 @@ atarist_fullname="Atari ST/STE"
 coco_exts=".cas .wav .bas .asc .dmk .jvc .os9 .dsk .vdk .rom .ccc .sna"
 coco_fullname="TRS-80 Color Computer (CoCo)"
 
+coleco_exts=".bin .col .rom .zip"
+coleco_fullname="ColecoVision"
+
 c64_exts=".crt .d64 .g64 .prg .t64 .tap .x64 .zip .vsf"
 c64_fullname="Commodore 64"
 

--- a/scriptmodules/emulators/coolcv.sh
+++ b/scriptmodules/emulators/coolcv.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+# 
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# 
+# See the LICENSE.md file at the top-level directory of this distribution and 
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="coolcv"
+rp_module_desc="CoolCV Colecovision Emulator"
+rp_module_menus="4+"
+
+function install_coolcv() {    
+    wget -O- -q $__archive_url/coolcv.tar.gz | tar -xvz -C "$md_inst"
+}
+
+function configure_coolcv() {
+    mkRomDir "coleco"
+
+    addSystem 1 "$md_id" "coleco colecovision colecovision" "$md_inst/coolcv/coolcv_pi %ROM%"
+}


### PR DESCRIPTION
Of course we'd first need to add the binary to the archive url

Binary is here (6.2):
http://atariage.com/forums/topic/240800-coolcv-emulator-for-mac-os-x-linux-windows-and-raspberry/page-1

I'm also not super sure on the bios for it and if I'd need to symlink
that to the bios folder.

Don't know if we want to wait until nanochess releases 6.3 for the
Pi with a potential configurable keyboard. Having the source code would make it a bit easier. 