### PR TITLE
show custom launching image when es art not found

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -738,8 +738,7 @@ function show_launch() {
             "$HOME/.emulationstation/downloaded_images/$system/${rom_bn}-image"
         )
     fi
-    images=(
-        "${images[@]}"
+    images+=(
         "$configdir/$system/launching"
         "$configdir/all/launching"
     )

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -737,13 +737,12 @@ function show_launch() {
             "$HOME/RetroPie/roms/$system/images/${rom_bn}-image"
             "$HOME/.emulationstation/downloaded_images/$system/${rom_bn}-image"
         )
-    else
-        # otherwise see if the user has a custom launching image
-        images=(
-            "$configdir/$system/launching"
-            "$configdir/all/launching"
-        )
     fi
+    images=(
+        "${images[@]}"
+        "$configdir/$system/launching"
+        "$configdir/all/launching"
+    )
 
     local image
     local path


### PR DESCRIPTION
show the custom launching image even if `use_art` is on.
Well... it's unfair to not show the custom launching art if the user enabled an option named "launch menu art" :-)
If it will be merged I'll change the wiki accordingly.