### PR TITLE
mupen64plus: add expansion pak switching

### DIFF
--- a/scriptmodules/supplementary/emulationstation/configscripts/mupen64plus.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/mupen64plus.sh
@@ -109,6 +109,12 @@ function map_mupen64plus_joystick() {
             keys=("C Button D")
             dir=("Down")
             ;;
+        leftthumb)
+            keys=("Mempak switch")
+            ;;
+        rightthumb)
+            keys=("Rumblepak switch")
+            ;;
         *)
             return
             ;;


### PR DESCRIPTION
If controller has left thumb and right thumb add expansion pak enable bindings:
leftthumb = mempak
rightthumb = rumblepak