### PR TITLE
replaced terminal-dependent escape sequences by curses mappings

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -693,7 +693,7 @@ _EOF_
 function joy2keyStart() {
     local params=("$@")
     if [[ "${#params[@]}" -eq 0 ]]; then
-        params=(1b5b44 1b5b43 1b5b41 1b5b42 0a 20)
+        params=(kcub1 kcuf1 kcuu1 kcud1 0x0a 0x20)
     fi
     # check if joy2key is installed
     [[ ! -f "$rootdir/supplementary/runcommand/joy2key.py" ]] && return 1

--- a/scriptmodules/supplementary/runcommand/joy2key.py
+++ b/scriptmodules/supplementary/runcommand/joy2key.py
@@ -10,6 +10,7 @@
 #
 
 import sys, struct, time, fcntl, termios, signal
+import curses
 
 #    struct js_event {
 #        __u32 time;     /* event timestamp in milliseconds */
@@ -38,14 +39,23 @@ signal.signal(signal.SIGINT, signal_handler)
 button_codes = []
 axis_codes = []
 
+curses.setupterm()
+
+def get_hex_chars(key_str):
+    if (key_str.startswith("0x")):
+        return key_str[2:].decode('hex')
+    else:
+        return curses.tigetstr(key_str)
+
 i = 0
 for arg in sys.argv[2:]:
+    chars = get_hex_chars(arg)
     if i < 4:
-        axis_codes.append(arg)
+        axis_codes.append(chars)
     else:
-        button_codes.append(arg)
+        button_codes.append(chars)
     i += 1
-
+  
 event_format = 'IhBB'
 event_size = struct.calcsize(event_format)
 
@@ -98,5 +108,5 @@ while True:
 
     if hex_chars:
         last_press = time.time()
-        for c in hex_chars.decode('hex'):
+        for c in hex_chars:
             fcntl.ioctl(tty_fd, termios.TIOCSTI, c)

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -84,7 +84,10 @@ function start_joy2key() {
     [[ -z "$__joy2key_dev" ]] && __joy2key_dev="$(ls -1 /dev/input/js* 2>/dev/null | head -n1)"
     # if joy2key.py is installed run it with cursor keys for axis, and enter + tab for buttons 0 and 1
     if [[ -f "$rootdir/supplementary/runcommand/joy2key.py" && -n "$__joy2key_dev" ]] && ! pgrep -f joy2key.py >/dev/null; then
-        "$rootdir/supplementary/runcommand/joy2key.py" "$__joy2key_dev" 1b5b44 1b5b43 1b5b41 1b5b42 0a 09 &
+
+        # call joy2key.py: arguments are curses capability names or hex values starting with '0x'
+        # see: http://pubs.opengroup.org/onlinepubs/7908799/xcurses/terminfo.html
+        "$rootdir/supplementary/runcommand/joy2key.py" "$__joy2key_dev" kcub1 kcuf1 kcuu1 kcud1 0x0a 0x09 &
         __joy2key_pid=$!
     fi
 }

--- a/scriptmodules/supplementary/wikiview.sh
+++ b/scriptmodules/supplementary/wikiview.sh
@@ -65,7 +65,7 @@ function gui_wikiview() {
                         file=$(choose_wikipage_wikiview "$wikidir" ".*.md" ".*_.*")
                         if [[ -n "$file" ]]; then
                             joy2keyStop
-                            joy2keyStart 00 00 1b5b327e 1b5b337e 20 71
+                            joy2keyStart 0x00 0x00 kich1 kdch1 0x20 0x71
                             pandoc "$wikidir/$file" | lynx -localhost -restrictions=all -stdin >/dev/tty
                             joy2keyStop
                             joy2keyStart


### PR DESCRIPTION
Removed hardcoded escape sequences (cursor keys etc.) and replaced by terminal-independent curses calls that uses terminfo to map to sequences working for the actual terminal.

The problem was that on x86 Lubuntu the DPad of my X360 Gamepad was not working in runcommand because the hardcoded escape sequences were not working for my terminal:
https://retropie.org.uk/forum/topic/4115/xbox360-dpad-not-working-in-runcommand-menu

Is this ok for you? Please do not merge yet, I did not test it yet for RPi but I would like to ask before if you would support this PR.