### PR TITLE
Updated splashscreen.sh and asplashscreen

### DIFF
--- a/scriptmodules/supplementary/splashscreen.sh
+++ b/scriptmodules/supplementary/splashscreen.sh
@@ -24,7 +24,7 @@ function install_splashscreen() {
     gitPullOrClone "$md_inst" https://github.com/RetroPie/retropie-splashscreens.git
 
     mkUserDir "$datadir/splashscreens"
-    echo "Place your own splashscreen in here, each one with its own folder" >"$datadir/splashscreens/README.txt"
+    echo "Place your own splashscreens in here." >"$datadir/splashscreens/README.txt"
     chown $user:$user "$datadir/splashscreens/README.txt"
 }
 
@@ -40,16 +40,113 @@ function remove_splashscreen() {
     insserv -r asplashscreen
 }
 
+function submenu_splashscreen() {
+    local action="$1"
+    local options=(
+        1 "Choose RetroPie splashscreen"
+        2 "Choose own splashscreen (from $datadir/splashscreens)"
+    )
+    if [[ "$action" == "preview" ]]; then
+        options+=(
+            3 "View slideshow of all RetroPie splashscreens"
+            4 "View slideshow of all splashscreens in $datadir/splashscreens"
+            5 "Choose RetroPie video splashscreen"
+            6 "Choose own video splashscreen (from $datadir/splashscreens/videos)"
+        )
+    elif [[ "$action" == "randomize" ]]; then
+        options=(
+            1 "Randomize RetroPie splashscreens"
+            2 "Randomize own splashscreens (from $datadir/splashscreens)"
+            3 "Randomize all splashscreens"
+            4 "Randomize /etc/splashscreen.list"
+        )
+    fi
+    local cmd=(dialog --backtitle "$__backtitle" --menu "Choose an option." 22 86 16)
+    while true; do
+        local splashscreen="-"
+        local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
+        if [[ -n "$choice" ]]; then
+            if [[ $((choice % 2)) == 1 ]]; then local path="$md_inst"; else local path="$datadir/splashscreens"; fi
+            if [[ "$action" == "preview" ]]; then
+                case $choice in
+                    [1-2])
+                        while [[ -n "$splashscreen" ]]; do
+                            splashscreen=$(choose_splashscreen "$path" "$action" "image")
+                            if [[ -n "$splashscreen" ]]; then fbi --noverbose --autozoom "$splashscreen"; fi
+                        done
+                        ;;
+                    [3-4])
+                        find "$path" -type f ! -regex ".*/.git/.*" ! -regex ".*LICENSE" ! -regex ".*README.*" | grep -v "$videoextens" | sort > /etc/slideshow.list
+                        if [[ -s /etc/slideshow.list ]]; then
+                            fbi --timeout 6 --once --autozoom --list /etc/slideshow.list
+                        else
+                            printMsgs "dialog" "There are no splashscreens installed in $path"
+                        fi
+                        rm /etc/slideshow.list
+                        ;;
+                    [5-6])
+                        while [[ -n "$splashscreen" ]]; do
+                            splashscreen=$(choose_splashscreen "$path" "$action" "video")
+                            if [[ -n "$splashscreen" ]]; then omxplayer -b --layer 10000 "$splashscreen"; fi
+                        done
+                        ;;
+                esac
+            elif [[ "$action" == "randomize" ]]; then
+                case $choice in
+                    1)
+                        iniSet "RANDOMIZE" "retropie"
+                        printMsgs "dialog" "Splashscreen randomizer enabled in directory $path"
+                        ;;
+                    2)
+                        iniSet "RANDOMIZE" "custom"
+                        printMsgs "dialog" "Splashscreen randomizer enabled in directory $path"
+                        ;;
+                    3)
+                        iniSet "RANDOMIZE" "all"
+                        printMsgs "dialog" "Splashscreen randomizer enabled for both splashscreen directories."
+                        ;;
+                    4)
+                        iniSet "RANDOMIZE" "list"
+                        printMsgs "dialog" "Splashscreen randomizer enabled for entries in /etc/splashscreen.list"
+                        ;;
+                esac
+                break
+            else #set and append
+                case $choice in
+                    [1-2])
+                        while [[ -n "$splashscreen" ]]; do
+                            splashscreen=$(choose_splashscreen "$path" "$action")
+                            if [[ "$action" == "set" ]]; then break 2; fi
+                        done
+                        ;;
+                esac
+            fi
+        else
+            break
+        fi
+    done
+}
+
 function choose_splashscreen() {
     local path="$1"
+    local mode="$2"
+    local type="$3"
     local options=()
     local i=0
     local splashdir
     while read splashdir; do
         splashdir=${splashdir/$path\//}
-        options+=("$i" "$splashdir")
-        ((i++))
-    done < <(find "$path" -mindepth 1 -maxdepth 1 -type d -not -path "*/.git" | sort)
+        if [[ "$type" == "video" && "$mode" == "preview" ]] && ( echo "$splashdir" | grep -q "$videoextens" ); then
+            options+=("$i" "$splashdir")
+            ((i++))
+        elif [[ "$type" == "image" && "$mode" == "preview" ]] && ! ( echo "$splashdir" | grep -q "$videoextens" ); then
+            options+=("$i" "$splashdir")
+            ((i++))
+        elif [[ "$mode" != "preview" ]]; then
+            options+=("$i" "$splashdir")
+            ((i++))
+        fi
+    done < <(find "$path" -type f ! -regex ".*/.git/.*" ! -regex ".*LICENSE" ! -regex ".*README.*" | sort)
     if [[ ${#options[@]} -eq 0 ]]; then
         printMsgs "dialog" "There are no splashscreens installed in $path"
         return
@@ -59,8 +156,15 @@ function choose_splashscreen() {
     if [[ -n "$choice" ]]; then
         choice=$((choice*2+1))
         splashdir=${options[choice]}
-        find "$path/$splashdir" -type f >/etc/splashscreen.list
-        printMsgs "dialog" "Splashscreen set to '$splashdir'."
+        if [[ "$mode" == "set" ]]; then
+            find "$path/$splashdir" -type f | tee /etc/splashscreen.list
+            printMsgs "dialog" "Splashscreen set to '$splashdir'."
+        elif [[ "$mode" == "preview" ]]; then
+            find "$path/$splashdir" -type f
+        elif [[ "$mode" == "append" ]]; then
+            find "$path/$splashdir" -type f | tee -a /etc/splashscreen.list
+            printMsgs "dialog" "Splashscreen '$splashdir' appended to splashscreen.list"
+        fi
     fi
 }
 
@@ -69,45 +173,67 @@ function configure_splashscreen() {
         rp_callModule splashscreen depends
         rp_callModule splashscreen install
     fi
-
+    videoextens=".avi\|.mov\|.mp4\|.mkv\|.3gp\|.mpg\|.mp3\|.wav\|.m4a\|.aac\|.ogg\|.flac"
+    iniConfig "=" '"' /etc/init.d/asplashscreen
     local cmd=(dialog --backtitle "$__backtitle" --menu "Choose an option." 22 86 16)
-    local options=(
-        1 "Choose RetroPie splashscreen"
-        2 "Choose own splashscreen (from $datadir/splashscreens)"
-        3 "Enable custom splashscreen on boot"
-        4 "Disable custom splashscreen on boot"
-        5 "Use default splashscreen"
-        6 "Manually edit splashscreen list"
-        7 "Update RetroPie splashscreens"
-    )
     while true; do
-    local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
+        local options=( 1 "Choose splashscreen" )
+        if [[ -n $( find "/etc/rcS.d" -type l -regex ".*asplashscreen" ) ]]; then
+            options+=( 2 "Disable splashscreen on boot (Enabled)" )
+            iniGet "RANDOMIZE"
+            if [[ "$ini_value" = "disabled" ]]; then
+                options+=( 3 "Enable splashscreen randomizer (Disabled)" )
+            elif [[ -n "$ini_value" ]]; then
+                options+=( 3 "Disable splashscreen randomizer (Enabled)" )
+            fi
+        else
+            options+=( 2 "Enable splashscreen on boot (Disabled)" )
+        fi
+        options+=(
+            4 "Use default splashscreen"
+            5 "Manually edit splashscreen list"
+            6 "Append splashscreen to list (for multiple entries)"
+            7 "Preview splashscreens"
+            8 "Update RetroPie splashscreens"
+        )
+        local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
         if [[ -n "$choice" ]]; then
             case $choice in
                 1)
-                    choose_splashscreen "$md_inst"
+                    rp_callModule splashscreen submenu "set"
                     ;;
                 2)
-                    choose_splashscreen "$datadir/splashscreens"
+                    if [[ -n $( find "/etc/rcS.d" -type l -regex ".*asplashscreen" ) ]]; then
+                        remove_splashscreen
+                        printMsgs "dialog" "Disabled splashscreen on boot."
+                    else
+                        [[ ! -f /etc/splashscreen.list ]] && rp_CallModule splashscreen default
+                        enable_splashscreen
+                        printMsgs "dialog" "Enabled splashscreen on boot."
+                    fi
                     ;;
                 3)
-                    [[ ! -f /etc/splashscreen.list ]] && rp_CallModule splashscreen default
-                    enable_splashscreen
-                    printMsgs "dialog" "Enabled custom splashscreen on boot."
+                    if [[ "$ini_value" = "disabled" ]]; then
+                        rp_callModule splashscreen submenu "randomize"
+                    else
+                        iniSet "RANDOMIZE" "disabled"
+                        printMsgs "dialog" "Splashscreen randomizer disabled."
+                    fi
                     ;;
                 4)
-                    remove_splashscreen
-                    printMsgs "dialog" "Disabled custom splashscreen on boot."
-                    ;;
-                5)
                     default_splashscreen
                     printMsgs "dialog" "Splashscreen set to RetroPie default."
                     ;;
-
-                6)
+                5)
                     editFile /etc/splashscreen.list
                     ;;
