### PR TITLE
define __joy2key_dev in runcommand.cfg

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -68,6 +68,8 @@ function get_config() {
         iniGet "disable_menu"
         disable_menu="$ini_value"
         [[ "$disable_menu" -eq 1 ]] && disable_joystick=1
+        iniGet "joy2key_device"
+        __joy2key_dev="$ini_value"
     fi
 
     if [[ -f "$tvservice" ]]; then


### PR DESCRIPTION
I was wrong, user can't define `__joy2key_dev` in `runcommand-onstart.sh` because it's executed in a subshell.
As far as I know there is no way to make a child shell change a parent shell variable.
A possible solution is invoke `runcommand-onstart.sh` using `source`, but I think users can mess up some variables or even functions.
What do you think about a `joy2key_device` variable in `runcommand.cfg`?