### PR TITLE
mupen64plus: enable audio autoconf for rpi only

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -147,7 +147,11 @@ function configure_mupen64plus() {
         addSystem 1 "${md_id}-glide64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-glide64mk2 %ROM%"
     fi
 
-    addAutoConf mupen64plus_audio 1
+    if isPlatform "rpi"; then
+        addAutoConf mupen64plus_audio 1
+    else
+        addAutoConf mupen64plus_audio 0
+    fi
     addAutoConf mupen64plus_hotkeys 1
     addAutoConf mupen64plus_compatibility_check 1
 }


### PR DESCRIPTION
setAudio only works on a pi.