+                6)
+                    rp_callModule splashscreen submenu "append"
+                    ;;
                 7)
+                    rp_callModule splashscreen submenu "preview"
+                    ;;
+                8)
                     rp_callModule splashscreen install
                     ;;
             esac

--- a/scriptmodules/supplementary/splashscreen/asplashscreen
+++ b/scriptmodules/supplementary/splashscreen/asplashscreen
@@ -11,9 +11,23 @@
 # Description:       Show custom splashscreen
 ### END INIT INFO
 
+RANDOMIZE="disabled"
+
 do_start () {
     local config="/etc/splashscreen.list"
-    local line="$(head -1 "$config")"
+    local rootdir="/opt/retropie"
+    local datadir="/home/pi"
+    if [ "$RANDOMIZE" = "disabled" ]; then
+        local line="$(head -1 "$config")"
+    elif [ "$RANDOMIZE" = "retropie" ]; then
+        local line="$(find "$rootdir/supplementary/splashscreen" -type f ! -regex ".*/.git/.*" ! -regex ".*LICENSE" ! -regex ".*README.*" | shuf -n1)"
+    elif [ "$RANDOMIZE" = "custom" ]; then
+        local line="$(find "$datadir/RetroPie/splashscreens" -type f ! -regex ".*README.*" | shuf -n1)"
+    elif [ "$RANDOMIZE" = "all" ]; then
+        local line="$( (find "$rootdir/supplementary/splashscreen" -type f ! -regex ".*/.git/.*" ! -regex ".*LICENSE" ! -regex ".*README.*" && find "$datadir/RetroPie/splashscreens" -type f ! -regex ".*README.*") | shuf -n1)"
+    elif [ "$RANDOMIZE" = "list" ]; then
+        local line="$(cat "$config" | shuf -n1)"
+    fi
     if $(echo "$line" | grep -q ".avi\|.mov\|.mp4\|.mkv\|.3gp\|.mpg\|.mp3\|.wav\|.m4a\|.aac\|.ogg\|.flac"); then
         # wait for dbus
         while ! pgrep "dbus" >/dev/null; do
@@ -21,11 +35,19 @@ do_start () {
         done
         omxplayer -b --layer 10000 "$line"
     else
-        local count=$(wc -l <"$config")
+        if [ "$RANDOMIZE" = "disabled" ]; then
+            local count=$(wc -l <"$config")
+        else
+            local count=1
+        fi
         [ $count -eq 0 ] && count=1
         [ $count -gt 20 ] && count=20
         local delay=$((20/count))
-        fbi -T 2 -once -t $delay -noverbose -a -l "$config" >/dev/null 2>&1
+        if [ "$RANDOMIZE" = "disabled" ]; then
+            fbi -T 2 -once -t $delay -noverbose -a -l "$config" >/dev/null 2>&1
+        else
+            fbi -T 2 -once -t $delay -noverbose -a "$line" >/dev/null 2>&1
+        fi
     fi
     exit 0
 }


### PR DESCRIPTION
* Changed from a directory search to a file search to allow for future restructuring in the splashscreen github to not require files in directories.
* Added an append option to make up for the lost ability to select a directory and append all contained files to the splashscreen.list.
* Added Preview options for images and videos.
* Restructured menus to have toggle options.
* Added a randomizer option that won't show up until an updated asplashscreen has been copied over to /etc/init.d/ during the splashscreen update.