### PR TITLE
m64p: some modifications

### DIFF
--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -13,7 +13,9 @@ AUDIO_PLUGIN="mupen64plus-audio-sdl"
 VIDEO_PLUGIN="$1"
 ROM="$2"
 RES="$3"
+RSP_PLUGIN="$4"
 [[ -n "$RES" ]] && RES="--resolution $RES"
+[[ -z "$RSP_PLUGIN" ]] && RSP_PLUGIN="mupen64plus-rsp-hle"
 rootdir="/opt/retropie"
 configdir="$rootdir/configs"
 config="$configdir/n64/mupen64plus.cfg"
@@ -286,7 +288,7 @@ getAutoConf mupen64plus_audio && setAudio
 
 if [[ "$(sed -n '/^Hardware/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo)" == *BCM27* ]]; then
     # If a raspberry pi is used lower resolution to 320x240 and enable SDL dispmanx scaling mode 1
-    SDL_VIDEO_RPI_SCALE_MODE=1 "$rootdir/emulators/mupen64plus/bin/mupen64plus" --noosd --windowed $RES --gfx ${VIDEO_PLUGIN}.so --audio ${AUDIO_PLUGIN}.so --configdir "$configdir/n64" --datadir "$configdir/n64" "$ROM"
+    SDL_VIDEO_RPI_SCALE_MODE=1 "$rootdir/emulators/mupen64plus/bin/mupen64plus" --noosd --windowed $RES --rsp ${RSP_PLUGIN}.so --gfx ${VIDEO_PLUGIN}.so --audio ${AUDIO_PLUGIN}.so --configdir "$configdir/n64" --datadir "$configdir/n64" "$ROM"
 else
-    "$rootdir/emulators/mupen64plus/bin/mupen64plus" --noosd --fullscreen --gfx ${VIDEO_PLUGIN}.so --audio mupen64plus-audio-sdl.so --configdir "$configdir/n64" --datadir "$configdir/n64" "$ROM"
+    "$rootdir/emulators/mupen64plus/bin/mupen64plus" --noosd --fullscreen --rsp ${RSP_PLUGIN}.so --gfx ${VIDEO_PLUGIN}.so --audio mupen64plus-audio-sdl.so --configdir "$configdir/n64" --datadir "$configdir/n64" "$ROM"
 fi


### PR DESCRIPTION
common:
-use „-flto“. All mupen64plus plugins use OPTFLAGS = -flto. We
overwrite OPTFLAGS with our CFLAGS until now.

x86:
-add CXD4 and Z64 RSP LLE plugins
-add GLideN64 LLE mode. Allows for example SW Rogue Squadron to start
up.
-add GLideN64 Intel OGL3.3 graphics workaround. This workaround should
be obsolete when Ubuntu 16.04.2 arrives (new mesa 12.1 with OGL4.3
support). There are glitches because OGL3.3 does not support all necessary features.
-enable SSSE3 optimizations. Even ten year old CPUs support SSSE3.