### PR TITLE
Added missing quotes around file variable

### DIFF
--- a/scriptmodules/inifuncs.sh
+++ b/scriptmodules/inifuncs.sh
@@ -95,7 +95,7 @@ function iniGet() {
     local delim_strip=${delim// /}
     # if the stripped delimiter is empty - such as in the case of a space, just use the delimiter instead
     [[ -z "$delim_strip" ]] && delim_strip="$delim"
-    ini_value=$(sed -rn "s/^[[:space:]]*$key[[:space:]]*$delim_strip[[:space:]]*$quote(.+)$quote.*/\1/p" $file)
+    ini_value=$(sed -rn "s/^[[:space:]]*$key[[:space:]]*$delim_strip[[:space:]]*$quote(.+)$quote.*/\1/p" "$file")
 }
 
 # arg 1: key, arg 2: default value (optional - is 1 if not used)


### PR DESCRIPTION
This affected [scriptmodules/emulators/mupen64plus/mupen64plus.sh](https://github.com/RetroPie/RetroPie-Setup/blob/master/scriptmodules/emulators/mupen64plus/mupen64plus.sh) in case the retroarch configuration file has spaces in the file name.