### PR TITLE
updated scummvm to 1.8 - use github directly for source, and enable sdl2

### DIFF
--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -12,10 +12,10 @@
 rp_module_id="scummvm"
 rp_module_desc="ScummVM"
 rp_module_menus="2+"
-rp_module_flags="dispmanx !mali"
+rp_module_flags="!mali"
 
 function depends_scummvm() {
-    getDepends libsdl1.2-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng12-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev
+    getDepends libsdl2-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng12-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev
     if [[ "$__raspbian_ver" -lt "8" ]]; then
         getDepends libjpeg8-dev
     else
@@ -24,11 +24,35 @@ function depends_scummvm() {
 }
 
 function sources_scummvm() {
-    wget -O- -q $__archive_url/scummvm-1.7.0.tar.gz | tar -xvz --strip-components=1
+    gitPullOrClone "$md_build" https://github.com/scummvm/scummvm.git "branch-1-8"
+    patch -p1 <<\_EOF_
+diff --git a/configure b/configure
+index 31dbf5a..58e9563 100755
+--- a/configure
++++ b/configure
+@@ -2651,10 +2651,6 @@ if test -n "$_host"; then
+ 			append_var LDFLAGS "-L$RPI_ROOT/opt/vc/lib"
+ 			# This is so optional OpenGL ES includes are found.
+ 			append_var CXXFLAGS "-I$RPI_ROOT/opt/vc/include"
+-			_savegame_timestamp=no
+-			_eventrec=no
+-			_build_scalers=no
+-			_build_hq_scalers=no
+ 			# We prefer SDL2 on the Raspberry Pi: acceleration now depends on it
+ 			# since SDL2 manages dispmanx/GLES2 very well internally.
+ 			# SDL1 is bit-rotten on this platform.
+_EOF_
 }
 
 function build_scummvm() {
-    ./configure --enable-vkeybd --enable-release --disable-debug --enable-keymapper --disable-eventrecorder --prefix="$md_inst"
+    local params=(--enable-all-engines --enable-vkeybd --enable-release --disable-debug --enable-keymapper --disable-eventrecorder --prefix="$md_inst")
+    isPlatform "rpi" && params+=(--host=raspberrypi)
+    # stop scummvm using arm-linux-gnueabihf-g++ which is v4.6 on wheezy and doesn't like rpi2 cpu flags
+    if isPlatform "rpi"; then
+        CC="gcc" CXX="g++" ./configure "${params[@]}"
+    else
+        ./configure "${params[@]}"
+    fi
     make clean
     make
     strip "$md_build/scummvm"


### PR DESCRIPTION
The only thing I'm thinking of changing is a few of the parameters which are set when building for the RPI. The savegame timestamps are switched off - this was because the RPI doesn't have a battery backed up clock, but internet connected RPI do have the correct time, so we might want this.

Also the hq scalers are switched off. Sure for performance we don't want them, but some people may want to run in a higher res with a scaler to get a "better image". so It might be worth including them. The event recorder is also switched off, but i dont personally think it will cause any sd card wear to worry about (no more than the system logging etc). 
