### PR TITLE
resetromdirs: Actually fix permissions

### DIFF
--- a/scriptmodules/supplementary/resetromdirs.sh
+++ b/scriptmodules/supplementary/resetromdirs.sh
@@ -19,4 +19,6 @@ function gui_resetromdirs() {
     mkUserDir "$biosdir"
     chown -R $user:$user "$romdir"
     chown -R $user:$user "$biosdir"
+    chmod -R ug+rwX "$romdir"
+    chmod -R ug+rwX "$biosdir"
 }


### PR DESCRIPTION
People end up with bad permissions for a variety of reasons. This script
module currently just resets ownership, it makes no changes to
permissions, even though it claims to.

Add `chmod -R ug+rwX` to fix permissions.

Signed-off-by: Jamie Bainbridge <jamie.bainbridge@gmail.com>