### PR TITLE
libretro-fba is now 0.2.97.38.

### DIFF
--- a/scriptmodules/libretrocores/lr-fba-next.sh
+++ b/scriptmodules/libretrocores/lr-fba-next.sh
@@ -10,7 +10,7 @@
 #
 
 rp_module_id="lr-fba-next"
-rp_module_desc="Arcade emu - Final Burn Alpha (0.2.97.37) port for libretro"
+rp_module_desc="Arcade emu - Final Burn Alpha (0.2.97.38) port for libretro"
 rp_module_menus="2+"
 rp_module_flags=""
 


### PR DESCRIPTION
Wiki has been updated. Last remaining reference to the old version!