### PR TITLE
add the ability to remove the dependencies for a module - by doing ./…

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -129,8 +129,17 @@ function getDepends() {
         if [[ "$required" == "libraspberrypi-dev" ]] && hasPackage rbp-bootloader-osmc; then
             required="rbp-userland-dev-osmc"
         fi
-        hasPackage "$required" || packages+=("$required")
+        if [[ "$__depends_mode" == "remove" ]]; then
+            hasPackage "$required" && packages+=("$required")
+        else
+            hasPackage "$required" || packages+=("$required")
+        fi
     done
+    if [[ "$__depends_mode" == "remove" ]]; then
+        apt-get remove --purge -y "${packages[@]}"
+        apt-get autoremove --purge -y
+        return 0
+    fi
     if [[ ${#packages[@]} -ne 0 ]]; then
         echo "Did not find needed package(s): ${packages[@]}. I am trying to install them now."
 

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -134,6 +134,11 @@ function rp_callModule() {
     case "$mode" in
         depends)
             action="Installing dependencies for"
+            if [[ "$1" == "remove" ]]; then
+                __depends_mode="remove"
+            else
+                __depends_mode="install"
+            fi
             ;;
         sources)
             action="Getting sources for"


### PR DESCRIPTION
…retropie_packages.sh module depends remove

it will remove all direct dependencies, and then remove any of those package dependencies with autoremove - including configs
if a package was installed before, it will be removed if listed, so this isn't a feature to "remove everything that retropie
installed" but is still useful for dependency testing etc