### PR TITLE
mupen64plus: highres fix

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -119,6 +119,8 @@ function install_mupen64plus() {
 
 function configure_mupen64plus() {
     if isPlatform "rpi"; then
+        addSystem 0 "${md_id}-gles2n64$name" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-n64 %ROM% 320x240"
+        addSystem 0 "${md_id}-videocore$name" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-videocore %ROM% 320x240"
         local res
         for res in "320x240" "640x480"; do
             local def=0
@@ -127,8 +129,6 @@ function configure_mupen64plus() {
             [[ "$res" == "640x480" ]] && name="-highres"
             addSystem $def "${md_id}-GLideN64$name" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM% $res"
             addSystem 0 "${md_id}-gles2rice$name" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-rice %ROM% $res"
-            addSystem 0 "${md_id}-gles2n64$name" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-n64 %ROM% $res"
-            addSystem 0 "${md_id}-videocore$name" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-videocore %ROM% $res"
         done
     else
         addSystem 0 "${md_id}-GLideN64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM%"


### PR DESCRIPTION
Don’t add highres options for video plugins which do not use
„—resolution“ startup parameter.