### PR TITLE
runcommand.sh: fix wrong fb_res restore

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -210,6 +210,12 @@ function load_mode_defaults() {
         fi
     fi
 
+    # get default fb_res
+    fb_orig=""
+    fb_orig=$(fbset)
+    fb_orig=${fb_orig##*mode \"}
+    fb_orig=${fb_orig%%\"*}
+
     mode_def_emu=""
     mode_def_rom=""
     fb_def_emu=""
@@ -557,7 +563,7 @@ function restore_mode() {
 
 function restore_fb() {
     sleep 1
-    switch_fb_res "${mode_orig[2]}x${mode_orig[3]}"
+    switch_fb_res "$fb_orig"
 }
 
 function config_dispmanx() {


### PR DESCRIPTION
If overscan is enabled `fb_res_h = display_res_h - overscan_r
-overscan_l` and `fb_res_v = display_res_v - overscan_t -overscan_b`.
It is false to use display resolution. Just store original fb
resolution and use this value for restore_fb().