### PR TITLE
Config editor

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -82,7 +82,7 @@ function configure_retroarch() {
     fi
 
     # configure default options
-    iniConfig " = " "" "$config"
+    iniConfig " = " '"' "$config"
     iniSet "cache_directory" "/tmp/retroarch"
     iniSet "system_directory" "$biosdir"
     iniSet "config_save_on_exit" "false"

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -315,13 +315,15 @@ function setDispmanx() {
 }
 
 function iniFileEditor() {
-    local config="$1"
+    local delim="$1"
+    local quote="$2"
+    local config="$3"
     [[ ! -f "$config" ]] && return
 
     # disable globbing
     set -f
 
-    iniConfig " = " "" "$config"
+    iniConfig "$delim" "$quote" "$config"
     local sel
     local value
     local option
@@ -555,7 +557,7 @@ function ensureSystemretroconfig {
     fi
 
     # add the per system default settings
-    iniConfig " = " "" "$config"
+    iniConfig " = " '"' "$config"
     iniSet "input_remapping_directory" "$configdir/$system/"
 
     if [[ -n "$shader" ]]; then

--- a/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
+++ b/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
@@ -47,9 +47,5 @@ function configure_lr-pcsx-rearmed() {
     mkRomDir "psx"
     ensureSystemretroconfig "psx"
 
-    # system-specific, PSX
-    iniConfig " = " "" "$configdir/psx/retroarch.cfg"
-    iniSet "rewind_enable" "false"
-
     addSystem 1 "$md_id" "psx" "$md_inst/libretro.so"
 }

--- a/scriptmodules/supplementary/configedit.sh
+++ b/scriptmodules/supplementary/configedit.sh
@@ -129,7 +129,7 @@ function basic_configedit() {
         'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick'
     )
 
-    iniFileEditor "$config"
+    iniFileEditor " = " '"' "$config"
 }
 
 function advanced_configedit() {
@@ -211,7 +211,7 @@ function advanced_configedit() {
         'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick'
     )
 
-    iniFileEditor "$config"
+    iniFileEditor " = " '"' "$config"
 }
 
 function choose_config_configedit() {

--- a/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh
@@ -13,7 +13,7 @@ function onstart_retroarch_joystick() {
     local device_type=$1
     local device_name=$2
 
-    iniConfig " = " "" "$configdir/all/retroarch.cfg"
+    iniConfig " = " '"' "$configdir/all/retroarch.cfg"
     iniGet "input_joypad_driver"
     local input_joypad_driver="$ini_value"
     if [[ -z "$input_joypad_driver" ]]; then
@@ -26,7 +26,7 @@ function onstart_retroarch_joystick() {
 }
 
 function onstart_retroarch_keyboard() {
-    iniConfig " = " "" "$configdir/all/retroarch.cfg"
+    iniConfig " = " '"' "$configdir/all/retroarch.cfg"
 
     declare -Ag retroarchkeymap
     # SDL codes from https://wiki.libsdl.org/SDLKeycodeLookup

--- a/scriptmodules/supplementary/retroarchinput.sh
+++ b/scriptmodules/supplementary/retroarchinput.sh
@@ -45,7 +45,7 @@ function keyboard_retroarchinput() {
 }
 
 function hotkey_retroarchinput() {
-    iniConfig " = " "" "$configdir/all/retroarch.cfg"
+    iniConfig " = " '"' "$configdir/all/retroarch.cfg"
     cmd=(dialog --backtitle "$__backtitle" --menu "Choose the desired hotkey behaviour." 22 76 16)
     options=(1 "Hotkeys enabled. (default)"
              2 "Press ALT to enable hotkeys."


### PR DESCRIPTION
Switching to use quoted values for retroarch.cfg - when retroarch saves the configs itself it uses quotes, since we were not, it broke the config editor - so we might as well just use quotes (even though their skeleton config file does not.