### PR TITLE
Exclude downloaded_images from configedit

### DIFF
--- a/scriptmodules/supplementary/configedit.sh
+++ b/scriptmodules/supplementary/configedit.sh
@@ -229,7 +229,7 @@ function choose_config_configedit() {
         configs+=("$config")
         options+=("$i" "$config")
         ((i++))
-    done < <(find "$path" -type f -regex "$include" ! -regex "$exclude" | sort)
+    done < <(find "$path" -type f -regex "$include" ! -regex "$exclude" ! -regex ".*/downloaded_images/.*" | sort)
     local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
     if [[ -n "$choice" ]]; then
         echo "${configs[choice]}"


### PR DESCRIPTION
All scraped images are loaded into the configuration editor list, so depending on how many games are scraped, it can get impractical to navigate.