### PR TITLE
Optimize mupen64plus

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -73,7 +73,7 @@ function build_mupen64plus() {
     # build GLideN64
     $md_build/GLideN64/src/getRevision.sh
     pushd $md_build/GLideN64/projects/cmake
-    cmake -DMUPENPLUSAPI=On ../../src/
+    cmake -DMUPENPLUSAPI=On -DOPT ../../src/
     make
     popd
 

--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -116,12 +116,13 @@ function install_mupen64plus() {
 }
 
 function configure_mupen64plus() {
-    addSystem 0 "${md_id}-GLideN64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM%"
     if isPlatform "rpi"; then
-        addSystem 1 "${md_id}-gles2rice" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-rice %ROM%"
+        addSystem 1 "${md_id}-GLideN64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM%"
+        addSystem 0 "${md_id}-gles2rice" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-rice %ROM%"
         addSystem 0 "${md_id}-gles2n64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-n64 %ROM%"
         addSystem 0 "${md_id}-videocore" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-videocore %ROM%"
     else
+        addSystem 0 "${md_id}-GLideN64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM%"
         addSystem 1 "${md_id}-glide64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-glide64mk2 %ROM%"
     fi
 
@@ -156,7 +157,7 @@ function configure_mupen64plus() {
         su "$user" -c "$cmd"
     fi
 
-    iniConfig " = " '"' "$config"
+    iniConfig " = " "" "$config"
     iniSet "ScreenshotPath" "$romdir/n64"
     iniSet "SaveStatePath" "$romdir/n64"
     iniSet "SaveSRAMPath" "$romdir/n64"
@@ -167,15 +168,14 @@ function configure_mupen64plus() {
         if ! grep -q "\[Video-GLideN64\]" "$config"; then
             echo "[Video-GLideN64]" >> "$config"
         fi
-
         # Settings version. Don't touch it.
-        iniSet "configVersion" "10"
-
+        iniSet "configVersion" "11"
         # Bilinear filtering mode (0=N64 3point, 1=standard)
         iniSet "bilinearMode" "0"
-
         # Size of texture cache in megabytes. Good value is VRAM*3/4
         iniSet "CacheSize" "192"
+        # Disable FB emulation until visual issues are sorted out
+        iniSet "EnableFBEmulation" "False"
     fi
 
     chown -R $user:$user "$md_conf_root/n64"

--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -73,7 +73,7 @@ function build_mupen64plus() {
     # build GLideN64
     $md_build/GLideN64/src/getRevision.sh
     pushd $md_build/GLideN64/projects/cmake
-    cmake -DMUPENPLUSAPI=On -DOPT ../../src/
+    cmake -DMUPENPLUSAPI=On ../../src/
     make
     popd
 
@@ -175,7 +175,7 @@ function configure_mupen64plus() {
         # Size of texture cache in megabytes. Good value is VRAM*3/4
         iniSet "CacheSize" "192"
         # Disable FB emulation until visual issues are sorted out
-        iniSet "EnableFBEmulation" "False"
+        iniSet "EnableFBEmulation" "True"
     fi
 
     chown -R $user:$user "$md_conf_root/n64"

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -200,4 +200,4 @@ function testCompatibility() {
 getAutoConf mupen64plus_hotkeys || remap
 getAutoConf mupen64plus_compatibility_check || testCompatibility
 getAutoConf mupen64plus_audio || setAudio
-"$rootdir/emulators/mupen64plus/bin/mupen64plus" --noosd --fullscreen --gfx ${VIDEO_PLUGIN}.so --configdir "$configdir/n64" --datadir "$configdir/n64" "$ROM"
+SDL_VIDEO_RPI_SCALE_MODE=1 "$rootdir/emulators/mupen64plus/bin/mupen64plus" --noosd --windowed --resolution 320x240 --gfx ${VIDEO_PLUGIN}.so --configdir "$configdir/n64" --datadir "$configdir/n64" "$ROM"


### PR DESCRIPTION
-Default render resolution is 320x240 for best performance. Use dispmanx to upscale video.
-Use GlideN64 as default video plugin.
-Enable GlideN64 optimizations (NEON assembler).
-Update GlideN64 configVersion.
-Disable GlideN64 FBEmulation. I don't know why but games like MK64 and Castlevania have visual glitches since this morning. Mupen64plus-Core repo was updated today. There could be a correlation. @loganmc10 do you have visual issues with the newest Mupen64plus-Core as well? 