### PR TITLE
Add QuickNES core to Experimental

### DIFF
--- a/scriptmodules/libretrocores/lr-quicknes.sh
+++ b/scriptmodules/libretrocores/lr-quicknes.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+# 
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# 
+# See the LICENSE.md file at the top-level directory of this distribution and 
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-quicknes"
+rp_module_desc="NES emulator - QuickNES Port for libretro"
+rp_module_menus="4+"
+
+function sources_lr-quicknes() {
+    gitPullOrClone "$md_build" https://github.com/libretro/QuickNES_Core.git
+}
+
+function build_lr-quicknes() {
+    make clean
+    make
+    md_ret_require="$md_build/quicknes_libretro.so"
+}
+
+function install_lr-quicknes() {
+    md_ret_files=(
+        'quicknes_libretro.so'
+    )
+}
+
+function configure_lr-quicknes() {
+    mkRomDir "nes"
+    ensureSystemretroconfig "nes"
+
+    addSystem 0 "$md_id" "nes" "$md_inst/quicknes_libretro.so"
+}


### PR DESCRIPTION
Added the QuickNES core to RetroPie. It only supports the NES and not the Famicom Disk System. It is currently the only NES core that supports RetroAchievements as supported by Retroarch.