### PR TITLE
retropiemenu - rework retropie menu to support multiple frontends

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -772,7 +772,7 @@ function iniFileEditor() {
 ## @brief Adds a system entry for Emulation Station (to /etc/emulationstation/es_systems.cfg).
 function setESSystem() {
     local function
-    for function in $(compgen -A function _addsystem_); do
+    for function in $(compgen -A function _add_system_); do
         "$function" "$@"
     done
 }

--- a/scriptmodules/supplementary/attractmode.sh
+++ b/scriptmodules/supplementary/attractmode.sh
@@ -14,7 +14,7 @@ rp_module_desc="Attract Mode emulator frontend"
 rp_module_section="exp"
 rp_module_flags="!mali frontend"
 
-function _addsystem_attractmode() {
+function _add_system_attractmode() {
     local attract_dir="$configdir/all/attractmode"
     [[ ! -d "$attract_dir" ]] && return 0
 
@@ -62,6 +62,33 @@ ${tab}romlist              $fullname
 _EOF_
         chown $user:$user "$config"
     fi
+}
+
+function _add_rom_attractmode() {
+    local system_name="$1"
+    local system_fullname="$2"
+    local path="$3"
+    local name="$4"
+    local desc="$5"
+    local image="$6"
+
+    local attract_dir="$configdir/all/attractmode"
+    local config="$attract_dir/romlists/$system_fullname.txt"
+
+    # remove extension
+    path="${path/%.*}"
+
+    if [[ ! -f "$config" ]]; then
+        echo "#Name;Title;Emulator;CloneOf;Year;Manufacturer;Category;Players;Rotation;Control;Status;DisplayCount;DisplayType;AltRomname;AltTitle;Extra;Buttons" >"$config"
+    fi
+
+    # if the entry already exists, remove it
+    if grep -q "^$path;" "$config"; then
+        sed -i "/^$path/d" "$config"
+    fi
+
+    echo "$path;$name;$system_fullname;;;;;;;;;;;;;;" >>"$config"
+    chown $user:$user "$config"
 }
 
 function depends_attractmode() {

--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -35,7 +35,7 @@ function _sort_systems_emulationstation() {
         "/etc/emulationstation/es_systems.cfg.bak" >"/etc/emulationstation/es_systems.cfg"
 }
 
-function _addsystem_emulationstation() {
+function _add_system_emulationstation() {
     local fullname="$1"
     local name="$2"
     local path="$3"
@@ -73,6 +73,40 @@ function _addsystem_emulationstation() {
     fi
 
     _sort_systems_emulationstation "name"
+}
+
+function _add_rom_emulationstation() {
+    local system_name="$1"
+    local system_fullname="$2"
+    local path="./$3"
+    local name="$4"
+    local desc="$5"
+    local image="$6"
+
+    local config_dir="$configdir/all/emulationstation/gamelists/$system_name"
+    mkUserDir "$config_dir"
+    local config="$config_dir/gamelist.xml"
+
+    if [[ ! -f "$config" ]]; then
+        echo "<gameList />" >"$config"
+    fi
+
+    if [[ $(xmlstarlet sel -t -v "count(/gameList/game[path='$path'])" "$config") -eq 0 ]]; then
+        xmlstarlet ed -L -s "/gameList" -t elem -n "game" -v "" \
+            -s "/gameList/game[last()]" -t elem -n "path" -v "$path" \
+            -s "/gameList/game[last()]" -t elem -n "name" -v "$name" \
+            -s "/gameList/game[last()]" -t elem -n "desc" -v "$desc" \
+            -s "/gameList/game[last()]" -t elem -n "image" -v "$image" \
+            "$config"
+    else
+        xmlstarlet ed -L \
+            -u "/gameList/game[name='$name']/path" -v "$path" \
+            -u "/gameList/game[name='$name']/name" -v "$name" \
+            -u "/gameList/game[name='$name']/desc" -v "$desc" \
+            -u "/gameList/game[name='$name']/image" -v "$image" \
+            "$config"
+    fi
+    chown $user:$user "$config"
 }
 
 function depends_emulationstation() {

--- a/scriptmodules/supplementary/retropiemenu.sh
+++ b/scriptmodules/supplementary/retropiemenu.sh
@@ -26,47 +26,94 @@ function depends_retropiemenu() {
     getDepends mc
 }
 
-function install_bin_retropiemenu()
-{
+function install_bin_retropiemenu() {
     local rpdir="$home/RetroPie/retropiemenu"
     mkdir -p "$rpdir"
+    cp -Rv "$md_data/icons" "$rpdir/"
+    chown -R $user:$user "$rpdir"
+}
 
-    files=(
-        'rpsetup.rp'
-        'configedit.rp'
-        'retroarch.rp'
-        'retronetplay.rp'
-        'filemanager.rp'
-        'showip.rp'
-        'wifi.rp'
-        'runcommand.rp'
-        'bluetooth.rp'
-        'esthemes.rp'
-    )
-
-    if isPlatform "rpi"; then
-        files+=(
-            'raspiconfig.rp'
-            'audiosettings.rp'
-            'splashscreen.rp'
-        )
-        # remove the dispmanx.rp menu entry
-        rm -f "$rpdir/dispmanx.rp"
-    fi
-
-    for file in "${files[@]}"; do
-        touch "$rpdir/$file"
-    done
+function configure_retropiemenu()
+{
+    isPlatform "rpi" && rm -f "$rpdir/dispmanx.rp"
 
     # add the gameslist / icons
-    mkdir -p "$home/.emulationstation/gamelists/retropie/"
-    cp -v "$md_data/gamelist.xml" "$home/.emulationstation/gamelists/retropie/gamelist.xml"
-    cp -Rv "$md_data/icons" "$rpdir/"
+    local files=(
+        'audiosettings'
+        'bluetooth'
+        'configedit'
+        'esthemes'
+        'filemanager'
+        'raspiconfig'
+        'retroarch'
+        'retronetplay'
+        'rpsetup'
+        'runcommand'
+        'showip'
+        'splashscreen'
+        'wifi'
+    )
 
-    chown -R $user:$user "$rpdir"
-    chown -RL $user:$user "$home/.emulationstation"
+    local names=(
+        'Audio'
+        'Bluetooth'
+        'Configuration Editor'
+        'ES Themes'
+        'File Manager'
+        'Raspi-Config'
+        'Retroarch'
+        'RetroArch Net Play'
+        'RetroPie Setup'
+        'Run Command Configuration'
+        'Show IP'
+        'Splash Screens'
+        'WiFi'
+    )
 
-    setESSystem "RetroPie" "retropie" "~/RetroPie/retropiemenu" ".rp .sh" "sudo $scriptdir/retropie_packages.sh retropiemenu launch %ROM% </dev/tty >/dev/tty" "" "retropie"
+    local descs=(
+        'Configure audio settings. Choose default of auto, 3.5mm jack, or HDMI. Mixer controls, and apply default settings.'
+        'Register and connect to bluetooth devices. Unregister and remove devices, and display registered and connected devices.'
+        'Change common RetroArch options, and manually edit RetroArch configs, global configs, and non-RetroArch configs.'
+        'Install, uninstall, or update EmulationStation themes. Most themes can be previewed at https://github.com/retropie/ RetroPie-Setup/wiki/themes.'
+        'Basic ascii file manager for linux allowing you to browse, copy, delete, and move files.'
+        'Change user password, boot options, internationalization, camera, add your pi to Rastrack, overclock, overscan, memory split, SSH and more.'
+        'Launches the RetroArch GUI so you can change RetroArch options. Note: Changes will not be saved unless you have enabled the "Save Configuration On Exit" option.'
+        'Set up RetroArch Netplay options, choose host or client, port, host IP, delay frames, and your nickname.'
+        'Install RetroPie from binary or source, install experimental packages, additional drivers, edit samba shares, custom scraper, as well as other RetroPie-related configurations.'
+        'Change what appears on the runcommand screen. Enable or disable the menu, enable or disable box art, and change CPU configuration.'
+        'Displays your current IP address, as well as other information provided by the command, "ip addr show."'
+        'Enable or disable the splashscreen on RetroPie boot. Choose a splashscreen, download new splashscreens, and return splashscreen to default.'
+        'Connect to or disconnect from a wifi network and configure wifi settings.'
+    )
+
+    local file
+    local name
+    local desc
+    local image
+    local i
+    for i in "${!files[@]}"; do
+        case "${files[i]}" in
+            audiosettings|raspiconfig|splashscreen)
+                ! isPlatform "rpi" && continue
+                ;;
+            wifi)
+                [[ "$__os_id" != "Raspbian" ]] && continue
+        esac
+
+        file="${files[i]}"
+        name="${names[i]}"
+        desc="${descs[i]}"
+        image="$home/RetroPie/retropiemenu/icons/${files[i]}.png"
+
+        touch "$rpdir/$file.rp"
+
+        local function
+        for function in $(compgen -A function _add_rom_); do
+            "$function" "retropie" "RetroPie" "$file.rp" "$name" "$desc" "$image"
+        done
+    done
+
+    setESSystem "RetroPie" "retropie" "$home/RetroPie/retropiemenu" ".rp .sh" "sudo $scriptdir/retropie_packages.sh retropiemenu launch %ROM% </dev/tty >/dev/tty" "" "retropie"
 }
 
 function remove_retropiemenu() {


### PR DESCRIPTION
 * call a _add_rom_module function for each setting
 * add _add_rom_emulationstation function for managing gamelists
 * add _add_rom_attractmode function for managing attractmode romlists
 * rename _addsystem_module to _add_system_module