### PR TITLE
Better rpi3 cflags

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -216,7 +216,7 @@ function platform_rpi2() {
 # note the rpi3 currently uses the rpi2 binaries - for ease of maintenance - rebuilding from source
 # could improve performance with the compiler options below but needs further testing
 function platform_rpi3() {
-    __default_cflags="-O3 -mcpu=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard -funsafe-math-optimizations"
+    __default_cflags="-O3 -march=armv8-a+crc -mtune=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard -funsafe-math-optimizations"
     __default_asflags=""
     __default_makeflags="-j2"
     __platform_flags="arm armv8 neon rpi"


### PR DESCRIPTION
Use -march=armv8-a+crc so CRC extensions can be used.
https://github.com/gizmo98/GLideN64/commit/4f74a0d6598b6ed4b29e26ffe59bd4e8ff2eeee4