### PR TITLE
Add Direct Launch to Helper Script (set essystem function)

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -301,6 +301,7 @@ function setESSystem() {
     local command=$5
     local platform=$6
     local theme=$7
+    local directlaunch=$8
 
     local conf="/etc/emulationstation/es_systems.cfg"
     mkdir -p "/etc/emulationstation"
@@ -318,6 +319,7 @@ function setESSystem() {
             -s "/systemList/system[last()]" -t elem -n "command" -v "$command" \
             -s "/systemList/system[last()]" -t elem -n "platform" -v "$platform" \
             -s "/systemList/system[last()]" -t elem -n "theme" -v "$theme" \
+            -s "/systemList/system[last()]" -t elem -n "directlaunch" -v "$directlaunch" \
             "$conf"
     else
         xmlstarlet ed -L \
@@ -327,6 +329,7 @@ function setESSystem() {
             -u "/systemList/system[name='$name']/command" -v "$command" \
             -u "/systemList/system[name='$name']/platform" -v "$platform" \
             -u "/systemList/system[name='$name']/theme" -v "$theme" \
+            -u "/systemList/system[name='$name']/directlaunch" -v "$directlaunch" \
             "$conf"
     fi
 
@@ -476,7 +479,7 @@ function addSystem() {
     # add the extensions again as uppercase
     exts+=" ${exts^^}"
 
-    setESSystem "$fullname" "$es_name" "$es_path" "$exts" "$es_cmd" "$platform" "$theme"
+    setESSystem "$fullname" "$es_name" "$es_path" "$exts" "$es_cmd" "$platform" "$theme" "$directlaunch"
 
     # create a config folder for the system
     if [[ ! -d "$configdir/$system" ]]; then


### PR DESCRIPTION
Preliminary support for direct launch through emulationstation as a result of https://github.com/RetroPie/EmulationStation/pull/1

For example in implementation with kodi: The direct launch path and system name are really only needed and then you indicate a 'true' at the end to enable directlaunch :

```
setESSystem 'Kodi' 'kodi' '' '' '/opt/retropie/supplementary/runcommand/runcommand.sh 0 "kodi-standalone" "kodi"' '' '' 'true'
```

Kodi seems to crash on exit when using directlaunch which may be a separate bug or some conflict with runcommand which may need to be further investigated. I have not tested with other systems and am unsure if it is specific to kodi or if it will happen with all systems.

