### PR TITLE
launching image per game

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -846,6 +846,7 @@ function show_launch() {
     if [[ "$USE_ART" -eq 1 ]]; then
         # if using art look for images in paths for es art.
         images+=(
+            "$HOME/RetroPie/roms/$SYSTEM/images/${ROM_BN}-launching"
             "$HOME/RetroPie/roms/$SYSTEM/images/${ROM_BN}-image"
             "$HOME/.emulationstation/downloaded_images/$SYSTEM/${ROM_BN}-image"
         )


### PR DESCRIPTION
Show a launching image for a specific game if "Launch menu art" is enabled **and** there's a file named `RetroPie/roms/SYSTEM/images/RomName-launching.png` (or `.jpg`).

Inspired by [this user request](https://retropie.org.uk/forum/topic/4611/runcommand-system-splashscreens/100).

I tested with some of the amazing lilbud and Rookerviks images from [retropie-splashscreens-extra](https://github.com/HerbFargus/retropie-splashscreens-extra) (final fight, castlevania, TMNT, megaman, etc.) and it looks really nice.