### PR TITLE
Reicast optimizations

### DIFF
--- a/scriptmodules/emulators/reicast.sh
+++ b/scriptmodules/emulators/reicast.sh
@@ -27,6 +27,7 @@ function sources_reicast() {
     else
         gitPullOrClone "$md_build" https://github.com/RetroPie/reicast-emulator.git retropie
     fi
+    sed -i "s/CXXFLAGS += -fno-rtti -fpermissive -fno-operator-names/CXXFLAGS += -fno-rtti -fpermissive -fno-operator-names -D_GLIBCXX_USE_CXX11_ABI=0/g" shell/linux/Makefile
 }
 
 function build_reicast() {

--- a/scriptmodules/emulators/reicast/reicast.sh
+++ b/scriptmodules/emulators/reicast/reicast.sh
@@ -67,12 +67,12 @@ if [[ -f "$HOME/RetroPie/BIOS/dc_boot.bin" ]]; then
         echo "backend = oss" >> "$conf"
         echo "disable = 0" >> "$conf"
         echo "" >> "$conf"
-        aoss "$rootdir/emulators/reicast/bin/reicast" -config config:homedir="$HOME" -config config:image="$ROM" >> /dev/null
+        aoss "$rootdir/emulators/reicast/bin/reicast" -config config:homedir="$HOME" -config config:image="$ROM" -config x11:fullscreen=1 >> /dev/null
     else
         echo "backend = alsa" >> "$conf"
         echo "disable = 0" >> "$conf"
         echo "" >> "$conf"
-        "$rootdir/emulators/reicast/bin/reicast" -config config:homedir="$HOME" -config config:image="$ROM" >> /dev/null
+        "$rootdir/emulators/reicast/bin/reicast" -config config:homedir="$HOME" -config config:image="$ROM" -config x11:fullscreen=1 >> /dev/null
     fi
 else
     dialog --msgbox "You need to copy the Dreamcast BIOS files (dc_boot.bin and dc_flash.bin) to the folder $biosdir to boot the Dreamcast emulator." 22 76

--- a/scriptmodules/emulators/reicast/reicast.sh
+++ b/scriptmodules/emulators/reicast/reicast.sh
@@ -56,6 +56,9 @@ function mapInput() {
     fi
     echo "joystick_device_id = -1" >> "$conf"
     echo "" >> "$conf"
+    echo "[players]" >> "$conf"
+    echo "nb = $device_counter" >> "$conf"
+    echo "" >> "$conf"
 }
 
 if [[ -f "$HOME/RetroPie/BIOS/dc_boot.bin" ]]; then


### PR DESCRIPTION
-fix controller setup under ubuntu 15.10/16.04 (gcc 5.x issue).
-prepare startup script for multiplayer setup. Controller count = player count.
-enable fullscreen for x11 targets.

Tested with Raspbian Jessie and Ubuntu 16.04 x86.