### PR TITLE
splashscreen:

### DIFF
--- a/scriptmodules/inifuncs.sh
+++ b/scriptmodules/inifuncs.sh
@@ -54,6 +54,10 @@ function iniProcess() {
 
     [[ "$cmd" == "unset" ]] && key="# $key"
 
+    # escape backslashes and pipes for sed
+    value="${value//\\/\\\\}"
+    value="${value//|/\\|}"
+
     local replace="$key$delim$quote$value$quote"
     if [[ -z "$match" ]]; then
         # add key-value pair

--- a/scriptmodules/supplementary/splashscreen.sh
+++ b/scriptmodules/supplementary/splashscreen.sh
@@ -30,6 +30,8 @@ function install_splashscreen() {
     cp "$scriptdir/scriptmodules/$md_type/$md_id/asplashscreen" "/etc/init.d/"
 
     iniConfig "=" '"' /etc/init.d/asplashscreen
+    iniSet "ROOTDIR" "$rootdir"
+    iniSet "DATADIR" "$datadir"
     iniSet "REGEX_IMAGE" "$(_image_exts_splashscreen)"
     iniSet "REGEX_VIDEO" "$(_video_exts_splashscreen)"
 

--- a/scriptmodules/supplementary/splashscreen.sh
+++ b/scriptmodules/supplementary/splashscreen.sh
@@ -14,6 +14,14 @@ rp_module_desc="Configure Splashscreen"
 rp_module_menus="3+configure"
 rp_module_flags="nobin !x86"
 
+function _image_exts_splashscreen() {
+    echo '\.bmp\|\.jpg\|\.jpeg\|\.gif\|\.png\|\.ppm\|\.tiff\|\.webp'
+}
+
+function _video_exts_splashscreen() {
+    echo '\.avi\|\.mov\|\.mp4\|\.mkv\|\.3gp\|\.mpg\|\.mp3\|\.wav\|\.m4a\|\.aac\|\.ogg\|\.flac'
+}
+
 function depends_splashscreen() {
     getDepends fbi omxplayer
 }
@@ -40,132 +48,137 @@ function remove_splashscreen() {
     insserv -r asplashscreen
 }
 
-function submenu_splashscreen() {
-    local action="$1"
+function choose_path_splashscreen() {
     local options=(
-        1 "Choose RetroPie splashscreen"
-        2 "Choose own splashscreen (from $datadir/splashscreens)"
+        1 "RetroPie splashscreens"
+        2 "Own splashscreens (from $datadir/splashscreens)"
     )
-    if [[ "$action" == "preview" ]]; then
-        options+=(
-            3 "View slideshow of all RetroPie splashscreens"
-            4 "View slideshow of all splashscreens in $datadir/splashscreens"
-            5 "Choose RetroPie video splashscreen"
-            6 "Choose own video splashscreen (from $datadir/splashscreens/videos)"
-        )
-    elif [[ "$action" == "randomize" ]]; then
-        options=(
-            1 "Randomize RetroPie splashscreens"
-            2 "Randomize own splashscreens (from $datadir/splashscreens)"
-            3 "Randomize all splashscreens"
-            4 "Randomize /etc/splashscreen.list"
-        )
-    fi
     local cmd=(dialog --backtitle "$__backtitle" --menu "Choose an option." 22 86 16)
+    local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
+    [[ "$choice" -eq 1 ]] && echo "$md_inst"
+    [[ "$choice" -eq 2 ]] && echo "$datadir/splashscreens"
+}
+
+function set_append_splashscreen() {
+    local mode="$1"
+    [[ -z "$mode" ]] && mode="set"
+    local path
+    local file
     while true; do
-        local splashscreen="-"
-        local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
-        if [[ -n "$choice" ]]; then
-            if [[ $((choice % 2)) == 1 ]]; then local path="$md_inst"; else local path="$datadir/splashscreens"; fi
-            if [[ "$action" == "preview" ]]; then
-                case $choice in
-                    [1-2])
-                        while [[ -n "$splashscreen" ]]; do
-                            splashscreen=$(choose_splashscreen "$path" "$action" "image")
-                            if [[ -n "$splashscreen" ]]; then fbi --noverbose --autozoom "$splashscreen"; fi
-                        done
-                        ;;
-                    [3-4])
-                        find "$path" -type f ! -regex ".*/.git/.*" ! -regex ".*LICENSE" ! -regex ".*README.*" | grep -v "$videoextens" | sort > /etc/slideshow.list
-                        if [[ -s /etc/slideshow.list ]]; then
-                            fbi --timeout 6 --once --autozoom --list /etc/slideshow.list
-                        else
-                            printMsgs "dialog" "There are no splashscreens installed in $path"
-                        fi
-                        rm /etc/slideshow.list
-                        ;;
-                    [5-6])
-                        while [[ -n "$splashscreen" ]]; do
-                            splashscreen=$(choose_splashscreen "$path" "$action" "video")
-                            if [[ -n "$splashscreen" ]]; then omxplayer -b --layer 10000 "$splashscreen"; fi
-                        done
-                        ;;
-                esac
-            elif [[ "$action" == "randomize" ]]; then
-                case $choice in
-                    1)
-                        iniSet "RANDOMIZE" "retropie"
-                        printMsgs "dialog" "Splashscreen randomizer enabled in directory $path"
-                        ;;
-                    2)
-                        iniSet "RANDOMIZE" "custom"
-                        printMsgs "dialog" "Splashscreen randomizer enabled in directory $path"
-                        ;;
-                    3)
-                        iniSet "RANDOMIZE" "all"
-                        printMsgs "dialog" "Splashscreen randomizer enabled for both splashscreen directories."
-                        ;;
-                    4)
-                        iniSet "RANDOMIZE" "list"
-                        printMsgs "dialog" "Splashscreen randomizer enabled for entries in /etc/splashscreen.list"
-                        ;;
-                esac
+        path="$(choose_path_splashscreen)"
+        [[ -z "$path" ]] && break
+        file=$(choose_splashscreen "$path")
+        if [[ -n "$file" ]]; then
+            if [[ "$mode" == "set" ]]; then
+                echo "$file" >/etc/splashscreen.list
+                printMsgs "dialog" "Splashscreen set to '$file'"
                 break
