### PR TITLE
Added experimental script for ResidualVM

### DIFF
--- a/scriptmodules/emulators/residualvm.sh
+++ b/scriptmodules/emulators/residualvm.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+# 
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# 
+# See the LICENSE.md file at the top-level directory of this distribution and 
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="residualvm"
+rp_module_desc="ResidualVM - A 3D Game Interpreter"
+rp_module_menus="4+"
+rp_module_flags="dispmanx !mali"
+
+function depends_residualvm() {
+    getDepends libsdl1.2-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng12-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev
+    if [[ "$__raspbian_ver" -lt "8" ]]; then
+        getDepends libjpeg8-dev
+    else
+        getDepends libjpeg-dev
+    fi
+}
+
+function sources_residualvm() {
+    gitPullOrClone "$md_build" https://github.com/ResidualVM/ResidualVM.git
+}
+
+function build_residualvm() {
+    ./configure --enable-vkeybd --enable-release --disable-debug --enable-keymapper --prefix="$md_inst"
+    make clean
+    make
+    strip "$md_build/residualvm"
+    md_ret_require="$md_build/residualvm"
+}
+
+function install_residualvm() {
+    make install
+    mkdir -p "$md_inst/extra"
+    cp -v backends/vkeybd/packs/vkeybd_*.zip "$md_inst/extra"
+}
+
+function configure_residualvm() {
+    mkRomDir "residualvm"
+
+    moveConfigDir "$home/.residualvm" "$configdir/residualvm"
+    moveConfigFile "$home/.residualvmrc" "$configdir/scummvm/residualvmrc"
+
+    # Create startup script
+    rm -f "$romdir/residualvm/+Launch GUI.sh"
+    cat > "$romdir/residualvm/+Start ResidualVM.sh" << _EOF_
+#!/bin/bash
+game="\$1"
+[[ "\$game" =~ ^\+ ]] && game=""
+pushd "$romdir/residualvm" >/dev/null
+$md_inst/bin/residualvm --fullscreen --joystick=0 --extrapath="$md_inst/extra" \$game
+while read line; do
+    id=(\$line);
+    touch "$romdir/residualvm/\$id.svm"
+done < <($md_inst/bin/residualvm --list-targets | tail -n +3)
+popd >/dev/null
+_EOF_
+    chown $user:$user "$romdir/residualvm/+Start ResidualVM.sh"
+    chmod u+x "$romdir/residualvm/+Start ResidualVM.sh"
+
+    addSystem 1 "$md_id" "residualvm" "$romdir/residualvm/+Start\ ResidualVM.sh %BASENAME%" "ResidualVM" ".sh .svm"
+}


### PR DESCRIPTION
Using pretty much the exact same setup as SCUMMVM with the exception of one particular configure flag. Tested with Grim Fandango in software mode on an overclocked Raspberry Pi 2, working well aside from laggy movies as far as I've seen to this point. OpenGL crashes the program entirely. Disabled "Fullscreen" to get full screen, ironically. Recognized joystick controls on its own without issue. Loading games directly from emulationstation works however it appears that the settings used in the ResidualVM GUI are ignored when launched in this manner. Might have to take a look and see if SCUMMVM has similar behavior. 

(I appeared to be unable to squash this for whatever reason.)