### PR TITLE
Add Emerson Arcadia 2001 console to lr-mess script.

### DIFF
--- a/scriptmodules/libretrocores/lr-mess.sh
+++ b/scriptmodules/libretrocores/lr-mess.sh
@@ -33,10 +33,12 @@ function configure_lr-mess() {
     mkRomDir "nes"
     mkRomDir "gameboy"
     mkRomDir "coleco"
+    mkRomDir "arcadia"
     ensureSystemretroconfig "nes"
     ensureSystemretroconfig "gameboy"
     ensureSystemretroconfig "coleco"
-
+    ensureSystemretroconfig "arcadia"
+    
     setRetroArchCoreOption "mame_softlists_enable" "enabled"
     setRetroArchCoreOption "mame_softlists_auto_media" "enabled"
     setRetroArchCoreOption "mame_boot_from_cli" "enabled"
@@ -47,4 +49,5 @@ function configure_lr-mess() {
     addSystem 0 "$md_id" "nes" "$md_inst/mess_libretro.so"
     addSystem 0 "$md_id" "gameboy" "$md_inst/mess_libretro.so"
     addSystem 0 "$md_id" "coleco" "$md_inst/mess_libretro.so"
+    addSystem 0 "$md_id" "arcadia" "$md_inst/mess_libretro.so"
 }


### PR DESCRIPTION
Added the Emerson Arcadia 2001 console to the lr-mess script.

Notes: Runs 100% on Pi 2. No BIOS required. MAME software list ROMs in $romdir/arcadia.