### PR TITLE
Add lr-reicast for platfom x86

### DIFF
--- a/scriptmodules/libretrocores/lr-reicast.sh
+++ b/scriptmodules/libretrocores/lr-reicast.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+# 
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# 
+# See the LICENSE.md file at the top-level directory of this distribution and 
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-reicast"
+rp_module_desc="Dremcast emu - Reicast port for libretro"
+rp_module_menus="4+"
+rp_module_flags="!arm"
+
+function sources_lr-reicast() {
+    gitPullOrClone "$md_build" https://github.com/libretro/reicast-emulator.git
+}
+
+function build_lr-reicast() {
+    make clean
+    make
+    md_ret_require="$md_build/reicast_libretro.so"
+}
+
+function install_lr-reicast() {
+    md_ret_files=(
+        'reicast_libretro.so'
+    )
+}
+
+function configure_lr-reicast() {
+    mkRomDir "dreamcast"
+    ensureSystemretroconfig "dreamcast" 
+
+    # symlink bios
+    mkUserDir "$biosdir/dc"
+    ln -sf "$biosdir/dc/"{dc_boot.bin,dc_flash.bin} "$configdir/dreamcast/data"
+
+    # system-specific
+    iniConfig " = " "" "$configdir/dreamcast/retroarch.cfg"
+    iniSet "video_shared_context" "true"
+
+    addSystem 0 "$md_id" "dreamcast" "$md_inst/reicast_libretro.so"
+}


### PR DESCRIPTION
The current source code cannot be used for rpi. But x86 build works quite well.  