### PR TITLE
retroarch changes

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -83,6 +83,8 @@ function remove_overlays_retroarch() {
 }
 
 function configure_retroarch() {
+    [[ "$md_mode" == "remove" ]] && return
+
     mkUserDir "$configdir/all/retroarch-joypads"
 
     mkUserDir "$md_inst/assets"

--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -32,9 +32,6 @@ function depends_retroarch() {
 
 function sources_retroarch() {
     gitPullOrClone "$md_build" https://github.com/libretro/RetroArch.git
-    gitPullOrClone "$md_build/overlays" https://github.com/libretro/common-overlays.git
-    isPlatform "rpi" && gitPullOrClone "$md_build/shader" https://github.com/RetroPie/common-shaders.git rpi
-    isPlatform "x11" && gitPullOrClone "$md_build/shader" https://github.com/libretro/common-shaders.git
     # disable the search dialog
     sed -i 's|menu_input_ctl(MENU_INPUT_CTL_SEARCH_START|//menu_input_ctl(MENU_INPUT_CTL_SEARCH_START|g' menu/menu_entry.c
     if isPlatform "mali"; then
@@ -58,17 +55,40 @@ function build_retroarch() {
 
 function install_retroarch() {
     make install
-    mkdir -p "$md_inst/"{shader,assets,overlays}
-    cp -v -a "$md_build/shader/"* "$md_inst/shader/"
-    cp -v -a "$md_build/overlays/"* "$md_inst/overlays/"
-    chown $user:$user -R "$md_inst/"{shader,assets,overlays}
     md_ret_files=(
         'retroarch.cfg'
     )
 }
 
+function update_shaders_retroarch() {
+    local branch=""
+    isPlatform "rpi" && branch="rpi"
+    # remove if not git repository for fresh checkout
+    [[ ! -d "$md_inst/shader/.git" ]] && rm -rf "$md_inst/shader"
+    gitPullOrClone "$md_inst/shader" https://github.com/RetroPie/common-shaders.git "$branch"
+}
+
+function update_overlays_retroarch() {
+    # remove if not a git repository for fresh checkout
+    [[ ! -d "$md_inst/overlays/.git" ]] && rm -rf "$md_inst/overlays"
+    gitPullOrClone "$md_inst/overlays" https://github.com/libretro/common-overlays.git
+}
+
+function remove_shaders_retroarch() {
+    rm -rf "$md_inst/shader"
+}
+
+function remove_overlays_retroarch() {
+    rm -rf "$md_inst/overlays"
+}
+
 function configure_retroarch() {
     mkUserDir "$configdir/all/retroarch-joypads"
+
+    mkUserDir "$md_inst/assets"
+
+    # install shaders by default
+    update_shaders_retroarch
 
     local config="$configdir/all/retroarch.cfg"
     # if the user has an existing config we will not overwrite it, but instead copy the
@@ -137,4 +157,47 @@ function configure_retroarch() {
     iniSet "input_joypad_driver" "udev"
 
     chown $user:$user "$config"
+}
+
+function gui_retroarch() {
+    while true; do
+        local options=()
+        local dir
+        local name
+        local i=1
+        for name in shaders overlays; do
+            dir="$name"
+            [[ "$dir" == "shaders" ]] && dir="shader"
+            if [[ -d "$md_inst/$dir/.git" ]]; then
+                options+=("$i" "Manage $name (installed)")
+            else
+                options+=("$i" "Manage $name (uninstalled)")
+            fi
+            ((i++))
+        done
+        local cmd=(dialog --backtitle "$__backtitle" --menu "Choose an option" 22 76 16)
+        local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
+        [[ -z "$choice" ]] && break
+        [[ "$choice" -eq 1 ]] && dir="shaders"
+        [[ "$choice" -eq 2 ]] && dir="overlays"
+        options=(1 "Install/Update $dir" 2 "Uninstall $dir" )
+        cmd=(dialog --backtitle "$__backtitle" --menu "Choose an option for $dir" 12 40 06)
+        choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
+
+        case "$choice" in
+            1)
+                "update_${dir}_retroarch"
+                ;;
+            2)
+                "remove_${dir}_retroarch"
+                ;;
+            *)
+                exit
+                continue
+                ;;
+
+        esac
+    done
+
+
 }


### PR DESCRIPTION
 * manage shaders/overlays from a retroarch gui function, so they can be updated separately from retroarch.
 * only install shaders by default (to save on space).

this solves the issue that retroarch binaries are huge by default due to all the overlays, and the fact that people can't easily just update the shaders etc. Once this is in, I will rebuild the binaries to not include the shaders/overlays.