### PR TITLE
M64p opts

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -176,6 +176,10 @@ function configure_mupen64plus() {
         iniSet "EnableFBEmulation" "False"
         # Use native res
         iniSet "nativeResFactor" "1"
+
+        # Disable gles2n64 autores feature and use dispmanx upscaling
+        iniConfig " = " "" "$md_conf_root/n64/gles2n64.conf"
+        iniSet "auto resolution" "0"
         
         addAutoConf mupen64plus_audio 1
         addAutoConf mupen64plus_compatibility_check 1

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -158,6 +158,13 @@ function testCompatibility() {
     # fallback for glesn64 and rice plugin
     # some roms lead to a black screen of death
     local game
+    local blacklist=(
+        resident
+        gauntlet
+        rogue
+        squadron
+    )
+
     local glesn64_blacklist=(
         zelda
         paper
@@ -184,12 +191,20 @@ function testCompatibility() {
         gemini
         majora
         1080
+        quake
     )
 
     local GLideN64LegacyBlending_blacklist=(
         empire
         beetle
     )
+
+    for game in "${blacklist[@]}"; do
+        if [[ "${ROM,,}" == *"$game"* ]]; then
+            dialog --msgbox "This game is not supported." 22 76
+            exit
+        fi
+    done
 
     if [[ "$VIDEO_PLUGIN" == "mupen64plus-video-n64" ]];then
         for game in "${glesn64_blacklist[@]}"; do

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -232,13 +232,12 @@ function testCompatibility() {
                 fi
             done
             ;;
-        "mupen64plus-video-n64")
+        "mupen64plus-video-n64"|"mupen64plus-video-rice")
             for game in "${glesn64_blacklist[@]}"; do
                 if [[ "${ROM,,}" == *"$game"* ]]; then
                     VIDEO_PLUGIN="mupen64plus-video-rice"
                 fi
             done
-        *)
             for game in "${glesn64rice_blacklist[@]}"; do
                 if [[ "${ROM,,}" == *"$game"* ]]; then
                     VIDEO_PLUGIN="mupen64plus-video-GLideN64"

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -201,53 +201,51 @@ function testCompatibility() {
 
     for game in "${blacklist[@]}"; do
         if [[ "${ROM,,}" == *"$game"* ]]; then
-            dialog --msgbox "This game is not supported." 22 76
             exit
         fi
     done
 
-    if [[ "$VIDEO_PLUGIN" == "mupen64plus-video-n64" ]];then
-        for game in "${glesn64_blacklist[@]}"; do
-            if [[ "${ROM,,}" == *"$game"* ]]; then
-                VIDEO_PLUGIN="mupen64plus-video-rice"
+    case "$VIDEO_PLUGIN" in
+        "mupen64plus-video-GLideN64")
+            if ! grep -q "\[Video-GLideN64\]" "$config"; then
+                echo "[Video-GLideN64]" >> "$config"
             fi
-        done
-    fi
-
-    if [[ "$VIDEO_PLUGIN" != "mupen64plus-video-GLideN64" ]];then
-        for game in "${glesn64rice_blacklist[@]}"; do
-            if [[ "${ROM,,}" == *"$game"* ]]; then
-                VIDEO_PLUGIN="mupen64plus-video-GLideN64"
-            fi
-        done
-    fi
-
-    if [[ "$VIDEO_PLUGIN" == "mupen64plus-video-GLideN64" ]];then
-        if ! grep -q "\[Video-GLideN64\]" "$config"; then
-            echo "[Video-GLideN64]" >> "$config"
-        fi
-        iniConfig " = " "" "$config"
-        # Settings version. Don't touch it.
-        iniSet "configVersion" "12"
-        # Enable FBEmulation if necessary
-        iniSet "EnableFBEmulation" "False"
-        # Set native resolution factor of 1
-        iniSet "nativeResFactor" "1"
-        for game in "${GLideN64FBEMU_whitelist[@]}"; do
-            if [[ "${ROM,,}" == *"$game"* ]]; then
-                iniSet "EnableFBEmulation" "True"
-                break
-            fi
-        done
-        # Disable LegacyBlending if necessary
-        iniSet "enableLegacyBlending" "True"
-        for game in "${GLideN64LegacyBlending_blacklist[@]}"; do
-            if [[ "${ROM,,}" == *"$game"* ]]; then
-                iniSet "enableLegacyBlending" "False"
-                break
-            fi
-        done
-    fi
+            iniConfig " = " "" "$config"
+            # Settings version. Don't touch it.
+            iniSet "configVersion" "12"
+            # Enable FBEmulation if necessary
+            iniSet "EnableFBEmulation" "False"
+            # Set native resolution factor of 1
+            iniSet "nativeResFactor" "1"
+            for game in "${GLideN64FBEMU_whitelist[@]}"; do
+                if [[ "${ROM,,}" == *"$game"* ]]; then
+                    iniSet "EnableFBEmulation" "True"
+                    break
+                fi
+            done
+            # Disable LegacyBlending if necessary
+            iniSet "enableLegacyBlending" "True"
+            for game in "${GLideN64LegacyBlending_blacklist[@]}"; do
+                if [[ "${ROM,,}" == *"$game"* ]]; then
+                    iniSet "enableLegacyBlending" "False"
+                    break
+                fi
+            done
+            ;;
+        "mupen64plus-video-n64")
+            for game in "${glesn64_blacklist[@]}"; do
+                if [[ "${ROM,,}" == *"$game"* ]]; then
+                    VIDEO_PLUGIN="mupen64plus-video-rice"
+                fi
+            done
+        *)
+            for game in "${glesn64rice_blacklist[@]}"; do
+                if [[ "${ROM,,}" == *"$game"* ]]; then
+                    VIDEO_PLUGIN="mupen64plus-video-GLideN64"
+                fi
+            done
+            ;;
+    esac
 }
 
 if ! grep -q "\[Core\]" "$config"; then


### PR DESCRIPTION
-Add blacklist for games which crash the pi or aren't playable with any video plugin. Exit script if game is found.
-Disable glesn64 autores feature. Use resolution set in gles2n64.conf and dispmanx upscaling.
-Enable FBEmulation for quake.
-Cleanup startup script video plugin check.