### PR TITLE
Add support for scraping Arcade system as MAME for sselph scraper.

### DIFF
--- a/scriptmodules/supplementary/scraper.sh
+++ b/scriptmodules/supplementary/scraper.sh
@@ -47,7 +47,7 @@ function scrape_scraper() {
     params+=(-output_file "$gamelist")
     params+=(-rom_dir "$romdir/$system")
     params+=(-workers "4")
-    [[ "$system" =~ ^mame-|fba|neogeo ]] && params+=(-mame -mame_img t,m,s)
+    [[ "$system" =~ ^mame-|arcade|fba|neogeo ]] && params+=(-mame -mame_img t,m,s)
     sudo -u $user "$md_inst/scraper" ${params[@]} -thumb_only -skip_check
 }
 


### PR DESCRIPTION
Now that Retropie supports having a merged arcade folder in Retropie 3.5, add support for scraping the arcade folder as MAME.