### PR TITLE
Added libretro core for latest MESS.

### DIFF
--- a/scriptmodules/libretrocores/lr-mess.sh
+++ b/scriptmodules/libretrocores/lr-mess.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+# 
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# 
+# See the LICENSE.md file at the top-level directory of this distribution and 
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-mess"
+rp_module_desc="MESS emulator - MESS Port for libretro"
+rp_module_menus="4+"
+
+function sources_lr-mess() {
+    gitPullOrClone "$md_build" https://github.com/libretro/MAME.git
+}
+
+function build_lr-mess() {
+    make -f Makefile.libretro clean
+    make -f Makefile.libretro SUBTARGET=mess
+    md_ret_require="$md_build/mess_libretro.so"
+}
+
+function install_lr-mess() {
+    md_ret_files=(
+        'mess_libretro.so'
+    )
+}
+
+function configure_lr-mess() {
+    mkRomDir "nes"
+    mkRomDir "gameboy"
+    mkRomDir "coleco"
+    ensureSystemretroconfig "nes"
+    ensureSystemretroconfig "gameboy"
+    ensureSystemretroconfig "coleco"
+
+    setRetroArchCoreOption "mame_softlists_enable" "enabled"
+    setRetroArchCoreOption "mame_softlists_auto_media" "enabled"
+    setRetroArchCoreOption "mame_boot_from_cli" "enabled"
+
+    mkdir "$biosdir/mame/hash"
+    cp -rv "$md_build/hash" "$biosdir/mame"
+    chown -R $user:$user "$biosdir/mame"
+    addSystem 0 "$md_id" "nes" "$md_inst/mess_libretro.so"
+    addSystem 0 "$md_id" "gameboy" "$md_inst/mess_libretro.so"
+    addSystem 0 "$md_id" "coleco" "$md_inst/mess_libretro.so"
+}


### PR DESCRIPTION
Added libretro core for latest MESS pulled from git, currently 0.171.
Some additional symlinks or folders may need to be created for systems to work properly.
Documentation on how to set up MESS using this core will be coming in the future to the RetroPie wiki and has yet to be written.
Systems that have been set up for use with this MESS core are only those found to work approximately 100% speed. These include the following: Nintendo Gameboy (uses "gameboy" directory instead of "gb"), Nintendo Entertainment System and Colecovision with more added in the future as they get tested.

Systems that have been tested and that are not up to speed and therefore disabled at the moment include the following (as tested by a Raspberry Pi 2 overclocked to 1067mhz):

Amstrad GX4000 (60% speed)
Atari 2600 (70-85% speed)
Atari 5200 (50-60% speed)
Nintendo Gameboy Advance (50% speed)
Sega Game Gear (80% speed)
Sega Genesis (50% speed)
Sharp X68000 (14% speed)
SNK Neo Geo AES (60-65% speed)

Compilation of the core takes approximately 3 hours as I did not include the number of jobs to compile at once. Let me know if you require information for testing.