### PR TITLE
Add Libretro Beetle Lynx

### DIFF
--- a/scriptmodules/libretrocores/lr-beetle-lynx.sh
+++ b/scriptmodules/libretrocores/lr-beetle-lynx.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+# 
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# 
+# See the LICENSE.md file at the top-level directory of this distribution and 
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-beetle-lynx"
+rp_module_desc="Atari Lynx emulator - Mednafen Lynx Port for libretro, itself a fork of Handy"
+rp_module_menus="4+"
+
+function sources_lr-beetle-lynx() {
+    gitPullOrClone "$md_build" https://github.com/libretro/beetle-lynx-libretro.git
+}
+
+function build_lr-beetle-lynx() {
+    make clean
+    make
+    md_ret_require="$md_build/mednafen_lynx_libretro.so"
+}
+
+function install_lr-beetle-lynx() {
+    md_ret_files=(
+        'mednafen_lynx_libretro.so'
+    )
+}
+
+function configure_lr-beetle-lynx() {
+    mkRomDir "atarilynx"
+    ensureSystemretroconfig "atarilynx"
+
+    addSystem 0 "$md_id" "atarilynx" "$md_inst/mednafen_vb_libretro.so"
+}


### PR DESCRIPTION
There are some caveats, lynxboot.img bios is needed in the roms folder and doesn't quite yet launch from emulationstation for some reason. Was hoping that it would address https://github.com/RetroPie/RetroPie-Setup/issues/823 but there might be some upstream things that need to be addressed as it pertains to system directory stuff (particulary with the mednafen emulators it would seem: https://github.com/RetroPie/RetroPie-Setup/issues/1162). 

For reference I have linked the verbose output when launching from the terminal (note the 4096 error is just due to me lacking the BIOS file) 

http://pastebin.com/tXXreyfy