### PR TITLE
[dosbox] hide commands and change to c:

### DIFF
--- a/scriptmodules/emulators/dosbox.sh
+++ b/scriptmodules/emulators/dosbox.sh
@@ -56,7 +56,7 @@ function configure_dosbox() {
 #!/bin/bash
 params=("\$@")
 if [[ -z "\${params[0]}" ]]; then
-    params=(-c "MOUNT C $romdir/pc")
+    params=(-c "@MOUNT C $romdir/pc" -c "@C:")
 elif [[ "\${params[0]}" == *.sh ]]; then
     bash "\${params[@]}"
     exit


### PR DESCRIPTION
When launching DOSBox, the mount of the C drive is visible which looks messy, and it doesn't change to C: drive automatically which is inconvenient.

Use @ to hide the commands from the user, and automatically change to the mounted C: drive.

The MOUNT command message displays the mounted path so there is no loss of information about where DOSBox has gotten the C drive from.