### PR TITLE
Added core option defaults to lr-fba-next.

### DIFF
--- a/scriptmodules/libretrocores/lr-fba-next.sh
+++ b/scriptmodules/libretrocores/lr-fba-next.sh
@@ -52,6 +52,9 @@ function configure_lr-fba-next() {
     ensureSystemretroconfig "fba"
     ensureSystemretroconfig "neogeo"
 
+    # Set core options
+    setRetroArchCoreOption "fba-diagnostic-input" "Hold Start"
+
     local def=1
     isPlatform "armv6" && def=0
     addSystem 0 "$md_id" "arcade" "$md_inst/fba_libretro.so"


### PR DESCRIPTION
Now, if Retropad Start button is held, the game's diagnostic menu appears, allowing various dipswitch settings to add free play and offer effects to FBA and Neogeo games. These settings are saved in the /roms/<system>/ folder as .fs files, and are automatically loaded on game load.