### PR TITLE
reicast: added message box if no joystick is connected

### DIFF
--- a/scriptmodules/emulators/reicast/reicast.sh
+++ b/scriptmodules/emulators/reicast/reicast.sh
@@ -69,17 +69,32 @@ function mapInput() {
     params+="-config input:joystick_device_id=-1 "
     params+="-config players:nb=$device_counter "
     echo "$params"
+
+    if [[ -z $device_counter ]]; then
+        exit 1
+    fi
 }
 
-if [[ -f "$HOME/RetroPie/BIOS/dc_boot.bin" ]]; then
-    params="-config config:homedir=$HOME -config x11:fullscreen=1 "
-    getAutoConf reicast_input && params+=$(mapInput)
-    params+=" -config audio:backend=$AUDIO -config audio:disable=0 "
-    if [[ "$AUDIO" == "oss" ]]; then
-        aoss "$rootdir/emulators/reicast/bin/reicast" $params -config config:image="$ROM" >> /dev/null
-    else
-        "$rootdir/emulators/reicast/bin/reicast" $params -config config:image="$ROM" >> /dev/null
-    fi
-else
-    dialog --msgbox "You need to copy the Dreamcast BIOS files (dc_boot.bin and dc_flash.bin) to the folder $biosdir to boot the Dreamcast emulator." 22 76
+function message() {
+    dialog --msgbox "$1" 22 76
+}
+
+if [[ ! -f "$HOME/RetroPie/BIOS/dc_boot.bin" ]]; then
+    message "You need to copy the Dreamcast BIOS files (dc_boot.bin and dc_flash.bin) to the folder $biosdir to boot the Dreamcast emulator."
+    exit
 fi
+
+params="-config config:homedir=$HOME -config x11:fullscreen=1 "
+getAutoConf reicast_input && params+=$(mapInput)
+
+if [[ $? == 1 ]]; then
+    message "No joystick found! Please connect at least one joystick!"
+    exit
+fi
+
+params+=" -config audio:backend=$AUDIO -config audio:disable=0 "
+prefix=""
+if [[ "$AUDIO" == "oss" ]]; then
+    prefix="aoss"
+fi
+$prefix "$rootdir/emulators/reicast/bin/reicast" $params -config config:image="$ROM" >> /dev/null


### PR DESCRIPTION
After stupid me searched about 1 hour why my Reicast was just crashing at startup, I discovered that I had just no joystick connected (command line parameter was then like "--player-nb=" which crashes Reicast). I thought it would be cool to pop a message to the user in that case.
Also I tried to simplify the if-conditions in the script to reduce code indentation.

Better look twice: don't trust my bash skills.
