### PR TITLE
usbromservice - support mounting of usb stick over ~/RetroPie

### DIFF
--- a/scriptmodules/supplementary/usbromservice.sh
+++ b/scriptmodules/supplementary/usbromservice.sh
@@ -39,9 +39,15 @@ function install_usbromservice() {
 }
 
 function enable_usbromservice() {
-    cp -v "$md_data/01_retropie_copyroms" /etc/usbmount/mount.d/
-    sed -i -e "s/USERTOBECHOSEN/$user/g" /etc/usbmount/mount.d/01_retropie_copyroms
-    chmod +x /etc/usbmount/mount.d/01_retropie_copyroms
+    # copy our mount.d scripts over
+    local file
+    local dest
+    for file in "$md_data/"*; do
+        dest="/etc/usbmount/mount.d/${file##*/}"
+        sed "s/USERTOBECHOSEN/$user/g" "$file" >"$dest"
+        chmod +x "$dest"
+    done
+
     iniConfig "=" '"' /etc/usbmount/usbmount.conf
     local fs
     for fs in ntfs exfat; do
@@ -59,7 +65,11 @@ function enable_usbromservice() {
 }
 
 function disable_usbromservice() {
-    rm -f /etc/usbmount/mount.d/01_retropie_copyroms
+    local file
+    for file in "$md_data/"*; do
+        file="/etc/usbmount/mount.d/${file##*/}"
+        rm -f "$file"
+    done
 }
 
 function remove_usbromservice() {

--- a/scriptmodules/supplementary/usbromservice/01_retropie_copyroms
+++ b/scriptmodules/supplementary/usbromservice/01_retropie_copyroms
@@ -32,6 +32,14 @@ function log() {
     logger -p user.$1 -t usbmount-"$hook_name"-[$$] -- "$2"
 }
 
+function log_cmd() {
+    local ret
+    local error
+    error="$("$@" 2>&1 >/dev/null)"
+    ret=$?
+    [[ "$ret" -ne 0 ]] && log err "$* - returned $ret - $error"
+}
+
 ## some sanity checking
 if [[ -z "$UM_MOUNTPOINT" ]]; then
     log err "UM_MOUNTPOINT not set!"
@@ -59,7 +67,7 @@ find "$retropie_path/roms" -mindepth 1 -maxdepth 1 -type d -printf "$usb_path/ro
 # copy ROMs/BIOS from USB stick to local SD card
 for dir in roms BIOS; do
     log info "Syncing $dir ..."
-    rsync -rtu --exclude '._*' --max-delete=-1 "$usb_path/$dir" "$retropie_path/" >/dev/null 2>&1 || log err "rsync failed to sync $dir, returned error code $?"
+    log_cmd rsync -rtu --exclude '._*' --max-delete=-1 "$usb_path/$dir" "$retropie_path/"
     chown -R $user:$user "$retropie_path/$dir"
 done
 
@@ -67,7 +75,7 @@ log info "Syncing configs ..."
 # copy configs to usb
 for to in "${!path_mapping[@]}"; do
     from=${path_mapping[$to]}
-    rsync -rtu --exclude '._*' --max-delete=-1 "$from/" "$usb_path_from_rp/$to/" >/dev/null 2>&1 || log err "rsync failed to sync $from/ -> $usb_path_from_rp/$to/, returned error code $?"
+    log_cmd rsync -rtu --exclude '._*' --max-delete=-1 "$from/" "$usb_path_from_rp/$to/"
 done
 
 # copy configs from usb
@@ -76,7 +84,7 @@ for from in $(find "$usb_path_to_rp/" -mindepth 1 -maxdepth 1); do
     from_bn=${from##*/}
     to=${path_mapping[$from_bn]}
     if [[ -n "$to" ]]; then
-        rsync -rtu --exclude '._*' --max-delete=-1 "$from/" "$to/" >/dev/null 2>&1 || log err "rsync failed to sync $from/ -> $to/ configuration, returned error code $?"
+        log_cmd rsync -rtu --exclude '._*' --max-delete=-1 "$from/" "$to/"
         chown -R $user:$user "$to"
     fi
 done

--- a/scriptmodules/supplementary/usbromservice/10_retropie_mount
+++ b/scriptmodules/supplementary/usbromservice/10_retropie_mount
@@ -50,7 +50,9 @@ if [[ ! -d "$usb_path" ]]; then
 fi
 
 if [[ -z "$(ls -A "$usb_path")" ]]; then
+    log info "Copying existing $retropie_path to $usb_path ..."
     log_cmd rsync -rtu "$retropie_path/" "$usb_path/"
 fi
 
+log info "Mounting $usb_path over $retropie_path ..."
 log_cmd mount -o bind "$usb_path" "$retropie_path"

--- a/scriptmodules/supplementary/usbromservice/10_retropie_mount
+++ b/scriptmodules/supplementary/usbromservice/10_retropie_mount
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+## config / defaults
+user="USERTOBECHOSEN"
+
+home="$(eval echo ~$user)"
+retropie_path="$home/RetroPie"
+
+usb_path="$UM_MOUNTPOINT/retropie-mount"
+
+## internals
+hook_name=${0##*/}
+
+## functions
+function log() {
+    logger -p user.$1 -t usbmount-"$hook_name"-[$$] -- "$2"
+}
+
+function log_cmd() {
+    local ret
+    local error
+    error="$("$@" 2>&1 >/dev/null)"
+    ret=$?
+    [[ "$ret" -ne 0 ]] && log err "$* - returned $ret - $error"
+}
+
+## some sanity checking
+if [[ -z "$UM_MOUNTPOINT" ]]; then
+    log err "UM_MOUNTPOINT not set!"
+    exit 0
+fi
+
+if [[ ! -d "$UM_MOUNTPOINT" ]]; then
+    log err "UM_MOUNTPOINT is not a directory"
+    exit 0
+fi
+
+# check for a retropie-mount folder
+if [[ ! -d "$usb_path" ]]; then
+    exit 0
+fi
+
+if [[ -z "$(ls -A "$usb_path")" ]]; then
+    log_cmd rsync -rtu "$retropie_path/" "$usb_path/"
+fi
+
+log_cmd mount -o bind "$usb_path" "$retropie_path"


### PR DESCRIPTION
 * add a new mount.d script to allow mounting of a usb stick directly over ~/RetroPie
 * script will check for existance of a retropie-mount folder in the root. If it exists and is empty, the existing ~/RetroPie folder will be copied to it. Then it will be mounted.

Thought I would go for a simple option for allowing users to have their ~/RetroPie folder on a usb stick using the existing usbromservice module.

as mentioned above - you just need a folder in the root called "retropie-mount" and then that folder will be automatically mounted over `~/RetroPie/`

can add some simple gui later to save people having to do this by having a "prep usb stick" function or so, but simple enough to do this on a pc.

Only possible issue is if for some reason ES loads before it is mounted, but it didn't in my tests. If so we might need to add a delay to ES loading if using this or something.