### PR TITLE
Ports

### DIFF
--- a/scriptmodules/libretrocores/lr-nxengine.sh
+++ b/scriptmodules/libretrocores/lr-nxengine.sh
@@ -30,22 +30,23 @@ function install_lr-nxengine() {
 }
 
 function configure_lr-nxengine() {
-    # remove old install folder
-    rm -rf "$rootdir/$md_type/cavestory"
+    setConfigRoot "ports"
 
-    mkRomDir "ports"
-    ensureSystemretroconfig "cavestory"
-
-    local msg="You need the original Cave Story game files to use $md_id. Please unpack the game to $romdir/ports/CaveStory so you have the file $romdir/ports/CaveStory/Doukutsu.exe present."
-
-    addPort "$md_id" "cavestory" "Cave Story" "$emudir/retroarch/bin/retroarch -L $md_inst/nxengine_libretro.so --config $configdir/cavestory/retroarch.cfg $romdir/ports/CaveStory/Doukutsu.exe" << _EOF_
+    addPort "$md_id" "cavestory" "Cave Story" "$emudir/retroarch/bin/retroarch -L $md_inst/nxengine_libretro.so --config $md_conf_root/cavestory/retroarch.cfg $romdir/ports/CaveStory/Doukutsu.exe" << _EOF_
 #!/bin/bash
 if [[ ! -f "$romdir/ports/CaveStory/Doukutsu.exe" ]]; then
     dialog --msgbox "$msg" 22 76
 else
-    "$rootdir/supplementary/runcommand/runcommand.sh" 0 _SYS_ cavestory
+    "$rootdir/supplementary/runcommand/runcommand.sh" 0 _PORT_ cavestory
 fi
 _EOF_
 
+    ensureSystemretroconfig "ports/cavestory"
+
+    local msg="You need the original Cave Story game files to use $md_id. Please unpack the game to $romdir/ports/CaveStory so you have the file $romdir/ports/CaveStory/Doukutsu.exe present."
+
     __INFMSGS+=("$msg")
+
+    # remove old install folder
+    rm -rf "$rootdir/$md_type/cavestory"
 }

