### PR TITLE
Don't fail installation if /dev/tty doesn't exist

### DIFF
--- a/retropie_packages.sh
+++ b/retropie_packages.sh
@@ -73,5 +73,5 @@ fi
 printMsgs "console" "${__INFMSGS[@]}"
 
 if [[ -n $__joy2key_pid ]]; then
-    kill -INT $__joy2key_pid 2>/dev/null
+    kill -INT $__joy2key_pid 2>/dev/null || echo "Failed to kill joy2key"
 fi

--- a/scriptmodules/supplementary/runcommand/joy2key.py
+++ b/scriptmodules/supplementary/runcommand/joy2key.py
@@ -40,7 +40,11 @@ for arg in sys.argv[2:]:
 event_format = 'IhBB'
 event_size = struct.calcsize(event_format)
 
-tty_fd = open("/dev/tty", "w")
+try:
+    tty_fd = open('/dev/tty', 'w')
+except:
+    print 'Unable to access /dev/tty, exiting'
+    sys.exit(0)
 js_fd = open(sys.argv[1], "rb")
 
 buttons_state = 0
@@ -65,7 +69,7 @@ while True:
     if js_type == JS_EVENT_BUTTON:
         if js_number < len(button_codes) and js_value == 1:
             hex_chars = button_codes[js_number]
-    
+
     if js_type == JS_EVENT_AXIS:
         if js_number % 2 == 0:
             if js_value <= JS_MIN * JS_THRESH:


### PR DESCRIPTION
I use ansible to provision my RetroPie. This fails for me now, because it depends on `/dev/tty` existing.
This tries to get around that. 