### PR TITLE
explicit use of rgui as the menu_driver

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -104,6 +104,7 @@ function configure_retroarch() {
     iniSet "core_options_path" "$configdir/all/retroarch-core-options.cfg"
     iniSet "assets_directory" "$md_inst/assets"
     iniSet "overlay_directory" "$md_inst/overlays"
+    iniSet "menu_driver" "rgui"
     isPlatform "x11" && iniSet "video_fullscreen" "true"
 
     # set default render resolution to 640x480 for rpi1


### PR DESCRIPTION
As reported by @RetroResolution [in the forum](https://retropie.org.uk/forum/topic/3728/playstation-ffmpeg-recording-causes-seg-fault-in-retropie-4-0-2-recording-megadrive-vcs-etc-still-fine/), the default `menu_driver` for RetroArch on raspi3 is xmb (raspi3 owners can reproduce it after reinstall RetroArch from source and don't explicit set anything for `menu_driver` in retroarch.cfg).

@dankcushions said [here](https://retropie.org.uk/forum/post/23421) that he checked with libretro guys and "apparently it's defaulted differently on different systems". I checked here that raspi3 defaults to `xmb` and raspi2 and 1 defaults to `rgui`. For the sake of uniformity, it's better to explicitly set `menu_driver = "rgui"`, otherwise raspi3 users will get confused by the `xmb`.