### PR TITLE
Update lr-glupen64.sh

### DIFF
--- a/scriptmodules/libretrocores/lr-glupen64.sh
+++ b/scriptmodules/libretrocores/lr-glupen64.sh
@@ -17,7 +17,6 @@ rp_module_flags="!mali"
 
 function sources_lr-glupen64() {
     gitPullOrClone "$md_build" https://github.com/loganmc10/GLupeN64.git
-    runCmd git submodule update --init
 }
 
 function build_lr-glupen64() {


### PR DESCRIPTION
I've done away with the submodules, since it forces pulling in the history of each submodule, which is going to be a lot. So you don't need this anymore when pulling the repo.

You guys can use --depth=1 to speed it up as well but I don't know what the syntax for that would be with the macros you are using.