### PR TITLE
fs-uae - added integration into emulationstation. Supporting ZIPs containing multiple disks

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -1,6 +1,9 @@
 3do_exts=".iso"
 3do_fullname="3DO Interactive Multiplayer"
 
+amiga_exts=".adf .adz .dms .ipf .zip"
+amiga_fullname="Commodore Amiga"
+
 amstradcpc_exts=".cdt .cpc .dsk"
 amstradcpc_fullname="Amstrad CPC"
 

--- a/scriptmodules/emulators/fs-uae.sh
+++ b/scriptmodules/emulators/fs-uae.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="fs-uae"
 rp_module_desc="Amiga emulator - FS-UAE integrates the most accurate Amiga emulation code available from WinUAE"
-rp_module_help="ROM Extension: .adf"
+rp_module_help="ROM Extension: .adf  .adz .dms .ipf .zip\n\nCopy your Amiga games to $romdir/amiga\n\nCopy a required BIOS file (e.g. kick13.rom) to $biosdir"
 rp_module_section="exp"
 rp_module_flags="!arm"
 
@@ -47,16 +47,28 @@ function remove_fs-uae() {
 function configure_fs-uae() {
     mkRomDir "amiga"
 
-    mkUserDir "$home/.config"
+    # copy configuring start script
+    mkdir "$md_inst/bin"
+    cp "$md_data/fs-uae.sh" "$md_inst/bin"
+    chmod +x "$md_inst/bin/fs-uae.sh"
+
     mkUserDir "$md_conf_root/amiga"
-    moveConfigDir "$home/.config/fs-uae" "$md_conf_root/amiga/fs-uae"
+    mkUserDir "$home/Documents/FS-UAE"
+    mkUserDir "$home/Documents/FS-UAE/Configurations"
+    moveConfigDir "$home/Documents/FS-UAE/Configurations" "$md_conf_root/amiga/fs-uae"
 
-    cat > "$romdir/amiga/+Start FS-UAE.sh" << _EOF_
-#!/bin/bash
-fs-uae-launcher
-_EOF_
-    chmod a+x "$romdir/amiga/+Start FS-UAE.sh"
-    chown $user:$user "$romdir/amiga/+Start FS-UAE.sh"
-
-    addSystem 1 "$md_id" "amiga" "bash $romdir/amiga/+Start\ FS-UAE.sh" "Amiga" ".sh"
+    # copy default config file
+    local config="$(mktemp)"
+    iniConfig " = " "" "$config"
+    iniSet "fullscreen" "1"
+    iniSet "keep_aspect" "1"
+    iniSet "zoom" "full"
+    iniSet "fsaa" "0"
+    iniSet "scanlines" "0"
+    iniSet "floppy_drive_speed" "100"
+    copyDefaultConfig "$config" "$md_conf_root/amiga/fs-uae/Default.fs-uae"
+    rm "$config"
+    
+    local exts=$(getSystemExtensions amiga)
+    addSystem 1 "$md_id" "amiga" "bash $md_inst/bin/fs-uae.sh '$exts' %ROM%"
 }

--- a/scriptmodules/emulators/fs-uae/fs-uae.sh
+++ b/scriptmodules/emulators/fs-uae/fs-uae.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+exts="$1"
+rom="$2"
+
+rootdir="/opt/retropie"
+datadir="$HOME/RetroPie"
+romdir="$datadir/roms/amiga"
+savedir="$romdir"
+biosdir="$datadir/BIOS"
+kickfile="$biosdir/kick13.rom"
+
+source "$rootdir/lib/archivefuncs.sh"
+
+if [[ ! -f "$kickfile" ]]; then
+    dialog --msgbox "You need to copy the Amiga kickstart file (kick13.rom) to the folder $biosdir to boot the Amiga emulator." 22 76
+    exit 1
+fi
+
+archiveExtract "$rom" "$exts"
+
+# check successful extraction and if we have at least one file
+if [[ $? == 0 ]]; then
+    rom="${arch_files[0]}"
+    romdir="$arch_dir"
+
+    floppy_images=()
+    for i in "${!arch_files[@]}"; do
+        floppy_images+=("--floppy_image_$i=${arch_files[$i]}")
+    done
+fi
+
+fs-uae --floppy_drive_0="$rom" "${floppy_images[@]}" --kickstart_file="$kickfile" --floppies_dir="$romdir" --save_states_dir="$savedir"
+archiveCleanup


### PR DESCRIPTION
So, me again ;)

Another try on integrating fs-uae into ES. Now taking the ZIP functions into account (so no multi-disk-discovery needed anymore).

Some explanations on some points (does not make them necessarily good decisions ofc):

-  I thought about adding Amiga to platforms.cfg and to store the supported extensions there. But the extensions are depending on the emulator. So fs-uae supports IPF, ADF etc. (and now ZIP) while uae4all seems to be ADF only. I don't know if platforms.cfg is supposed to handle this so I added the extensions as a variable to the emulator script. Actually I wanted to have it (FSUAE_EXTS) readonly but when I declare it readonly it is always empty later in the configure function. I could not find out why.

- I changed the config directory symbolic link from `~/.config/fs-uae` to `~/Documents/FS-UAE/Configuration` since this is the directory that fs-uae creates on first run to store and read the config from.

- I added a hopefully sensible default config for fs-uae to have it run in fullscreen by default. Also some other parameters are in there so they can be changed easily by the user.

Looking forward to your input!