### PR TITLE
fix ti99 paths so bios actually goes in bios folder

### DIFF
--- a/scriptmodules/emulators/ti99sim.sh
+++ b/scriptmodules/emulators/ti99sim.sh
@@ -36,7 +36,7 @@ function install_ti99sim() {
 function configure_ti99sim() {
     mkRomDir "ti99"
     moveConfigDir "$home/.ti99sim" "$md_conf_root/ti99/"
+    ln -sf "$biosdir/TI-994A.ctg" "$md_inst/TI-994A.ctg"
 
-    addSystem 1 "$md_id" "ti99" "pushd $romdir/ti99; $md_inst/ti99sim-sdl -f %ROM%; popd" "TI99" ".ctg .CTG"
+    addSystem 1 "$md_id" "ti99" "pushd $md_inst; $md_inst/ti99sim-sdl -f %ROM%; popd" "TI99" ".ctg .CTG"
 }
-


### PR DESCRIPTION
see also:

https://retropie.org.uk/forum/topic/3033/getting-ti99-emulator-to-work

https://retropie.org.uk/forum/topic/5649/ti-99-emulator-not-working

https://retropie.org.uk/forum/topic/4299/unable-to-locate-console-roms-on-ti99sim

there is also a 1.4 update as of June http://www.mrousseau.org/programs/ti99sim/archives/ not sure if we want to update to that as well and perhaps incorporate some platform specific building with armhf etc. also not sure how much of a priority this system is ;)