### PR TITLE
Filename change. Avoids script error when rebuilding from source.

### DIFF
--- a/scriptmodules/libretrocores/lr-mame2003.sh
+++ b/scriptmodules/libretrocores/lr-mame2003.sh
@@ -37,7 +37,7 @@ function build_lr-mame2003() {
 function install_lr-mame2003() {
     md_ret_files=(
         'mame2003_libretro.so'
-        'README'
+        'README.md'
         'changed.txt'
         'whatsnew.txt'
         'whatsold.txt'
@@ -56,6 +56,7 @@ function configure_lr-mame2003() {
     # Set core options
     setRetroArchCoreOption "mame2003-skip_disclaimer" "enabled"
     setRetroArchCoreOption "mame2003-dcs-speedhack" "enabled"
+    setRetroArchCoreOption "mame2003-samples" "enabled"
 
     addSystem 0 "$md_id" "arcade" "$md_inst/mame2003_libretro.so"
     addSystem 1 "$md_id" "mame-libretro arcade mame" "$md_inst/mame2003_libretro.so"


### PR DESCRIPTION
Binaries will subsequently need to be rebuilt to avoid a similar error from installing from old binaries, I presume.

Samples now a core option, rather than hard-coded, so added that, even though they default to enabled. Cheats and sample rates are a core option, but I think these should remain user-preferences.

This is all following https://github.com/libretro/mame2003-libretro/pull/29
Should this PR be extended so the script moves the old paths to the new ones? I believe that should be possible, but may end up making this all a bit messy. I could just update the [wiki](https://github.com/RetroPie/RetroPie-Setup/wiki/lr-mame2003) with a warning?