### PR TITLE
bluetooth: fix connection problems

### DIFF
--- a/scriptmodules/supplementary/bluetooth.sh
+++ b/scriptmodules/supplementary/bluetooth.sh
@@ -17,7 +17,7 @@ rp_module_flags="nobin"
 function depends_bluetooth() {
     local depends=(bluetooth python-dbus python-gobject)
     if isPlatform "rpi3" && hasPackage raspberrypi-bootloader && [[ "$__raspbian_ver" -ge "8" ]]; then
-        depends+=(pi-bluetooth)
+        depends+=(pi-bluetooth raspberrypi-sys-mods)
     fi
     getDepends "${depends[@]}"
 }

--- a/scriptmodules/supplementary/ps3controller.sh
+++ b/scriptmodules/supplementary/ps3controller.sh
@@ -17,7 +17,7 @@ rp_module_flags="nobin"
 function depends_ps3controller() {
     local depends=(checkinstall libusb-dev bluetooth libbluetooth-dev joystick)
     if isPlatform "rpi3" && hasPackage raspberrypi-bootloader && [[ "$__raspbian_ver" -ge "8" ]]; then
-        depends+=(pi-bluetooth)
+        depends+=(pi-bluetooth raspberrypi-sys-mods)
     fi
     getDepends "${depends[@]}"
 }


### PR DESCRIPTION
After installation of newest pi-bluetooth package bluetooth is broken. Add necessary package rapberrypi-sys-mods.

@joolswills I don't know if this should be already merged. If raspberrypi-sys-mods will be installed there is a risk users will be asked if an udev rule should be changed.