### PR TITLE
Clean launch

### DIFF
--- a/scriptmodules/emulators/frotz.sh
+++ b/scriptmodules/emulators/frotz.sh
@@ -33,5 +33,6 @@ function configure_frotz() {
 
     chown -R $user:$user "$romdir/zmachine/"*
 
-    addSystem 1 "$md_id" "zmachine" "pushd $romdir/zmachine; frotz %ROM%; popd" "Z-machine" ".dat .z5"
+    # CON: to stop runcommand from redirecting stdout to log
+    addSystem 1 "$md_id" "zmachine" "CON:pushd $romdir/zmachine; frotz %ROM%; popd" "Z-machine" ".dat .z5"
 }

--- a/scriptmodules/supplementary/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand.sh
@@ -29,6 +29,7 @@ function install_runcommand() {
         iniSet "use_art" "0"
         iniSet "disable_joystick" "0"
         iniSet "governor" ""
+        iniSet "disable_menu" "0"
         chown $user:$user "$configdir/all/runcommand.cfg"
     fi
 }
@@ -82,6 +83,15 @@ function gui_runcommand() {
             options+=(3 "Turn on joystick control in pre launch menu (currently off)")
         fi
 
+        iniGet "disable_menu"
+        local disable_menu="$ini_value"
+        [[ "$disable_menu" != 1 ]] && disable_joystick=0
+        if [[ "$disable_menu" -eq 0 ]]; then
+            options+=(4 "Turn off pre launch menu (currently on)")
+        else
+            options+=(4 "Turn on pre launch menu (currently off)")
+        fi
+
         local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
         if [[ -n "$choice" ]]; then
             case $choice in
@@ -93,6 +103,9 @@ function gui_runcommand() {
                     ;;
                 3)
                     iniSet "disable_joystick" "$((disable_joystick ^ 1))"
+                    ;;
+                4)
+                    iniSet "disable_menu" "$((disable_menu ^ 1))"
                     ;;
             esac
         else

