### PR TITLE
VICE multi-disk ZIP support

### DIFF
--- a/scriptmodules/archivefuncs.sh
+++ b/scriptmodules/archivefuncs.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+## @file archivefuncs.sh
+## @brief RetroPie archivefuncs library
+## @copyright GPLv3
+
+readonly arch_dir="/tmp/retropie-archive"
+
+## @fn archiveExtract()
+## @param src_file Full path to archive file to extract
+## @param disk_exts Space seperated list of supported disk extensions (e.g. ".d64 .t64")
+## @brief Extracts an archive to a temporary directory
+## @details After calling this the variable arch_dir will contain the directory that was used
+## for extraction. Also the variable arch_files will contain an array of filenames that are
+## considered as game disks according to parameter disk_exts.
+function archiveExtract() {
+    local src_file="$1"
+    local disk_exts="$2"
+
+    # clean temp directory if needed
+    archiveCleanup
+    mkdir "$arch_dir"
+
+    local ext="${src_file##*.}"
+
+    case "${ext,,}" in
+        zip)
+            unzip "$src_file" -d "$arch_dir"
+            ;;
+        *)
+            echo "Unsupported archive: $src_file"
+            return 1
+            ;;
+    esac
+
+    # build a regex portion from the passed extensions
+    regexPart=$(echo ${disk_exts} | sed 's/ /\\|/g')
+
+    IFS=$'\n' read -d '' -r -a arch_files < <(find "$arch_dir" -iregex ".*.\(${regexPart}\)$")
+
+    if [[ ${#arch_files[@]} -eq 0 ]]; then
+        return 2
+    fi
+}
+
+## @fn archiveCleanup()
+## @brief Purges archive temp directory from previous calls to archiveExtract
+function archiveCleanup() {
+    [[ -d "$arch_dir" ]] && rm -rf "$arch_dir"
+}

--- a/scriptmodules/archivefuncs.sh
+++ b/scriptmodules/archivefuncs.sh
@@ -43,9 +43,9 @@ function archiveExtract() {
     esac
 
     # build a regex portion from the passed extensions
-    regexPart=$(echo ${disk_exts} | sed 's/ /\\|/g')
+    local regex="${disk_exts// /\\|}"
 
-    IFS=$'\n' read -d '' -r -a arch_files < <(find "$arch_dir" -iregex ".*.\(${regexPart}\)$")
+    IFS=$'\n' read -d '' -r -a arch_files < <(find "$arch_dir" -iregex ".*.\(${regex}\)$" | sort)
 
     if [[ ${#arch_files[@]} -eq 0 ]]; then
         return 2

--- a/scriptmodules/emulators/vice.sh
+++ b/scriptmodules/emulators/vice.sh
@@ -45,15 +45,44 @@ function install_vice() {
 }
 
 function configure_vice() {
+    # get a list of supported extensions
+    c64_exts=$(getSystemExtensions c64)
+
+    # install the vice start script
+    mkdir "$md_inst/bin/"
+    cat > "$md_inst/bin/vice.sh" << _EOF_
+#!/bin/bash
+
+BIN="\${0%/*}/\$1"
+ROM="\$2"
+
+romdir="\${ROM%/*}"
+ext="\${ROM##*.}"
+source "$rootdir/lib/archivefuncs.sh"
+
+archiveExtract "\$ROM" "$c64_exts"
+
+# check successful extraction and if we have at least one file
+if [[ \$? == 0 ]]; then
+    ROM="\${arch_files[0]}"
+    romdir="\$arch_dir"
+fi
+
+"\$BIN" -chdir "\$romdir" "\$ROM"
+archiveCleanup
+_EOF_
+
+    chmod +x "$md_inst/bin/vice.sh"
+
     mkRomDir "c64"
 
-    addSystem 1 "$md_id-x64" "c64" "$md_inst/bin/x64 %ROM%"
-    addSystem 0 "$md_id-x64sc" "c64" "$md_inst/bin/x64sc %ROM%"
-    addSystem 0 "$md_id-x128" "c64" "$md_inst/bin/x128 %ROM%"
-    addSystem 0 "$md_id-xpet" "c64" "$md_inst/bin/xpet %ROM%"
-    addSystem 0 "$md_id-xplus4" "c64" "$md_inst/bin/xplus4 %ROM%"
-    addSystem 0 "$md_id-xvic" "c64" "$md_inst/bin/xvic %ROM%"
-    addSystem 0 "$md_id-xvic-cart" "c64" "$md_inst/bin/xvic -cartgeneric %ROM%"
+    addSystem 1 "$md_id-x64" "c64" "$md_inst/bin/vice.sh x64 %ROM%"
+    addSystem 0 "$md_id-x64sc" "c64" "$md_inst/bin/vice.sh x64sc %ROM%"
+    addSystem 0 "$md_id-x128" "c64" "$md_inst/bin/vice.sh x128 %ROM%"
+    addSystem 0 "$md_id-xpet" "c64" "$md_inst/bin/vice.sh xpet %ROM%"
+    addSystem 0 "$md_id-xplus4" "c64" "$md_inst/bin/vice.sh xplus4 %ROM%"
+    addSystem 0 "$md_id-xvic" "c64" "$md_inst/bin/vice.sh xvic %ROM%"
+    addSystem 0 "$md_id-xvic-cart" "c64" "$md_inst/bin/vice.sh 'xvic -cartgeneric' %ROM%"
 
     [[ "$md_mode" == "remove" ]] && return
 

--- a/scriptmodules/emulators/vice.sh
+++ b/scriptmodules/emulators/vice.sh
@@ -46,7 +46,7 @@ function install_vice() {
 
 function configure_vice() {
     # get a list of supported extensions
-    c64_exts=$(getSystemExtensions c64)
+    c64_exts="$(getSystemExtensions c64)"
 
     # install the vice start script
     mkdir "$md_inst/bin/"

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -926,7 +926,7 @@ function getSystemExtensions() {
     iniConfig "=" '"' "$config"
     iniGet "$1_exts"
 
-    echo $ini_value
+    echo "$ini_value"
 }
 
 ## @fn applyPatch()

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -347,9 +347,12 @@ function ensureRootdirExists() {
 
     # make sure we have inifuncs.sh in place and that it is up to date
     mkdir -p "$rootdir/lib"
-    if [[ ! -f "$rootdir/lib/inifuncs.sh" || "$rootdir/lib/inifuncs.sh" -ot "$scriptdir/scriptmodules/inifuncs.sh" ]]; then
-        cp --preserve=timestamps "$scriptdir/scriptmodules/inifuncs.sh" "$rootdir/lib/inifuncs.sh"
-    fi
+    local helper_libs=(inifuncs.sh archivefuncs.sh)
+    for helper in "${helper_libs[@]}"; do
+        if [[ ! -f "$rootdir/lib/$helper" || "$rootdir/lib/$helper" -ot "$scriptdir/scriptmodules/$helper" ]]; then
+            cp --preserve=timestamps "$scriptdir/scriptmodules/$helper" "$rootdir/lib/$helper"
+        fi
+    done
 
     # create template for autoconf.cfg and make sure it is owned by $user
     local config="$configdir/all/autoconf.cfg"
@@ -908,6 +911,22 @@ function loadModuleConfig() {
             echo "local $key=\"$ini_value\""
         fi
     done
+}
+
+## @fn getSystemExtensions()
+## @param system sytem name to fetch extensions for
+## @brief Prints a space separated string of disk extensions supported by the system 
+## @details Example: ".a26 .bin .rom .zip .gz"
+function getSystemExtensions() {
+    local config
+    for config in "$configdir/all/platforms.cfg" "$scriptdir/platforms.cfg"; do
+         [[ -f "$config" ]] && break
+    done
+    
+    iniConfig "=" '"' "$config"
+    iniGet "$1_exts"
+
+    echo $ini_value
 }
 
 ## @fn applyPatch()


### PR DESCRIPTION
Out of the box VICE can load ZIP files but only uses the first disk from the ZIP. This PR should make it possible to put all the disks belonging to a game into one ZIP. Upon startup the ZIP will be extracted into a temp directory and VICE will be started to autoload the first disk from that directory.
The temp directory (containing all unzipped disks) will be passed to VICE as working directory so when the user uses the disk swap functions in VICE he will see the (temp) directory containing all the relevant disks.

This is pretty much just a proof of concept. If you like it I will polish it a bit and test it more. Also I would like to put the unzip functions into a common shell script because I would also like to use it for emulators that do not support ZIP natively (fs-uae currently).