### PR TITLE
Add experimental gc/wii emulator dolphin

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -103,6 +103,12 @@ ngpc_fullname="Neo Geo Pocket (Color)"
 nes_exts=".nes .zip"
 nes_fullname="Nintendo Entertainment System"
 
+gc_exts=".iso"
+gc_fullname="Nintendo Gamecube"
+
+wii_exts=".iso"
+wii_fullname="Nintendo Wii"
+
 pc_exts=".bat .com .exe .sh"
 pc_fullname="PC (x86)"
 

--- a/scriptmodules/emulators/dolphin.sh
+++ b/scriptmodules/emulators/dolphin.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="dolphin"
+rp_module_desc="Gamecube/Wii emulator Dolphin"
+rp_module_help="ROM Extensions: .iso\n\nCopy your gamecube roms to $romdir/gamecube and Wii roms to $romdir/wii"
+rp_module_section="exp"
+rp_module_flags="!arm"
+
+function depends_dolphin() {
+    hasPackage dolphin-emu && dpkg --remove dolphin-emu
+    local depends=(cmake pkg-config git libao-dev libasound2-dev libavcodec-dev libavformat-dev libbluetooth-dev libenet-dev libgtk2.0-dev liblzo2-dev libminiupnpc-dev libopenal-dev libpulse-dev libreadline-dev libsfml-dev libsoil-dev libsoundtouch-dev libswscale-dev libusb-1.0-0-dev libwxbase3.0-dev libwxgtk3.0-dev libxext-dev libxrandr-dev portaudio19-dev zlib1g-dev libudev-dev libevdev-dev libmbedtls-dev libcurl4-openssl-dev libegl1-mesa-dev)
+    getDepends "${depends[@]}"
+}
+
+function sources_dolphin() {
+    gitPullOrClone "$md_build" https://github.com/dolphin-emu/dolphin.git
+}
+
+function build_dolphin() {
+    mkdir Build && cd Build
+    cmake .. -DENABLE_HEADLESS=1
+    make
+}
+
+function install_dolphin() {
+    cd Build
+    make install
+}
+
+function configure_dolphin() {
+    mkRomDir "gc"
+    mkRomDir "wii"
+
+    addSystem 1 "${md_id}" "gc" "dolphin-emu -b -e %ROM%"
+    addSystem 1 "${md_id}" "wii" "dolphin-emu -b -e %ROM%"
+}


### PR DESCRIPTION
-x86 only.
-no hotkeys. (dolphin seems to have no hotkey support?!)
-runs zelda ww with 15-30fps on a Pentium N3050 (Atom based) which is
real good for such a low end platform.
-only system wide installation atm.
-build time > 1h on a Pentium N3050.
-you need a mouse to get emulator window in front.
https://github.com/RetroPie/RetroPie-Setup/issues/1633