### PR TITLE
Platform.cfg changes / customise system theme

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -32,10 +32,10 @@ atarijaguar_exts=".j64 .jag .zip"
 atarijaguar_fullname="Atari Jaguar"
 
 atarist_exts=".st .stx .img .rom .raw .ipf .ctr"
-atarist_fullname="Atari ST/STE"
+atarist_fullname="Atari ST"
 
 coco_exts=".cas .wav .bas .asc .dmk .jvc .os9 .dsk .vdk .rom .ccc .sna"
-coco_fullname="TRS-80 Color Computer (CoCo)"
+coco_fullname="TRS-80 Color Computer"
 
 coleco_exts=".bin .col .rom .zip"
 coleco_fullname="ColecoVision"
@@ -72,21 +72,25 @@ intellivision_fullname="Intellivision"
 
 mame-advmame_exts=".zip"
 mame-advmame_fullname="Multiple Arcade Machine Emulator"
+mame-advmame_theme="mame"
 
 mame-mame4all_exts=".zip"
 mame-mame4all_fullname="Multiple Arcade Machine Emulator"
+mame-mame4all_theme="mame"
 
 mame-libretro_exts=".zip"
 mame-libretro_fullname="Multiple Arcade Machine Emulator"
+mame-libretro_theme="mame"
 
 mastersystem_exts=".sms .bin .zip"
 mastersystem_fullname="Sega Master System"
 
 megadrive_exts=".smd .bin .gen .md .sg .zip"
-megadrive_fullname="Sega Mega Drive / Genesis"
+megadrive_fullname="Sega Mega Drive"
+megadrive_theme="megadrive"
 
 msx_exts=".rom .mx1 .mx2 .col .dsk .zip"
-msx_fullname="MSX / MSX2"
+msx_fullname="MSX"
 
 n64_exts=".z64 .n64 .v64"
 n64_fullname="Nintendo 64"
@@ -101,7 +105,7 @@ ngp_exts=".ngp .zip"
 ngp_fullname="Neo Geo Pocket"
 
 ngpc_exts=".ngc .zip"
-ngpc_fullname="Neo Geo Pocket (Color)"
+ngpc_fullname="Neo Geo Pocket Color"
 
 nes_exts=".nes .zip"
 nes_fullname="Nintendo Entertainment System"
@@ -113,10 +117,11 @@ wii_exts=".iso"
 wii_fullname="Nintendo Wii"
 
 pc_exts=".bat .com .exe .sh"
-pc_fullname="PC (x86)"
+pc_fullname="PC"
 
 pcengine_exts=".pce .ccd .cue .zip"
-pcengine_fullname="TurboGrafx 16 (PC Engine)"
+pcengine_fullname="PC Engine"
+pcengine_theme="pcengine"
 
 pcfx_exts=".pce .ccd .cue .iso"
 pcfx_fullname="PC-FX"
@@ -134,7 +139,7 @@ sega32x_exts=".32x .smd .bin .md .zip"
 sega32x_fullname="Sega 32X"
 
 segacd_exts=".iso .cue"
-segacd_fullname="Sega/Mega CD"
+segacd_fullname="Mega CD"
 
 sg-1000_exts=".sg .bin .zip"
 sg-1000_fullname="Sega SG-1000"
@@ -152,7 +157,7 @@ vectrex_exts=".vec .gam .bin .zip"
 vectrex_fullname="Vectrex"
 
 videopac_exts=".bin .zip"
-videopac_fullname="Odyssey 2 / Videopac"
+videopac_fullname="Videopac"
 
 virtualboy_exts=".vb .zip"
 virtualboy_fullname="Virtual Boy"
@@ -161,7 +166,7 @@ wonderswan_exts=".ws .zip"
 wonderswan_fullname="Wonderswan"
 
 wonderswancolor_exts=".wsc .zip"
-wonderswancolor_fullname="Wonderswan (Color)"
+wonderswancolor_fullname="Wonderswan Color"
 
 zxspectrum_exts=".sna .szx .z80 .tap .tzx .gz .udi .mgt .img .trd .scl .dsk .zip"
 zxspectrum_fullname="ZX Spectrum"

--- a/scriptmodules/emulators/fs-uae.sh
+++ b/scriptmodules/emulators/fs-uae.sh
@@ -69,6 +69,6 @@ function configure_fs-uae() {
     copyDefaultConfig "$config" "$md_conf_root/amiga/fs-uae/Default.fs-uae"
     rm "$config"
     
-    local exts=$(getSystemExtensions amiga)
+    local exts=$(getPlatformConfig amiga_exts)
     addSystem 1 "$md_id" "amiga" "bash $md_inst/bin/fs-uae.sh '$exts' %ROM%"
 }

