### PR TITLE
fix snap path for attractmode

### DIFF
--- a/scriptmodules/supplementary/attractmode.sh
+++ b/scriptmodules/supplementary/attractmode.sh
@@ -58,7 +58,7 @@ function _add_system_attractmode() {
     fi
     iniSet "artwork flyer" "$path/flyer"
     iniSet "artwork marquee" "$path/marquee"
-    iniSet "artwork snap" "$path/$snap"
+    iniSet "artwork snap" "$path/snap"
     iniSet "artwork wheel" "$path/wheel"
 
     chown $user:$user "$config"


### PR DESCRIPTION
using $path/$snap is defaulting to the rom directory as $snap is not
defined.