### PR TITLE
remove some entries from retropiemenu for non-rpi installations

### DIFF
--- a/scriptmodules/supplementary/retropiemenu.sh
+++ b/scriptmodules/supplementary/retropiemenu.sh
@@ -104,10 +104,16 @@ function configure_retropiemenu()
     for i in "${!files[@]}"; do
         case "${files[i]}" in
             audiosettings|raspiconfig|splashscreen)
-                ! isPlatform "rpi" && continue
+                if ! isPlatform "rpi"; then
+                    rm -f "$rpdir/${files[i]}.rp"
+                    continue
+                fi
                 ;;
             wifi)
-                [[ "$__os_id" != "Raspbian" ]] && continue
+                if [[ "$__os_id" != "Raspbian" ]]; then
+                    rm -f "$rpdir/${files[i]}.rp"
+                    continue
+                fi
         esac
 
         file="${files[i]}"


### PR DESCRIPTION
After installing RetroPie on a x86 I noticed raspiconfig on RetroPie menu (with no icon).
These changes remove unnecessary entries on RetroPie menu for non-rpi platforms.