### PR TITLE
hatari - disable quit confirmation, disable statusbar. use fullscreen or x11

### DIFF
--- a/scriptmodules/emulators/hatari.sh
+++ b/scriptmodules/emulators/hatari.sh
@@ -83,9 +83,16 @@ function configure_hatari() {
 
     # move any old configs to new location
     moveConfigDir "$home/.hatari" "$md_conf_root/atarist"
-
-    addSystem 1 "$md_id-fast" "atarist" "$md_inst/bin/hatari --zoom 1 --compatible 0 --timer-d 1 -w --borders 0 %ROM%"
-    addSystem 0 "$md_id-fast-borders" "atarist" "$md_inst/bin/hatari --zoom 1 --compatible 0 --timer-d 1 -w --borders 1 %ROM%"
-    addSystem 0 "$md_id-compatible" "atarist" "$md_inst/bin/hatari --zoom 1 --compatible 1 --timer-d 0 -w --borders 0 %ROM%"
-    addSystem 0 "$md_id-compatible-borders" "atarist" "$md_inst/bin/hatari --zoom 1 --compatible 1 --timer-d 0 -w --borders 1 %ROM%"
+    
+    local common_config=("--confirm-quit 0" "--statusbar 0")
+    if ! isPlatform "x11"; then
+        common_config+=("--zoom 1" "-w")
+    else
+        common_config+=("-f")
+    fi
+    
+    addSystem 1 "$md_id-fast" "atarist" "$md_inst/bin/hatari ${common_config[*]} --compatible 0 --timer-d 1 --borders 0 %ROM%"
+    addSystem 0 "$md_id-fast-borders" "atarist" "$md_inst/bin/hatari ${common_config[*]} --compatible 0 --timer-d 1 --borders 1 %ROM%"
+    addSystem 0 "$md_id-compatible" "atarist" "$md_inst/bin/hatari ${common_config[*]} --compatible 1 --timer-d 0 --borders 0 %ROM%"
+    addSystem 0 "$md_id-compatible-borders" "atarist" "$md_inst/bin/hatari ${common_config[*]} --compatible 1 --timer-d 0 --borders 1 %ROM%"
 }


### PR DESCRIPTION
I would like to propose these config changes for hatari:
- disable statusbar (permanently visible otherwise)
- disable quit confirmation (needs an extra click otherwise to quit the emu. Other emulators also quit instantly on SIGTERM)
- added fullscreen option for x11
