### PR TITLE
Update mupen64plus Pt.5

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -73,7 +73,9 @@ function build_mupen64plus() {
     # build GLideN64
     $md_build/GLideN64/src/getRevision.sh
     pushd $md_build/GLideN64/projects/cmake
-    cmake -DMUPENPLUSAPI=On ../../src/
+    params=("-DMUPENPLUSAPI=On" "-DVEC4_OPT=On")
+    isPlatform "neon" && params+=("-DNEON_OPT=On")
+    cmake "${params[@]}" ../../src/
     make
     popd
 
@@ -157,13 +159,9 @@ function configure_mupen64plus() {
         su "$user" -c "$cmd"
     fi
 
-    iniConfig " = " "" "$config"
-    iniSet "ScreenshotPath" "$romdir/n64"
-    iniSet "SaveStatePath" "$romdir/n64"
-    iniSet "SaveSRAMPath" "$romdir/n64"
-
     # RPI GLideN64 settings
     if isPlatform "rpi"; then
+        iniConfig " = " "" "$config"
         # Create GlideN64 section in .cfg
         if ! grep -q "\[Video-GLideN64\]" "$config"; then
             echo "[Video-GLideN64]" >> "$config"
@@ -178,11 +176,15 @@ function configure_mupen64plus() {
         iniSet "EnableFBEmulation" "False"
         # Use native res
         iniSet "nativeResFactor" "1"
+        
+        addAutoConf mupen64plus_audio 1
+        addAutoConf mupen64plus_compatibility_check 1
+    else
+        addAutoConf mupen64plus_audio 0
+        addAutoConf mupen64plus_compatibility_check 0
     fi
 
-    chown -R $user:$user "$md_conf_root/n64"
-
-    addAutoConf mupen64plus_audio 0
     addAutoConf mupen64plus_hotkeys 1
-    addAutoConf mupen64plus_compatibility_check 1
+
+    chown -R $user:$user "$md_conf_root/n64"
 }

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
+AUDIO_PLUGIN="mupen64plus-audio-sdl"
 VIDEO_PLUGIN="$1"
 ROM="$2"
 rootdir="/opt/retropie"
 configdir="$rootdir/configs"
+config="$configdir/n64/mupen64plus.cfg"
+
+user="$SUDO_USER"
+[[ -z "$user" ]] && user=$(id -un)
+home="$(eval echo ~$user)"
+datadir="$home/RetroPie"
+romdir="$datadir/roms"
 
 source "$rootdir/lib/inifuncs.sh"
 
@@ -126,7 +134,13 @@ function remap() {
     local hotkeys_m64p=( "Joy Mapping Stop" "Joy Mapping Load State" "Joy Mapping Save State" )
     local i
     local j
-    
+
+    iniConfig " = " "" "$config"
+    if ! grep -q "\[CoreEvents\]" "$config"; then
+        echo "[CoreEvents]" >> "$config"
+        echo "Version = 1" >> "$config"
+    fi
+
     for i in {0..2}; do
         bind=""
         for device_num in "${!devices[@]}"; do
@@ -140,27 +154,44 @@ function remap() {
             fi
         done
         # write hotkey to mupen64plus.cfg
-        iniConfig " = " "\"" "$configdir/n64/mupen64plus.cfg"
+        iniConfig " = " "\"" "$config"
         iniSet "${hotkeys_m64p[$i]}" "$bind"
     done
 }
 
 function setAudio() {
-    local audio_device=$(amixer cget numid=3)
-    iniConfig " = " "\"" "$configdir/n64/mupen64plus.cfg"
-    if [[ "$audio_device" == *": values=0"* ]]; then
-        local video_device=$(tvservice -s)
-        if [[ "$video_device" == *HDMI* ]]; then
-            iniSet "OUTPUT_PORT" "1"
-        else
-            iniSet "OUTPUT_PORT" "0"
+    if [[ "$(sed -n '/^Hardware/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo)" == *BCM27* ]]; then
+        # If a raspberry pi is used try to set the right output and use audio omx if possible
+        local audio_device=$(amixer)
+        if [[ "$audio_device" == *PCM* ]]; then
+            # use audio omx if we use rpi internal audio device
+            AUDIO_PLUGIN="mupen64plus-audio-omx"
+            iniConfig " = " "\"" "$config"
+            # create section if necessary
+            if ! grep -q "\[Audio-OMX\]" "$config"; then
+                echo "[Audio-OMX]" >> "$config"
+                echo "Version = 1" >> "$config"
+            fi
+            # read output configuration
+            local audio_port=$(amixer cget numid=3)
+            # set output port
+            if [[ "$audio_port" == *": values=0"* ]]; then
+                # echo "auto configuration"
+                # try to find the best solution
+                local video_device=$(tvservice -s)
+                if [[ "$video_device" == *HDMI* ]]; then
+                    iniSet "OUTPUT_PORT" "1"
+                else
+                    iniSet "OUTPUT_PORT" "0"
+                fi
+            elif [[ "$audio_port" == *": values=1"* ]]; then
+                # echo "audio jack"
+                iniSet "OUTPUT_PORT" "0"
+            else
+                # echo "hdmi"
+                iniSet "OUTPUT_PORT" "1"
+            fi
         fi
-    elif [[ "$audio_device" == *": values=1"* ]]; then
-        # echo "audio jack"
-        iniSet "OUTPUT_PORT" "0"
-    else
-        # echo "hdmi"
-        iniSet "OUTPUT_PORT" "1"
     fi
 }
 
@@ -180,6 +211,19 @@ function testCompatibility() {
         yoshi
     )
 
+    local GLideN64FBEMU_whitelist=(
+        ocarina
+        empire
+        pokemon
+        rayman
+        donald
+        diddy
+    )
+
+    local GLideN64_blacklist=(
+        majora
+    )
+
     if [[ "$VIDEO_PLUGIN" == "mupen64plus-video-n64" ]];then
         for game in "${glesn64_blacklist[@]}"; do
             if [[ "${ROM,,}" == *"$game"* ]]; then
@@ -195,9 +239,47 @@ function testCompatibility() {
             fi
         done
     fi
+
+    if [[ "$VIDEO_PLUGIN" == "mupen64plus-video-GLideN64" ]];then
+        if ! grep -q "\[Video-GLideN64\]" "$config"; then
+            echo "[Video-GLideN64]" >> "$config"
+        fi
+        iniConfig " = " "" "$config"
+        # Settings version. Don't touch it.
+        iniSet "configVersion" "11"
+        # Enable FBEmulation if necessary
+        iniSet "EnableFBEmulation" "False"
+        for game in "${GLideN64FBEMU_whitelist[@]}"; do
+            if [[ "${ROM,,}" == *"$game"* ]]; then
+                iniSet "EnableFBEmulation" "True"
+                break
+            fi
+        done
+        # Use rice video plugin if necessary
+        for game in "${GLideN64_blacklist[@]}"; do
+            if [[ "${ROM,,}" == *"$game"* ]]; then
+                VIDEO_PLUGIN="mupen64plus-video-rice"
+            fi
+        done
+    fi
 }
+
+if ! grep -q "\[Core\]" "$config"; then
+    echo "[Core]" >> "$config"
+    echo "Version = 1.010000" >> "$config"
+fi
+iniConfig " = " "\"" "$config"
+iniSet "ScreenshotPath" "$romdir/n64"
+iniSet "SaveStatePath" "$romdir/n64"
+iniSet "SaveSRAMPath" "$romdir/n64"
 
 getAutoConf mupen64plus_hotkeys || remap
 getAutoConf mupen64plus_compatibility_check || testCompatibility
 getAutoConf mupen64plus_audio || setAudio
-SDL_VIDEO_RPI_SCALE_MODE=1 "$rootdir/emulators/mupen64plus/bin/mupen64plus" --noosd --windowed --resolution 320x240 --gfx ${VIDEO_PLUGIN}.so --configdir "$configdir/n64" --datadir "$configdir/n64" "$ROM"
+
+if [[ "$(sed -n '/^Hardware/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo)" == *BCM27* ]]; then
+    # If a raspberry pi is used lower resolution to 320x240 and enable SDL dispmanx scaling mode 1
+    SDL_VIDEO_RPI_SCALE_MODE=1 "$rootdir/emulators/mupen64plus/bin/mupen64plus" --noosd --windowed --resolution 320x240 --gfx ${VIDEO_PLUGIN}.so --audio ${AUDIO_PLUGIN}.so --configdir "$configdir/n64" --datadir "$configdir/n64" "$ROM"
+else
+    "$rootdir/emulators/mupen64plus/bin/mupen64plus" --noosd --fullscreen --gfx ${VIDEO_PLUGIN}.so --audio mupen64plus-audio-sdl.so --configdir "$configdir/n64" --datadir "$configdir/n64" "$ROM"
+fi


### PR DESCRIPTION
-Enable some GLideN64 optimizations again. 
-Use audio-omx as default audio plugin. Games run much faster if audio-omx is used.
-Switch audio plugin if internal rpi audio device is not used.
-Add GLideN64 FBEmulation enable switch for certain games (Zelda,
Rayman, Pokemon, Diddy Kong Racing etc.).
-Add GLideN64 Rice fallback for majora's mask.
-Make mupen64plus.cfg editing more secure. Add section if section does not exists.
-Take care ScreenshotPath, SaveStatePath and SaveSRAMPath stay the same even if you delete mupen64plus.cfg.
-Fix startup script for other platforms (x86, odroid).