### PR TITLE
Use stable URLs to download Solarus games

### DIFF
--- a/scriptmodules/ports/solarus.sh
+++ b/scriptmodules/ports/solarus.sh
@@ -20,9 +20,9 @@ function depends_solarus() {
 
 function sources_solarus() {
     wget -O- -q http://www.solarus-games.org/downloads/solarus/solarus-1.4.5-src.tar.gz | tar -xvz --strip-components=1
-    wget -O- -q http://www.zelda-solarus.com/zs/download/zmosdx-src/ | tar -xvz
-    wget -O- -q http://www.zelda-solarus.com/zs/download/zmosxd-src/ | tar -xvz
-    wget -O- -q http://www.zelda-solarus.com/zs/download/zroth-src/ | tar -xvz
+    wget -O- -q http://www.zelda-solarus.com/downloads/zsdx/zsdx-1.10.3.tar.gz | tar -xvz
+    wget -O- -q http://www.zelda-solarus.com/downloads/zsxd/zsxd-1.10.3.tar.gz | tar -xvz
+    wget -O- -q http://www.zelda-solarus.com/downloads/zelda-roth-se/zelda-roth-se-1.0.8.tar.gz | tar -xvz
 }
 
 function build_solarus() {


### PR DESCRIPTION
Download games compatible with Solarus 1.4 rather than the latest ones