### PR TITLE
Fix lr-gambatte

### DIFF
--- a/scriptmodules/libretrocores/lr-gambatte.sh
+++ b/scriptmodules/libretrocores/lr-gambatte.sh
@@ -19,9 +19,9 @@ function sources_lr-gambatte() {
 }
 
 function build_lr-gambatte() {
-    make -C libgambatte -f Makefile.libretro clean
-    make -C libgambatte -f Makefile.libretro
-    md_ret_require="$md_build/libgambatte/gambatte_libretro.so"
+    make -f Makefile.libretro clean
+    make -f Makefile.libretro
+    md_ret_require="$md_build/gambatte_libretro.so"
 }
 
 function install_lr-gambatte() {
@@ -29,7 +29,7 @@ function install_lr-gambatte() {
         'COPYING'
         'changelog'
         'README'
-        'libgambatte/gambatte_libretro.so'
+        'gambatte_libretro.so'
     )
 }
 


### PR DESCRIPTION
Makefile location changed:
https://github.com/libretro/gambatte-libretro/commit/4e4fb2b4a6a4e86242a
9b63c6fc235ef25303d06
https://retropie.org.uk/forum/topic/3789/gambatte-fails-to-install-from-
source-4-0-2-x86