### PR TITLE
emulationstation - add '--hide-menubar' to gnome-terminal options oth…

### DIFF
--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -125,7 +125,7 @@ _EOF_
         cat > /usr/local/share/applications/retropie.desktop << _EOF_
 [Desktop Entry]
 Type=Application
-Exec=gnome-terminal --full-screen -e emulationstation
+Exec=gnome-terminal --full-screen --hide-menubar -e emulationstation
 Hidden=false
 NoDisplay=false
 X-GNOME-Autostart-enabled=true


### PR DESCRIPTION
When autostarting ES on Xfce the menubar of the fullscreen terminal is visible. Using option "--hide-menubar" of gnome-terminal fixes that.