### PR TITLE
adding joystick selection for RetroArch players 1-4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+# Use new trusty images, should yield newer compilers and packages
+sudo: required
+dist: precise
+language: cpp
+
+matrix:
+  include:
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+      env: 
+       - COMPILER=g++-4.9
+       - ARCH=arm
+
+before_install:
+  - sudo apt-get update -qq
+
+script:
+  - "bash -ex ./test/travis-ci.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,9 @@
 sudo: required
 dist: precise
 language: cpp
-compiler: gcc
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.9
 
 git:
   depth: 3
-
-env:
-  - PKGID=100
-  - PKGID=200
 
 matrix:
   include:
@@ -27,11 +16,14 @@ matrix:
           packages:
             - g++-4.9
       env: 
-       - COMPILER=g++-4.9
-       - ARCH=arm
+         - COMPILER=g++-4.9
+         - ARCH=arm
+         - env:
+          PKGID=100
+          PKGID=200
 
 before_install:
   - sudo apt-get update -qq
 
 script:
-  - "bash -ex ./tools/test/travis-ci.sh $PKGID"
+  - "bash -ex ./tools/test/travis-ci.sh ${PKGID}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
        - ARCH=arm
          matrix:
          - PKGID=100
-         - PKGID=200
+         - PKGID=200 
 
 before_install:
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
   - ARCH=arm
   matrix:
     - __platform=rpi3
-    - __platform=rpi1
+    - __platform=rpi1 
 
 # matrix:
 #   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: cpp
 compiler: gcc
 
 env:
-  - __platform=rpi1
   - __platform=rpi2
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
   - ARCH=arm
   matrix:
     - __platform=rpi3
-    - __platform=rpi1 
+    - __platform=rpi1
 
 # matrix:
 #   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: required
 dist: precise
 language: cpp
 
+git:
+  depth: 3
+
 matrix:
   include:
     - compiler: gcc
@@ -20,4 +23,4 @@ before_install:
   - sudo apt-get update -qq
 
 script:
-  - "bash -ex ./test/travis-ci.sh"
+  - "bash -ex ./tools/test/travis-ci.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ matrix:
          - COMPILER=g++-4.9
          - ARCH=arm
          - env:
-          PKGID=100
-          PKGID=200
+             - PKGID=100
+             - PKGID=200
 
 before_install:
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-          packages:
-            - g++-4.9
       env: 
        - COMPILER=g++-4.9
        - ARCH=arm
@@ -22,8 +20,6 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-          packages:
-            - g++-4.9
       env: 
        - COMPILER=g++-4.9
        - ARCH=arm

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ language: cpp
 git:
   depth: 3
 
+env:
+  matrix:
+   - PKGID=100
+   - PKGID=200
+
 matrix:
   include:
     - compiler: gcc
@@ -23,4 +28,4 @@ before_install:
   - sudo apt-get update -qq
 
 script:
-  - "bash -ex ./tools/test/travis-ci.sh"
+  - "bash -ex ./tools/test/travis-ci.sh $PKGID"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,35 +2,50 @@
 sudo: required
 dist: precise
 language: cpp
+compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
 
 git:
   depth: 3
 
-matrix:
-  include:
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-4.9
-      env: 
-       - COMPILER=g++-4.9
-       - ARCH=arm
-       - PKGID=100
+env:
+  global:
+  - COMPILER=g++-4.9
+  - ARCH=arm
+  matrix:
+    - __platform=rpi3
+    - __platform=rpi1
 
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-4.9
-      env: 
-       - COMPILER=g++-4.9
-       - ARCH=arm
-       - PKGID=200
+# matrix:
+#   include:
+#     - compiler: gcc
+#       addons:
+#         apt:
+#           sources:
+#             - ubuntu-toolchain-r-test
+#           packages:
+#             - g++-4.9
+#       env: 
+#        - COMPILER=g++-4.9
+#        - ARCH=arm
+#        - PKGID=100
+
+#     - compiler: gcc
+#       addons:
+#         apt:
+#           sources:
+#             - ubuntu-toolchain-r-test
+#           packages:
+#             - g++-4.9
+#       env: 
+#        - COMPILER=g++-4.9
+#        - ARCH=arm
+#        - PKGID=200
 
 before_install:
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ git:
   depth: 3
 
 env:
-  global:
   - COMPILER=g++-4.9
   - ARCH=arm
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,49 +2,32 @@
 sudo: required
 dist: precise
 language: cpp
-compiler: gcc
+
+matrix:
+  include:
+    - compiler: gcc
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
             - g++-4.9
+      env: 
+       - COMPILER=g++-4.9
+       - ARCH=arm
+       - __platform=rpi1
 
-git:
-  depth: 3
-
-env:
-  - COMPILER=g++-4.9
-  - ARCH=arm
-  matrix:
-    - __platform=rpi3
-    - __platform=rpi1
-
-# matrix:
-#   include:
-#     - compiler: gcc
-#       addons:
-#         apt:
-#           sources:
-#             - ubuntu-toolchain-r-test
-#           packages:
-#             - g++-4.9
-#       env: 
-#        - COMPILER=g++-4.9
-#        - ARCH=arm
-#        - PKGID=100
-
-#     - compiler: gcc
-#       addons:
-#         apt:
-#           sources:
-#             - ubuntu-toolchain-r-test
-#           packages:
-#             - g++-4.9
-#       env: 
-#        - COMPILER=g++-4.9
-#        - ARCH=arm
-#        - PKGID=200
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+      env: 
+       - COMPILER=g++-4.9
+       - ARCH=arm
+       - __platform=rpi2
 
 before_install:
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,7 @@ matrix:
       env: 
        - COMPILER=g++-4.9
        - ARCH=arm
-         matrix:
-         - PKGID=100
-         - PKGID=200 
+       - PKGID=100
 
 before_install:
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,24 +8,6 @@ env:
   - __platform=rpi1
   - __platform=rpi2
 
-# matrix:
-#   include:
-#     - compiler: gcc
-#       addons:
-#         apt:
-#           sources:
-#             - ubuntu-toolchain-r-test
-#       env: 
-#        - __platform=rpi1
-
-#     - compiler: gcc
-#       addons:
-#         apt:
-#           sources:
-#             - ubuntu-toolchain-r-test
-#       env: 
-#        - __platform=rpi2
-
 before_install:
   - sudo apt-get update -qq
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,20 @@
 sudo: required
 dist: precise
 language: cpp
+compiler: gcc
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.9
 
 git:
   depth: 3
 
 env:
-  matrix:
-   - PKGID=100
-   - PKGID=200
+  - PKGID=100
+  - PKGID=200
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,18 @@ matrix:
        - ARCH=arm
        - PKGID=100
 
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+      env: 
+       - COMPILER=g++-4.9
+       - ARCH=arm
+       - PKGID=200
+
 before_install:
   - sudo apt-get update -qq
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,28 +2,29 @@
 sudo: required
 dist: precise
 language: cpp
+compiler: gcc
 
-matrix:
-  include:
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-      env: 
-       - COMPILER=g++-4.9
-       - ARCH=arm
-       - __platform=rpi1
+env:
+  - __platform=rpi1
+  - __platform=rpi2
 
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-      env: 
-       - COMPILER=g++-4.9
-       - ARCH=arm
-       - __platform=rpi2
+# matrix:
+#   include:
+#     - compiler: gcc
+#       addons:
+#         apt:
+#           sources:
+#             - ubuntu-toolchain-r-test
+#       env: 
+#        - __platform=rpi1
+
+#     - compiler: gcc
+#       addons:
+#         apt:
+#           sources:
+#             - ubuntu-toolchain-r-test
+#       env: 
+#        - __platform=rpi2
 
 before_install:
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,14 @@ matrix:
           packages:
             - g++-4.9
       env: 
-         - COMPILER=g++-4.9
-         - ARCH=arm
-         - env:
-             - PKGID=100
-             - PKGID=200
+       - COMPILER=g++-4.9
+       - ARCH=arm
+         matrix:
+         - PKGID=100
+         - PKGID=200
 
 before_install:
   - sudo apt-get update -qq
 
 script:
-  - "bash -ex ./tools/test/travis-ci.sh ${PKGID}"
+  - "bash -ex ./tools/test/travis-ci.sh"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 RetroPie-Setup
 ==============
 
+| Status ||
+| --- | --- |
+| Core Components | [![Build Status](https://travis-ci.org/RetroPie/RetroPie-Setup.svg?branch=travisci-test)](https://travis-ci.org/RetroPie/RetroPie-Setup) |
+
 General Usage
 -------------
 

--- a/scriptmodules/supplementary/joystickselect.sh
+++ b/scriptmodules/supplementary/joystickselect.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+# joystickselect.sh
+############################ official disclaimer #############################
+# This file is part of The RetroPie Project
+# 
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# 
+# See the LICENSE.md file at the top-level directory of this distribution and 
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+##############################################################################
+# Show the available joysticks and let the user choose what controller to
+# use for RetroArch Player 1-4.
+#
+# This program relies on the output of the jslist program to get the
+# available joysticks and their respective indexes.
+#
+# Short description of what this script does:
+# - puts at the beginning of $configdir/all/retroarch.cfg an "#include" 
+#   pointing to the file $configdir/all/input-selection.cfg
+# - let the user manage the input-selection.cfg through dialogs (this file
+#   contains the configs for input_playerN_joypad_index for players 1-4).
+#
+# OBS.: the joystick selection doesn't work if the config_save_on_exit is set to true,
+#       because the retroarch.cfg is overwritten frequently.
+#
+# TODO:
+#      - implement the same functionality for non-libretro emulators.
+#      - [robustness] alert the user if the Player 1 has no joystick.
+#      - [robustness] verify if the "#include ...input-selection.cfg" line
+#        is before any input_playerN_joypad_index in the retroarch.cfg.
+#
+# meleu, 2016/06
+
+
+rp_module_id="joystickselect"
+rp_module_desc="Show the available joysticks and let you choose which to use for RetroArch Players 1-4."
+rp_module_section="config"
+
+jslist_exe="$rootdir/supplementary/jslist"
+js_list_file="/tmp/jslist-$$"
+retroarchcfg="$configdir/all/retroarch.cfg"
+inputcfg="$configdir/all/input-selection.cfg"
+
+
+function depends_joystickselect() {
+    # libsdl2-dev package is needed for jslist.c compilation
+    getDepends libsdl2-dev
+
+    [[ -x "$jslist_exe" ]] || {
+        wget -O /tmp/jslist.c \
+          https://raw.githubusercontent.com/meleu/RetroPie-input-selection/master/jslist.c
+
+        gcc /tmp/jslist.c -o "$jslist_exe" $(sdl2-config --cflags --libs) ||
+          fatalError "Unable to compile jslist.c!"
+    }
+}
+
+
+
+###############################################################################
+# Puts the default joystick input configuration content in the given
+# file ($1 argument).
+# The default is:
+# input_player1_joypad_index = "0"
+# input_player2_joypad_index = "1"
+# input_player3_joypad_index = "2"
+# input_player4_joypad_index = "3"
+#
+# Globals:
+#   None
+#
+# Arguments:
+#   $1 : NEEDED. The file where the default config will be put.
+#
+# Returns:
+#   1: if fails.
+function default_input_config() {
+    [[ "$1" ]] || fatalError "default_input_config: missing argument!"
+
+    local temp_inputcfg
+    temp_inputcfg="$1"
+
+    cat << _EOF_ > "$temp_inputcfg"
+# This file is used to choose which controller to use for each player.
+input_player1_joypad_index = "0"
+input_player2_joypad_index = "1"
+input_player3_joypad_index = "2"
+input_player4_joypad_index = "3"
+_EOF_
+    if [ "$?" -ne 0 ]; then
+        printMsgs "dialog" "Unable to create a default configuration"
+        return 1
+    fi
+
+    chown $user.$user "$temp_inputcfg"
+}
+
+
+
+###############################################################################
+# Fills the js_list_file with the available joysticks and their indexes.
+#
+# Globals:
+#   jslist_exe
+#   js_list_file
+#
+# Arguments:
+#   None
+#
+# Returns:
+#   1: if no joystick found.
+function fill_js_list_file() {
+    local temp_file
+    temp_file=$(mktemp deleteme.XXXX)
+
+    # the jslist returns a non-zero value if it doesn't find any joystick
+    $jslist_exe > $temp_file || {
+        printMsgs "dialog" "No joystick found. :("
+        rm -f "$temp_file"
+        return 1
+    }
+
+    # This obscure command searches for duplicated joystick names and puts
+    # a sequential number at the end of the repeated ones
+    # credit goes to fedorqui (http://stackoverflow.com/users/1983854/fedorqui)
+    awk -F: 'FNR==NR {count[$2]++; next}
+             count[$2]>1 {$0=$0 OFS "#"++times[$2]}
+             1' $temp_file $temp_file > $js_list_file
+
+    # No need for this file anymore
+    rm -f "$temp_file"
+}
+
+
+
+###############################################################################
+# Checking the following:
+#   - if retroarch.cfg has the "#include" line for input-selection.cfg, in
+#     failure case let the user decide if we can add it to the file.
+#   - if input-selection.cfg exists, create it if doesn't.
+#   - if jslist exists and is executable
+#
+# Globals:
+#   retroarchcfg
+#   inputcfg
+#   jslist_exe
+#
+# Arguments:
+#   None
+#
+# Returns:
+#   1: if fails
+function check_files() {
+    # checking if the "#include ..." line is in the retroarch.cfg
+    grep -q "^#include \"$inputcfg\"$" "$retroarchcfg" || {
+        dialog \
+          --backtitle "$__backtitle" \
+          --title "Error" \
+          --yesno \
+"Your retroarch.cfg isn't properly configured to work with this method of
+joystick selection. You need to put the following line on your \"$retroarchcfg\"
+(preferably at the beginning):
+\n\n#include \"$inputcfg\"\n\n
+Do you want me to put it at the beginning of the retroarch.cfg now?
+\n(if you choose \"No\", I will stop now)" \
+          0 0 >/dev/tty || {
+            return 1;
+        }
+
+          # Putting the "#include ..." at the beginning line of retroarch.cfg
+          sed -i "1i\
+# $(date +%Y-%m-%d): The following line was added to allow joystick selection\n\
+#include \"$inputcfg\"\n" \
+            "$retroarchcfg" || return 1
+    } # end of failed grep
+
+    # if the input-selection.cfg doesn't exist or is empty, create it with
+    # default values
+    [[ -s "$inputcfg" ]] || default_input_config "$inputcfg"
+
+    # checking if jslist exists and is executable
+    [[ -x "$jslist_exe" ]] || {
+        printMsgs "dialog" "\"$jslist_exe\" not found or isn't executable!" 
+        return 1
+    } # end of failed jslist_exe
+
+} # end of check_files
+
+
+
+###############################################################################
+# Show the input config with the joystick names, and let the user decide if
+# he/she wants to continue.
+# The caller of this function must deal with the user decision. It returns
+# 1 if the user choose "No", and 0 if the user choose "Yes".
+#
+# Globals:
+#   js_list_file
+#
+# Arguments:
+#   $1 : NEEDED. The input-selection.cfg file. It's just a
+#        retroarch.cfg like file with the input_playerN_joypad_index variables.
+#   $2 : OPTIONAL. Its a string with a question to ask in the yesno dialog.
+#        Keep in mind that the "No" answer always exit.
+#
+# Returns:
+#   -1: if it fails
+#    1: if the user choose No in the --yesno dialog box.
+#    0: if the user choose Yes in the --yesno dialog box.
+function show_input_config() {
+    [[ -f "$1" ]] || {
+        fatalError "Error: show_input_config: invalid argument!"
+        return -1
+    }
+
+    fill_js_list_file
+
+    local cfg_file
+    cfg_file="$1"
+
+    local question
+    question=${2:-"Would you like to continue?"}
+
+    local current_config_string
+
+    for i in $(seq 1 4); do
+        # the command sequence below takes the number after the = sign,
+        # deleting the "double quotes" if they exist.
+        js_index_p[$i]=$(
+          grep -m 1 "^input_player${i}_joypad_index" "$cfg_file" \
+          | cut -d= -f2 \
+          | sed 's/ *"\?\([0-9]\)*"\?.*/\1/' \
+        )
+
+        # getting the joystick names
+        if [[ -z "${js_index_p[$i]}" ]]; then
+            js_name_p[$i]="** NO JOYSTICK! **"
+        else 
+            js_name_p[$i]=$(
+              grep "^${js_index_p[$i]}" "$js_list_file" \
+              | cut -d: -f2
+            )
+
+            [[ -z "${js_name_p[$i]}" ]] &&
+                js_name_p[$i]="** NO JOYSTICK! **"
+        fi
+
+        current_config_string="$current_config_string\n\
+Player $i is set to \"${js_index_p[$i]}\" (${js_name_p[$i]})"
+
+    done
+
+    dialog \
+      --backtitle "$__backtitle" \
+      --title "Joystick selection" \
+      --yesno "$current_config_string\n\n$question" \
+      0 0 >/dev/tty || return 1
+
+    return 0
+} # end of show_input_config
+
+
+
+###############################################################################
+# Start a new joystick input selection configuration for players 1-4.
+#
+# Globals:
+#   inputcfg
+#   js_list_file
+#
+# Arguments:
+#   None
+#
+# Returns:
+#   1: if fails.
+#   0: if the user don't want to change the config
+function new_input_config() {
+    fill_js_list_file || return 1
+
+    local temp_file
+    local temp_inputcfg
+    local options
+    local choice
+    local old
+    local new
+
+    temp_file=$(mktemp temp.XXXX)
+    temp_inputcfg=$(mktemp inputcfg.XXXX)
+
+    cat "$inputcfg" > "$temp_inputcfg"
+    for i in $(seq 1 4); do
+        options="K \"Keep the current configuration for player $i\""
+        # The sed below obtain the joystick list with the format
+        # index "Joystick Name"
+        # to use as dialog menu options
+        options="$options $(sed 's/:\(.*\)/ "\1"/' $js_list_file)"
+        choice=$(echo "$options" \
+                    | xargs dialog \
+                        --backtitle "$__backtitle" \
+                        --title "Player $i joystick selection" \
+                        --menu "Which controller do you want to use for Player $i?" \
+                        0 0 0 2>&1 >/dev/tty
+        )
+
+        # if the user choose K or Cancel, it'll keep the current config
+        if [ -n "$choice" -a "$choice" != "K" ]; then
+            old="^input_player${i}_joypad_index.*"
+            new="input_player${i}_joypad_index = $choice"
+
+            sed "s/$old/$new/" "$temp_inputcfg" > "$temp_file"
+
+            cat "$temp_file" > "$temp_inputcfg"
+        fi
+    done
+
+    show_input_config "$temp_inputcfg" "Do you accept this config?" || return 1
+
+    # If the script reaches this point, the user accepted the config
+    cat "$temp_inputcfg" > "$inputcfg"
+
+    rm -f "$temp_file" "$temp_inputcfg"
+} # end of new_input_config
+
+
+###############################################################################
+# This is a kind of "main()" function.
+#
+# Globals:
+#   js_list_file
+#   jslist_exe
+#   inputcfg
+#
+# Returns:
+#   1: if there is some problem with the config files
+function gui_joystickselect() {
+    local temp_file
+    local options
+    local choices
+
+    temp_file=$(mktemp input-cfg.XXXX)
+
+    check_files || return 1
+
+    while true; do
+        cmd=(dialog --backtitle "$__backtitle"
+             --menu "Joystick selection for RetroArch players 1-4." 18 80 12)
+        options=(
+            1 "Show current joystick selection for players 1-4."
+            2 "Start a new joystick selection for players 1-4."
+            3 "Restore the default settings."
+        )
+        choices=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
+
+        if [[ -n "$choices" ]]; then
+            case $choices in
+                1) show_input_config "$inputcfg" \
+                     "Choose Yes or No to go to the previous menu." ;;
+
+                2) new_input_config ;;
+
+                3) default_input_config "$temp_file"
+                   show_input_config "$temp_file" \
+                     "This is the default configuration. Do you accept it?" || continue
+ 
+                   cat "$temp_file" > "$inputcfg"
+                   ;;
+
+            esac
+        else
+            rm -f "$js_list_file" "$temp_file"
+            break
+        fi
+    done
+}

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -71,7 +71,7 @@ if [ -e "/.chroot_is_done" ]; then
   # Commands used to run the tests
 
   # emulators
