### PR TITLE
user can define __joy2key_dev

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -79,8 +79,9 @@ function get_config() {
 
 function start_joy2key() {
     [[ "$disable_joystick" -eq 1 ]] && return
+    # get the first joystick device (if not already set)
+    [[ -z "$__joy2key_dev" ]] && __joy2key_dev="$(ls -1 /dev/input/js* 2>/dev/null | head -n1)"
     # if joy2key.py is installed run it with cursor keys for axis, and enter + tab for buttons 0 and 1
-    __joy2key_dev=$(ls -1 /dev/input/js* 2>/dev/null | head -n1)
     if [[ -f "$rootdir/supplementary/runcommand/joy2key.py" && -n "$__joy2key_dev" ]] && ! pgrep -f joy2key.py >/dev/null; then
         "$rootdir/supplementary/runcommand/joy2key.py" "$__joy2key_dev" 1b5b44 1b5b43 1b5b41 1b5b42 0a 09 &
         __joy2key_pid=$!


### PR DESCRIPTION
Same logic as in `helpers.sh`.

Since the `runcommand-onstart.sh` was implemented, the user can define another joystick device to use with joy2key.