--- a/scriptmodules/emulators/vice.sh
+++ b/scriptmodules/emulators/vice.sh
@@ -46,7 +46,7 @@ function install_vice() {
 
 function configure_vice() {
     # get a list of supported extensions
-    c64_exts="$(getSystemExtensions c64)"
+    local exts="$(getPlatformConfig c64_exts)"
 
     # install the vice start script
     mkdir "$md_inst/bin/"
@@ -60,7 +60,7 @@ romdir="\${ROM%/*}"
 ext="\${ROM##*.}"
 source "$rootdir/lib/archivefuncs.sh"
 
-archiveExtract "\$ROM" "$c64_exts"
+archiveExtract "\$ROM" "$exts"
 
 # check successful extraction and if we have at least one file
 if [[ \$? == 0 ]]; then

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -1039,6 +1039,10 @@ function addSystem() {
         theme="$system"
     fi
 
+    local temp
+    temp="$(getPlatformConfig "${system}_theme")"
+    [[ -n "$temp" ]] && theme="$temp"
+
     # check if we are removing the system
     if [[ "$md_mode" == "remove" ]]; then
         delSystem "$id" "$system"
@@ -1056,7 +1060,7 @@ function addSystem() {
         exts=(".sh")
         fullname="Ports"
     else
-        local temp="$(getPlatformConfig "${system}_fullname")"
+        temp="$(getPlatformConfig "${system}_fullname")"
         [[ -n "$temp" ]] && fullname="$temp"
         exts+=("$(getPlatformConfig "${system}_exts")")
 

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -875,22 +875,6 @@ function loadModuleConfig() {
     done
 }
 
-## @fn getSystemExtensions()
-## @param system sytem name to fetch extensions for
-## @brief Prints a space separated string of disk extensions supported by the system 
-## @details Example: ".a26 .bin .rom .zip .gz"
-function getSystemExtensions() {
-    local config
-    for config in "$configdir/all/platforms.cfg" "$scriptdir/platforms.cfg"; do
-         [[ -f "$config" ]] && break
-    done
-    
-    iniConfig "=" '"' "$config"
-    iniGet "$1_exts"
-
-    echo "$ini_value"
-}
-
 ## @fn applyPatch()
 ## @param patch filename of patch to apply
 ## @brief Apply a patch if it has not already been applied to current folder.
@@ -983,6 +967,24 @@ function joy2keyStop() {
     fi
 }
 
+## @fn getPlatformConfig()
+## @param key key to look up
+## @brief gets a config from a platforms.cfg ini
+## @details gets a config from a platforms.cfg ini first looking in
+## `$configdir/all/platforms.cfg` then `$scriptdir/platforms.cfg`
+## allowing users to override any parts of `$scriptdir/platforms.cfg`
+function getPlatformConfig() {
+    local key="$1"
+    local conf
+    for conf in "$configdir/all/platforms.cfg" "$scriptdir/platforms.cfg"; do
+        [[ ! -f "$conf" ]] && continue
+        iniConfig "=" '"' "$conf"
+        iniGet "$key"
+        [[ -n "$ini_value" ]] && break
+    done
+    echo "$ini_value"
+}
+
 ## @fn addSystem()
 ## @param default 1 to make the emulator / command default for the system if no default already set
 ## @param id unique id of the module / command
@@ -1054,19 +1056,9 @@ function addSystem() {
         exts=(".sh")
         fullname="Ports"
     else
-        local conf=""
-        if [[ -f "$configdir/all/platforms.cfg" ]]; then
-            conf="$configdir/all/platforms.cfg"
-        else
-            conf="$scriptdir/platforms.cfg"
-        fi
-
-        # get extensions to show
-        iniConfig "=" '"' "$conf"
-        iniGet "${system}_fullname"
-        [[ -n "$ini_value" ]] && fullname="$ini_value"
-        iniGet "${system}_exts"
-        [[ -n "$ini_value" ]] && exts+=($ini_value)
+        local temp="$(getPlatformConfig "${system}_fullname")"
+        [[ -n "$temp" ]] && fullname="$temp"
+        exts+=("$(getPlatformConfig "${system}_exts")")
 
         # automatically add parameters for libretro modules
         if [[ "$id" =~ ^lr- ]]; then
@@ -1074,7 +1066,7 @@ function addSystem() {
         fi
     fi
 
-    exts="${exts[@]}"
+    exts="${exts[*]}"
     # add the extensions again as uppercase
     exts+=" ${exts^^}"
 


### PR DESCRIPTION
Before a user could have a `configs/all/platform.cfg` file which would be used if it existed. It needed to contain all the information from the retropie distributed platforms.cfg though - which isn't too useful to keep up to date with customisations.

Now it will just override anything in the retropie platforms.cfg - if a key isn't in the user platforms.cfg the system one will be used.

In addition you can now force themes per platform.. eg for North American users - they can create a `configs/all/platforms.cfg` containing

```
megadrive_fullname="Sega Genesis"
megadrive_theme="genesis"
```

and then update any megadrive/genesis emulator and ES will use the above name and theme. 