--- a/scriptmodules/supplementary/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand.sh
@@ -42,13 +42,13 @@ function governor_runcommand() {
     if [[ -n "$choices" ]]; then
         governor="${governors[$choices]}"
         iniSet "governor" "$governor"
+        chown $user:$user "$configdir/all/runcommand.cfg"
     fi
 }
 
 function gui_runcommand() {
     mkUserDir "$configdir/all"
     iniConfig "=" '"' "$configdir/all/runcommand.cfg"
-    chown $user:$user "$configdir/all/runcommand.cfg"
 
     local cmd=(dialog --backtitle "$__backtitle" --menu "Choose an option." 22 86 16)
     while true; do
@@ -73,6 +73,7 @@ function gui_runcommand() {
                     ;;
                 2)
                     iniSet "use_art" "$((use_art ^ 1))"
+                    chown $user:$user "$configdir/all/runcommand.cfg"
                     ;;
             esac
         else

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -651,6 +651,8 @@ if [[ -f "$runcommand_conf" ]]; then
     use_art="$ini_value"
     iniGet "disable_joystick"
     disable_joystick="$ini_value"
+    iniGet "disable_menu"
+    disable_menu="$ini_value"
 fi
 
 if [[ -f "$tvservice" ]]; then
@@ -679,18 +681,20 @@ fi
 image="$configdir/all/emulationstation/downloaded_images/${system}/${rom_bn}-image.jpg"
 if [[ "$use_art" -eq 1 && -n "$(which fbi)" && -f "$image" ]]; then
     sudo fbi -T 1 -1 -t 5 -noverbose -a -e "$configdir/all/emulationstation/downloaded_images/${system}/${rom_bn}-image.jpg" &>/dev/null
-else
-    use_art=0
+elif [[ "$disable_menu" -ne 1 ]]; then
     dialog --infobox "\nLaunching $emulator ...\n\nPress a button to configure\n\nErrors are logged to /tmp/runcommand.log" 9 60
 fi
-IFS= read -s -t 2 -N 1 key </dev/tty
-if [[ -n "$key" ]]; then
-    if [[ $has_tvs -eq 1 ]]; then
-        get_all_modes
+
+if [[ "$disable_menu" -ne 1 ]]; then
+    IFS= read -s -t 2 -N 1 key </dev/tty
+    if [[ -n "$key" ]]; then
+        if [[ $has_tvs -eq 1 ]]; then
+            get_all_modes
+        fi
+        main_menu
+        dont_launch=$?
+        clear
     fi
-    main_menu
-    dont_launch=$?
-    clear
 fi
 
 if [[ -n $__joy2key_pid ]]; then

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -683,7 +683,7 @@ else
     use_art=0
     dialog --infobox "\nLaunching $emulator ...\n\nPress a button to configure\n\nErrors are logged to /tmp/runcommand.log" 9 60
 fi
-IFS= read -s -t 1 -N 1 key </dev/tty
+IFS= read -s -t 2 -N 1 key </dev/tty
 if [[ -n "$key" ]]; then
     if [[ $has_tvs -eq 1 ]]; then
         get_all_modes

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -653,6 +653,7 @@ if [[ -f "$runcommand_conf" ]]; then
     disable_joystick="$ini_value"
     iniGet "disable_menu"
     disable_menu="$ini_value"
+    [[ "$disable_menu" -eq 1 ]] && disable_joystick=1
 fi
 
 if [[ -f "$tvservice" ]]; then

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -678,7 +678,7 @@ fi
 # check for x/m key pressed to choose a screenmode (x included as it is useful on the picade)
 image="$configdir/all/emulationstation/downloaded_images/${system}/${rom_bn}-image.jpg"
 if [[ "$use_art" -eq 1 && -n "$(which fbi)" && -f "$image" ]]; then
-    sudo fbi -T 1 -1 -t 5 -noverbose -a "$configdir/all/emulationstation/downloaded_images/${system}/${rom_bn}-image.jpg" &>/dev/null
+    sudo fbi -T 1 -1 -t 5 -noverbose -a -e "$configdir/all/emulationstation/downloaded_images/${system}/${rom_bn}-image.jpg" &>/dev/null
 else
     use_art=0
     dialog --infobox "\nLaunching $emulator ...\n\nPress a button to configure\n\nErrors are logged to /tmp/runcommand.log" 9 60
@@ -738,6 +738,6 @@ fi
 # reset/restore framebuffer res (if it was changed)
 [[ -n "$fb_new" ]] && restore_fb
 
-clear
+reset
 
 exit 0

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -681,7 +681,7 @@ fi
 # check for x/m key pressed to choose a screenmode (x included as it is useful on the picade)
 image="$configdir/all/emulationstation/downloaded_images/${system}/${rom_bn}-image.jpg"
 if [[ "$use_art" -eq 1 && -n "$(which fbi)" && -f "$image" ]]; then
-    sudo fbi -T 1 -1 -t 5 -noverbose -a -e "$configdir/all/emulationstation/downloaded_images/${system}/${rom_bn}-image.jpg" &>/dev/null
+    sudo fbi -T 1 -1 -t 5 -noverbose -a "$configdir/all/emulationstation/downloaded_images/${system}/${rom_bn}-image.jpg" </dev/null &>/dev/null
 elif [[ "$disable_menu" -ne 1 ]]; then
     if [[ -n "$rom_bn" ]]; then
         launch_name="$rom_bn ($emulator)"

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -663,8 +663,7 @@ if [[ -f "$rootdir/supplementary/runcommand/joy2key.py" && -n "$__joy2key_dev" ]
 fi
 
 # check for x/m key pressed to choose a screenmode (x included as it is useful on the picade)
-clear
-echo "Press a key (or joypad button 0) to configure launch options for emulator/port ($emulator). Errors will be logged to /tmp/runcommand.log"
+dialog --infobox "\nLaunching $emulator ...\n\nPress a button to configure\n\nErrors are logged to /tmp/runcommand.log" 9 60
 IFS= read -s -t 1 -N 1 key </dev/tty
 if [[ -n "$key" ]]; then
     if [[ $has_tvs -eq 1 ]]; then
@@ -699,8 +698,10 @@ config_dispmanx "$save_emu"
 
 retroarch_append_config
 
+clear
+
 # run command
-eval $command </dev/tty 2>/tmp/runcommand.log
+eval $command </dev/tty &>/tmp/runcommand.log
 
 # restore default cpu scaling governor
 [[ -n "$governor" ]] && restore_governor
@@ -712,5 +713,7 @@ fi
 
 # reset/restore framebuffer res (if it was changed)
 [[ -n "$fb_new" ]] && restore_fb
+
+clear
 
 exit 0

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -647,6 +647,8 @@ if [[ -f "$runcommand_conf" ]]; then
     iniConfig "=" '"' "$runcommand_conf"
     iniGet "governor"
     governor="$ini_value"
+    iniGet "use_art"
+    use_art="$ini_value"
 fi
 
 if [[ -f "$tvservice" ]]; then
@@ -672,7 +674,13 @@ if [[ -f "$rootdir/supplementary/runcommand/joy2key.py" && -n "$__joy2key_dev" ]
 fi
 
 # check for x/m key pressed to choose a screenmode (x included as it is useful on the picade)
-dialog --infobox "\nLaunching $emulator ...\n\nPress a button to configure\n\nErrors are logged to /tmp/runcommand.log" 9 60
+image="$configdir/all/emulationstation/downloaded_images/${system}/${rom_bn}-image.jpg"
+if [[ "$use_art" -eq 1 && -n "$(which fbi)" && -f "$image" ]]; then
+    sudo fbi -T 1 -noverbose -a "$configdir/all/emulationstation/downloaded_images/${system}/${rom_bn}-image.jpg"
+else
+    use_art=0
+    dialog --infobox "\nLaunching $emulator ...\n\nPress a button to configure\n\nErrors are logged to /tmp/runcommand.log" 9 60
+fi
 IFS= read -s -t 1 -N 1 key </dev/tty
 if [[ -n "$key" ]]; then
     if [[ $has_tvs -eq 1 ]]; then
@@ -716,6 +724,8 @@ if [[ "$emulator" == frotz || "$is_console" -eq 1 || "$is_sys" -eq 0 ]]; then
 else
     eval $command </dev/tty &>/tmp/runcommand.log
 fi
+
+[[ "$use_art" -eq 1 ]] && sudo killall fbi
 
 # restore default cpu scaling governor
 [[ -n "$governor" ]] && restore_governor

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -676,7 +676,7 @@ fi
 # check for x/m key pressed to choose a screenmode (x included as it is useful on the picade)
 image="$configdir/all/emulationstation/downloaded_images/${system}/${rom_bn}-image.jpg"
 if [[ "$use_art" -eq 1 && -n "$(which fbi)" && -f "$image" ]]; then
-    sudo fbi -T 1 -noverbose -a "$configdir/all/emulationstation/downloaded_images/${system}/${rom_bn}-image.jpg" &>/dev/null
+    sudo fbi -T 1 -1 -t 5 -noverbose -a "$configdir/all/emulationstation/downloaded_images/${system}/${rom_bn}-image.jpg" &>/dev/null
 else
     use_art=0
     dialog --infobox "\nLaunching $emulator ...\n\nPress a button to configure\n\nErrors are logged to /tmp/runcommand.log" 9 60
@@ -724,8 +724,6 @@ if [[ "$emulator" == frotz || "$is_console" -eq 1 || "$is_sys" -eq 0 ]]; then
 else
     eval $command </dev/tty &>/tmp/runcommand.log
 fi
-
-[[ "$use_art" -eq 1 ]] && sudo killall fbi
 
 # restore default cpu scaling governor
 [[ -n "$governor" ]] && restore_governor

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -676,7 +676,7 @@ fi
 # check for x/m key pressed to choose a screenmode (x included as it is useful on the picade)
 image="$configdir/all/emulationstation/downloaded_images/${system}/${rom_bn}-image.jpg"
 if [[ "$use_art" -eq 1 && -n "$(which fbi)" && -f "$image" ]]; then
-    sudo fbi -T 1 -noverbose -a "$configdir/all/emulationstation/downloaded_images/${system}/${rom_bn}-image.jpg"
+    sudo fbi -T 1 -noverbose -a "$configdir/all/emulationstation/downloaded_images/${system}/${rom_bn}-image.jpg" &>/dev/null
 else
     use_art=0
     dialog --infobox "\nLaunching $emulator ...\n\nPress a button to configure\n\nErrors are logged to /tmp/runcommand.log" 9 60

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -682,7 +682,12 @@ image="$configdir/all/emulationstation/downloaded_images/${system}/${rom_bn}-ima
 if [[ "$use_art" -eq 1 && -n "$(which fbi)" && -f "$image" ]]; then
     sudo fbi -T 1 -1 -t 5 -noverbose -a -e "$configdir/all/emulationstation/downloaded_images/${system}/${rom_bn}-image.jpg" &>/dev/null
 elif [[ "$disable_menu" -ne 1 ]]; then
-    dialog --infobox "\nLaunching $emulator ...\n\nPress a button to configure\n\nErrors are logged to /tmp/runcommand.log" 9 60
+    if [[ -n "$rom_bn" ]]; then
+        launch_name="$rom_bn ($emulator)"
+    else
+        launch_name="$emulator"
+    fi
+    dialog --infobox "\nLaunching $launch_name ...\n\nPress a button to configure\n\nErrors are logged to /tmp/runcommand.log" 9 60
 fi
 
 if [[ "$disable_menu" -ne 1 ]]; then

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -649,6 +649,8 @@ if [[ -f "$runcommand_conf" ]]; then
     governor="$ini_value"
     iniGet "use_art"
     use_art="$ini_value"
+    iniGet "disable_joystick"
+    disable_joystick="$ini_value"
 fi
 
 if [[ -f "$tvservice" ]]; then
@@ -667,7 +669,7 @@ dont_launch=0
 
 # if joy2key.py is installed run it with cursor keys for axis, and enter + tab for buttons 0 and 1
 __joy2key_dev=$(ls -1 /dev/input/js* 2>/dev/null | head -n1)
-if [[ -f "$rootdir/supplementary/runcommand/joy2key.py" && -n "$__joy2key_dev" ]] && ! pgrep -f joy2key.py >/dev/null; then
+if [[ "$disable_joystick" -ne 1 && -f "$rootdir/supplementary/runcommand/joy2key.py" && -n "$__joy2key_dev" ]] && ! pgrep -f joy2key.py >/dev/null; then
     __joy2key_dev=$(ls -1 /dev/input/js* | head -n1)
     "$rootdir/supplementary/runcommand/joy2key.py" "$__joy2key_dev" 1b5b44 1b5b43 1b5b41 1b5b42 0a 09 &
     __joy2key_pid=$!


### PR DESCRIPTION
This has been requested on a few occasions - making the launching less verbose and slightly prettier.
changes are:

Dialog when launching by default.

stdout/stderr logged to /tmp/runcommand.log unless a console app is used like frotz

can switch on use_art for runcommand to show ES artwork before launch - configurable from the runcommand config in retropie-setup