### PR TITLE
mupen64plus: Update gliden64 configVersion

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -174,7 +174,7 @@ function configure_mupen64plus() {
             echo "[Video-GLideN64]" >> "$config"
         fi
         # Settings version. Don't touch it.
-        iniSet "configVersion" "12"
+        iniSet "configVersion" "13"
         # Bilinear filtering mode (0=N64 3point, 1=standard)
         iniSet "bilinearMode" "1"
         # Size of texture cache in megabytes. Good value is VRAM*3/4
@@ -182,7 +182,7 @@ function configure_mupen64plus() {
         # Disable FB emulation until visual issues are sorted out
         iniSet "EnableFBEmulation" "False"
         # Use native res
-        iniSet "nativeResFactor" "1"
+        iniSet "UseNativeResolutionFactor" "1"
 
         # Disable gles2n64 autores feature and use dispmanx upscaling
         iniConfig " = " "" "$md_conf_root/n64/gles2n64.conf"

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -216,11 +216,11 @@ function testCompatibility() {
             fi
             iniConfig " = " "" "$config"
             # Settings version. Don't touch it.
-            iniSet "configVersion" "12"
+            iniSet "configVersion" "13"
             # Enable FBEmulation if necessary
             iniSet "EnableFBEmulation" "False"
             # Set native resolution factor of 1
-            iniSet "nativeResFactor" "1"
+            iniSet "UseNativeResolutionFactor" "1"
             for game in "${GLideN64FBEMU_whitelist[@]}"; do
                 if [[ "${ROM,,}" == *"$game"* ]]; then
                     iniSet "EnableFBEmulation" "True"
@@ -228,10 +228,10 @@ function testCompatibility() {
                 fi
             done
             # Disable LegacyBlending if necessary
-            iniSet "enableLegacyBlending" "True"
+            iniSet "EnableLegacyBlending" "True"
             for game in "${GLideN64LegacyBlending_blacklist[@]}"; do
                 if [[ "${ROM,,}" == *"$game"* ]]; then
-                    iniSet "enableLegacyBlending" "False"
+                    iniSet "EnableLegacyBlending" "False"
                     break
                 fi
             done


### PR DESCRIPTION
https://github.com/gonetz/GLideN64/pull/1087/files

@joolswills 
Mupen64plus needs to be updated. Old gliden64 plugins will not work properly with configVersion 13.