### PR TITLE
add dinothawr

### DIFF
--- a/scriptmodules/libretrocores/lr-dinothawr.sh
+++ b/scriptmodules/libretrocores/lr-dinothawr.sh
@@ -19,7 +19,7 @@ function sources_lr-dinothawr() {
 
 function build_lr-dinothawr() {
     make clean
-    make
+    make DEBUG=1
     md_ret_require="$md_build/dinothawr_libretro.so"
 }
 
@@ -44,5 +44,3 @@ function configure_lr-dinothawr() {
     chown $user:$user -R "$romdir/ports/dinothawr/"
 
 }
-
-

--- a/scriptmodules/libretrocores/lr-dinothawr.sh
+++ b/scriptmodules/libretrocores/lr-dinothawr.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+# 
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# 
+# See the LICENSE.md file at the top-level directory of this distribution and 
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-dinothawr"
+rp_module_desc="Dinothawr - standalone libretro puzzle game"
+rp_module_section="exp"
+
+function sources_lr-dinothawr() {
+    gitPullOrClone "$md_build" https://github.com/libretro/Dinothawr.git
+}
+
+function build_lr-dinothawr() {
+    make clean
+    make
+    md_ret_require="$md_build/dinothawr_libretro.so"
+}
+
+function install_lr-dinothawr() {
+    md_ret_files=(
+        'dinothawr_libretro.so'
+        'dinothawr'
+    )
+}
+
+
+function configure_lr-dinothawr() {
+    setConfigRoot "ports"
+
+    addPort "$md_id" "dinothawr" "Dinothawr" "$emudir/retroarch/bin/retroarch -L $md_inst/dinothawr_libretro.so --config $md_conf_root/dinothawr/retroarch.cfg $romdir/ports/dinothawr/dinothawr/dinothawr.game"
+
+    mkRomDir "ports/dinothawr"
+    ensureSystemretroconfig "ports/dinothawr"
+
+    cp -R "$md_inst/dinothawr/" "$romdir/ports/dinothawr/"
+
+    chown $user:$user -R "$romdir/ports/dinothawr/"
+
+}
+
+


### PR DESCRIPTION
dont know if we want this here or if we should throw it on zerojays repo. Likely the module needs a little more work

addresses https://github.com/RetroPie/RetroPie-Setup/issues/1509

works on pc, on the pi it gives an error possible related discussion: http://libretro.com/forums/showthread.php?t=725: 

Supposedly if we compile it in debug mode it should work, so I'll see if I can sort that
```
filestream_read_file: Failed to open /home/pi/RetroPie/roms/ports/dinothawr/dinothawr/dinothawr.srm: No such file or directory
pure virtual method called
terminate called without an active exception
/opt/retropie/supplementary/runcommand/runcommand.sh: line 804:  5407 Aborted                 /opt/retropie/emulators/retroarch/bin/retroarch -L /opt/retropie/libretrocores/lr-dinothawr/dinothawr_libretro.so --config /opt/retropie/configs/ports/dinothawr/retroarch.cfg /home/pi/RetroPie/roms/ports/dinothawr/dinothawr/dinothawr.game --appendconfig /tmp/retroarch.cfg
```