-            else #set and append
-                case $choice in
-                    [1-2])
-                        while [[ -n "$splashscreen" ]]; do
-                            splashscreen=$(choose_splashscreen "$path" "$action")
-                            if [[ "$action" == "set" ]]; then break 2; fi
-                        done
-                        ;;
-                esac
             fi
-        else
-            break
+            if [[ "$mode" == "append" ]]; then
+                echo "$file" >>/etc/splashscreen.list
+                printMsgs "dialog" "Splashscreen '$file' appended to /etc/splashscreen.list"
+            fi
         fi
     done
 }
 
 function choose_splashscreen() {
     local path="$1"
-    local mode="$2"
-    local type="$3"
+    local type="$2"
+
+    local regex
+    [[ "$type" == "image" ]] && regex=$(_image_exts_splashscreen)
+    [[ "$type" == "video" ]] && regex=$(_video_exts_splashscreen)
+
     local options=()
     local i=0
-    local splashdir
     while read splashdir; do
         splashdir=${splashdir/$path\//}
-        if [[ "$type" == "video" && "$mode" == "preview" ]] && ( echo "$splashdir" | grep -q "$videoextens" ); then
-            options+=("$i" "$splashdir")
-            ((i++))
-        elif [[ "$type" == "image" && "$mode" == "preview" ]] && ! ( echo "$splashdir" | grep -q "$videoextens" ); then
-            options+=("$i" "$splashdir")
-            ((i++))
-        elif [[ "$mode" != "preview" ]]; then
+        if echo "$splashdir" | grep -q "$regex"; then 
             options+=("$i" "$splashdir")
             ((i++))
         fi
     done < <(find "$path" -type f ! -regex ".*/.git/.*" ! -regex ".*LICENSE" ! -regex ".*README.*" | sort)
-    if [[ ${#options[@]} -eq 0 ]]; then
+    if [[ "${#options[@]}" -eq 0 ]]; then
         printMsgs "dialog" "There are no splashscreens installed in $path"
         return
     fi
     local cmd=(dialog --backtitle "$__backtitle" --menu "Choose splashscreen." 22 76 16)
     local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
-    if [[ -n "$choice" ]]; then
-        choice=$((choice*2+1))
-        splashdir=${options[choice]}
-        if [[ "$mode" == "set" ]]; then
-            find "$path/$splashdir" -type f | tee /etc/splashscreen.list
-            printMsgs "dialog" "Splashscreen set to '$splashdir'."
-        elif [[ "$mode" == "preview" ]]; then
-            find "$path/$splashdir" -type f
-        elif [[ "$mode" == "append" ]]; then
-            find "$path/$splashdir" -type f | tee -a /etc/splashscreen.list
-            printMsgs "dialog" "Splashscreen '$splashdir' appended to splashscreen.list"
-        fi
-    fi
+    [[ -n "$choice" ]] && echo "$path/${options[choice*2+1]}"
+}
+
+function randomize_splashscreen() {
+    options=(
+        1 "Randomize RetroPie splashscreens"
+        2 "Randomize own splashscreens (from $datadir/splashscreens)"
+        3 "Randomize all splashscreens"
+        4 "Randomize /etc/splashscreen.list"
+    )
+    local cmd=(dialog --backtitle "$__backtitle" --menu "Choose an option." 22 86 16)
+    local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
+    iniConfig "=" '"' /etc/init.d/asplashscreen
+    case "$choice" in
+        1)
+            iniSet "RANDOMIZE" "retropie"
+            printMsgs "dialog" "Splashscreen randomizer enabled in directory $path"
+            ;;
+        2)
+            iniSet "RANDOMIZE" "custom"
+            printMsgs "dialog" "Splashscreen randomizer enabled in directory $path"
+            ;;
+        3)
+            iniSet "RANDOMIZE" "all"
+            printMsgs "dialog" "Splashscreen randomizer enabled for both splashscreen directories."
+            ;;
+        4)
+            iniSet "RANDOMIZE" "list"
+            printMsgs "dialog" "Splashscreen randomizer enabled for entries in /etc/splashscreen.list"
+            ;;
+    esac
+}
+
+function preview_splashscreen() {
+    local options=(
+        1 "View single splashscreen"
+        2 "View slideshow of all splashscreens"
+        3 "Play video splash"
+    )
+
+    local path
+    local file
+    while true; do
+        local cmd=(dialog --backtitle "$__backtitle" --menu "Choose an option." 22 86 16)
+        local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
+        [[ -z "$choice" ]] && break
+        path="$(choose_path_splashscreen)"
+        [[ -z "$path" ]] && break
+        while true; do
+            case "$choice" in
+                1)
+                    file=$(choose_splashscreen "$path" "image")
+                    [[ -z "$file" ]] && break
+                    fbi --noverbose --autozoom "$file"
+                    ;;
+                2)
+                    file=$(mktemp)
+                    find "$path" -type f ! -regex ".*/.git/.*" ! -regex ".*LICENSE" ! -regex ".*README.*" | sort > "$file"
+                    if [[ -s "$file" ]]; then
+                        fbi --timeout 6 --once --autozoom --list "$file"
+                    else
+                        printMsgs "dialog" "There are no splashscreens installed in $path"
+                    fi
+                    rm -f "$file"
+                    break
+                    ;;
+                3)
+                    file=$(choose_splashscreen "$path" "video")
+                    [[ -z "$file" ]] && break
+                    omxplayer -b --layer 10000 "$file"
+                    ;;
+            esac
+        done
+    done
 }
 
 function configure_splashscreen() {
@@ -173,21 +186,25 @@ function configure_splashscreen() {
         rp_callModule splashscreen depends
         rp_callModule splashscreen install
     fi
-    videoextens=".avi\|.mov\|.mp4\|.mkv\|.3gp\|.mpg\|.mp3\|.wav\|.m4a\|.aac\|.ogg\|.flac"
-    iniConfig "=" '"' /etc/init.d/asplashscreen
     local cmd=(dialog --backtitle "$__backtitle" --menu "Choose an option." 22 86 16)
     while true; do
-        local options=( 1 "Choose splashscreen" )
-        if [[ -n $( find "/etc/rcS.d" -type l -regex ".*asplashscreen" ) ]]; then
-            options+=( 2 "Disable splashscreen on boot (Enabled)" )
+        local enabled=0
+        local random=0
+        [[ -n "$(find "/etc/rcS.d" -type l -name "S*asplashscreen")" ]] && enabled=1
+        local options=(1 "Choose splashscreen")
+        if [[ "$enabled" -eq 1 ]]; then
+            options+=(2 "Disable splashscreen on boot (Enabled)")
+            iniConfig "=" '"' /etc/init.d/asplashscreen
             iniGet "RANDOMIZE"
-            if [[ "$ini_value" = "disabled" ]]; then
-                options+=( 3 "Enable splashscreen randomizer (Disabled)" )
-            elif [[ -n "$ini_value" ]]; then
-                options+=( 3 "Disable splashscreen randomizer (Enabled)" )
+            random=1
+            [[ "$ini_value" == "disabled" ]] && random=0
+            if [[ "$random" -eq 1 ]]; then
+                options+=(3 "Disable splashscreen randomizer (Enabled)")
+            else
+                options+=(3 "Enable splashscreen randomizer (Disabled)")
             fi
         else
-            options+=( 2 "Enable splashscreen on boot (Disabled)" )
+            options+=(2 "Enable splashscreen on boot (Disabled)")
         fi
         options+=(
             4 "Use default splashscreen"
@@ -198,12 +215,12 @@ function configure_splashscreen() {
         )
         local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
         if [[ -n "$choice" ]]; then
-            case $choice in
+            case "$choice" in
                 1)
-                    rp_callModule splashscreen submenu "set"
+                    set_append_splashscreen set
                     ;;
                 2)
-                    if [[ -n $( find "/etc/rcS.d" -type l -regex ".*asplashscreen" ) ]]; then
+                    if [[ "$enabled" -eq 1 ]]; then
                         remove_splashscreen
                         printMsgs "dialog" "Disabled splashscreen on boot."
                     else
@@ -213,11 +230,11 @@ function configure_splashscreen() {
                     fi
                     ;;
                 3)
-                    if [[ "$ini_value" = "disabled" ]]; then
-                        rp_callModule splashscreen submenu "randomize"
-                    else
+                    if [[ "$random" -eq 1 ]]; then
                         iniSet "RANDOMIZE" "disabled"
                         printMsgs "dialog" "Splashscreen randomizer disabled."
+                    else
+                        randomize_splashscreen
                     fi
                     ;;
                 4)
