### PR TITLE
8bitdo mapping improvements

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -156,6 +156,9 @@ function configure_retroarch() {
 
     copyDefaultConfig "$config" "$configdir/all/retroarch.cfg"
     rm "$config"
+
+    # remapping hack for old 8bitdo firmware
+    addAutoConf "8bitdo_hack" 1
 }
 
 function gui_retroarch() {

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -252,11 +252,20 @@ function gitPullOrClone() {
 
 function ensureRootdirExists() {
     mkdir -p "$rootdir"
+
     # make sure we have inifuncs.sh in place and that it is up to date
     mkdir -p "$rootdir/lib"
     if [[ ! -f "$rootdir/lib/inifuncs.sh" || "$rootdir/lib/inifuncs.sh" -ot "$scriptdir/scriptmodules/inifuncs.sh" ]]; then
         cp --preserve=timestamps "$scriptdir/scriptmodules/inifuncs.sh" "$rootdir/lib/inifuncs.sh"
     fi
+
+    # create template for autoconf.cfg and make sure it is owned by $user
+    local config="$configdir/all/autoconf.cfg"
+    if [[ ! -f "$config" ]]; then
+        echo "# this file can be used to enable/disable retropie autoconfiguration features" >"$config"
+    fi
+    chown $user:$user "$config"
+
     mkUserDir "$datadir"
     mkUserDir "$configdir"
     mkUserDir "$configdir/all"

--- a/scriptmodules/inifuncs.sh
+++ b/scriptmodules/inifuncs.sh
@@ -108,16 +108,22 @@ function addAutoConf() {
        default="1"
     fi
 
-    if [ ! -f "$file" ]; then
-        echo "# this file can be used to enable/disable retropie autoconfiguration features" >> "$file"
-    fi
-
     iniConfig " = " "" "$file"
     iniGet "$key"
     ini_value="${ini_value// /}"
     if [[ -z "$ini_value" ]]; then
         iniSet "$key" "$default"
     fi
+}
+
+# arg 1: key, arg 2: value
+function setAutoConf() {
+    local key="$1"
+    local value="$2"
+    local file="$configdir/all/autoconf.cfg"
+
+    iniConfig " = " "" "$file"
+    iniSet "$key" "$value"
 }
 
 # arg 1: key

--- a/scriptmodules/supplementary/bluetooth.sh
+++ b/scriptmodules/supplementary/bluetooth.sh
@@ -331,6 +331,8 @@ _EOF_
 }
 
 function gui_bluetooth() {
+    addAutoConf "8bitdo_hack" 1
+
     while true; do
         local connect_mode="$(_get_connect_mode)"
 
@@ -343,6 +345,15 @@ function gui_bluetooth() {
             C "Connect now to all registered devices"
             M "Configure bluetooth connect mode (currently: $connect_mode)"
         )
+
+        local atebitdo
+        if getAutoConf 8bitdo_hack; then
+            atebitdo=1
+            options+=(8 "8Bitdo mapping hack (ON - old firmware)")
+        else
+            atebitdo=0
+            options+=(8 "8Bitdo mapping hack (OFF - new firmware)")
+        fi
 
         local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
         if [[ -n "$choice" ]]; then
@@ -364,6 +375,10 @@ function gui_bluetooth() {
                     ;;
                 M)
                     connect_mode_bluetooth
+                    ;;
+                8)
+                    atebitdo="$((atebitdo ^ 1))"
+                    setAutoConf "8bitdo_hack" "$atebitdo"
                     ;;
             esac
         else

--- a/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh
@@ -20,6 +20,9 @@ function onstart_retroarch_joystick() {
         input_joypad_driver="udev"
     fi
 
+    _atebitdo_hack=0
+    getAutoConf "8bitdo_hack" && _atebitdo_hack=1
+
     iniConfig " = " "\"" "/tmp/tempconfig.cfg"
     iniSet "input_device" "$device_name"
     iniSet "input_driver" "$input_joypad_driver"
@@ -242,21 +245,18 @@ function map_retroarch_joystick() {
                 ;;
             *)
                 key+="_btn"
+                value="$input_id"
+
                 # workaround for mismatched controller mappings
                 iniGet "input_driver"
                 if [[ "$ini_value" == "udev" ]]; then
-                    case "$device_name" in 
+                    case "$device_name" in
                         "8Bitdo FC30"*|"8Bitdo NES30"*|"8Bitdo SFC30"*|"8Bitdo SNES30"*|"8Bitdo Zero"*)
-                            if [[ "$input_id" -lt "17" ]]; then
-                                value=$(($input_id+11))
+                            if [[ "$_atebitdo_hack" -eq 1 ]]; then
+                                value="$((input_id+11))"
                             fi
                             ;;
-                        *)
-                            value="$input_id"
-                            ;;
                     esac
-                else
-                    value="$input_id"
                 fi
                 ;;
         esac


### PR DESCRIPTION
 * add autoconf.cfg parameter 8bitdo_hack (default 1) to decide whether to add the offset to the inputs for retroarch - which is required on the older firmware
 * make sure autoconf.cfg is owned by $user - it would be created as root previously
 * add setAutoConf function
 * cleanup retroarch config generation code