### PR TITLE
Update mupen64plus Pt.4

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -171,20 +171,18 @@ function configure_mupen64plus() {
         # Settings version. Don't touch it.
         iniSet "configVersion" "11"
         # Bilinear filtering mode (0=N64 3point, 1=standard)
-        iniSet "bilinearMode" "0"
+        iniSet "bilinearMode" "1"
         # Size of texture cache in megabytes. Good value is VRAM*3/4
         iniSet "CacheSize" "192"
         # Disable FB emulation until visual issues are sorted out
-        iniSet "EnableFBEmulation" "True"
+        iniSet "EnableFBEmulation" "False"
+        # Use native res
+        iniSet "nativeResFactor" "1"
     fi
 
     chown -R $user:$user "$md_conf_root/n64"
 
-    if isPlatform "rpi"; then
-        addAutoConf mupen64plus_audio 1
-    else
-        addAutoConf mupen64plus_audio 0
-    fi
+    addAutoConf mupen64plus_audio 0
     addAutoConf mupen64plus_hotkeys 1
     addAutoConf mupen64plus_compatibility_check 1
 }


### PR DESCRIPTION
-Use bilinear filtering standard mode to fix super smash brothers and
mario kart texture corruption. https://github.com/RetroPie/RetroPie-Setup/pull/1563#issuecomment-231420842
-Disable audio OMX audio output auto configuration. We use SDL audio
now.
-Disable FBEmulation for now. Conker BFD, Bomberman, Castlevania, Banjo
Kazooie, Super Smash Brothers, Goldeneye and Rayman 2 have extreme visual corruptions if this feature is
enabled. Need to find a way to enable it for Zelda games and Star Wars - SOTE. 
-Use native resolution if FBEmulation is enabled.