### PR TITLE
Create rc.local

### DIFF
--- a/rc.local
+++ b/rc.local
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+sudo chmod +x /dev/uinput
+
+xboxdrv --trigger-as-button --wid 0 --led 2 --detach-kernel-driver --quiet --silent & sleep 1


### PR DESCRIPTION
Suggest that xboxdrv and this code be added to your rc.local file being included in future RetroPie image releases for two major reasons:
(1) More accurate input reads: The default driver being used erroneously reads inputthat is not actually being sent (most noticeable when trying to assign trigger buttons during initial controller setup on first boot), where as using this configuration fixes it.
(2) retroarch. Retroarch does not initially recognize controller input after a fresh image install, and therefore requires a keyboard for initial setup.

The rc.local proposal here will allow the 360 controller be recognized in such a way that anyone running a new RetroPie image will not ever need a keyboard for initial use unless they want to do low-level modifications (which I would assume would just be done via SSH anyways). It is a very lightweight solution which will benefit many xbox360 controller users with virtually no impact to startup time, and without any risk of hangupsfor users not electing to use an xbox360 controller.