### PR TITLE
using "$datadir" instead of "$home/RetroPie" in remove function

### DIFF
--- a/scriptmodules/supplementary/retropie-manager.sh
+++ b/scriptmodules/supplementary/retropie-manager.sh
@@ -67,7 +67,7 @@ function disable_retropie-manager() {
 
 function remove_retropie-manager() {
     sed -i "/rpmanager\.sh.*--start/d" /etc/rc.local
-    rm -f "$home/RetroPie/retropiemenu/retropie-manager.rp"
+    rm -f "$datadir/retropiemenu/retropie-manager.rp"
 }
 
 function gui_retropie-manager() {


### PR DESCRIPTION
I saw you ( @joolswills ) did it in `install` function, and thought it would be OK to do it in `remove` function too.
I didn't know this trick... :-)