-  for index in {100..150}
+  for (( index=100; i <= 150; index++ ))
   do
     sudo ./retropie_packages.sh $index depends
     sudo ./retropie_packages.sh $index install_bin
@@ -79,15 +79,15 @@ if [ -e "/.chroot_is_done" ]; then
   done
 
   # RetroArch cores
-  for index in {200..250}
+  for (( index=200; i <= 250; index++ ))
   do
-    sudo ./retropie_packages.sh $index depends
+    sudo ./retropie_packages.sh ${index} depends
     sudo ./retropie_packages.sh $index install_bin
     sudo ./retropie_packages.sh $index configure
   done
 
   # ports
-  for index in {300..350}
+  for (( index=300; i <= 350; index++ ))
   do
     sudo ./retropie_packages.sh $index depends
     sudo ./retropie_packages.sh $index install_bin

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -22,8 +22,6 @@ function setup_arm_chroot {
     sudo mkdir -p ${CHROOT_DIR}
     pushd /usr/share/debootstrap/scripts; sudo ln -s sid jessie; popd
 
-    export QEMU_CPU=cortex-a15
-
     sudo debootstrap --foreign --no-check-gpg --include=fakeroot,build-essential --arch=${CHROOT_ARCH} ${VERSION} ${CHROOT_DIR} ${MIRROR}
     sudo cp /usr/bin/qemu-arm-static ${CHROOT_DIR}/usr/bin/
     sudo chroot ${CHROOT_DIR} ./debootstrap/debootstrap --second-stage
@@ -39,8 +37,7 @@ function setup_arm_chroot {
 
     # Create file with environment variables which will be used inside chrooted
     # environment
-    echo "export ARCH=${ARCH}" > envvars.sh
-    echo "export TRAVIS_BUILD_DIR=${TRAVIS_BUILD_DIR}" >> envvars.sh
+    echo "export TRAVIS_BUILD_DIR=${TRAVIS_BUILD_DIR}" > envvars.sh
     echo "export __platform=${__platform}" >> envvars.sh
     chmod a+x envvars.sh
 
@@ -69,6 +66,11 @@ if [ -e "/.chroot_is_done" ]; then
   echo "Environment: $(uname -a)"
 
   # Commands used to run the tests
+
+  # RetroArch
+  sudo __platform=${__platform} ./retropie_packages.sh retroarch depends || exit 1
+  sudo __platform=${__platform} ./retropie_packages.sh retroarch install_bin || exit 1
+  sudo __platform=${__platform} ./retropie_packages.sh retroarch configure || exit 1
 
   # EmulationStation
   sudo __platform=${__platform} ./retropie_packages.sh emulationstation depends || exit 1

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -43,6 +43,9 @@ function setup_arm_chroot {
     echo "export __platform=${__platform}" >> envvars.sh
     chmod a+x envvars.sh
 
+    sudo echo "en_US.UTF-8 UTF-8" > ${CHROOT_DIR}/etc/locale.gen
+    sudo chroot ${CHROOT_DIR} /usr/sbin/locale-gen
+
     # Install dependencies inside chroot
     sudo chroot ${CHROOT_DIR} apt-get update
     sudo chroot ${CHROOT_DIR} apt-get --allow-unauthenticated install \

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -95,9 +95,7 @@ if [ -e "/.chroot_is_done" ]; then
   done
 
 else
-  if [ "${ARCH}" = "arm" ]; then
-    # ARM test run, need to set up chrooted environment first
-    echo "Setting up chrooted ARM environment"
-    setup_arm_chroot
-  fi
+  # ARM test run, need to set up chrooted environment first
+  echo "Setting up chrooted ARM environment"
+  setup_arm_chroot
 fi

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -32,6 +32,20 @@ function setup_arm_chroot {
         ${VERSION} ${CHROOT_DIR} ${MIRROR}
 
     sudo cp /etc/resolv.conf "${CHROOT_DIR}/etc/resolv.conf"
+
+cat << EOF > "${CHROOT_DIR}/etc/resolv.conf"
+# KEYBOARD CONFIGURATION FILE
+
+# Consult the keyboard(5) manual page.
+
+XKBMODEL="pc105"
+XKBLAYOUT="gb"
+XKBVARIANT=""
+XKBOPTIONS="lv3:ralt_switch"
+
+BACKSPACE="guess"
+EOF
+
     sudo mount -o bind /proc "${CHROOT_DIR}/proc"
     sudo mount -o bind /dev "${CHROOT_DIR}/dev"
     sudo mount -o bind /dev/pts "${CHROOT_DIR}/dev/pts"

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -89,28 +89,9 @@ if [ -e "/.chroot_is_done" ]; then
   # Commands used to run the tests
 
   # emulators
-  for (( index=100; i <= 150; index++ ))
-  do
-    sudo __platform=${__platform} ./retropie_packages.sh $index depends || return 1
-    sudo __platform=${__platform} ./retropie_packages.sh $index install_bin || return 1
-    sudo __platform=${__platform} ./retropie_packages.sh $index configure || return 1
-  done
-
-  # RetroArch cores
-  for (( index=200; i <= 250; index++ ))
-  do
-    sudo __platform=${__platform} ./retropie_packages.sh ${index} depends || return 1
-    sudo __platform=${__platform} ./retropie_packages.sh $index install_bin || return 1
-    sudo __platform=${__platform} ./retropie_packages.sh $index configure || return 1
-  done
-
-  # ports
-  for (( index=300; i <= 350; index++ ))
-  do
-    sudo __platform=${__platform} ./retropie_packages.sh $index depends || return 1
-    sudo __platform=${__platform} ./retropie_packages.sh $index install_bin || return 1
-    sudo __platform=${__platform} ./retropie_packages.sh $index configure || return 1
-  done
+  sudo __platform=${__platform} ./retropie_packages.sh retroarch depends || return 1
+  sudo __platform=${__platform} ./retropie_packages.sh retroarch install_bin || return 1
+  sudo __platform=${__platform} ./retropie_packages.sh retroarch configure || return 1
 
 else
   # ARM test run, need to set up chrooted environment first

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -28,12 +28,12 @@ function setup_arm_chroot {
     sudo sbuild-createchroot --arch=${CHROOT_ARCH} --foreign --setup-only \
         ${VERSION} ${CHROOT_DIR} ${MIRROR}
 
-    mkdir -p "${CHROOT_DIR}/run/resolvconf"
-    echo "nameserver 8.8.8.8" >"${CHROOT_DIR}/etc/resolv.conf"
-    rm -f "${CHROOT_DIR}/etc/ld.so.preload"
+    sudo mkdir -p "${CHROOT_DIR}/run/resolvconf"
+    sudo echo "nameserver 8.8.8.8" >"${CHROOT_DIR}/etc/resolv.conf"
+    sudo rm -f "${CHROOT_DIR}/etc/ld.so.preload"
 
-    mount -o bind /proc "${CHROOT_DIR}/proc"
-    mount -o bind /dev "${CHROOT_DIR}/dev"
+    sudo mount -o bind /proc "${CHROOT_DIR}/proc"
+    sudo mount -o bind /dev "${CHROOT_DIR}/dev"
 
     export QEMU_CPU=cortex-a15
 

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -34,6 +34,7 @@ function setup_arm_chroot {
     sudo cp /etc/resolv.conf "${CHROOT_DIR}/etc/resolv.conf"
     sudo mount -o bind /proc "${CHROOT_DIR}/proc"
     sudo mount -o bind /dev "${CHROOT_DIR}/dev"
+    sudo mount -o bind /dev/pts "${CHROOT_DIR}/dev/pts"
 
     # Create file with environment variables which will be used inside chrooted
     # environment
@@ -67,7 +68,24 @@ if [ -e "/.chroot_is_done" ]; then
   echo "Environment: $(uname -a)"
 
   # Commands used to run the tests
-  sudo __platform=rpi3 ./retropie_packages.sh lr-pocketsnes
+
+  # emulators
+  for i in {100..150}
+  do
+    sudo __platform=rpi3 ./retropie_packages.sh $i
+  done
+
+  # RetroArch cores
+  for i in {200..250}
+  do
+    sudo __platform=rpi3 ./retropie_packages.sh $i
+  done
+
+  # ports
+  for i in {300..350}
+  do
+    sudo __platform=rpi3 ./retropie_packages.sh $i
+  done
 
 else
   if [ "${ARCH}" = "arm" ]; then

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -72,7 +72,9 @@ if [ -e "/.chroot_is_done" ]; then
   # Commands used to run the tests
 
   # emulators
-  sudo __platform=rpi3 ./retropie_packages.sh ${PKGID} binaries
+  sudo __platform=rpi3 ./retropie_packages.sh ${PKGID} depends
+  sudo __platform=rpi3 ./retropie_packages.sh ${PKGID} install_bin
+  sudo __platform=rpi3 ./retropie_packages.sh ${PKGID} configure
 
 else
   if [ "${ARCH}" = "arm" ]; then

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -28,6 +28,15 @@ function setup_arm_chroot {
     sudo sbuild-createchroot --arch=${CHROOT_ARCH} --foreign --setup-only \
         ${VERSION} ${CHROOT_DIR} ${MIRROR}
 
+    mkdir -p "${CHROOT_DIR}/run/resolvconf"
+    echo "nameserver 8.8.8.8" >"${CHROOT_DIR}/etc/resolv.conf"
+    rm -f "${CHROOT_DIR}/etc/ld.so.preload"
+
+    mount -o bind /proc "${CHROOT_DIR}/proc"
+    mount -o bind /dev "${CHROOT_DIR}/dev"
+
+    export QEMU_CPU=cortex-a15
+
     # Create file with environment variables which will be used inside chrooted
     # environment
     echo "export ARCH=${ARCH}" > envvars.sh

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -31,13 +31,11 @@ function setup_arm_chroot {
     sudo sbuild-createchroot --arch=${CHROOT_ARCH} --foreign --setup-only \
         ${VERSION} ${CHROOT_DIR} ${MIRROR}
 
-    sudo "cp /etc/resolv.conf "${CHROOT_DIR}/etc/resolv.conf""
+    sudo cp /etc/resolv.conf "${CHROOT_DIR}/etc/resolv.conf"
 
-    sudo "cat << EOF > \"${CHROOT_DIR}/etc/default/keyboard\""
+    sudo cat << EOF > "${CHROOT_DIR}/etc/default/keyboard"
 # KEYBOARD CONFIGURATION FILE
-
 # Consult the keyboard(5) manual page.
-
 XKBMODEL="pc105"
 XKBLAYOUT="gb"
 XKBVARIANT=""

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -73,25 +73,25 @@ if [ -e "/.chroot_is_done" ]; then
   # emulators
   for (( index=100; i <= 150; index++ ))
   do
-    sudo ./retropie_packages.sh $index depends
-    sudo ./retropie_packages.sh $index install_bin
-    sudo ./retropie_packages.sh $index configure
+    sudo __platform=${__platform} ./retropie_packages.sh $index depends
+    sudo __platform=${__platform} ./retropie_packages.sh $index install_bin
+    sudo __platform=${__platform} ./retropie_packages.sh $index configure
   done
 
   # RetroArch cores
   for (( index=200; i <= 250; index++ ))
   do
-    sudo ./retropie_packages.sh ${index} depends
-    sudo ./retropie_packages.sh $index install_bin
-    sudo ./retropie_packages.sh $index configure
+    sudo __platform=${__platform} ./retropie_packages.sh ${index} depends
+    sudo __platform=${__platform} ./retropie_packages.sh $index install_bin
+    sudo __platform=${__platform} ./retropie_packages.sh $index configure
   done
 
   # ports
   for (( index=300; i <= 350; index++ ))
   do
-    sudo ./retropie_packages.sh $index depends
-    sudo ./retropie_packages.sh $index install_bin
-    sudo ./retropie_packages.sh $index configure
+    sudo __platform=${__platform} ./retropie_packages.sh $index depends
+    sudo __platform=${__platform} ./retropie_packages.sh $index install_bin
+    sudo __platform=${__platform} ./retropie_packages.sh $index configure
   done
 
 else

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -2,8 +2,6 @@
 # Based on a test script from avsm/ocaml repo https://github.com/avsm/ocaml
 # based on the script from https://www.tomaz.me/2013/12/02/running-travis-ci-tests-on-arm.html
 
-PKGID=$1
-
 CHROOT_DIR=$HOME/arm-chroot
 MIRROR=http://archive.raspbian.org/raspbian
 
@@ -42,6 +40,7 @@ function setup_arm_chroot {
     # environment
     echo "export ARCH=${ARCH}" > envvars.sh
     echo "export TRAVIS_BUILD_DIR=${TRAVIS_BUILD_DIR}" >> envvars.sh
+    echo "export __platform=${__platform}" >> envvars.sh
     chmod a+x envvars.sh
 
     # Install dependencies inside chroot
@@ -57,7 +56,7 @@ function setup_arm_chroot {
     sudo touch ${CHROOT_DIR}/.chroot_is_done
 
     # Call ourselves again which will cause tests to run
-    sudo chroot ${CHROOT_DIR} bash -c "cd ${TRAVIS_BUILD_DIR} && ./tools/test/travis-ci.sh ${PKGID}"
+    sudo chroot ${CHROOT_DIR} bash -c "cd ${TRAVIS_BUILD_DIR} && ./tools/test/travis-ci.sh"
 }
 
 if [ -e "/.chroot_is_done" ]; then
@@ -72,9 +71,28 @@ if [ -e "/.chroot_is_done" ]; then
   # Commands used to run the tests
 
   # emulators
-  sudo __platform=rpi3 ./retropie_packages.sh 100 depends
-  sudo __platform=rpi3 ./retropie_packages.sh 100 install_bin
-  sudo __platform=rpi3 ./retropie_packages.sh 100 configure
+  for index in {100..150}
+  do
+    sudo ./retropie_packages.sh $index depends
+    sudo ./retropie_packages.sh $index install_bin
+    sudo ./retropie_packages.sh $index configure
+  done
+
+  # RetroArch cores
+  for index in {200..250}
+  do
+    sudo ./retropie_packages.sh $index depends
+    sudo ./retropie_packages.sh $index install_bin
+    sudo ./retropie_packages.sh $index configure
+  done
+
+  # ports
+  for index in {300..350}
+  do
+    sudo ./retropie_packages.sh $index depends
+    sudo ./retropie_packages.sh $index install_bin
+    sudo ./retropie_packages.sh $index configure
+  done
 
 else
   if [ "${ARCH}" = "arm" ]; then

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -72,9 +72,9 @@ if [ -e "/.chroot_is_done" ]; then
   # Commands used to run the tests
 
   # emulators
-  sudo __platform=rpi3 ./retropie_packages.sh ${PKGID} depends
-  sudo __platform=rpi3 ./retropie_packages.sh ${PKGID} install_bin
-  sudo __platform=rpi3 ./retropie_packages.sh ${PKGID} configure
+  sudo __platform=rpi3 ./retropie_packages.sh 100 depends
+  sudo __platform=rpi3 ./retropie_packages.sh 100 install_bin
+  sudo __platform=rpi3 ./retropie_packages.sh 100 configure
 
 else
   if [ "${ARCH}" = "arm" ]; then

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -24,12 +24,10 @@ function setup_arm_chroot {
 
     export QEMU_CPU=cortex-a15
 
-    sudo debootstrap --foreign --no-check-gpg --include=fakeroot,build-essential \
-        --arch=${CHROOT_ARCH} ${VERSION} ${CHROOT_DIR} ${MIRROR}
+    sudo debootstrap --foreign --no-check-gpg --include=fakeroot,build-essential --arch=${CHROOT_ARCH} ${VERSION} ${CHROOT_DIR} ${MIRROR}
     sudo cp /usr/bin/qemu-arm-static ${CHROOT_DIR}/usr/bin/
     sudo chroot ${CHROOT_DIR} ./debootstrap/debootstrap --second-stage
-    sudo sbuild-createchroot --arch=${CHROOT_ARCH} --foreign --setup-only \
-        ${VERSION} ${CHROOT_DIR} ${MIRROR}
+    sudo sbuild-createchroot --arch=${CHROOT_ARCH} --foreign --setup-only ${VERSION} ${CHROOT_DIR} ${MIRROR}
 
     sudo cp /etc/resolv.conf "${CHROOT_DIR}/etc/resolv.conf"
 
@@ -48,10 +46,9 @@ function setup_arm_chroot {
     chmod a+x envvars.sh
 
     # Install dependencies inside chroot
-    sudo chroot ${CHROOT_DIR} echo "deb http://archive.raspberrypi.org/debian/ ${VERSION} main" >> /etc/apt/sources.list
+    sudo chroot ${CHROOT_DIR} "echo \"deb http://archive.raspberrypi.org/debian/ ${VERSION} main\" >> /etc/apt/sources.list"
     sudo chroot ${CHROOT_DIR} apt-get update
-    sudo chroot ${CHROOT_DIR} apt-get --allow-unauthenticated install \
-        -qq -y ${GUEST_DEPENDENCIES}
+    sudo chroot ${CHROOT_DIR} apt-get --allow-unauthenticated install -qq -y ${GUEST_DEPENDENCIES}
 
     # Create build dir and copy travis build files to our chroot environment
     sudo mkdir -p ${CHROOT_DIR}/${TRAVIS_BUILD_DIR}

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -67,11 +67,6 @@ if [ -e "/.chroot_is_done" ]; then
 
   # Commands used to run the tests
 
-  # RetroArch
-  sudo __platform=${__platform} ./retropie_packages.sh retroarch depends || exit 1
-  sudo __platform=${__platform} ./retropie_packages.sh retroarch install_bin || exit 1
-  sudo __platform=${__platform} ./retropie_packages.sh retroarch configure || exit 1
-
   # EmulationStation
   sudo __platform=${__platform} ./retropie_packages.sh emulationstation depends || exit 1
   sudo __platform=${__platform} ./retropie_packages.sh emulationstation install_bin || exit 1

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -48,6 +48,7 @@ function setup_arm_chroot {
     chmod a+x envvars.sh
 
     # Install dependencies inside chroot
+    sudo chroot ${CHROOT_DIR} echo "deb http://archive.raspberrypi.org/debian/ ${VERSION} main" >> /etc/apt/sources.list
     sudo chroot ${CHROOT_DIR} apt-get update
     sudo chroot ${CHROOT_DIR} apt-get --allow-unauthenticated install \
         -qq -y ${GUEST_DEPENDENCIES}

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -12,7 +12,7 @@ CHROOT_ARCH=armhf
 HOST_DEPENDENCIES="debootstrap qemu-user-static binfmt-support sbuild"
 
 # Debian package dependencies for the chrooted environment
-GUEST_DEPENDENCIES="build-essential git m4 sudo cmake g++-4.9 gcc-4.9 python locales"
+GUEST_DEPENDENCIES="build-essential git m4 sudo cmake g++-4.9 gcc-4.9 python"
 
 function setup_arm_chroot {
     # Host dependencies
@@ -45,14 +45,6 @@ function setup_arm_chroot {
     echo "export TRAVIS_BUILD_DIR=${TRAVIS_BUILD_DIR}" >> envvars.sh
     echo "export __platform=${__platform}" >> envvars.sh
 
-    sudo echo -e "echo \"en_US.UTF-8 UTF-8\" > /etc/locale.gen" >> envvars.sh
-    sudo echo -e "XKBMODEL=\"pc105\" > /etc/default/keyboard" >> envvars.sh
-    sudo echo -e "XKBLAYOUT=\"gb\" >> /etc/default/keyboard" >> envvars.sh
-    sudo echo -e "XKBVARIANT=\"\" >> /etc/default/keyboard" >> envvars.sh
-    sudo echo -e "XKBOPTIONS=\"lv3:ralt_switch\" >> /etc/default/keyboard" >> envvars.sh
-    sudo echo -e "BACKSPACE=\"guess\" >> /etc/default/keyboard" >> envvars.sh
-    sudo echo "/usr/sbin/locale-gen" >> envvars.sh
-
     chmod a+x envvars.sh
 
     # Install dependencies inside chroot
@@ -82,10 +74,15 @@ if [ -e "/.chroot_is_done" ]; then
 
   # Commands used to run the tests
 
-  # RetroArch as exemplary emulator
+  # RetroArch
   sudo __platform=${__platform} ./retropie_packages.sh retroarch depends || return 1
   sudo __platform=${__platform} ./retropie_packages.sh retroarch install_bin || return 1
   sudo __platform=${__platform} ./retropie_packages.sh retroarch configure || return 1
+
+  # EmulationStation
+  sudo __platform=${__platform} ./retropie_packages.sh emulationstation depends || return 1
+  sudo __platform=${__platform} ./retropie_packages.sh emulationstation install_bin || return 1
+  sudo __platform=${__platform} ./retropie_packages.sh emulationstation configure || return 1
 
 else
   # ARM test run, need to set up chrooted environment first

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -47,7 +47,7 @@ function setup_arm_chroot {
     sudo touch ${CHROOT_DIR}/.chroot_is_done
 
     # Call ourselves again which will cause tests to run
-    sudo chroot ${CHROOT_DIR} bash -c "cd ${TRAVIS_BUILD_DIR} && ./test/travis-ci.sh"
+    sudo chroot ${CHROOT_DIR} bash -c "cd ${TRAVIS_BUILD_DIR} && ./tools/test/travis-ci.sh"
 }
 
 if [ -e "/.chroot_is_done" ]; then

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -31,9 +31,9 @@ function setup_arm_chroot {
     sudo sbuild-createchroot --arch=${CHROOT_ARCH} --foreign --setup-only \
         ${VERSION} ${CHROOT_DIR} ${MIRROR}
 
-    sudo 'cp /etc/resolv.conf "${CHROOT_DIR}/etc/resolv.conf"'
+    sudo "cp /etc/resolv.conf "${CHROOT_DIR}/etc/resolv.conf""
 
-    sudo 'cat << EOF > "${CHROOT_DIR}/etc/default/keyboard"'
+    sudo "cat << EOF > \"${CHROOT_DIR}/etc/default/keyboard\""
 # KEYBOARD CONFIGURATION FILE
 
 # Consult the keyboard(5) manual page.

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -31,6 +31,7 @@ function setup_arm_chroot {
     sudo sbuild-createchroot --arch=${CHROOT_ARCH} --foreign --setup-only \
         ${VERSION} ${CHROOT_DIR} ${MIRROR}
 
+    sudo cp /etc/resolv.conf "${CHROOT_DIR}/etc/resolv.conf"
     sudo mount -o bind /proc "${CHROOT_DIR}/proc"
     sudo mount -o bind /dev "${CHROOT_DIR}/dev"
 
@@ -53,14 +54,12 @@ function setup_arm_chroot {
     sudo touch ${CHROOT_DIR}/.chroot_is_done
 
     # Call ourselves again which will cause tests to run
-    sudo chroot --userspec 1000:1000 ${CHROOT_DIR} bash -c "cd ${TRAVIS_BUILD_DIR} && ./tools/test/travis-ci.sh"
+    sudo chroot ${CHROOT_DIR} bash -c "cd ${TRAVIS_BUILD_DIR} && ./tools/test/travis-ci.sh"
 }
 
 if [ -e "/.chroot_is_done" ]; then
   # We are inside ARM chroot
   echo "Running inside chrooted environment"
-
-  sudo echo "nameserver 8.8.8.8" >"/etc/resolv.conf"
 
   . ./envvars.sh
 

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -33,7 +33,7 @@ function setup_arm_chroot {
 
     sudo cp /etc/resolv.conf "${CHROOT_DIR}/etc/resolv.conf"
 
-cat << EOF > "${CHROOT_DIR}/etc/resolv.conf"
+sudo cat << EOF > "${CHROOT_DIR}/etc/default/keyboard"
 # KEYBOARD CONFIGURATION FILE
 
 # Consult the keyboard(5) manual page.

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -2,6 +2,8 @@
 # Based on a test script from avsm/ocaml repo https://github.com/avsm/ocaml
 # based on the script from https://www.tomaz.me/2013/12/02/running-travis-ci-tests-on-arm.html
 
+PKGID=$1
+
 CHROOT_DIR=$HOME/arm-chroot
 MIRROR=http://archive.raspbian.org/raspbian
 
@@ -55,7 +57,7 @@ function setup_arm_chroot {
     sudo touch ${CHROOT_DIR}/.chroot_is_done
 
     # Call ourselves again which will cause tests to run
-    sudo chroot ${CHROOT_DIR} bash -c "cd ${TRAVIS_BUILD_DIR} && ./tools/test/travis-ci.sh"
+    sudo chroot ${CHROOT_DIR} bash -c "cd ${TRAVIS_BUILD_DIR} && ./tools/test/travis-ci.sh $PKGID"
 }
 
 if [ -e "/.chroot_is_done" ]; then
@@ -70,22 +72,7 @@ if [ -e "/.chroot_is_done" ]; then
   # Commands used to run the tests
 
   # emulators
-  for i in {100..150}
-  do
-    sudo __platform=rpi3 ./retropie_packages.sh $i
-  done
-
-  # RetroArch cores
-  for i in {200..250}
-  do
-    sudo __platform=rpi3 ./retropie_packages.sh $i
-  done
-
-  # ports
-  for i in {300..350}
-  do
-    sudo __platform=rpi3 ./retropie_packages.sh $i
-  done
+  sudo __platform=rpi3 ./retropie_packages.sh $PKGID binaries
 
 else
   if [ "${ARCH}" = "arm" ]; then

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -57,7 +57,7 @@ function setup_arm_chroot {
     sudo touch ${CHROOT_DIR}/.chroot_is_done
 
     # Call ourselves again which will cause tests to run
-    sudo chroot ${CHROOT_DIR} bash -c "cd ${TRAVIS_BUILD_DIR} && ./tools/test/travis-ci.sh $PKGID"
+    sudo chroot ${CHROOT_DIR} bash -c "cd ${TRAVIS_BUILD_DIR} && ./tools/test/travis-ci.sh ${PKGID}"
 }
 
 if [ -e "/.chroot_is_done" ]; then
@@ -72,7 +72,7 @@ if [ -e "/.chroot_is_done" ]; then
   # Commands used to run the tests
 
   # emulators
-  sudo __platform=rpi3 ./retropie_packages.sh $PKGID binaries
+  sudo __platform=rpi3 ./retropie_packages.sh ${PKGID} binaries
 
 else
   if [ "${ARCH}" = "arm" ]; then

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -33,17 +33,6 @@ function setup_arm_chroot {
 
     sudo cp /etc/resolv.conf "${CHROOT_DIR}/etc/resolv.conf"
 
-    sudo cat << EOF > "${CHROOT_DIR}/etc/default/keyboard"
-# KEYBOARD CONFIGURATION FILE
-# Consult the keyboard(5) manual page.
-XKBMODEL="pc105"
-XKBLAYOUT="gb"
-XKBVARIANT=""
-XKBOPTIONS="lv3:ralt_switch"
-
-BACKSPACE="guess"
-EOF
-
     sudo mount -o bind /proc "${CHROOT_DIR}/proc"
     sudo mount -o bind /dev "${CHROOT_DIR}/dev"
     sudo mount -o bind /dev/pts "${CHROOT_DIR}/dev/pts"
@@ -57,6 +46,11 @@ EOF
     echo "export __platform=${__platform}" >> envvars.sh
 
     sudo echo -e "echo \"en_US.UTF-8 UTF-8\" > /etc/locale.gen" >> envvars.sh
+    sudo echo -e "XKBMODEL=\"pc105\" > /etc/default/keyboard" >> envvars.sh
+    sudo echo -e "XKBLAYOUT=\"gb\" >> /etc/default/keyboard" >> envvars.sh
+    sudo echo -e "XKBVARIANT=\"\" >> /etc/default/keyboard" >> envvars.sh
+    sudo echo -e "XKBOPTIONS=\"lv3:ralt_switch\" >> /etc/default/keyboard" >> envvars.sh
+    sudo echo -e "BACKSPACE=\"guess\" >> /etc/default/keyboard" >> envvars.sh
     sudo echo "/usr/sbin/locale-gen" >> envvars.sh
 
     chmod a+x envvars.sh
@@ -88,7 +82,7 @@ if [ -e "/.chroot_is_done" ]; then
 
   # Commands used to run the tests
 
-  # emulators
+  # RetroArch as exemplary emulator
   sudo __platform=${__platform} ./retropie_packages.sh retroarch depends || return 1
   sudo __platform=${__platform} ./retropie_packages.sh retroarch install_bin || return 1
   sudo __platform=${__platform} ./retropie_packages.sh retroarch configure || return 1

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -21,21 +21,24 @@ function setup_arm_chroot {
     # Create chrooted environment
     sudo mkdir -p ${CHROOT_DIR}
     pushd /usr/share/debootstrap/scripts; sudo ln -s sid jessie; popd
+
+    sudo mkdir -p "${CHROOT_DIR}/run/resolvconf"
+    sudo echo "nameserver 8.8.8.8" >"${CHROOT_DIR}/etc/resolv.conf"
+    sudo rm -f "${CHROOT_DIR}/etc/ld.so.preload"
+
+    sudo mkdir -p "${CHROOT_DIR}/proc"
+    sudo mkdir -p "${CHROOT_DIR}/dev"
+    sudo mount -o bind /proc "${CHROOT_DIR}/proc"
+    sudo mount -o bind /dev "${CHROOT_DIR}/dev"
+
+    export QEMU_CPU=cortex-a15
+
     sudo debootstrap --foreign --no-check-gpg --include=fakeroot,build-essential \
         --arch=${CHROOT_ARCH} ${VERSION} ${CHROOT_DIR} ${MIRROR}
     sudo cp /usr/bin/qemu-arm-static ${CHROOT_DIR}/usr/bin/
     sudo chroot ${CHROOT_DIR} ./debootstrap/debootstrap --second-stage
     sudo sbuild-createchroot --arch=${CHROOT_ARCH} --foreign --setup-only \
         ${VERSION} ${CHROOT_DIR} ${MIRROR}
-
-    sudo mkdir -p "${CHROOT_DIR}/run/resolvconf"
-    sudo echo "nameserver 8.8.8.8" >"${CHROOT_DIR}/etc/resolv.conf"
-    sudo rm -f "${CHROOT_DIR}/etc/ld.so.preload"
-
-    sudo mount -o bind /proc "${CHROOT_DIR}/proc"
-    sudo mount -o bind /dev "${CHROOT_DIR}/dev"
-
-    export QEMU_CPU=cortex-a15
 
     # Create file with environment variables which will be used inside chrooted
     # environment

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -67,7 +67,7 @@ if [ -e "/.chroot_is_done" ]; then
   echo "Environment: $(uname -a)"
 
   # Commands used to run the tests
-  sudo ./retropie_packages.sh lr-pocketsnes
+  sudo __platform=rpi3 ./retropie_packages.sh lr-pocketsnes
 
 else
   if [ "${ARCH}" = "arm" ]; then

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -35,16 +35,19 @@ function setup_arm_chroot {
     sudo mount -o bind /proc "${CHROOT_DIR}/proc"
     sudo mount -o bind /dev "${CHROOT_DIR}/dev"
     sudo mount -o bind /dev/pts "${CHROOT_DIR}/dev/pts"
+    sudo mount -o bind /sys "${CHROOT_DIR}/sys"
+    sudo mount -o bind /run "${CHROOT_DIR}/run"
 
     # Create file with environment variables which will be used inside chrooted
     # environment
     echo "export ARCH=${ARCH}" > envvars.sh
     echo "export TRAVIS_BUILD_DIR=${TRAVIS_BUILD_DIR}" >> envvars.sh
     echo "export __platform=${__platform}" >> envvars.sh
-    chmod a+x envvars.sh
 
-    sudo echo "en_US.UTF-8 UTF-8" > ${CHROOT_DIR}/etc/locale.gen
-    sudo chroot ${CHROOT_DIR} /usr/sbin/locale-gen
+    sudo echo -e "echo \"en_US.UTF-8 UTF-8\" > \${CHROOT_DIR}/etc/locale.gen" >> envvars.sh
+    sudo echo "/usr/sbin/locale-gen" >> envvars.sh
+
+    chmod a+x envvars.sh
 
     # Install dependencies inside chroot
     sudo chroot ${CHROOT_DIR} apt-get update

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -31,9 +31,9 @@ function setup_arm_chroot {
     sudo sbuild-createchroot --arch=${CHROOT_ARCH} --foreign --setup-only \
         ${VERSION} ${CHROOT_DIR} ${MIRROR}
 
-    sudo cp /etc/resolv.conf "${CHROOT_DIR}/etc/resolv.conf"
+    sudo 'cp /etc/resolv.conf "${CHROOT_DIR}/etc/resolv.conf"'
 
-sudo cat << EOF > "${CHROOT_DIR}/etc/default/keyboard"
+    sudo 'cat << EOF > "${CHROOT_DIR}/etc/default/keyboard"'
 # KEYBOARD CONFIGURATION FILE
 
 # Consult the keyboard(5) manual page.
@@ -93,25 +93,25 @@ if [ -e "/.chroot_is_done" ]; then
   # emulators
   for (( index=100; i <= 150; index++ ))
   do
-    sudo __platform=${__platform} ./retropie_packages.sh $index depends
-    sudo __platform=${__platform} ./retropie_packages.sh $index install_bin
-    sudo __platform=${__platform} ./retropie_packages.sh $index configure
+    sudo __platform=${__platform} ./retropie_packages.sh $index depends || return 1
+    sudo __platform=${__platform} ./retropie_packages.sh $index install_bin || return 1
+    sudo __platform=${__platform} ./retropie_packages.sh $index configure || return 1
   done
 
   # RetroArch cores
   for (( index=200; i <= 250; index++ ))
   do
-    sudo __platform=${__platform} ./retropie_packages.sh ${index} depends
-    sudo __platform=${__platform} ./retropie_packages.sh $index install_bin
-    sudo __platform=${__platform} ./retropie_packages.sh $index configure
+    sudo __platform=${__platform} ./retropie_packages.sh ${index} depends || return 1
+    sudo __platform=${__platform} ./retropie_packages.sh $index install_bin || return 1
+    sudo __platform=${__platform} ./retropie_packages.sh $index configure || return 1
   done
 
   # ports
   for (( index=300; i <= 350; index++ ))
   do
-    sudo __platform=${__platform} ./retropie_packages.sh $index depends
-    sudo __platform=${__platform} ./retropie_packages.sh $index install_bin
-    sudo __platform=${__platform} ./retropie_packages.sh $index configure
+    sudo __platform=${__platform} ./retropie_packages.sh $index depends || return 1
+    sudo __platform=${__platform} ./retropie_packages.sh $index install_bin || return 1
+    sudo __platform=${__platform} ./retropie_packages.sh $index configure || return 1
   done
 
 else

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Based on a test script from avsm/ocaml repo https://github.com/avsm/ocaml
-# based on the script from https://www.tomaz.me/2013/12/02/running-travis-ci-tests-on-arm.html
+# Based on the script from https://www.tomaz.me/2013/12/02/running-travis-ci-tests-on-arm.html
 
 CHROOT_DIR=$HOME/arm-chroot
 MIRROR=http://archive.raspbian.org/raspbian
@@ -15,7 +15,7 @@ HOST_DEPENDENCIES="debootstrap qemu-user-static binfmt-support sbuild"
 GUEST_DEPENDENCIES="build-essential git m4 sudo cmake g++-4.9 gcc-4.9 python"
 
 function setup_arm_chroot {
-    # Host dependencies
+    # Install host dependencies
     sudo apt-get install -qq -y ${HOST_DEPENDENCIES}
 
     # Create chrooted environment
@@ -42,11 +42,9 @@ function setup_arm_chroot {
     echo "export ARCH=${ARCH}" > envvars.sh
     echo "export TRAVIS_BUILD_DIR=${TRAVIS_BUILD_DIR}" >> envvars.sh
     echo "export __platform=${__platform}" >> envvars.sh
-
     chmod a+x envvars.sh
 
     # Install dependencies inside chroot
-    sudo chroot ${CHROOT_DIR} "echo \"deb http://archive.raspberrypi.org/debian/ ${VERSION} main\" >> /etc/apt/sources.list"
     sudo chroot ${CHROOT_DIR} apt-get update
     sudo chroot ${CHROOT_DIR} apt-get --allow-unauthenticated install -qq -y ${GUEST_DEPENDENCIES}
 
@@ -71,11 +69,6 @@ if [ -e "/.chroot_is_done" ]; then
   echo "Environment: $(uname -a)"
 
   # Commands used to run the tests
-
-  # RetroArch
-  sudo __platform=${__platform} ./retropie_packages.sh retroarch depends || exit 1
-  sudo __platform=${__platform} ./retropie_packages.sh retroarch install_bin || exit 1
-  sudo __platform=${__platform} ./retropie_packages.sh retroarch configure || exit 1
 
   # EmulationStation
   sudo __platform=${__platform} ./retropie_packages.sh emulationstation depends || exit 1

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Based on a test script from avsm/ocaml repo https://github.com/avsm/ocaml
+# based on the script from https://www.tomaz.me/2013/12/02/running-travis-ci-tests-on-arm.html
+
+CHROOT_DIR=$HOME/arm-chroot
+MIRROR=http://archive.raspbian.org/raspbian
+
+VERSION=jessie
+CHROOT_ARCH=armhf
+
+# Debian package dependencies for the host
+HOST_DEPENDENCIES="debootstrap qemu-user-static binfmt-support sbuild"
+
+# Debian package dependencies for the chrooted environment
+GUEST_DEPENDENCIES="build-essential git m4 sudo cmake g++-4.9 gcc-4.9 python"
+
+function setup_arm_chroot {
+    # Host dependencies
+    sudo apt-get install -qq -y ${HOST_DEPENDENCIES}
+
+    # Create chrooted environment
+    sudo mkdir -p ${CHROOT_DIR}
+    pushd /usr/share/debootstrap/scripts; sudo ln -s sid jessie; popd
+    sudo debootstrap --foreign --no-check-gpg --include=fakeroot,build-essential \
+        --arch=${CHROOT_ARCH} ${VERSION} ${CHROOT_DIR} ${MIRROR}
+    sudo cp /usr/bin/qemu-arm-static ${CHROOT_DIR}/usr/bin/
+    sudo chroot ${CHROOT_DIR} ./debootstrap/debootstrap --second-stage
+    sudo sbuild-createchroot --arch=${CHROOT_ARCH} --foreign --setup-only \
+        ${VERSION} ${CHROOT_DIR} ${MIRROR}
+
+    # Create file with environment variables which will be used inside chrooted
+    # environment
+    echo "export ARCH=${ARCH}" > envvars.sh
+    echo "export TRAVIS_BUILD_DIR=${TRAVIS_BUILD_DIR}" >> envvars.sh
+    chmod a+x envvars.sh
+
+    # Install dependencies inside chroot
+    sudo chroot ${CHROOT_DIR} apt-get update
+    sudo chroot ${CHROOT_DIR} apt-get --allow-unauthenticated install \
+        -qq -y ${GUEST_DEPENDENCIES}
+
+    # Create build dir and copy travis build files to our chroot environment
+    sudo mkdir -p ${CHROOT_DIR}/${TRAVIS_BUILD_DIR}
+    sudo rsync -av ${TRAVIS_BUILD_DIR}/ ${CHROOT_DIR}/${TRAVIS_BUILD_DIR}/
+
+    # Indicate chroot environment has been set up
+    sudo touch ${CHROOT_DIR}/.chroot_is_done
+
+    # Call ourselves again which will cause tests to run
+    sudo chroot ${CHROOT_DIR} bash -c "cd ${TRAVIS_BUILD_DIR} && ./test/travis-ci.sh"
+}
+
+if [ -e "/.chroot_is_done" ]; then
+  # We are inside ARM chroot
+  echo "Running inside chrooted environment"
+
+  . ./envvars.sh
+
+  echo "Running tests"
+  echo "Environment: $(uname -a)"
+
+  # Commands used to run the tests
+  sudo ./retropie_packages.sh lr-pocketsnes
+
+else
+  if [ "${ARCH}" = "arm" ]; then
+    # ARM test run, need to set up chrooted environment first
+    echo "Setting up chrooted ARM environment"
+    setup_arm_chroot
+  fi
+fi

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -75,14 +75,14 @@ if [ -e "/.chroot_is_done" ]; then
   # Commands used to run the tests
 
   # RetroArch
-  sudo __platform=${__platform} ./retropie_packages.sh retroarch depends || return 1
-  sudo __platform=${__platform} ./retropie_packages.sh retroarch install_bin || return 1
-  sudo __platform=${__platform} ./retropie_packages.sh retroarch configure || return 1
+  sudo __platform=${__platform} ./retropie_packages.sh retroarch depends || exit 1
+  sudo __platform=${__platform} ./retropie_packages.sh retroarch install_bin || exit 1
+  sudo __platform=${__platform} ./retropie_packages.sh retroarch configure || exit 1
 
   # EmulationStation
-  sudo __platform=${__platform} ./retropie_packages.sh emulationstation depends || return 1
-  sudo __platform=${__platform} ./retropie_packages.sh emulationstation install_bin || return 1
-  sudo __platform=${__platform} ./retropie_packages.sh emulationstation configure || return 1
+  sudo __platform=${__platform} ./retropie_packages.sh emulationstation depends || exit 1
+  sudo __platform=${__platform} ./retropie_packages.sh emulationstation install_bin || exit 1
+  sudo __platform=${__platform} ./retropie_packages.sh emulationstation configure || exit 1
 
 else
   # ARM test run, need to set up chrooted environment first

--- a/tools/test/travis-ci.sh
+++ b/tools/test/travis-ci.sh
@@ -12,7 +12,7 @@ CHROOT_ARCH=armhf
 HOST_DEPENDENCIES="debootstrap qemu-user-static binfmt-support sbuild"
 
 # Debian package dependencies for the chrooted environment
-GUEST_DEPENDENCIES="build-essential git m4 sudo cmake g++-4.9 gcc-4.9 python"
+GUEST_DEPENDENCIES="build-essential git m4 sudo cmake g++-4.9 gcc-4.9 python locales"
 
 function setup_arm_chroot {
     # Host dependencies
@@ -44,7 +44,7 @@ function setup_arm_chroot {
     echo "export TRAVIS_BUILD_DIR=${TRAVIS_BUILD_DIR}" >> envvars.sh
     echo "export __platform=${__platform}" >> envvars.sh
 
-    sudo echo -e "echo \"en_US.UTF-8 UTF-8\" > \${CHROOT_DIR}/etc/locale.gen" >> envvars.sh
+    sudo echo -e "echo \"en_US.UTF-8 UTF-8\" > /etc/locale.gen" >> envvars.sh
     sudo echo "/usr/sbin/locale-gen" >> envvars.sh
 
     chmod a+x envvars.sh


### PR DESCRIPTION
This module shows the available joysticks and let the user choose what controller to use for RetroArch Player 1-4.

Short description of how it does its job:
- puts at the beginning of $configdir/all/retroarch.cfg an "#include" pointing to the file $configdir/all/input-selection.cfg
- let the user manage the input-selection.cfg through dialogs (this file contains the configs for input_playerN_joypad_index for players 1-4).

OBS. 1: the joystick selection doesn't work if the config_save_on_exit is set to true, because the retroarch.cfg is overwritten frequently.
OBS. 2: This program relies on the output of the jslist program to get the available joysticks and their respective indexes. This program will be put at /opt/retropie/supplementary/jslist