### PR TITLE
fs-uae integration

### DIFF
--- a/scriptmodules/emulators/fs-uae.sh
+++ b/scriptmodules/emulators/fs-uae.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="fs-uae"
 rp_module_desc="Amiga emulator - FS-UAE integrates the most accurate Amiga emulation code available from WinUAE"
-rp_module_help="ROM Extension: .adf"
+rp_module_help="ROM Extension: .adf .ipf .dms .adz .zip\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required kickstart file kick13.bin to $biosdir"
 rp_module_section="exp"
 rp_module_flags="!arm"
 
@@ -37,26 +37,30 @@ function depends_fs-uae() {
 }
 
 function install_bin_fs-uae() {
-    aptInstall fs-uae fs-uae-launcher fs-uae-arcade
+    aptInstall fs-uae
 }
 
 function remove_fs-uae() {
-    aptRemove fs-uae fs-uae-launcher fs-uae-arcade
+    aptRemove fs-uae
 }
 
 function configure_fs-uae() {
     mkRomDir "amiga"
 
+    mkUserDir "$md_conf_root/amiga"
+    mkUserDir "$md_conf_root/amiga/$md_id"
+    
+    # copy configuring start script
+    mkdir "$md_inst/bin/"
+    cp "$scriptdir/scriptmodules/$md_type/$md_id/fs-uae.sh" "$md_inst/bin/"
+    chmod +x "$md_inst/bin/fs-uae.sh"
+
+    # copy default config file
+    cp -v "$scriptdir/scriptmodules/$md_type/$md_id/default_cfg.fs-uae" "$md_conf_root/amiga"
+    
     mkUserDir "$home/.config"
     mkUserDir "$md_conf_root/amiga"
     moveConfigDir "$home/.config/fs-uae" "$md_conf_root/amiga/fs-uae"
 
-    cat > "$romdir/amiga/+Start FS-UAE.sh" << _EOF_
-#!/bin/bash
-fs-uae-launcher
-_EOF_
-    chmod a+x "$romdir/amiga/+Start FS-UAE.sh"
-    chown $user:$user "$romdir/amiga/+Start FS-UAE.sh"
-
-    addSystem 1 "$md_id" "amiga" "bash $romdir/amiga/+Start\ FS-UAE.sh" "Amiga" ".sh"
+    addSystem 1 "$md_id" "amiga" "bash $md_inst/bin/fs-uae.sh %ROM%" Amiga ".adf .ipf .dms .adz .zip"
 }

--- a/scriptmodules/emulators/fs-uae/default_cfg.fs-uae
+++ b/scriptmodules/emulators/fs-uae/default_cfg.fs-uae
@@ -1,4 +1,6 @@
 fullscreen = 1
 keep_aspect = 1
+zoom = full
+fsaa = 0
 scanlines = 0
 floppy_drive_speed = 100

--- a/scriptmodules/emulators/fs-uae/default_cfg.fs-uae
+++ b/scriptmodules/emulators/fs-uae/default_cfg.fs-uae
@@ -1,0 +1,4 @@
+fullscreen = 1
+keep_aspect = 1
+scanlines = 0
+floppy_drive_speed = 100

--- a/scriptmodules/emulators/fs-uae/fs-uae.sh
+++ b/scriptmodules/emulators/fs-uae/fs-uae.sh
@@ -23,8 +23,26 @@ romdir="$datadir/roms"
 biosdir="$datadir/BIOS"
 kickfile="$biosdir/kick13.rom"
 
+# this function takes one argument like "/home/vbs/RetroPie/roms/amiga/0-B/Barbarian II (1991)(Psygnosis)[cr FLT](Disk 1 of 2).adf"
+# then it finds all files that start with the same prefix "/home/vbs/RetroPie/roms/amiga/0-B/Barbarian II (1991)(Psygnosis)[cr FLT](Disk"
+# if the initial filename does not contain "(Disk" then it returns just the initial file
+function getFiles() {
+    DIR=$(dirname "$1")
+    BASE=$(basename "$1")
+    PATTERN=$(echo "$BASE" | sed s/\(Disk.*/\(Disk/g)
+    find "$DIR" | grep -F "$PATTERN" | sort
+}
+
+FLOPPYIMAGES=()
+n=0
+while read i
+do
+    FLOPPYIMAGES+=("--floppy_image_$n=$i")
+    (( n += 1))
+done < <(getFiles "$ROM")
+
 if [[ -f "$kickfile" ]]; then
-    fs-uae "$config" --floppy_drive_0="$ROM" --kickstart_file="$kickfile" --floppies_dir="$romdir/amiga" --save_states_dir="$romdir/amiga"
+    fs-uae "$config" --floppy_drive_0="$ROM" "${FLOPPYIMAGES[@]}" --kickstart_file="$kickfile" --floppies_dir="$romdir/amiga" --save_states_dir="$romdir/amiga"
 else
     dialog --msgbox "You need to copy the Amiga kickstart file (kick13.rom) to the folder $biosdir to boot the Amiga emulator." 22 76
 fi

--- a/scriptmodules/emulators/fs-uae/fs-uae.sh
+++ b/scriptmodules/emulators/fs-uae/fs-uae.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+ROM="$1"
+
+rootdir="/opt/retropie"
+configdir="$rootdir/configs"
+config="$configdir/amiga/default_cfg.fs-uae"
+
+user="$SUDO_USER"
+[[ -z "$user" ]] && user=$(id -un)
+home="$(eval echo ~$user)"
+datadir="$home/RetroPie"
+romdir="$datadir/roms"
+biosdir="$datadir/BIOS"
+kickfile="$biosdir/kick13.rom"
+
+if [[ -f "$kickfile" ]]; then
+    fs-uae "$config" --floppy_drive_0="$ROM" --kickstart_file="$kickfile" --floppies_dir="$romdir/amiga" --save_states_dir="$romdir/amiga"
+else
+    dialog --msgbox "You need to copy the Amiga kickstart file (kick13.rom) to the folder $biosdir to boot the Amiga emulator." 22 76
+fi
+


### PR DESCRIPTION
This integrates Amiga emulator fs-uae into Retropie.
Multi-disk games are supported but will only use one drive.
Removed fs-uae-launcher since it is IMO not needed anymore after Retropie integration.
