### PR TITLE
Rpi3

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -62,7 +62,7 @@ function build_mupen64plus() {
             make -C "$dir/projects/unix" clean
             params=()
             isPlatform "rpi1" && params+=("VC=1" "VFP=1" "VFP_HARD=1")
-            isPlatform "rpi2" && params+=("VC=1" "NEON=1")
+            isPlatform "neon" && params+=("VC=1" "NEON=1")
             isPlatform "x11" && params+=("OSD=1")
             [[ "$dir" == "mupen64plus-ui-console" ]] && params+=("COREDIR=$md_inst/lib/" "PLUGINDIR=$md_inst/lib/mupen64plus/")
             make -C "$dir/projects/unix" all "${params[@]}" OPTFLAGS="$CFLAGS"

--- a/scriptmodules/emulators/pcsx-rearmed.sh
+++ b/scriptmodules/emulators/pcsx-rearmed.sh
@@ -24,7 +24,7 @@ function sources_pcsx-rearmed() {
 }
 
 function build_pcsx-rearmed() {
-    if isPlatform "rpi2"; then
+    if isPlatform "neon"; then
         ./configure --sound-drivers=alsa --enable-neon
     else
         ./configure --sound-drivers=alsa

--- a/scriptmodules/emulators/reicast.sh
+++ b/scriptmodules/emulators/reicast.sh
@@ -31,7 +31,7 @@ function sources_reicast() {
 
 function build_reicast() {
     cd shell/linux
-    if isPlatform "rpi2"; then
+    if isPlatform "rpi"; then
         make platform=rpi2 clean
         make platform=rpi2
     else
@@ -43,7 +43,7 @@ function build_reicast() {
 
 function install_reicast() {
     cd shell/linux
-    if isPlatform "rpi2"; then
+    if isPlatform "rpi"; then
         make platform=rpi2 PREFIX="$md_inst" install
     else
         make PREFIX="$md_inst" install

--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -49,7 +49,7 @@ function build_retroarch() {
     isPlatform "rpi" && params+=(--enable-dispmanx)
     isPlatform "mali" && params+=(--enable-mali_fbdev)
     isPlatform "arm" && params+=(--enable-floathard)
-    isPlatform "armv7" && params+=(--enable-neon)
+    isPlatform "neon" && params+=(--enable-neon)
     ./configure --prefix="$md_inst" "${params[@]}"
     make clean
     make

--- a/scriptmodules/emulators/uae4all.sh
+++ b/scriptmodules/emulators/uae4all.sh
@@ -75,7 +75,7 @@ function build_uae4all() {
     make
     popd
     make -f Makefile.pi clean
-    if isPlatform "rpi2"; then
+    if isPlatform "neon"; then
         make -f Makefile.pi NEON=1 DEFS="-DUSE_ARMV7 -DUSE_ARMNEON"
     else
         make -f Makefile.pi

--- a/scriptmodules/libretrocores/lr-beetle-supergrafx.sh
+++ b/scriptmodules/libretrocores/lr-beetle-supergrafx.sh
@@ -21,7 +21,7 @@ function build_lr-beetle-supergrafx() {
     make clean
     local params=()
     isPlatform "armv6" && params=("platform=armv")
-    isPlatform "armv7" && params=("platform=armvneon")
+    isPlatform "neon" && params=("platform=armvneon")
     make "${params[@]}"
     md_ret_require="$md_build/mednafen_supergrafx_libretro.so"
 }

--- a/scriptmodules/libretrocores/lr-mgba.sh
+++ b/scriptmodules/libretrocores/lr-mgba.sh
@@ -20,7 +20,7 @@ function sources_lr-mgba() {
 
 function build_lr-mgba() {
     make -f Makefile.libretro clean
-    if isPlatform "armv7"; then
+    if isPlatform "neon"; then
         make -f Makefile.libretro HAVE_NEON=1
     else
         make -f Makefile.libretro

--- a/scriptmodules/libretrocores/lr-ppsspp.sh
+++ b/scriptmodules/libretrocores/lr-ppsspp.sh
@@ -16,13 +16,13 @@ rp_module_flags="!armv6"
 
 function depends_lr-ppsspp() {
     local depends=()
-    isPlatform "rpi2" && depends+=(libraspberrypi-dev)
+    isPlatform "rpi" && depends+=(libraspberrypi-dev)
     [[ "$__default_gcc_version" == "4.7" ]] && depends+=(gcc-4.8 g++-4.8)
     getDepends "${depends[@]}"
 }
 
 function sources_lr-ppsspp() {
-    if isPlatform "rpi2"; then
+    if isPlatform "rpi"; then
         gitPullOrClone "$md_build" https://github.com/joolswills/ppsspp.git libretro_rpi_fix
     else
         gitPullOrClone "$md_build" https://github.com/libretro/libretro-ppsspp.git
@@ -40,7 +40,7 @@ function build_lr-ppsspp() {
     
     make -C libretro clean
     local params=()
-    isPlatform "rpi2" && params+=("platform=rpi2")
+    isPlatform "rpi" && params+=("platform=rpi2")
     if [[ "$__default_gcc_version" == "4.7" ]]; then
         make -C libretro "${params[@]}" CC=gcc-4.8 CXX=g++-4.8
     else

--- a/scriptmodules/libretrocores/lr-snes9x-next.sh
+++ b/scriptmodules/libretrocores/lr-snes9x-next.sh
@@ -22,7 +22,7 @@ function sources_lr-snes9x-next() {
 
 function build_lr-snes9x-next() {
     make -f Makefile.libretro clean
-    if isPlatform "armv7"; then
+    if isPlatform "neon"; then
         make -f Makefile.libretro platform=armvneon
     else
         make -f Makefile.libretro

--- a/scriptmodules/libretrocores/lr-vba-next.sh
+++ b/scriptmodules/libretrocores/lr-vba-next.sh
@@ -20,7 +20,7 @@ function sources_lr-vba-next() {
 
 function build_lr-vba-next() {
     make -f Makefile.libretro clean
-    if isPlatform "armv7"; then
+    if isPlatform "neon"; then
         make -f Makefile.libretro platform=armvhardfloatunix TILED_RENDERING=1 HAVE_NEON=1
     else
         make -f Makefile.libretro

--- a/scriptmodules/libretrocores/lr-yabause.sh
+++ b/scriptmodules/libretrocores/lr-yabause.sh
@@ -21,7 +21,7 @@ function sources_lr-yabause() {
 function build_lr-yabause() {
     cd libretro
     make clean
-    if isPlatform "armv7"; then
+    if isPlatform "neon"; then
         make platform=armvneonhardfloat
     else
         make

--- a/scriptmodules/supplementary/scraper.sh
+++ b/scriptmodules/supplementary/scraper.sh
@@ -39,7 +39,7 @@ function install_scraper() {
         local ver="$(latest_ver_scraper)"
         mkdir -p "$md_build"
         local name="scraper_rpi.zip"
-        isPlatform "armv7" && name="scraper_rpi2.zip"
+        isPlatform "neon" && name="scraper_rpi2.zip"
         wget -O "$md_build/scraper.zip" "https://github.com/sselph/scraper/releases/download/$ver/$name"
         unzip -o "$md_build/scraper.zip" -d "$md_inst"
         rm -f "$md_build/scraper.zip"

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -17,33 +17,7 @@ function setup_env() {
     __memory_phys=$(free -m | awk '/^Mem:/{print $2}')
     __memory_total=$(free -m -t | awk '/^Total:/{print $2}')
 
-    if [[ -z "$__platform" ]]; then
-        case $(sed -n '/^Hardware/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo) in
-            BCM2708)
-                __platform="rpi1"
-                ;;
-            BCM2709)
-                __platform="rpi2"
-                ;;
-            ODROIDC)
-                __platform="odroid-c1"
-                ;;
-            *)
-                local architecture=$(uname --machine)
-                case $architecture in
-                    i686|x86_64|amd64)
-                        __platform="x86"
-                        ;;
-                esac
-                ;;
-        esac
-    fi
-
-    if fnExists "platform_${__platform}"; then
-        platform_${__platform}
-    else
-        fatalError "Unknown platform - please manually set the __platform variable to one of the following: $(compgen -A function platform_ | cut -b10- | paste -s -d' ')"
-    fi
+    get_platform
 
     get_os_version
     get_default_gcc
@@ -162,6 +136,36 @@ function get_retropie_depends() {
     if ! getDepends "${depends[@]}"; then
         fatalError "Unable to install packages required by $0 - ${md_ret_errors[@]}"
     fi
+}
+
+function get_platform() {
+    if [[ -z "$__platform" ]]; then
+        case $(sed -n '/^Hardware/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo) in
+            BCM2708)
+                __platform="rpi1"
+                ;;
+            BCM2709)
+                __platform="rpi2"
+                ;;
+            ODROIDC)
+                __platform="odroid-c1"
+                ;;
+            *)
+                local architecture=$(uname --machine)
+                case $architecture in
+                    i686|x86_64|amd64)
+                        __platform="x86"
+                        ;;
+                esac
+                ;;
+        esac
+    fi
+
+    if ! fnExists "platform_${__platform}"; then
+        fatalError "Unknown platform - please manually set the __platform variable to one of the following: $(compgen -A function platform_ | cut -b10- | paste -s -d' ')"
+    fi
+
+    platform_${__platform}
 }
 
 function platform_rpi1() {

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -201,15 +201,18 @@ function platform_rpi2() {
     __has_binaries=1
 }
 
+# note the rpi3 currently uses the rpi2 binaries - for ease of maintenance - rebuilding from source
+# could improve performance with the compiler options below but needs further testing
 function platform_rpi3() {
-    platform_rpi2
-}
-
-function platform_rpi3-64() {
-    __default_cflags="-O2 -mcpu=cortex-a53 -mfpu=neon-vfpv4 -mfloat-abi=hard"
+    __default_cflags="-O2 -mcpu=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard"
     __default_asflags=""
     __default_makeflags="-j2"
     __platform_flags="arm armv8 neon rpi"
+    __has_binaries=1
+}
+
+function platform_rpi3-64() {
+    platform_rpi3
     __has_binaries=0
 }
 

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -188,6 +188,14 @@ function platform_rpi2() {
     __has_binaries=1
 }
 
+function platform_rpi3() {
+    __default_cflags="-O2 -mcpu=cortex-a53 -mfpu=neon-vfpv4 -mfloat-abi=hard"
+    __default_asflags=""
+    __default_makeflags="-j2"
+    __platform_flags="arm armv8 neon rpi"
+    __has_binaries=0
+}
+
 function platform_odroid-c1() {
     __default_cflags="-O2 -mcpu=cortex-a5 -mfpu=neon-vfpv4 -mfloat-abi=hard"
     __default_asflags=""

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -139,19 +139,28 @@ function get_retropie_depends() {
 }
 
 function get_platform() {
+    local architecture=$(uname --machine)
     if [[ -z "$__platform" ]]; then
         case $(sed -n '/^Hardware/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo) in
             BCM2708)
                 __platform="rpi1"
                 ;;
             BCM2709)
-                __platform="rpi2"
+                local revision=$(sed -n '/^Revision/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo)
+                if [[ "$revision" == "a02082" ]]; then
+                    if [[ "$architecture" == "aarch64" ]]; then
+                        __platform="rpi3-64"
+                    else
+                        __platform="rpi3"
+                    fi
+                else
+                    __platform="rpi2"
+                fi
                 ;;
             ODROIDC)
                 __platform="odroid-c1"
                 ;;
             *)
-                local architecture=$(uname --machine)
                 case $architecture in
                     i686|x86_64|amd64)
                         __platform="x86"
@@ -193,6 +202,10 @@ function platform_rpi2() {
 }
 
 function platform_rpi3() {
+    platform_rpi2
+}
+
+function platform_rpi3-64() {
     __default_cflags="-O2 -mcpu=cortex-a53 -mfpu=neon-vfpv4 -mfloat-abi=hard"
     __default_asflags=""
     __default_makeflags="-j2"

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -181,7 +181,7 @@ function platform_rpi2() {
     __default_cflags="-O2 -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard"
     __default_asflags=""
     __default_makeflags="-j2"
-    __platform_flags="arm armv7 rpi"
+    __platform_flags="arm armv7 neon rpi"
     # there is no support in qemu for cortex-a7 it seems, but it does have cortex-a15 which is architecturally
     # aligned with the a7, and allows the a7 targetted code to be run in a chroot/emulated environment
     __qemu_cpu=cortex-a15
@@ -192,7 +192,7 @@ function platform_odroid-c1() {
     __default_cflags="-O2 -mcpu=cortex-a5 -mfpu=neon-vfpv4 -mfloat-abi=hard"
     __default_asflags=""
     __default_makeflags="-j2"
-    __platform_flags="arm armv7 mali"
+    __platform_flags="arm armv7 neon mali"
     __qemu_cpu=cortex-a9
     __has_binaries=0
 }
@@ -217,6 +217,6 @@ function platform_armv7-mali() {
     __default_cflags="-O2 -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard"
     __default_asflags=""
     __default_makeflags="-j$(nproc)"
-    __platform_flags="arm armv7 mali"
+    __platform_flags="arm armv7 neon mali"
     __has_binaries=0
 }


### PR DESCRIPTION
Added a neon flag so we don't have to do isPlatform "armv7" for neon optimisations

RPI3 will id as rpi2 currently, which is fine - I expect it to use the rpi2 binaries. rpi3 runs in 32bit mode on Raspbian. if retropie-setup is run on aarch64 people can try __platform=rpi3 to build from source

this is all untested currently.