### PR TITLE
Config defaults

### DIFF
--- a/scriptmodules/emulators/mame4all.sh
+++ b/scriptmodules/emulators/mame4all.sh
@@ -59,12 +59,10 @@ function configure_mame4all() {
     # move old config
     moveConfigFile "mame.cfg" "$md_conf_root/$system/mame.cfg"
 
-    # if the user doesn't already have a config, we will copy the default.
-    if [[ ! -f "$md_conf_root/$system/mame.cfg" ]]; then
-        cp "mame.cfg.template" "$md_conf_root/$system/mame.cfg"
-    fi
+    local config="$(mktemp)"
+    copy "mame.cfg.template" "$config"
 
-    iniConfig "=" "" "$md_conf_root/$system/mame.cfg"
+    iniConfig "=" "" "$config"
     iniSet "cfg" "$md_conf_root/$system/cfg"
     iniSet "hi" "$md_conf_root/$system/hi"
     iniSet "inp" "$md_conf_root/$system/inp"
@@ -79,7 +77,8 @@ function configure_mame4all() {
 
     iniSet "samplerate" "44100"
 
-    chown -R $user:$user "$md_conf_root/$system"
+    copyDefaultConfig "$config" "$md_conf_root/$system/mame.cfg"
+    rm "$config"
 
     addSystem 0 "$md_id" "arcade" "$md_inst/mame %BASENAME%"
     addSystem 1 "$md_id" "$system arcade mame" "$md_inst/mame %BASENAME%"

--- a/scriptmodules/emulators/pifba.sh
+++ b/scriptmodules/emulators/pifba.sh
@@ -52,14 +52,9 @@ function configure_pifba() {
 
     local config
     for config in fba2x.cfg capex.cfg; do
-        # move old config
+        # move old config if it exists
         moveConfigFile "$md_inst/$config" "$md_conf_root/fba/$config"
-
-        # if the user doesn't already have a config, we will copy the default.
-        if [[ ! -f "$md_conf_root/fba/$config" ]]; then
-            cp "$config.template" "$md_conf_root/fba/$config"
-        fi
-        chown $user:$user "$md_conf_root/fba/$config"
+        copyDefaultConfig "$config.template" "$md_conf_root/fba/$config"
     done
 
     local def=0

--- a/scriptmodules/emulators/pisnes.sh
+++ b/scriptmodules/emulators/pisnes.sh
@@ -49,11 +49,7 @@ function configure_pisnes() {
 
     moveConfigFile "$md_inst/snes9x.cfg" "$md_conf_root/snes/snes9x.cfg"
 
-    # if the user doesn't already have a config, we will copy the default.
-    if [[ ! -f "$md_conf_root/snes/snes9x.cfg" ]]; then
-        cp "$md_inst/snes9x.cfg.template" "$md_conf_root/snes/snes9x.cfg"
-        chown $user:$user "$md_conf_root/snes/snes9x.cfg"
-    fi
+    copyDefaultConfig "$md_inst/snes9x.cfg.template" "$md_conf_root/snes/snes9x.cfg"
 
     addSystem 0 "$md_id" "snes" "$md_inst/snes9x %ROM%"
 }

--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -92,13 +92,9 @@ function configure_retroarch() {
     # install shaders by default
     update_shaders_retroarch
 
-    local config="$configdir/all/retroarch.cfg"
-    # if the user has an existing config we will not overwrite it, but instead copy the
-    # default configuration to retroarch.cfg.rp-dist so any new options can be manually
-    # copied across as needed without destroying users changes
-    [[ -f "$config" ]] && config+=".rp-dist"
+    local config="$(mktemp)"
 
-    cp -v "$md_inst/retroarch.cfg" "$config"
+    cp "$md_inst/retroarch.cfg" "$config"
 
     # configure default options
     iniConfig " = " '"' "$config"
@@ -158,7 +154,8 @@ function configure_retroarch() {
     iniSet "auto_remaps_enable" "true"
     iniSet "input_joypad_driver" "udev"
 
-    chown $user:$user "$config"
+    copyDefaultConfig "$config" "$configdir/all/retroarch.cfg"
+    rm "$config"
 }
 
 function gui_retroarch() {

--- a/scriptmodules/emulators/vice.sh
+++ b/scriptmodules/emulators/vice.sh
@@ -52,15 +52,10 @@ function configure_vice() {
         ln -snf "$md_inst/lib64" "$md_inst/lib"
     fi
 
-    # if we have an old config vice.cfg then move it to sdl-vicerc
-    if [[ -f "$md_conf_root/c64/vice.cfg" ]]; then
-        mv -v "$md_conf_root/c64/vice.cfg" "$md_conf_root/c64/sdl-vicerc"
-    elif [[ ! -f "$md_conf_root/c64/sdl-vicerc" ]]; then
-        echo "[C64]" > "$md_conf_root/c64/sdl-vicerc"
-    fi
-    chown -R $user:$user "$md_conf_root/c64"
+    local config="$(mktemp)"
+    echo "[C64]" > "$(mktemp)"
 
-    iniConfig "=" "" "$md_conf_root/c64/sdl-vicerc"
+    iniConfig "=" "" "$config"
     if ! isPlatform "x11"; then
         iniSet "SDLBitdepth" "8"
         iniSet "Mouse" "1"
@@ -73,6 +68,9 @@ function configure_vice() {
         iniSet "AutostartWarp" "0"
         iniSet "WarpMode" "0"
     fi
+
+    copyDefaultConfig "$config" "$md_conf_root/c64/sdl-vicerc"
+    rm "$config"
 
     if isPlatform "rpi"; then
         configure_dispmanx_on_vice

--- a/scriptmodules/emulators/zesarux.sh
+++ b/scriptmodules/emulators/zesarux.sh
@@ -55,8 +55,9 @@ _EOF_
 
     local ao="alsa"
     isPlatform "x11" && ao="pulse"
-    if [[ ! -f "$md_conf_root/zxspectrum/.zesaruxrc" ]]; then
-        cat > "$md_conf_root/zxspectrum/.zesaruxrc" << _EOF_
+    local config="$(mktemp)"
+    
+    cat > "$config" << _EOF_
 ;ZEsarUX sample configuration file
 ;
 ;Lines beginning with ; or # are ignored
@@ -76,8 +77,9 @@ _EOF_
 ;Remap Fire Event. Uncomment and amend if you wish to change the default button 3.
 ;--joystickevent 3 Fire
 _EOF_
-        chown $user:$user "$md_conf_root/zxspectrum/.zesaruxrc"
-    fi
+
+    copyDefaultConfig "$config" "$md_conf_root/zxspectrum/.zesaruxrc"
+    rm "$config"
 
     if isPlatform "rpi"; then
         setDispmanx "$md_id" 1


### PR DESCRIPTION
Previously things like retroarch.rp-dist files were always created, even if there were no customisations to the retroarch.cfg files. Now it works a bit more like debian, so these files are only changed if the new default config is different from the existing config (we still don't overwrite users configs).

It does this via a new function, copyDefaultConfig which also allows us to simplify some code, and it should be quicker to implement creation of a rp-dist file for other modules now without code duplication.