### PR TITLE
Added Cannonball engine script.

### DIFF
--- a/scriptmodules/ports/cannonball.sh
+++ b/scriptmodules/ports/cannonball.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+# 
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# 
+# See the LICENSE.md file at the top-level directory of this distribution and 
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="cannonball"
+rp_module_desc="cannonball - An Enhanced OutRun Engine"
+rp_module_menus="4+"
+rp_module_flags="!x11 !mali"
+
+function depends_cannonball() {
+    getDepends libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libboost-dev
+}
+
+function sources_cannonball() {
+    gitPullOrClone "$md_build" https://github.com/djyt/cannonball.git
+    sed -i "s/-march=armv6 -mfpu=vfp -mfloat-abi=hard//" $md_build/cmake/sdl2_rpi.cmake $md_build/cmake/sdl2gles_rpi.cmake
+}
+
+function build_cannonball() {
+    
+    mkdir build
+    cd build
+    cmake -G "Unix Makefiles" -DTARGET=sdl2gles_rpi -DCMAKE_INSTALL_PREFIX:PATH="$md_inst" ../cmake/
+    make
+    md_ret_require="$md_build/build/cannonball"
+}
+
+function install_cannonball() {
+    mkRomDir "ports/cannonball"
+    cp build/cannonball "$md_inst"
+    ln -s "$romdir/ports/cannonball" "$md_inst/roms"
+    mkdir "$md_inst/res/"
+    cp -R roms/* "$romdir/ports/cannonball/"
+    cp res/tilemap.bin "$md_inst/res/"
+    cp res/tilepatch.bin "$md_inst/res/"
+    cp res/config.xml "$md_inst"
+    touch "$md_inst/hiscores.xml"
+}
+
+function configure_cannonball() {
+    addPort "$md_id" "cannonball" "Cannonball - OutRun Engine" "pushd $md_inst; $md_inst/cannonball; popd"
+    __INFMSGS+=("You need to unzip your OutRun set B from latest MAME (outrun.zip) to $romdir/ports/cannonball/. They should match the file names listed in the roms.txt file found in the roms folder. You will also need to rename the epr-10381a.132 file to epr-10381b.132 before it will work.")
+}


### PR DESCRIPTION
Added Cannonball engine script.

Jools, there's a compilation warning that seems harmless when compiling on the Pi 2 that I'm worried about when it comes to running on Pi 3. The repository that this is being pulled from hasn't been updated for anything Pi 3, so it's possible that his compile flags here may cause some issues on it. For each file compiled, the following warning is spit out: 

warning: switch -mcpu=cortex-a7 conflicts with -march=armv6 switch

So if you could give it a quick test whenever you get your Pi 3, I'd appreciate it.