### PR TITLE
giving to on[start|end] access to runcommand arguments

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -760,7 +760,7 @@ function check_menu() {
     return $dont_launch
 }
 
-[[ -f "$configdir/all/runcommand-onstart.sh" ]] && bash "$configdir/all/runcommand-onstart.sh"
+[[ -f "$configdir/all/runcommand-onstart.sh" ]] && bash "$configdir/all/runcommand-onstart.sh $@"
 
 # turn off cursor and clear screen
 tput civis
@@ -826,6 +826,6 @@ fi
 
 tput cnorm
 
-[[ -f "$configdir/all/runcommand-onend.sh" ]] && bash "$configdir/all/runcommand-onend.sh"
+[[ -f "$configdir/all/runcommand-onend.sh" ]] && bash "$configdir/all/runcommand-onend.sh $@"
 
 exit 0


### PR DESCRIPTION
There's some useful stuff to do if runcommand-on[start|end] have access to the ROM name (usually the 4th runcommand argument).