### PR TITLE
m64p-rpi3: use armv8 crc

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -78,6 +78,7 @@ function build_mupen64plus() {
     pushd $md_build/GLideN64/projects/cmake
     params=("-DMUPENPLUSAPI=On" "-DVEC4_OPT=On")
     isPlatform "neon" && params+=("-DNEON_OPT=On")
+    isPlatform "rpi3" && params+=("-DCRC_ARMV8=On")
     cmake "${params[@]}" ../../src/
     make
     popd


### PR DESCRIPTION
https://github.com/gonetz/GLideN64/commit/a471b130e79c71de1791c624ece068
468e89b615