### PR TITLE
Client can define __joy2key_dev

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -653,7 +653,8 @@ function joy2keyStart() {
     # check if joy2key is installed
     [[ ! -f "$rootdir/supplementary/runcommand/joy2key.py" ]] && return 1
 
-    __joy2key_dev=$(ls -1 /dev/input/js* 2>/dev/null | head -n1)
+    __joy2key_dev=${__joy2key_dev:-$(ls -1 /dev/input/js* 2>/dev/null | head -n1)}
+
 
     # if no joystick device, or joy2key is already running exit
     [[ -z "$__joy2key_dev" ]] || pgrep -f joy2key.py >/dev/null && return 1

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -655,7 +655,6 @@ function joy2keyStart() {
 
     __joy2key_dev=${__joy2key_dev:-$(ls -1 /dev/input/js* 2>/dev/null | head -n1)}
 
-
     # if no joystick device, or joy2key is already running exit
     [[ -z "$__joy2key_dev" ]] || pgrep -f joy2key.py >/dev/null && return 1
 


### PR DESCRIPTION
A client of the scriptmodules functions can define another device for __joy2key_dev.

I'm playing with customized scripts and sourcing the useful scriptmodules available with RetroPie-Setup. I would like to define another device to use with joy2key, and this simple change will let me do this by just setting another device in __joy2key_dev variable before call joy2keyStart:
```
    __joy2key_dev=${__joy2key_dev:-$(ls -1 /dev/input/js* 2>/dev/null | head -n1)}
```