@@ -228,10 +245,10 @@ function configure_splashscreen() {
                     editFile /etc/splashscreen.list
                     ;;
                 6)
-                    rp_callModule splashscreen submenu "append"
+                    set_append_splashscreen append
                     ;;
                 7)
-                    rp_callModule splashscreen submenu "preview"
+                    preview_splashscreen
                     ;;
                 8)
                     rp_callModule splashscreen install

--- a/scriptmodules/supplementary/splashscreen.sh
+++ b/scriptmodules/supplementary/splashscreen.sh
@@ -28,7 +28,13 @@ function depends_splashscreen() {
 
 function install_splashscreen() {
     cp "$scriptdir/scriptmodules/$md_type/$md_id/asplashscreen" "/etc/init.d/"
+
+    iniConfig "=" '"' /etc/init.d/asplashscreen
+    iniSet "REGEX_IMAGE" "$(_image_exts_splashscreen)"
+    iniSet "REGEX_VIDEO" "$(_video_exts_splashscreen)"
+
     chmod +x /etc/init.d/asplashscreen
+
     gitPullOrClone "$md_inst" https://github.com/RetroPie/retropie-splashscreens.git
 
     mkUserDir "$datadir/splashscreens"

--- a/scriptmodules/supplementary/splashscreen/asplashscreen
+++ b/scriptmodules/supplementary/splashscreen/asplashscreen
@@ -11,24 +11,25 @@
 # Description:       Show custom splashscreen
 ### END INIT INFO
 
+ROOTDIR=""
+DATADIR=""
 RANDOMIZE="disabled"
 REGEX_VIDEO=""
 REGEX_IMAGE=""
 
 do_start () {
     local config="/etc/splashscreen.list"
-    local rootdir="/opt/retropie"
-    local datadir="/home/pi"
+    local line
     if [ "$RANDOMIZE" = "disabled" ]; then
-        local line="$(head -1 "$config")"
+        line="$(head -1 "$config")"
     elif [ "$RANDOMIZE" = "retropie" ]; then
-        local line="$(find "$rootdir/supplementary/splashscreen" -type f ! -regex ".*/.git/.*" ! -regex ".*LICENSE" ! -regex ".*README.*" | shuf -n1)"
+        line="$(find "$ROOTDIR/supplementary/splashscreen" -type f ! -regex ".*/.git/.*" ! -regex ".*LICENSE" ! -regex ".*README.*" | shuf -n1)"
     elif [ "$RANDOMIZE" = "custom" ]; then
-        local line="$(find "$datadir/RetroPie/splashscreens" -type f ! -regex ".*README.*" | shuf -n1)"
+        line="$(find "$DATADIR/splashscreens" -type f ! -regex ".*README.*" | shuf -n1)"
     elif [ "$RANDOMIZE" = "all" ]; then
-        local line="$( (find "$rootdir/supplementary/splashscreen" -type f ! -regex ".*/.git/.*" ! -regex ".*LICENSE" ! -regex ".*README.*" && find "$datadir/RetroPie/splashscreens" -type f ! -regex ".*README.*") | shuf -n1)"
+        line="$( (find "$ROOTDIR/supplementary/splashscreen" -type f ! -regex ".*/.git/.*" ! -regex ".*LICENSE" ! -regex ".*README.*" && find "$DATADIR/splashscreens" -type f ! -regex ".*README.*") | shuf -n1)"
     elif [ "$RANDOMIZE" = "list" ]; then
-        local line="$(cat "$config" | shuf -n1)"
+        line="$(cat "$config" | shuf -n1)"
     fi
     if $(echo "$line" | grep -q "$REGEX_VIDEO"); then
         # wait for dbus

--- a/scriptmodules/supplementary/splashscreen/asplashscreen
+++ b/scriptmodules/supplementary/splashscreen/asplashscreen
@@ -12,6 +12,8 @@
 ### END INIT INFO
 
 RANDOMIZE="disabled"
+REGEX_VIDEO=""
+REGEX_IMAGE=""
 
 do_start () {
     local config="/etc/splashscreen.list"
@@ -28,13 +30,13 @@ do_start () {
     elif [ "$RANDOMIZE" = "list" ]; then
         local line="$(cat "$config" | shuf -n1)"
     fi
-    if $(echo "$line" | grep -q ".avi\|.mov\|.mp4\|.mkv\|.3gp\|.mpg\|.mp3\|.wav\|.m4a\|.aac\|.ogg\|.flac"); then
+    if $(echo "$line" | grep -q "$REGEX_VIDEO"); then
         # wait for dbus
         while ! pgrep "dbus" >/dev/null; do
             sleep 1
         done
         omxplayer -b --layer 10000 "$line"
-    else
+    elif $(echo "$line" | grep -q "$REGEX_IMAGE"); then
         if [ "$RANDOMIZE" = "disabled" ]; then
             local count=$(wc -l <"$config")
         else


### PR DESCRIPTION
 * addresses some of the points from https://github.com/RetroPie/RetroPie-Setup/pull/1480#issuecomment-219145076
 * make functions more standalone and simplify logic - eg choose_splashscreen just returns a splashscreen - setting / preview etc is handled in their own functions
 * put extensions into functions
 * paths for splashscreen locations is now handled in own function

this needs some testing