### PR TITLE
Platform arguments now handled by Makefile, handling these fixes and …

### DIFF
--- a/scriptmodules/libretrocores/lr-mame2003.sh
+++ b/scriptmodules/libretrocores/lr-mame2003.sh
@@ -19,18 +19,18 @@ function depends_lr-mame2003() {
 
 function sources_lr-mame2003() {
     gitPullOrClone "$md_build" https://github.com/libretro/mame2003-libretro.git
-    # some games crash (eg pacmania) when built with -mfpu=neon-vfpv4 / -O3 on arm
-    isPlatform "arm" && sed -i "s/-O3/-O2/" Makefile
     # quieter build
     sed -i "s/-Wcast-align//" Makefile
 }
 
 function build_lr-mame2003() {
     make clean
+    local params=()
+    isPlatform "arm" && params+=("ARM=1")
     if [[ "$__default_gcc_version" == "4.7" ]]; then
-        make ARCH="$CFLAGS -fsigned-char" CC="gcc-4.8" CXX="g++-4.8"
+        make ARCH="$CFLAGS" CC="gcc-4.8" CXX="g++-4.8" "${params[@]}"
     else
-        make ARCH="$CFLAGS -fsigned-char"
+        make ARCH="$CFLAGS" "${params[@]}"
     fi
 }
 


### PR DESCRIPTION
…the Pi 2/3 optimisations.

Tested this on a Pi3. Pac-mania works (proof of -O2) and hi load games like MK1 show no regression in performance. No noticeable improvements, either, of course! I also temporarily stuck an $error() in the Makefile to dump out the CFLAGS and PLATCFLAGS strings when testing, and they came back as I'd expect:
````
*** PLATCFLAGS is -Dstricmp=strcasecmp -marm -mcpu=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard -funsafe-math-optimizations -fomit-frame-pointer -ffast-math -fsigned-char -fPIC.  Stop.
````
````
*** CFLAGS is -O2 -mcpu=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard -pipe -fPIC -D__LIBRETRO__ -DPI=3.1415927 -DRETRO_PROFILE=0 -Wall -Wno-sign-compare -Wunused -Wpointer-arith -Wbad-function-cast  -Waggregate-return -Wshadow -Wstrict-prototypes -Wformat-security -Wwrite-strings -Wdisabled-optimization -DNDEBUG -O2 -mcpu=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard -pipe -O2 -fomit-frame-pointer -fstrict-aliasing -Isrc -Isrc/includes -Isrc/libretro -Isrc/cpu/m68000 -Isrc/cpu/m68000.  Stop.
````
There's some repetition in a few flags (I guess because of earlier overrides in the scripts), but everything seems to work!