### PR TITLE
Allow glupen64 to rise from the shadows

### DIFF
--- a/scriptmodules/libretrocores/lr-glupen64.sh
+++ b/scriptmodules/libretrocores/lr-glupen64.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-glupen64"
 rp_module_desc="N64 emu - GLupeN64 for libretro"
 rp_module_help="ROM Extensions: .z64 .n64 .v64\n\nCopy your N64 roms to $romdir/n64"
-rp_module_section="opt"
+rp_module_section="main"
 rp_module_flags="!mali"
 
 function sources_lr-glupen64() {


### PR DESCRIPTION
This core has received a fair amount of testing now on Linux, Windows, Android, and the Raspberry Pi. It is stable and matches the features of mupen64plus+GLideN64.

It's performance is probably still slightly worse than standalone mupen64plus, but that is because of the RetroArch rendering pipeline (the extra work it does to support custom shaders and whatnot), so there is not much that can be done at this point.

Framebuffer Emulation is disabled by default still for the Raspberry Pi since there are still hardware specific bugs present with it (same with standalone mupen64plus)