### PR TITLE
Add Stratagus

### DIFF
--- a/scriptmodules/emulators/stratagus.sh
+++ b/scriptmodules/emulators/stratagus.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="stratagus"
+rp_module_desc="Stratagus - A strategy game engine to play Warcraft I or II, Starcraft, and some similar open-source games"
+rp_module_menus="4+"
+rp_module_flags=""
+
+function depends_stratagus() {
+    getDepends libsdl1.2-dev libbz2-dev libogg-dev libvorbis-dev libtheora-dev libpng12-dev liblua5.1-0-dev libtolua++5.1-dev
+}
+
+function sources_stratagus() {
+    gitPullOrClone "$md_build" https://github.com/Wargus/stratagus.git
+}
+
+function build_stratagus() {
+    mkdir build
+    pushd build
+    cmake -DENABLE_STRIP=ON ..
+    make
+    popd
+    md_ret_require="$md_build/build/stratagus"
+}
+
+function install_stratagus() {
+    md_ret_files=(
+        '/build/stratagus'
+        '/COPYING'
+    )
+}
+
+function configure_stratagus() {
+    mkRomDir "stratagus"
+    mkUserDir "$configdir/stratagus"
+
+    addSystem 0 "$md_id" "stratagus" "$md_inst/stratagus -F -d %ROM%" "Stratagus Strategy Engine" ".wc1 .wc2 .sc .data"
+}


### PR DESCRIPTION
This adds the Stratagus engine that can be used to play Warcraft I + II and Starcraft (the latter in a more limited fashion). Extracting the game data into the Stratagus format is not part of the engine. The data has to be extracted from the original media (can be done by using the installers for https://github.com/Wargus/wargus, https://github.com/Wargus/war1gus,  https://github.com/Wargus/stargus on Windows, their debian packages, or their OS X bundles). The extracted folders must then be placed in the roms directory with the folder name ending in `.data`.

I don't know how to get OpenGL mode to work (it doesn't launch for me in that case), I suspect there needs to be work in the engine to support the Raspberry Pi. However, this is a simple 2d strategy engine and software mode works just fine for the three Blizzard games.