--- a/scriptmodules/libretrocores/lr-prboom.sh
+++ b/scriptmodules/libretrocores/lr-prboom.sh
@@ -31,12 +31,12 @@ function install_lr-prboom() {
 }
 
 function configure_lr-prboom() {
-    # remove old install folder
-    rm -rf "$rootdir/$md_type/doom"
+    setConfigRoot "ports"
 
-    mkRomDir "ports"
+    addPort "$md_id" "doom" "Doom" "$emudir/retroarch/bin/retroarch -L $md_inst/prboom_libretro.so --config $md_conf_root/doom/retroarch.cfg $romdir/ports/doom/doom1.wad"
+
     mkRomDir "ports/doom"
-    ensureSystemretroconfig "doom"
+    ensureSystemretroconfig "ports/doom"
 
     cp prboom.wad "$romdir/ports/doom/"
 
@@ -49,5 +49,6 @@ function configure_lr-prboom() {
     # remove old launch script
     rm -f "$romdir/ports/Doom 1 Shareware.sh"
 
-    addPort "$md_id" "doom" "Doom" "$emudir/retroarch/bin/retroarch -L $md_inst/prboom_libretro.so --config $configdir/doom/retroarch.cfg $romdir/ports/doom/doom1.wad"
+    # remove old install folder
+    rm -rf "$rootdir/$md_type/doom"
 }

--- a/scriptmodules/libretrocores/lr-tyrquake.sh
+++ b/scriptmodules/libretrocores/lr-tyrquake.sh
@@ -37,6 +37,7 @@ function install_lr-tyrquake() {
 }
 
 function download_quake_lr-tyrquake() {
+    mkRomDir "ports/quake"
     if [[ ! -f "$romdir/ports/quake/id1/pak0.pak" ]]; then
         # download / unpack / install quake shareware files
         wget "$__archive_url/quake106.zip" -O quake106.zip
@@ -52,14 +53,14 @@ function download_quake_lr-tyrquake() {
 }
 
 function configure_lr-tyrquake() {
+    setConfigRoot "ports"
+
+    addPort "$md_id" "quake" "Quake" "$emudir/retroarch/bin/retroarch -L $md_inst/tyrquake_libretro.so --config $md_conf_root/quake/retroarch.cfg $romdir/ports/quake/id1/pak0.pak"
+
+    ensureSystemretroconfig "ports/quake"
+
     # remove old install folder
     rm -rf "$rootdir/$md_type/tyrquake"
 
-    mkRomDir "ports"
-    mkRomDir "ports/quake"
-    ensureSystemretroconfig "quake"
-
     download_quake_lr-tyrquake
-
-    addPort "$md_id" "quake" "Quake" "$emudir/retroarch/bin/retroarch -L $md_inst/tyrquake_libretro.so --config $configdir/quake/retroarch.cfg $romdir/ports/quake/id1/pak0.pak"
 }

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -105,6 +105,15 @@ function rp_callModule() {
     local md_build="$__builddir/$mod_id"
     local md_inst="$rootdir/$md_type/$mod_id"
 
+    # set md_conf_root to $configdir and to $configdir/ports for ports
+    # ports in libretrocores or systems (as ES sees them) in ports will need to change it manually with setConfigRoot
+    local md_conf_root
+    if [[ "$md_type" == "ports" ]]; then
+        setConfigRoot "ports"
+    else
+        setConfigRoot ""
+    fi
+
     # remove source/build files
     if [[ "${mode}" == "clean" ]]; then
         rmDirExists "$md_build"

--- a/scriptmodules/ports/alephone.sh
+++ b/scriptmodules/ports/alephone.sh
@@ -33,8 +33,12 @@ function install_alephone() {
 }
 
 function configure_alephone() {
-    mkRomDir "ports"
-    mkRomDir "ports/$md_id/"
+    addPort "$md_id" "marathon" "Aleph One Engine - Marathon" "'$md_inst/bin/alephone' '$romdir/ports/$md_id/Marathon/'"
+    addPort "$md_id" "marathon2" "Aleph One Engine - Marathon 2" "'$md_inst/bin/alephone' '$romdir/ports/$md_id/Marathon 2/'"
+    addPort "$md_id" "marathoninfinity" "Aleph One Engine - Marathon Infinity" "'$md_inst/bin/alephone' '$romdir/ports/$md_id/Marathon Infinity/'"
+
+    mkRomDir "ports/$md_id"
+
     moveConfigDir "$home/.alephone" "$configDir/alephone"
 
     if [[ ! -f "$romdir/ports/$md_id/Marathon/Shapes.shps" ]]; then
@@ -61,9 +65,5 @@ function configure_alephone() {
         rm MarathonInfinity-20150620-Data.zip
     fi
 
-    addPort "$md_id" "marathon" "Aleph One Engine - Marathon" "'$md_inst/bin/alephone' '$romdir/ports/$md_id/Marathon/'"
-    addPort "$md_id" "marathon2" "Aleph One Engine - Marathon 2" "'$md_inst/bin/alephone' '$romdir/ports/$md_id/Marathon 2/'"
-    addPort "$md_id" "marathoninfinity" "Aleph One Engine - Marathon Infinity" "'$md_inst/bin/alephone' '$romdir/ports/$md_id/Marathon Infinity/'"
     __INFMSGS+=("To get the games running, make sure to set each game to use the software renderer and disable the enhanced HUD from the Plugins menu. For Marathon 1, disable both HUDs from the Plugins menu, start a game, quit back to the title screen and enable Enhanced HUD and it will work and properly.")
-
 }

--- a/scriptmodules/ports/cannonball.sh
+++ b/scriptmodules/ports/cannonball.sh
@@ -51,24 +51,22 @@ function install_cannonball() {
 }
 
 function configure_cannonball() {
-    mkRomDir "ports"
+    addPort "$md_id" "cannonball" "Cannonball - OutRun Engine" "pushd $md_inst; $md_inst/cannonball; popd"
+
     mkRomDir "ports/$md_id"
-    mkUserDir "$configdir/$md_id"
 
-    moveConfigFile "config.xml" "$configdir/$md_id/config.xml"
-    moveConfigFile "hiscores.xml" "$configdir/$md_id/hiscores.xml"
+    moveConfigFile "config.xml" "$md_conf_root/$md_id/config.xml"
+    moveConfigFile "hiscores.xml" "$md_conf_root/$md_id/hiscores.xml"
 
-    if [[ ! -f "$configdir/$md_id/config.xml" ]]; then
-        cp -v "$md_inst/config.xml.def" "$configdir/$md_id/config.xml"
+    if [[ ! -f "$md_conf_root/$md_id/config.xml" ]]; then
+        cp -v "$md_inst/config.xml.def" "$md_conf_root/$md_id/config.xml"
     fi
 
     cp -v roms.txt "$romdir/ports/$md_id/"
 
-    chown -R $user:$user "$romdir/ports/$md_id" "$configdir/$md_id"
+    chown -R $user:$user "$romdir/ports/$md_id" "$md_conf_root/$md_id"
 
     ln -snf "$romdir/ports/$md_id" "$md_inst/roms"
-
-    addPort "$md_id" "cannonball" "Cannonball - OutRun Engine" "pushd $md_inst; $md_inst/cannonball; popd"
 
     __INFMSGS+=("You need to unzip your OutRun set B from latest MAME (outrun.zip) to $romdir/ports/$md_id. They should match the file names listed in the roms.txt file found in the roms folder. You will also need to rename the epr-10381a.132 file to epr-10381b.132 before it will work.")
 }

--- a/scriptmodules/ports/cgenius.sh
+++ b/scriptmodules/ports/cgenius.sh
@@ -38,11 +38,11 @@ function install_cgenius() {
 }
 
 function configure_cgenius() {
-    mkRomDir "ports"
-    mkRomDir "ports/$md_id"
-    mkUserDir "$configdir/$md_id"
+    addPort "$md_id" "cgenius" "Commander Genius" "pushd $md_inst; ./CGeniusExe; popd"
 
-    moveConfigDir "$home/.CommanderGenius"  "$configdir/$md_id"
+    mkRomDir "ports/$md_id"
+
+    moveConfigDir "$home/.CommanderGenius"  "$md_conf_root/$md_id"
 
     mv "$md_inst/games" "$romdir/ports/$md_id/"
     mv "$md_inst/hqp" "$romdir/ports/$md_id/"
@@ -50,6 +50,4 @@ function configure_cgenius() {
     ln -snf "$romdir/ports/$md_id/games" "$md_inst"
 
     chown -R $user:$user "$romdir/ports/$md_id"
-
-    addPort "$md_id" "cgenius" "Commander Genius" "pushd $md_inst; ./CGeniusExe; popd"
 }

--- a/scriptmodules/ports/dxx-rebirth.sh
+++ b/scriptmodules/ports/dxx-rebirth.sh
@@ -70,13 +70,13 @@ function configure_dxx-rebirth() {
     local D1X_OGG_URL='http://www.dxx-rebirth.com/download/dxx/res/d1xr-sc55-music.dxa'
     local D2X_OGG_URL='http://www.dxx-rebirth.com/download/dxx/res/d2xr-sc55-music.dxa'
 
-    mkRomDir "ports"
-
     # Descent 1
+    addPort "$md_id" "descent1" "Descent Rebirth" "$md_inst/d1x-rebirth -hogdir $romdir/ports/descent1"
+
     mkRomDir "ports/descent1"
     
-    # copy any existing configs from ~/.d1x-rebirth and symlink the config folder to $configdir/descent1/
-    moveConfigDir "$home/.d1x-rebirth" "$configdir/descent1/"
+    # copy any existing configs from ~/.d1x-rebirth and symlink the config folder to $md_conf_root/descent1/
+    moveConfigDir "$home/.d1x-rebirth" "$md_conf_root/descent1/"
     
     # Download / unpack / install Descent shareware files
     if [[ ! -f "$romdir/ports/descent1/descent.hog" ]]; then
@@ -96,14 +96,14 @@ function configure_dxx-rebirth() {
     fi
 
     chown -R $user:$user "$romdir/ports/descent1"
-
-    addPort "$md_id" "descent1" "Descent Rebirth" "$md_inst/d1x-rebirth -hogdir $romdir/ports/descent1"
     
     # Descent 2
+    addPort "$md_id" "descent2" "Descent 2 Rebirth" "$md_inst/d2x-rebirth -hogdir $romdir/ports/descent2"
+
     mkRomDir "ports/descent2"
     
-    # copy any existing configs from ~/.d2x-rebirth and symlink the config folder to $configdir/descent2/
-    moveConfigDir "$home/.d1x-rebirth" "$configdir/descent1/"
+    # copy any existing configs from ~/.d2x-rebirth and symlink the config folder to $md_conf_root/descent2/
+    moveConfigDir "$home/.d1x-rebirth" "$md_conf_root/descent1/"
     
     # Download / unpack / install Descent 2 shareware files
     if [[ ! -f "$romdir/ports/descent2/D2DEMO.HOG" ]]; then
@@ -118,6 +118,4 @@ function configure_dxx-rebirth() {
     fi
 
     chown -R $user:$user "$romdir/ports/descent2"
-
-    addPort "$md_id" "descent2" "Descent 2 Rebirth" "$md_inst/d2x-rebirth -hogdir $romdir/ports/descent2"
 }

--- a/scriptmodules/ports/eduke32.sh
+++ b/scriptmodules/ports/eduke32.sh
@@ -57,10 +57,11 @@ function install_eduke32() {
 }
 
 function configure_eduke32() {
-    mkRomDir "ports"
+    addPort "$md_id" "duke3d" "Duke Nukem 3D" "$md_inst/eduke32 -j$romdir/ports/duke3d"
+
     mkRomDir "ports/duke3d"
 
-    moveConfigDir "$home/.eduke32" "$configdir/duke3d"
+    moveConfigDir "$home/.eduke32" "$md_conf_root/duke3d"
 
     local file
     local file_bn
@@ -72,6 +73,4 @@ function configure_eduke32() {
 
     # remove old launch script
     rm -f "$romdir/ports/Duke3D Shareware.sh"
-
-    addPort "$md_id" "duke3d" "Duke Nukem 3D" "$md_inst/eduke32 -j$romdir/ports/duke3d"
 }

--- a/scriptmodules/ports/gemrb.sh
+++ b/scriptmodules/ports/gemrb.sh
@@ -42,14 +42,14 @@ function configure_gemrb() {
     mkRomDir "ports/planescape"
     mkRomDir "ports/cache"
 
-    addPort "$md_id" "baldursgate1" "Baldurs Gate 1" "$md_inst/bin/gemrb -C $configdir/baldursgate1/GemRB.cfg"
-    addPort "$md_id" "baldursgate2" "Baldurs Gate 2" "$md_inst/bin/gemrb -C $configdir/baldursgate2/GemRB.cfg"
-    addPort "$md_id" "icewind1" "Icewind Dale 1" "$md_inst/bin/gemrb -C $configdir/icewind1/GemRB.cfg"
-    addPort "$md_id" "icewind2" "Icewind Dale 2" "$md_inst/bin/gemrb -C $configdir/icewind2/GemRB.cfg"
-    addPort "$md_id" "planescape" "Planescape Torment" "$md_inst/bin/gemrb -C $configdir/planescape/GemRB.cfg"
+    addPort "$md_id" "baldursgate1" "Baldurs Gate 1" "$md_inst/bin/gemrb -C $md_conf_root/baldursgate1/GemRB.cfg"
+    addPort "$md_id" "baldursgate2" "Baldurs Gate 2" "$md_inst/bin/gemrb -C $md_conf_root/baldursgate2/GemRB.cfg"
+    addPort "$md_id" "icewind1" "Icewind Dale 1" "$md_inst/bin/gemrb -C $md_conf_root/icewind1/GemRB.cfg"
+    addPort "$md_id" "icewind2" "Icewind Dale 2" "$md_inst/bin/gemrb -C $md_conf_root/icewind2/GemRB.cfg"
+    addPort "$md_id" "planescape" "Planescape Torment" "$md_inst/bin/gemrb -C $md_conf_root/planescape/GemRB.cfg"
 
     #create Baldurs Gate 1 configuration
-    cat > "$configdir/baldursgate1/GemRB.cfg" << _EOF_
+    cat > "$md_conf_root/baldursgate1/GemRB.cfg" << _EOF_
 GameType=bg1
 GameName=Baldurs Gate 1
 Width=640
@@ -67,7 +67,7 @@ CachePath=$romdir/ports/cache/
 _EOF_
 
     #create Baldurs Gate 2 configuration
-    cat > "$configdir/baldursgate2/GemRB.cfg" << _EOF_
+    cat > "$md_conf_root/baldursgate2/GemRB.cfg" << _EOF_
 GameType=bg2
 GameName=Baldurs Gate 2
 Width=640
@@ -85,7 +85,7 @@ CachePath=$romdir/ports/cache/
 _EOF_
 
     #create Icewind 1 configuration
-    cat > "$configdir/icewind1/GemRB.cfg" << _EOF_
+    cat > "$md_conf_root/icewind1/GemRB.cfg" << _EOF_
 GameType=auto
 GameName=Icewind Dale 1
 Width=640
@@ -105,7 +105,7 @@ CachePath=$romdir/ports/cache/
 _EOF_
 
     #create Icewind2 configuration
-    cat > "$configdir/icewind2/GemRB.cfg" << _EOF_
+    cat > "$md_conf_root/icewind2/GemRB.cfg" << _EOF_
 GameType=iwd2
 GameName=Icewind Dale 2
 Width=800
@@ -123,7 +123,7 @@ CachePath=$romdir/ports/cache/
 _EOF_
 
     #create Planescape configuration
-    cat > "$configdir/planescape/GemRB.cfg" << _EOF_
+    cat > "$md_conf_root/planescape/GemRB.cfg" << _EOF_
 GameType=pst
 GameName=Planescape Torment
 Width=640
@@ -140,9 +140,9 @@ CD1=$romdir/ports/planescape/data/
 CachePath=$romdir/ports/cache/
 _EOF_
 
-    chown $user:$user "$configdir/baldursgate1/GemRB.cfg"
-    chown $user:$user "$configdir/baldursgate2/GemRB.cfg"
-    chown $user:$user "$configdir/icewind1/GemRB.cfg"
-    chown $user:$user "$configdir/icewind2/GemRB.cfg"
-    chown $user:$user "$configdir/planescape/GemRB.cfg"
+    chown $user:$user "$md_conf_root/baldursgate1/GemRB.cfg"
+    chown $user:$user "$md_conf_root/baldursgate2/GemRB.cfg"
+    chown $user:$user "$md_conf_root/icewind1/GemRB.cfg"
+    chown $user:$user "$md_conf_root/icewind2/GemRB.cfg"
+    chown $user:$user "$md_conf_root/planescape/GemRB.cfg"
 }

--- a/scriptmodules/ports/giana.sh
+++ b/scriptmodules/ports/giana.sh
@@ -21,9 +21,7 @@ function install_giana() {
 }
 
 function configure_giana() {
-    mkRomDir "ports"
+    addPort "$md_id" "giana" "Giana's Return" "pushd $md_inst; $md_inst/giana_rpi; popd"
 
     chmod +x "$md_inst/giana_rpi"
-
-    addPort "$md_id" "giana" "Giana's Return" "pushd $md_inst; $md_inst/giana_rpi; popd"
 }

--- a/scriptmodules/ports/lincity-ng.sh
+++ b/scriptmodules/ports/lincity-ng.sh
@@ -23,8 +23,6 @@ function install_lincity-ng() {
 }
 
 function configure_lincity-ng() {
-    mkRomDir "ports"
-    moveConfigDir "$home/.lincity-ng" "$configDir/lincity-ng"
-
     addPort "$md_id" "lincity-ng" "LinCity-NG" "xinit lincity-ng"
+    moveConfigDir "$home/.lincity-ng" "$configDir/lincity-ng"
 }

--- a/scriptmodules/ports/love.sh
+++ b/scriptmodules/ports/love.sh
@@ -58,4 +58,5 @@ function configure_love() {
     fi
 
     addSystem 1 "$md_id" "love" "$md_inst/bin/love %ROM%" "Love" ".love"
+
 }

--- a/scriptmodules/ports/micropolis.sh
+++ b/scriptmodules/ports/micropolis.sh
@@ -23,7 +23,7 @@ function install_micropolis() {
 }
 
 function configure_micropolis() {
-    mkRomDir "ports"
+    addPort "$md_id" "micropolis" "Micropolis" "xinit $md_inst/micropolis.sh"
 
     mkdir -p "$md_inst"
     cat >"$md_inst/micropolis.sh" << _EOF_
@@ -33,6 +33,4 @@ matchbox-window-manager &
 /usr/games/micropolis
 _EOF_
     chmod +x "$md_inst/micropolis.sh"
-
-    addPort "$md_id" "micropolis" "Micropolis" "xinit $md_inst/micropolis.sh"
 }

--- a/scriptmodules/ports/minecraft.sh
+++ b/scriptmodules/ports/minecraft.sh
@@ -23,7 +23,7 @@ function install_minecraft() {
 }
 
 function configure_minecraft() {
-    mkRomDir "ports"
+    addPort "$md_id" "minecraft" "Minecraft" "xinit $md_inst/Minecraft.sh"
 
     cat >"$md_inst/Minecraft.sh" << _EOF_
 #!/bin/bash
@@ -33,5 +33,5 @@ $md_inst/minecraft-pi
 _EOF_
     chmod +x "$md_inst/Minecraft.sh"
 
-    addPort "$md_id" "minecraft" "Minecraft" "xinit $md_inst/Minecraft.sh"
+
 }

--- a/scriptmodules/ports/openbor.sh
+++ b/scriptmodules/ports/openbor.sh
@@ -39,9 +39,9 @@ function install_openbor() {
 }
 
 function configure_openbor() {
-    mkRomDir "ports"
+    addPort "$md_id" "openbor" "OpenBOR - Beats of Rage Engine" "pushd $md_inst; $md_inst/OpenBOR; popd"
+
     mkRomDir "ports/$md_id"
-    mkUserDir "$configdir/$md_id"
 
     cat >"$md_inst/extract.sh" <<_EOF_
 #!/bin/bash
@@ -65,14 +65,14 @@ done
 echo "Your games are extracted and ready to be played. Your originals are stored safely in $BORROMDIR/original/ but they won't be needed anymore. Everything within it can be deleted."
 _EOF_
     chmod +x "$md_inst/extract.sh"
-    mkdir "$configdir/$md_id/ScreenShots/"
-    mkdir "$configdir/$md_id/Logs/"
-    mkdir "$configdir/$md_id/Saves/"
-    ln -snf "$configdir/$md_id/ScreenShots/" "$md_inst/ScreenShots"
-    ln -snf "$configdir/$md_id/Logs/" "$md_inst/Logs"
-    ln -snf "$configdir/$md_id/Saves/" "$md_inst/Saves"
+    mkdir "$md_conf_root/$md_id/ScreenShots"
+    mkdir "$md_conf_root/$md_id/Logs"
+    mkdir "$md_conf_root/$md_id/Saves"
+    ln -snf "$md_conf_root/$md_id/ScreenShots" "$md_inst/ScreenShots"
+    ln -snf "$md_conf_root/$md_id/Logs" "$md_inst/Logs"
+    ln -snf "$md_conf_root/$md_id/Saves" "$md_inst/Saves"
 
-    ln -snf "$romdir/ports/$md_id/" "$md_inst/Paks"
-    addPort "$md_id" "openbor" "OpenBOR - Beats of Rage Engine" "pushd $md_inst; $md_inst/OpenBOR; popd"
+    ln -snf "$romdir/ports/$md_id" "$md_inst/Paks"
+
      __INFMSGS+=("OpenBOR games need to be extracted to function properly. Place your pak files in $romdir/ports/$md_id/ and then run $md_inst/extract.sh. When the script is done, your original pak files will be found in $romdir/ports/$md_id/originals/ and can be deleted.")
 }

--- a/scriptmodules/ports/openttd.sh
+++ b/scriptmodules/ports/openttd.sh
@@ -19,7 +19,5 @@ function install_openttd() {
 }
  
 function configure_openttd() {
-    mkRomDir "ports"
-
     addPort "$md_id" "openttd" "OpenTTD" "openttd"
 }

--- a/scriptmodules/ports/opentyrian.sh
+++ b/scriptmodules/ports/opentyrian.sh
@@ -37,7 +37,8 @@ function install_opentyrian() {
 }
 
 function configure_opentyrian() {
-    mkRomDir "ports"
+    addPort "$md_id" "opentyrian" "OpenTyrian" "$md_inst/bin/opentyrian --data $romdir/ports/opentyrian/data"
+
     mkRomDir "ports/opentyrian"
 
     # get Tyrian 2.1 (freeware game data)
@@ -45,10 +46,8 @@ function configure_opentyrian() {
     unzip -j -o tyrian21.zip -d "$romdir/ports/opentyrian/data"
     rm -f tyrian21.zip
 
-    moveConfigDir "$home/.config/opentyrian" "$configdir/opentyrian"
+    moveConfigDir "$home/.config/opentyrian" "$md_conf_root/opentyrian"
 
     # Enable dispmanx by default.
     setDispmanx "$md_id" 1
-
-    addPort "$md_id" "opentyrian" "OpenTyrian" "$md_inst/bin/opentyrian --data $romdir/ports/opentyrian/data"
 }

--- a/scriptmodules/ports/quake3.sh
+++ b/scriptmodules/ports/quake3.sh
@@ -40,11 +40,10 @@ function install_quake3() {
 }
 
 function configure_quake3() {
+    addPort "$md_id" "quake3" "Quake III Arena" "LD_LIBRARY_PATH=lib $md_inst/ioquake3.arm"
+
+    mkRomDir "ports/quake3"
+
     # Add user for no sudo run
     usermod -a -G video $user
-
-    mkRomDir "quake3"
-    mkRomDir "ports"
-
-    addPort "$md_id" "quake3" "Quake III Arena" "LD_LIBRARY_PATH=lib $md_inst/ioquake3.arm"
 }

--- a/scriptmodules/ports/sdlpop.sh
+++ b/scriptmodules/ports/sdlpop.sh
@@ -40,16 +40,12 @@ function install_sdlpop() {
 }
  
 function configure_sdlpop() {
-    mkRomDir "ports"
+    addPort "$md_id" "sdlpop" "Prince of Persia" "pushd $md_inst; $md_inst/prince full; popd"
 
-    mkUserDir "$configdir/$md_id"
+    moveConfigFile "$md_inst/SDLPoP.ini" "$md_conf_root/$md_id/SDLPoP.ini"
 
-    moveConfigFile "$md_inst/SDLPoP.ini" "$configdir/$md_id/SDLPoP.ini"
-
-    if [[ ! -f "$configdir/$md_id/SDLPoP.ini" ]]; then
-        cp -v "$md_inst/SDLPoP.ini.def" "$configdir/$md_id/SDLPoP.ini"
+    if [[ ! -f "$md_conf_root/$md_id/SDLPoP.ini" ]]; then
+        cp -v "$md_inst/SDLPoP.ini.def" "$md_conf_root/$md_id/SDLPoP.ini"
     fi
-    chown -R $user:$user "$configdir/$md_id"
-
-    addPort "$md_id" "SDLPoP" "Prince of Persia" "pushd $md_inst; $md_inst/prince full; popd"
+    chown -R $user:$user "$md_conf_root/$md_id"
 }

--- a/scriptmodules/ports/smw.sh
+++ b/scriptmodules/ports/smw.sh
@@ -33,7 +33,5 @@ function install_smw() {
 }
 
 function configure_smw() {
-    mkRomDir "ports"
-
     addPort "$md_id" "smw" "Super Mario War" "$md_inst/smw"
 }

--- a/scriptmodules/ports/solarus.sh
+++ b/scriptmodules/ports/solarus.sh
@@ -53,11 +53,12 @@ function install_solarus() {
 }
 
 function configure_solarus() {
-    mkRomDir "ports"
-    moveConfigDir "$home/.solarus" "$configdir/solarus"
     addPort "$md_id" "zsdx" "Solarus Engine - Zelda Mystery of Solarus DX" "LD_LIBRARY_PATH=$md_inst/lib/arm-linux-gnueabihf/ $md_inst/bin/solarus_run $md_inst/share/solarus/zsdx/"
     addPort "$md_id" "zsxd" "Solarus Engine - Zelda Mystery of Solarus XD" "LD_LIBRARY_PATH=$md_inst/lib/arm-linux-gnueabihf/ $md_inst/bin/solarus_run $md_inst/share/solarus/zsxd/"
     addPort "$md_id" "zelda_roth_se" "Solarus Engine - Zelda Return of the Hylian SE" "LD_LIBRARY_PATH=$md_inst/lib/arm-linux-gnueabihf/ $md_inst/bin/solarus_run $md_inst/share/solarus/zelda_roth_se/"
+
+    moveConfigDir "$home/.solarus" "$md_conf_root/solarus"
+
     chown -R $user:$user "$md_inst/share/solarus/zsdx/data.solarus"
     chown -R $user:$user "$md_inst/share/solarus/zsxd/data.solarus"
     chown -R $user:$user "$md_inst/share/solarus/zelda_roth_se/data.solarus"

--- a/scriptmodules/ports/supertux.sh
+++ b/scriptmodules/ports/supertux.sh
@@ -19,7 +19,5 @@ function install_supertux() {
 }
  
 function configure_supertux() {
-    mkRomDir "ports"
-
     addPort "$md_id" "supertux" "SuperTux" "supertux"
 }

--- a/scriptmodules/ports/tyrquake.sh
+++ b/scriptmodules/ports/tyrquake.sh
@@ -39,13 +39,12 @@ function install_tyrquake() {
 }
 
 function configure_tyrquake() {
-    mkRomDir "ports"
-    mkRomDir "ports/quake"
-
-    download_quake_lr-tyrquake
-
     addPort "$md_id" "quake" "Quake" "$md_inst/bin/tyr-quake -path $romdir/ports/quake/id1/pak0.pak"
     if isPlatform "x11"; then
         addPort "$md_id-gl" "quake" "Quake" "$md_inst/bin/tyr-glquake -path $romdir/ports/quake/id1/pak0.pak"
     fi
+
+    mkRomDir "ports/quake"
+
+    download_quake_lr-tyrquake
 }

--- a/scriptmodules/ports/uqm.sh
+++ b/scriptmodules/ports/uqm.sh
@@ -45,7 +45,5 @@ function install_uqm() {
 }
 
 function configure_uqm() {
-    mkRomDir "ports"
- 
     addPort "$md_id" "uqm" "Ur-quan Masters" "uqm -f"
 }

--- a/scriptmodules/ports/wolf4sdl.sh
+++ b/scriptmodules/ports/wolf4sdl.sh
@@ -56,10 +56,19 @@ function install_wolf4sdl() {
 }
 
 function configure_wolf4sdl() {
-    mkRomDir "ports"
+    local bin
+    local bins
+    while read -r bin; do
+        bins+=("$bin")
+    done < <(get_bins_wolf4sdl)
+    # called outside of above loop to avoid problems with addPort and stdin
+    for bin in "${bins[@]}"; do
+        addPort "$bin" "wolf3d" "Wolfenstein 3D" "$md_inst/bin/$bin"
+    done
+
     mkRomDir "ports/wolf3d"
 
-    moveConfigDir "$home/.wolf4sdl" "$configdir/wolf3d"
+    moveConfigDir "$home/.wolf4sdl" "$md_conf_root/wolf3d"
 
     # Get shareware game data
     wget -q -O wolf3d14.zip http://maniacsvault.net/ecwolf/files/shareware/wolf3d14.zip
@@ -67,19 +76,8 @@ function configure_wolf4sdl() {
     chown -R $user:$user "$romdir/ports/wolf3d"
     rm -f wolf3d14.zip
 
-    local bins
-    while read -r bin; do
-        bins+=("$bin")
-    done < <(get_bins_wolf4sdl)
-
     setDispmanx "$md_id" 1
     configure_dispmanx_on_wolf4sdl
-
-    local bin
-    # called outside of above loop to avoid problems with addPort and stdin
-    for bin in "${bins[@]}"; do
-        addPort "$bin" "wolf4sdl" "Wolfenstein 3D" "$md_inst/bin/$bin"
-    done
 }
 
 function configure_dispmanx_off_wolf4sdl() {

--- a/scriptmodules/ports/xrick.sh
+++ b/scriptmodules/ports/xrick.sh
@@ -35,7 +35,5 @@ function install_xrick() {
 }
  
 function configure_xrick() {
-    mkRomDir "ports"
-
     addPort "$md_id" "xrick" "XRick" "pushd $md_inst; $md_inst/xrick -fullscreen; popd"
 }

--- a/scriptmodules/ports/zdoom.sh
+++ b/scriptmodules/ports/zdoom.sh
@@ -48,17 +48,16 @@ function install_zdoom() {
 }
 
 function configure_zdoom() {
-    mkRomDir "ports"
+    addPort "$md_id" "doom" "Doom" "$md_inst/zdoom -iwad $romdir/ports/doom/doom1.wad"
+
     mkRomDir "ports/doom"
 
     mkUserDir "$home/.config"
-    moveConfigDir "$home/.config/zdoom" "$configdir/doom"
+    moveConfigDir "$home/.config/zdoom" "$md_conf_root/doom"
 
     # download doom 1 shareware
     if [[ ! -f "$romdir/ports/doom/doom1.wad" ]]; then
         wget "$__archive_url/doom1.wad" -O "$romdir/ports/doom/doom1.wad"
     fi
     chown $user:$user "$romdir/ports/doom/doom1.wad"
-
-    addPort "$md_id" "doom" "Doom" "$md_inst/zdoom -iwad $romdir/ports/doom/doom1.wad"
 }


### PR DESCRIPTION
It was getting confusing with so many "ports" config folders in /opt/retropie/configs/

this changeset moves all ports configs to $configdir/ports/NAME and that location is now used.

`$md_conf_root` points to $configdir usually, but is adjusted to "$configdir/ports" in addPort (addPort needs to be first now so this variable is set correctly).

This needs some testing. 
