### PR TITLE
Split addSystem to addEmulator / addSystem

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -43,6 +43,9 @@ coleco_fullname="ColecoVision"
 c64_exts=".crt .d64 .g64 .prg .t64 .tap .x64 .zip .vsf"
 c64_fullname="Commodore 64"
 
+daphne_exts=".daphne"
+daphne_fullname="Daphne"
+
 dragon32_exts=".cas .wav .bas .asc .dmk .jvc .os9 .dsk .vdk .rom .ccc .sna"
 dragon32_fullname="Dragon 32"
 
@@ -70,6 +73,12 @@ gbc_fullname="Game Boy Color"
 
 intellivision_exts=".int .bin"
 intellivision_fullname="Intellivision"
+
+macintosh_exts=".txt"
+macintosh_fullname="Apple Macintosh"
+
+macintoshplus_exts=".txt .dsk"
+macintosh_fullname="Apple Macintosh Plus"
 
 mame-advmame_exts=".zip"
 mame-advmame_fullname="Multiple Arcade Machine Emulator"
@@ -121,6 +130,10 @@ gc_fullname="Nintendo Gamecube"
 wii_exts=".iso"
 wii_fullname="Nintendo Wii"
 
+ports_exts=".sh"
+ports_fullname="Ports"
+ports_platform="pc"
+
 pc_exts=".bat .com .exe .sh"
 pc_fullname="PC"
 
@@ -158,6 +171,12 @@ saturn_fullname="Sega Saturn"
 snes_exts=".bin .smc .sfc .fig .swc .mgd .zip"
 snes_fullname="Super Nintendo"
 
+ti99_exts=".ctg"
+ti99_fullname="TI99"
+
+trs-80_exts=".dsk"
+trs-80_fullname="trs-80"
+
 vectrex_exts=".vec .gam .bin .zip"
 vectrex_fullname="Vectrex"
 
@@ -172,6 +191,9 @@ wonderswan_fullname="Wonderswan"
 
 wonderswancolor_exts=".wsc .zip"
 wonderswancolor_fullname="Wonderswan Color"
+
+zmachine_exts=".dat .zip .z1 .z2 .z3 .z4 .z5 .z6 .z7 .z8"
+zmachine_fullname="Z-machine"
 
 zxspectrum_exts=".sna .szx .z80 .tap .tzx .gz .udi .mgt .img .trd .scl .dsk .zip"
 zxspectrum_fullname="ZX Spectrum"

--- a/platforms.cfg
+++ b/platforms.cfg
@@ -1,7 +1,7 @@
 3do_exts=".iso"
 3do_fullname="3DO Interactive Multiplayer"
 
-amiga_exts=".adf .adz .dms .ipf .zip"
+amiga_exts=".adf .adz .dms .ipf .zip .sh"
 amiga_fullname="Commodore Amiga"
 
 amstradcpc_exts=".cdt .cpc .dsk"
@@ -59,6 +59,9 @@ fba_platform="arcade"
 fds_exts=".nes .fds .zip"
 fds_fullname="Famicom Disk System"
 
+gameandwatch_exts=".mgw"
+gameandwatch_fullname="Game and Watch"
+
 gamegear_exts=".gg .bin .sms .zip"
 gamegear_fullname="Sega Gamegear"
 
@@ -71,6 +74,9 @@ gb_fullname="Game Boy"
 gbc_exts=".gbc .zip"
 gbc_fullname="Game Boy Color"
 
+love_exts=".love"
+love_fullname="Love"
+
 intellivision_exts=".int .bin"
 intellivision_fullname="Intellivision"
 
@@ -78,7 +84,7 @@ macintosh_exts=".txt"
 macintosh_fullname="Apple Macintosh"
 
 macintoshplus_exts=".txt .dsk"
-macintosh_fullname="Apple Macintosh Plus"
+macintoshplus_fullname="Apple Macintosh Plus"
 
 mame-advmame_exts=".zip"
 mame-advmame_fullname="Multiple Arcade Machine Emulator"
@@ -124,6 +130,9 @@ ngpc_fullname="Neo Geo Pocket Color"
 nes_exts=".nes .zip"
 nes_fullname="Nintendo Entertainment System"
 
+oric_exts=".dsk .tap"
+oric_fullname="Oric 1"
+
 gc_exts=".iso"
 gc_fullname="Nintendo Gamecube"
 
@@ -134,7 +143,7 @@ ports_exts=".sh"
 ports_fullname="Ports"
 ports_platform="pc"
 
-pc_exts=".bat .com .exe .sh"
+pc_exts=".bat .com .exe .sh .conf"
 pc_fullname="PC"
 
 pcengine_exts=".pce .ccd .cue .zip"
@@ -168,6 +177,9 @@ samcoupe_fullname="SAM Coupe"
 saturn_exts=".iso .bin .zip"
 saturn_fullname="Sega Saturn"
 
+scummvm_exts=".sh .svm"
+scummvm_fullname="ScummVM"
+
 snes_exts=".bin .smc .sfc .fig .swc .mgd .zip"
 snes_fullname="Super Nintendo"
 
@@ -191,6 +203,9 @@ wonderswan_fullname="Wonderswan"
 
 wonderswancolor_exts=".wsc .zip"
 wonderswancolor_fullname="Wonderswan Color"
+
+x68000_exts=".dim"
+x68000_fullname="X68000"
 
 zmachine_exts=".dat .zip .z1 .z2 .z3 .z4 .z5 .z6 .z7 .z8"
 zmachine_fullname="Z-machine"

--- a/platforms.cfg
+++ b/platforms.cfg
@@ -51,6 +51,7 @@ dreamcast_fullname="Dreamcast"
 
 fba_exts=".fba .zip"
 fba_fullname="Final Burn Alpha"
+fba_platform="arcade"
 
 fds_exts=".nes .fds .zip"
 fds_fullname="Famicom Disk System"
@@ -72,14 +73,17 @@ intellivision_fullname="Intellivision"
 
 mame-advmame_exts=".zip"
 mame-advmame_fullname="Multiple Arcade Machine Emulator"
+mame-advmame_platform="arcade"
 mame-advmame_theme="mame"
 
 mame-mame4all_exts=".zip"
 mame-mame4all_fullname="Multiple Arcade Machine Emulator"
+mame-mame4all_platform="arcade"
 mame-mame4all_theme="mame"
 
 mame-libretro_exts=".zip"
 mame-libretro_fullname="Multiple Arcade Machine Emulator"
+mame-libretro_platform="arcade"
 mame-libretro_theme="mame"
 
 mastersystem_exts=".sms .bin .zip"

--- a/scriptmodules/emulators/advmame.sh
+++ b/scriptmodules/emulators/advmame.sh
@@ -228,6 +228,6 @@ function configure_advmame() {
             [[ "$version" == "1.4" ]] && default=1
         fi
         addSystem 0 "$md_id-$version" "arcade" "$md_inst/$version/bin/advmame %BASENAME%"
-        addSystem $default "$md_id-$version" "mame-advmame arcade mame" "$md_inst/$version/bin/advmame %BASENAME%"
+        addSystem $default "$md_id-$version" "mame-advmame" "$md_inst/$version/bin/advmame %BASENAME%"
     done
 }

--- a/scriptmodules/emulators/advmame.sh
+++ b/scriptmodules/emulators/advmame.sh
@@ -227,7 +227,9 @@ function configure_advmame() {
         else
             [[ "$version" == "1.4" ]] && default=1
         fi
-        addSystem 0 "$md_id-$version" "arcade" "$md_inst/$version/bin/advmame %BASENAME%"
-        addSystem $default "$md_id-$version" "mame-advmame" "$md_inst/$version/bin/advmame %BASENAME%"
+        addEmulator 0 "$md_id-$version" "arcade" "$md_inst/$version/bin/advmame %BASENAME%"
+        addEmulator $default "$md_id-$version" "mame-advmame" "$md_inst/$version/bin/advmame %BASENAME%"
     done
+    addSystem "arcade"
+    addSystem "mame-advmame"
 }

--- a/scriptmodules/emulators/ags.sh
+++ b/scriptmodules/emulators/ags.sh
@@ -36,8 +36,10 @@ function configure_ags() {
     mkRomDir "ags"
 
     if isPlatform "x11"; then
-        addSystem 1 "$md_id" "ags" "$md_inst/bin/ags --fullscreen %ROM%" "Adventure Game Studio" ".exe"
+        addEmulator 1 "$md_id" "ags" "$md_inst/bin/ags --fullscreen %ROM%" "Adventure Game Studio" ".exe"
     else
-        addSystem 1 "$md_id" "ags" "xinit $md_inst/bin/ags --fullscreen %ROM%" "Adventure Game Studio" ".exe"
+        addEmulator 1 "$md_id" "ags" "xinit $md_inst/bin/ags --fullscreen %ROM%" "Adventure Game Studio" ".exe"
     fi
+
+    addSystem "ags"
 }

--- a/scriptmodules/emulators/atari800.sh
+++ b/scriptmodules/emulators/atari800.sh
@@ -77,6 +77,8 @@ function configure_atari800() {
     fi
     moveConfigFile "$home/.atari800.cfg" "$md_conf_root/atari800/atari800.cfg"
 
-    addSystem 1 "atari800" "atari800" "$md_inst/bin/atari800 %ROM%"
-    addSystem 1 "atari800" "atari5200" "$md_inst/bin/atari800 %ROM%"
+    addEmulator 1 "atari800" "atari800" "$md_inst/bin/atari800 %ROM%"
+    addEmulator 1 "atari800" "atari5200" "$md_inst/bin/atari800 %ROM%"
+    addSystem "atari800"
+    addSystem "atari5200"
 }

--- a/scriptmodules/emulators/basilisk.sh
+++ b/scriptmodules/emulators/basilisk.sh
@@ -47,5 +47,6 @@ function configure_basilisk() {
 
     mkUserDir "$md_conf_root/macintosh"
 
-    addSystem 1 "$md_id" "macintosh" "$md_inst/bin/BasiliskII --rom $romdir/macintosh/mac.rom --disk $romdir/macintosh/disk.img --extfs $romdir/macintosh --config $md_conf_root/macintosh/basiliskii.cfg" "Apple Macintosh" ".txt"
+    addEmulator 1 "$md_id" "macintosh" "$md_inst/bin/BasiliskII --rom $romdir/macintosh/mac.rom --disk $romdir/macintosh/disk.img --extfs $romdir/macintosh --config $md_conf_root/macintosh/basiliskii.cfg"
+    addSystem "macintosh"
 }

--- a/scriptmodules/emulators/capricerpi.sh
+++ b/scriptmodules/emulators/capricerpi.sh
@@ -39,5 +39,6 @@ function install_capricerpi() {
 function configure_capricerpi() {
     mkRomDir "amstradcpc"
 
-    addSystem 0 "$md_id" "amstradcpc" "$md_inst/capriceRPI %ROM%"
+    addEmulator 0 "$md_id" "amstradcpc" "$md_inst/capriceRPI %ROM%"
+    addSystem "amstradcpc"
 }

--- a/scriptmodules/emulators/coolcv.sh
+++ b/scriptmodules/emulators/coolcv.sh
@@ -24,5 +24,6 @@ function configure_coolcv() {
 
     moveConfigFile "$home/coolcv_mapping.txt" "$md_conf_root/coleco/coolcv_mapping.txt"
 
-    addSystem 1 "$md_id" "coleco colecovision colecovision" "$md_inst/coolcv/coolcv_pi %ROM%"
+    addEmulator 1 "$md_id" "coleco colecovision colecovision" "$md_inst/coolcv/coolcv_pi %ROM%"
+    addSystem "colecovision"
 }

--- a/scriptmodules/emulators/daphne.sh
+++ b/scriptmodules/emulators/daphne.sh
@@ -70,5 +70,6 @@ _EOF_
     chown -R $user:$user "$md_inst"
     chown -R $user:$user "$md_conf_root/daphne/dapinput.ini"
 
-    addSystem 1 "$md_id" "daphne" "$md_inst/daphne.sh %ROM%" "Daphne" ".daphne"
+    addEmulator 1 "$md_id" "daphne" "$md_inst/daphne.sh %ROM%"
+    addSystem "daphne"
 }

--- a/scriptmodules/emulators/dgen.sh
+++ b/scriptmodules/emulators/dgen.sh
@@ -38,11 +38,15 @@ function install_dgen() {
     md_ret_require="$md_inst/bin/dgen"
 }
 
-function configure_dgen()
-{
-    mkRomDir "megadrive"
-    mkRomDir "segacd"
-    mkRomDir "sega32x"
+function configure_dgen() {
+    local system
+    for system in megadrive segacd sega32x; do
+        mkRomDir "$system"
+        addEmulator 0 "$md_id" "$system" "$md_inst/bin/dgen -r $md_conf_root/megadrive/dgenrc %ROM%"
+        addSystem "$system"
+    done
+
+    [[ "$md_mode" == "remove" ]] && return
 
     mkUserDir "$md_conf_root/megadrive"
 
@@ -94,8 +98,4 @@ function configure_dgen()
     iniSet "joy_pad2_start" "joystick1-button7"
 
     setDispmanx "$md_id" 1
-
-    addSystem 0 "$md_id" "megadrive" "$md_inst/bin/dgen -r $md_conf_root/megadrive/dgenrc %ROM%"
-    addSystem 0 "$md_id" "segacd" "$md_inst/bin/dgen -r $md_conf_root/megadrive/dgenrc %ROM%"
-    addSystem 0 "$md_id" "sega32x" "$md_inst/bin/dgen -r $md_conf_root/megadrive/dgenrc %ROM%"
 }

--- a/scriptmodules/emulators/dolphin.sh
+++ b/scriptmodules/emulators/dolphin.sh
@@ -53,8 +53,11 @@ _EOF_
         chown -R $user:$user "$md_conf_root/gc/Config"
     fi
 
-    addSystem 1 "$md_id" "gc" "$md_inst/bin/dolphin-emu-nogui -e %ROM%"
-    addSystem 0 "$md_id-gui" "gc" "$md_inst/bin/dolphin-emu -b -e %ROM%"
-    addSystem 1 "$md_id" "wii" "$md_inst/bin/dolphin-emu-nogui -e %ROM%"
-    addSystem 0 "$md_id-gui" "wii" "$md_inst/bin/dolphin-emu -b -e %ROM%"
+    addEmulator 1 "$md_id" "gc" "$md_inst/bin/dolphin-emu-nogui -e %ROM%"
+    addEmulator 0 "$md_id-gui" "gc" "$md_inst/bin/dolphin-emu -b -e %ROM%"
+    addEmulator 1 "$md_id" "wii" "$md_inst/bin/dolphin-emu-nogui -e %ROM%"
+    addEmulator 0 "$md_id-gui" "wii" "$md_inst/bin/dolphin-emu -b -e %ROM%"
+
+    addSystem "gc"
+    addSystem "wii"
 }

--- a/scriptmodules/emulators/dosbox.sh
+++ b/scriptmodules/emulators/dosbox.sh
@@ -79,6 +79,7 @@ _EOF_
 
     moveConfigDir "$home/.dosbox" "$md_conf_root/pc"
 
-    addSystem 1 "$md_id" "pc" "bash $romdir/pc/+Start\ DOSBox.sh %ROM%"
+    addEmulator 1 "$md_id" "pc" "bash $romdir/pc/+Start\ DOSBox.sh %ROM%"
+    addSystem "pc"
 }
 

--- a/scriptmodules/emulators/fbzx.sh
+++ b/scriptmodules/emulators/fbzx.sh
@@ -47,5 +47,6 @@ function install_fbzx() {
 function configure_fbzx() {
     mkRomDir "zxspectrum"
 
-    addSystem 0 "$md_id" "zxspectrum" "pushd $md_inst/share; $md_inst/bin/fbzx %ROM%; popd"
+    addEmulator 0 "$md_id" "zxspectrum" "pushd $md_inst/share; $md_inst/bin/fbzx %ROM%; popd"
+    addSystem "zxspectrum"
 }

--- a/scriptmodules/emulators/frotz.sh
+++ b/scriptmodules/emulators/frotz.sh
@@ -47,7 +47,8 @@ function configure_frotz() {
     mkRomDir "zmachine"
 
     # CON: to stop runcommand from redirecting stdout to log
-    addSystem 1 "$md_id" "zmachine" "CON:pushd $romdir/zmachine; frotz %ROM%; popd" "Z-machine" ".dat .zip .z1 .z2 .z3 .z4 .z5 .z6 .z7 .z8"
+    addEmulator 1 "$md_id" "zmachine" "CON:pushd $romdir/zmachine; frotz %ROM%; popd"
+    addSystem "zmachine"
 
     [[ "$md_mode" == "install" ]] && game_data_frotz
 }

--- a/scriptmodules/emulators/fs-uae.sh
+++ b/scriptmodules/emulators/fs-uae.sh
@@ -70,5 +70,6 @@ function configure_fs-uae() {
     rm "$config"
     
     local exts=$(getPlatformConfig amiga_exts)
-    addSystem 1 "$md_id" "amiga" "bash $md_inst/bin/fs-uae.sh '$exts' %ROM%"
+    addEmulator 1 "$md_id" "amiga" "bash $md_inst/bin/fs-uae.sh '$exts' %ROM%"
+    addSystem "amiga"
 }

--- a/scriptmodules/emulators/fuse.sh
+++ b/scriptmodules/emulators/fuse.sh
@@ -64,8 +64,9 @@ function configure_fuse() {
     setDispmanx "$md_id" 1
     configure_dispmanx_on_fuse
 
-    addSystem 0 "$md_id-48k" "zxspectrum" "$md_inst/bin/fuse --machine 48 %ROM%"
-    addSystem 0 "$md_id-128k" "zxspectrum" "$md_inst/bin/fuse --machine 128 %ROM%"
+    addEmulator 0 "$md_id-48k" "zxspectrum" "$md_inst/bin/fuse --machine 48 %ROM%"
+    addEmulator 0 "$md_id-128k" "zxspectrum" "$md_inst/bin/fuse --machine 128 %ROM%"
+    addSystem "zxspectrum"
 }
 
 function configure_dispmanx_on_fuse() {

--- a/scriptmodules/emulators/gngeopi.sh
+++ b/scriptmodules/emulators/gngeopi.sh
@@ -55,6 +55,8 @@ _EOF_
         chown -R $user:$user "$md_conf_root/neogeo/gngeorc"
     fi
 
-    addSystem 0 "$md_id" "arcade" "$md_inst/bin/gngeo -i $romdir/neogeo -B $md_inst/neogeobios %ROM%"
-    addSystem 0 "$md_id" "neogeo" "$md_inst/bin/gngeo -i $romdir/neogeo -B $md_inst/neogeobios %ROM%"
+    addEmulator 0 "$md_id" "arcade" "$md_inst/bin/gngeo -i $romdir/neogeo -B $md_inst/neogeobios %ROM%"
+    addEmulator 0 "$md_id" "neogeo" "$md_inst/bin/gngeo -i $romdir/neogeo -B $md_inst/neogeobios %ROM%"
+    addSystem "arcade"
+    addSystem "neogeo"
 }

--- a/scriptmodules/emulators/gpsp.sh
+++ b/scriptmodules/emulators/gpsp.sh
@@ -53,5 +53,6 @@ function configure_gpsp() {
     # move old config
     moveConfigFile "gpsp.cfg" "$md_conf_root/gba/gpsp.cfg"
 
-    addSystem 0 "$md_id" "gba" "$md_inst/gpsp %ROM%"
+    addEmulator 0 "$md_id" "gba" "$md_inst/gpsp %ROM%"
+    addSystem "gba"
 }

--- a/scriptmodules/emulators/hatari.sh
+++ b/scriptmodules/emulators/hatari.sh
@@ -92,8 +92,9 @@ function configure_hatari() {
         common_config+=("-f")
     fi
     
-    addSystem 1 "$md_id-fast" "atarist" "$md_inst/bin/hatari ${common_config[*]} --compatible 0 --timer-d 1 --borders 0 %ROM%"
-    addSystem 0 "$md_id-fast-borders" "atarist" "$md_inst/bin/hatari ${common_config[*]} --compatible 0 --timer-d 1 --borders 1 %ROM%"
-    addSystem 0 "$md_id-compatible" "atarist" "$md_inst/bin/hatari ${common_config[*]} --compatible 1 --timer-d 0 --borders 0 %ROM%"
-    addSystem 0 "$md_id-compatible-borders" "atarist" "$md_inst/bin/hatari ${common_config[*]} --compatible 1 --timer-d 0 --borders 1 %ROM%"
+    addEmulator 1 "$md_id-fast" "atarist" "$md_inst/bin/hatari ${common_config[*]} --compatible 0 --timer-d 1 --borders 0 %ROM%"
+    addEmulator 0 "$md_id-fast-borders" "atarist" "$md_inst/bin/hatari ${common_config[*]} --compatible 0 --timer-d 1 --borders 1 %ROM%"
+    addEmulator 0 "$md_id-compatible" "atarist" "$md_inst/bin/hatari ${common_config[*]} --compatible 1 --timer-d 0 --borders 0 %ROM%"
+    addEmulator 0 "$md_id-compatible-borders" "atarist" "$md_inst/bin/hatari ${common_config[*]} --compatible 1 --timer-d 0 --borders 1 %ROM%"
+    addSystem "atarist"
 }

--- a/scriptmodules/emulators/jzintv.sh
+++ b/scriptmodules/emulators/jzintv.sh
@@ -51,5 +51,6 @@ function configure_jzintv() {
         setDispmanx "$md_id" 1
     fi
 
-    addSystem 1 "$md_id" "intellivision" "$md_inst/bin/jzintv -p $biosdir -q %ROM%"
+    addEmulator 1 "$md_id" "intellivision" "$md_inst/bin/jzintv -p $biosdir -q %ROM%"
+    addSystem "intellivision"
 }

--- a/scriptmodules/emulators/linapple.sh
+++ b/scriptmodules/emulators/linapple.sh
@@ -54,5 +54,6 @@ function configure_linapple() {
         copyDefaultConfig "$file" "$md_conf_root/apple2/$file"
     done
 
-    addSystem 1 "$md_id" "apple2" "pushd $romdir/apple2; $md_inst/linapple -1 %ROM%; popd"
+    addEmulator 1 "$md_id" "apple2" "pushd $romdir/apple2; $md_inst/linapple -1 %ROM%; popd"
+    addSystem "apple2"
 }

--- a/scriptmodules/emulators/mame4all.sh
+++ b/scriptmodules/emulators/mame4all.sh
@@ -85,5 +85,5 @@ function configure_mame4all() {
     fi
 
     addSystem 0 "$md_id" "arcade" "$md_inst/mame %BASENAME%"
-    addSystem 1 "$md_id" "$system arcade mame" "$md_inst/mame %BASENAME%"
+    addSystem 1 "$md_id" "$system" "$md_inst/mame %BASENAME%"
 }

--- a/scriptmodules/emulators/mame4all.sh
+++ b/scriptmodules/emulators/mame4all.sh
@@ -84,6 +84,8 @@ function configure_mame4all() {
         chown -R $user:$user "$md_conf_root/$system"
     fi
 
-    addSystem 0 "$md_id" "arcade" "$md_inst/mame %BASENAME%"
-    addSystem 1 "$md_id" "$system" "$md_inst/mame %BASENAME%"
+    addEmulator 0 "$md_id" "arcade" "$md_inst/mame %BASENAME%"
+    addEmulator 1 "$md_id" "$system" "$md_inst/mame %BASENAME%"
+    addSystem "arcade"
+    addSystem "$system"
 }

--- a/scriptmodules/emulators/minivmac.sh
+++ b/scriptmodules/emulators/minivmac.sh
@@ -37,5 +37,6 @@ function configure_minivmac() {
 
     ln -sf "$biosdir/vMac.ROM" "$md_inst/vMac.ROM"
 
-    addSystem 1 "$md_id" "macintoshplus" "pushd $md_inst; $md_inst/minivmac $romdir/macintoshplus/System\ Tools.dsk %ROM%; popd" "Apple Macintosh Plus" ".txt .dsk"
+    addEmulator 1 "$md_id" "macintoshplus" "pushd $md_inst; $md_inst/minivmac $romdir/macintoshplus/System\ Tools.dsk %ROM%; popd"
+    addSystem "macintoshplus"
 }

--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -137,20 +137,21 @@ function configure_mupen64plus() {
             local name=""
             [[ "$res" == "320x240" ]] && def=1
             [[ "$res" == "640x480" ]] && name="-highres"
-            addSystem $def "${md_id}-GLideN64$name" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM% $res"
-            addSystem 0 "${md_id}-gles2rice$name" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-rice %ROM% $res"
+            addEmulator $def "${md_id}-GLideN64$name" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM% $res"
+            addEmulator 0 "${md_id}-gles2rice$name" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-rice %ROM% $res"
         done
-        addSystem 0 "${md_id}-gles2n64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-n64 %ROM%"
-        addSystem 0 "${md_id}-videocore" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-videocore %ROM%"
+        addEmulator 0 "${md_id}-gles2n64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-n64 %ROM%"
+        addEmulator 0 "${md_id}-videocore" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-videocore %ROM%"
     else
-        addSystem 0 "${md_id}-GLideN64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM%"
-        addSystem 0 "${md_id}-GLideN64-GL3-3" "n64" "MESA_GL_VERSION_OVERRIDE=3.3COMPAT $md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM%"
-        addSystem 1 "${md_id}-glide64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-glide64mk2 %ROM%"
+        addEmulator 0 "${md_id}-GLideN64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM%"
+        addEmulator 0 "${md_id}-GLideN64-GL3-3" "n64" "MESA_GL_VERSION_OVERRIDE=3.3COMPAT $md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM%"
+        addEmulator 1 "${md_id}-glide64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-glide64mk2 %ROM%"
         if isPlatform "x86"; then
-            addSystem 0 "${md_id}-GLideN64-LLE" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM% 640x480 mupen64plus-rsp-cxd4-ssse3"
-            addSystem 0 "${md_id}-GLideN64-LLE-GL3-3" "n64" "MESA_GL_VERSION_OVERRIDE=3.3COMPAT $md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM% 640x480 mupen64plus-rsp-cxd4-ssse3"
+            addEmulator 0 "${md_id}-GLideN64-LLE" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM% 640x480 mupen64plus-rsp-cxd4-ssse3"
+            addEmulator 0 "${md_id}-GLideN64-LLE-GL3-3" "n64" "MESA_GL_VERSION_OVERRIDE=3.3COMPAT $md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM% 640x480 mupen64plus-rsp-cxd4-ssse3"
         fi
     fi
+    addSystem "n64"
 
     mkRomDir "n64"
 

--- a/scriptmodules/emulators/openmsx.sh
+++ b/scriptmodules/emulators/openmsx.sh
@@ -42,5 +42,6 @@ function install_openmsx() {
 function configure_openmsx() {
     mkRomDir "msx"
 
-    addSystem 0 "$md_id" "msx" "$md_inst/bin/openmsx %ROM%"
+    addEmulator 0 "$md_id" "msx" "$md_inst/bin/openmsx %ROM%"
+    addSystem "msx"
 }

--- a/scriptmodules/emulators/oricutron.sh
+++ b/scriptmodules/emulators/oricutron.sh
@@ -59,8 +59,9 @@ function configure_oricutron() {
     for machine in atmos oric1 o16k telestrat pravetz; do
         default=0
         [[ "$machine" == "atmos" ]] && default=1
-        addSystem 1 "$md_id-$machine" "oric" "pushd $md_inst; $md_inst/oricutron --machine $machine %ROM% --fullscreen; popd" "Oric 1/Atmos" ".dsk .tap"
+        addEmulator 1 "$md_id-$machine" "oric" "pushd $md_inst; $md_inst/oricutron --machine $machine %ROM% --fullscreen; popd" "Oric 1/Atmos" ".dsk .tap"
     done
+    addSystem "oric"
 
     [[ "$md_mode" == "install" ]] && game_data_oricutron
 }

--- a/scriptmodules/emulators/oricutron.sh
+++ b/scriptmodules/emulators/oricutron.sh
@@ -59,7 +59,7 @@ function configure_oricutron() {
     for machine in atmos oric1 o16k telestrat pravetz; do
         default=0
         [[ "$machine" == "atmos" ]] && default=1
-        addEmulator 1 "$md_id-$machine" "oric" "pushd $md_inst; $md_inst/oricutron --machine $machine %ROM% --fullscreen; popd" "Oric 1/Atmos" ".dsk .tap"
+        addEmulator 1 "$md_id-$machine" "oric" "pushd $md_inst; $md_inst/oricutron --machine $machine %ROM% --fullscreen; popd"
     done
     addSystem "oric"
 

--- a/scriptmodules/emulators/osmose.sh
+++ b/scriptmodules/emulators/osmose.sh
@@ -42,6 +42,8 @@ function configure_osmose() {
     mkRomDir "gamegear"
     mkRomDir "mastersystem"
 
-    addSystem 0 "$md_id" "gamegear" "$md_inst/osmose %ROM% -tv -fs"
-    addSystem 0 "$md_id" "mastersystem" "$md_inst/osmose %ROM% -tv -fs"
+    addEmulator 0 "$md_id" "gamegear" "$md_inst/osmose %ROM% -tv -fs"
+    addEmulator 0 "$md_id" "mastersystem" "$md_inst/osmose %ROM% -tv -fs"
+    addSystem "gamegear"
+    addSystem "mastersystem"
 }

--- a/scriptmodules/emulators/pcsx-rearmed.sh
+++ b/scriptmodules/emulators/pcsx-rearmed.sh
@@ -63,5 +63,6 @@ function configure_pcsx-rearmed() {
 
     setDispmanx "$md_id" 1
 
-    addSystem 0 "$md_id" "psx" "$md_inst/pcsx -cfg $md_conf_root/psx/pcsx.cfg -cdfile %ROM%"
+    addEmulator 0 "$md_id" "psx" "$md_inst/pcsx -cfg $md_conf_root/psx/pcsx.cfg -cdfile %ROM%"
+    addSystem "psx"
 }

--- a/scriptmodules/emulators/pcsx2.sh
+++ b/scriptmodules/emulators/pcsx2.sh
@@ -26,6 +26,7 @@ function remove_pcsx2() {
 function configure_pcsx2() {
     mkRomDir "ps2"
 
-    addSystem 0 "$md_id-nogui" "ps2" "PCSX2 %ROM% --fullscreen --nogui"
-    addSystem 1 "$md_id" "ps2" "PCSX2 %ROM% --windowed"
+    addEmulator 0 "$md_id-nogui" "ps2" "PCSX2 %ROM% --fullscreen --nogui"
+    addEmulator 1 "$md_id" "ps2" "PCSX2 %ROM% --windowed"
+    addSystem "ps2"
 }

--- a/scriptmodules/emulators/pifba.sh
+++ b/scriptmodules/emulators/pifba.sh
@@ -61,5 +61,5 @@ function configure_pifba() {
     isPlatform "rpi1" && def=1
     addSystem 0 "$md_id" "arcade" "$md_inst/fba2x %ROM%"
     addSystem $def "$md_id" "neogeo" "$md_inst/fba2x %ROM%"
-    addSystem $def "$md_id" "fba arcade" "$md_inst/fba2x %ROM%"
+    addSystem $def "$md_id" "fba" "$md_inst/fba2x %ROM%"
 }

--- a/scriptmodules/emulators/pifba.sh
+++ b/scriptmodules/emulators/pifba.sh
@@ -59,7 +59,10 @@ function configure_pifba() {
 
     local def=0
     isPlatform "rpi1" && def=1
-    addSystem 0 "$md_id" "arcade" "$md_inst/fba2x %ROM%"
-    addSystem $def "$md_id" "neogeo" "$md_inst/fba2x %ROM%"
-    addSystem $def "$md_id" "fba" "$md_inst/fba2x %ROM%"
+    addEmulator 0 "$md_id" "arcade" "$md_inst/fba2x %ROM%"
+    addEmulator $def "$md_id" "neogeo" "$md_inst/fba2x %ROM%"
+    addEmulator $def "$md_id" "fba" "$md_inst/fba2x %ROM%"
+    addSystem "arcade"
+    addSystem "neogeo"
+    addSystem "fba"
 }

--- a/scriptmodules/emulators/pisnes.sh
+++ b/scriptmodules/emulators/pisnes.sh
@@ -51,5 +51,6 @@ function configure_pisnes() {
 
     copyDefaultConfig "$md_inst/snes9x.cfg.template" "$md_conf_root/snes/snes9x.cfg"
 
-    addSystem 0 "$md_id" "snes" "$md_inst/snes9x %ROM%"
+    addEmulator 0 "$md_id" "snes" "$md_inst/snes9x %ROM%"
+    addSystem "snes"
 }

--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -143,5 +143,6 @@ function configure_ppsspp() {
     mkUserDir "$md_conf_root/psp/PSP"
     ln -snf "$romdir/psp" "$md_conf_root/psp/PSP/GAME"
 
-    addSystem 0 "$md_id" "psp" "$md_inst/PPSSPPSDL %ROM%"
+    addEmulator 0 "$md_id" "psp" "$md_inst/PPSSPPSDL %ROM%"
+    addSystem "psp"
 }

--- a/scriptmodules/emulators/px68k.sh
+++ b/scriptmodules/emulators/px68k.sh
@@ -48,6 +48,6 @@ function configure_px68k() {
 
     setDispmanx "$md_id" 0
 
-    addEmulator 1 "$md_id" "x68000" "$md_inst/px68k %ROM%" "X68000" ".dim"
+    addEmulator 1 "$md_id" "x68000" "$md_inst/px68k %ROM%"
     addSystem "x68000"
 }

--- a/scriptmodules/emulators/px68k.sh
+++ b/scriptmodules/emulators/px68k.sh
@@ -48,5 +48,6 @@ function configure_px68k() {
 
     setDispmanx "$md_id" 0
 
-    addSystem 1 "$md_id" "x68000" "$md_inst/px68k %ROM%" "X68000" ".dim"
+    addEmulator 1 "$md_id" "x68000" "$md_inst/px68k %ROM%" "X68000" ".dim"
+    addSystem "x68000"
 }

--- a/scriptmodules/emulators/reicast.sh
+++ b/scriptmodules/emulators/reicast.sh
@@ -82,11 +82,12 @@ function configure_reicast() {
     # add system
     # possible audio backends: alsa, oss, omx
     if isPlatform "rpi"; then
-        addSystem 1 "${md_id}-audio-omx" "dreamcast" "CON:$md_inst/bin/reicast.sh omx %ROM%"
-        addSystem 0 "${md_id}-audio-oss" "dreamcast" "CON:$md_inst/bin/reicast.sh oss %ROM%"
+        addEmulator 1 "${md_id}-audio-omx" "dreamcast" "CON:$md_inst/bin/reicast.sh omx %ROM%"
+        addEmulator 0 "${md_id}-audio-oss" "dreamcast" "CON:$md_inst/bin/reicast.sh oss %ROM%"
     else
-        addSystem 1 "$md_id" "dreamcast" "CON:$md_inst/bin/reicast.sh oss %ROM%"
+        addEmulator 1 "$md_id" "dreamcast" "CON:$md_inst/bin/reicast.sh oss %ROM%"
     fi
+    addSystem "dreamcast"
 
     addAutoConf reicast_input 1
 }

--- a/scriptmodules/emulators/residualvm.sh
+++ b/scriptmodules/emulators/residualvm.sh
@@ -69,6 +69,7 @@ _EOF_
     chown $user:$user "$romdir/residualvm/+Start ResidualVM.sh"
     chmod u+x "$romdir/residualvm/+Start ResidualVM.sh"
 
-    addSystem 1 "$md_id" "residualvm" "bash $romdir/residualvm/+Start\ ResidualVM.sh opengl_shaders %BASENAME%" "ResidualVM" ".sh .svm"
-    addSystem 1 "$md_id-software" "residualvm" "bash $romdir/residualvm/+Start\ ResidualVM.sh software %BASENAME%" "ResidualVM" ".sh .svm"
+    addEmulator 1 "$md_id" "residualvm" "bash $romdir/residualvm/+Start\ ResidualVM.sh opengl_shaders %BASENAME%" "ResidualVM" ".sh .svm"
+    addEmulator 1 "$md_id-software" "residualvm" "bash $romdir/residualvm/+Start\ ResidualVM.sh software %BASENAME%" "ResidualVM" ".sh .svm"
+    addSystem "residualvm"
 }

--- a/scriptmodules/emulators/residualvm.sh
+++ b/scriptmodules/emulators/residualvm.sh
@@ -69,7 +69,7 @@ _EOF_
     chown $user:$user "$romdir/residualvm/+Start ResidualVM.sh"
     chmod u+x "$romdir/residualvm/+Start ResidualVM.sh"
 
-    addEmulator 1 "$md_id" "residualvm" "bash $romdir/residualvm/+Start\ ResidualVM.sh opengl_shaders %BASENAME%" "ResidualVM" ".sh .svm"
-    addEmulator 1 "$md_id-software" "residualvm" "bash $romdir/residualvm/+Start\ ResidualVM.sh software %BASENAME%" "ResidualVM" ".sh .svm"
-    addSystem "residualvm"
+    addEmulator 1 "$md_id" "residualvm" "bash $romdir/residualvm/+Start\ ResidualVM.sh opengl_shaders %BASENAME%"
+    addEmulator 1 "$md_id-software" "residualvm" "bash $romdir/residualvm/+Start\ ResidualVM.sh software %BASENAME%"
+    addSystem "residualvm" "ResidualVM" ".sh .svm"
 }

--- a/scriptmodules/emulators/rpix86.sh
+++ b/scriptmodules/emulators/rpix86.sh
@@ -42,5 +42,6 @@ _EOF_
     chown $user:$user "$romdir/pc/+Start rpix86.sh"
     ln -sfn "$romdir/pc" games
 
-    addSystem 0 "$md_id" "pc" "bash $romdir/pc/+Start\ rpix86.sh %ROM%"
+    addEmulator 0 "$md_id" "pc" "bash $romdir/pc/+Start\ rpix86.sh %ROM%"
+    addSystem "pc"
 }

--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -89,5 +89,6 @@ _EOF_
     chown $user:$user "$romdir/scummvm/+Start ScummVM.sh"
     chmod u+x "$romdir/scummvm/+Start ScummVM.sh"
 
-    addSystem 1 "$md_id" "scummvm" "bash $romdir/scummvm/+Start\ ScummVM.sh %BASENAME%" "ScummVM" ".sh .svm"
+    addEmulator 1 "$md_id" "scummvm" "bash $romdir/scummvm/+Start\ ScummVM.sh %BASENAME%" "ScummVM" ".sh .svm"
+    addSystem "scummvm"
 }

--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -89,6 +89,6 @@ _EOF_
     chown $user:$user "$romdir/scummvm/+Start ScummVM.sh"
     chmod u+x "$romdir/scummvm/+Start ScummVM.sh"
 
-    addEmulator 1 "$md_id" "scummvm" "bash $romdir/scummvm/+Start\ ScummVM.sh %BASENAME%" "ScummVM" ".sh .svm"
+    addEmulator 1 "$md_id" "scummvm" "bash $romdir/scummvm/+Start\ ScummVM.sh %BASENAME%" "ScummVM"
     addSystem "scummvm"
 }

--- a/scriptmodules/emulators/sdltrs.sh
+++ b/scriptmodules/emulators/sdltrs.sh
@@ -46,9 +46,10 @@ function configure_sdltrs() {
         ln -sf "$biosdir/$rom" "$md_inst/$rom"
     done
 
-    addSystem 1 "$md_id-model1" "trs-80" "$md_inst/sdltrs -model 1 -romfile $biosdir/level2.rom -showled -diskdir $romdir/trs-80 -disk0 %ROM%" "trs-80" ".dsk"
-    addSystem 0 "$md_id-model3" "trs-80" "$md_inst/sdltrs -model 3 -romfile3 $biosdir/level3.rom -showled -diskdir $romdir/trs-80 -disk0 %ROM%" "trs-80" ".dsk"
-    addSystem 0 "$md_id-model4" "trs-80" "$md_inst/sdltrs -model 4 -romfile3 $biosdir/level4.rom -showled -diskdir $romdir/trs-80 -disk0 %ROM%" "trs-80" ".dsk"
-    addSystem 0 "$md_id-model4p" "trs-80" "$md_inst/sdltrs -model 4p -romfile4p $biosdir/level4p.rom -showled -diskdir $romdir/trs-80 -disk0 %ROM%" "trs-80" ".dsk"
+    addEmulator 1 "$md_id-model1" "trs-80" "$md_inst/sdltrs -model 1 -romfile $biosdir/level2.rom -showled -diskdir $romdir/trs-80 -disk0 %ROM%"
+    addEmulator 0 "$md_id-model3" "trs-80" "$md_inst/sdltrs -model 3 -romfile3 $biosdir/level3.rom -showled -diskdir $romdir/trs-80 -disk0 %ROM%"
+    addEmulator 0 "$md_id-model4" "trs-80" "$md_inst/sdltrs -model 4 -romfile3 $biosdir/level4.rom -showled -diskdir $romdir/trs-80 -disk0 %ROM%"
+    addEmulator 0 "$md_id-model4p" "trs-80" "$md_inst/sdltrs -model 4p -romfile4p $biosdir/level4p.rom -showled -diskdir $romdir/trs-80 -disk0 %ROM%"
+    addSystem "trs-80"
 }
 

--- a/scriptmodules/emulators/simcoupe.sh
+++ b/scriptmodules/emulators/simcoupe.sh
@@ -45,5 +45,6 @@ function configure_simcoupe() {
     mkRomDir "samcoupe"
     moveConfigDir "$home/.simcoupe" "$md_conf_root/$md_id"
 
-    addSystem 1 "$md_id" "samcoupe" "pushd $md_inst; $md_inst/simcoupe autoboot -disk1 %ROM% -fullscreen; popd"
+    addEmulator 1 "$md_id" "samcoupe" "pushd $md_inst; $md_inst/simcoupe autoboot -disk1 %ROM% -fullscreen; popd"
+    addSystem "samcoupe"
 }

--- a/scriptmodules/emulators/snes9x.sh
+++ b/scriptmodules/emulators/snes9x.sh
@@ -45,5 +45,6 @@ function configure_snes9x() {
 
     setDispmanx "$md_id" 1
 
-    addSystem 0 "$md_id" "snes" "$md_inst/snes9x %ROM%"
+    addEmulator 0 "$md_id" "snes" "$md_inst/snes9x %ROM%"
+    addSystem "snes"
 }

--- a/scriptmodules/emulators/stella.sh
+++ b/scriptmodules/emulators/stella.sh
@@ -37,5 +37,6 @@ function configure_stella() {
         setDispmanx "$md_id" 1
     fi
 
-    addSystem 0 "$md_id" "atari2600" "stella -maxres 320x240 %ROM%"
+    addEmulator 0 "$md_id" "atari2600" "stella -maxres 320x240 %ROM%"
+    addSystem "atari2600"
 }

--- a/scriptmodules/emulators/stratagus.sh
+++ b/scriptmodules/emulators/stratagus.sh
@@ -41,6 +41,6 @@ function install_stratagus() {
 function configure_stratagus() {
     mkRomDir "stratagus"
 
-    addEmulator 0 "$md_id" "stratagus" "$md_inst/stratagus -F -d %ROM%" "Stratagus Strategy Engine" ".wc1 .wc2 .sc .data"
-    addSystem "stratagus"
+    addEmulator 0 "$md_id" "stratagus" "$md_inst/stratagus -F -d %ROM%"
+    addSystem "stratagus" "Stratagus Strategy Engine" ".wc1 .wc2 .sc .data"
 }

--- a/scriptmodules/emulators/stratagus.sh
+++ b/scriptmodules/emulators/stratagus.sh
@@ -41,5 +41,6 @@ function install_stratagus() {
 function configure_stratagus() {
     mkRomDir "stratagus"
 
-    addSystem 0 "$md_id" "stratagus" "$md_inst/stratagus -F -d %ROM%" "Stratagus Strategy Engine" ".wc1 .wc2 .sc .data"
+    addEmulator 0 "$md_id" "stratagus" "$md_inst/stratagus -F -d %ROM%" "Stratagus Strategy Engine" ".wc1 .wc2 .sc .data"
+    addSystem "stratagus"
 }

--- a/scriptmodules/emulators/ti99sim.sh
+++ b/scriptmodules/emulators/ti99sim.sh
@@ -38,5 +38,6 @@ function configure_ti99sim() {
     moveConfigDir "$home/.ti99sim" "$md_conf_root/ti99/"
     ln -sf "$biosdir/TI-994A.ctg" "$md_inst/TI-994A.ctg"
 
-    addSystem 1 "$md_id" "ti99" "pushd $md_inst; $md_inst/ti99sim-sdl -f %ROM%; popd" "TI99" ".ctg .CTG"
+    addEmulator 1 "$md_id" "ti99" "pushd $md_inst; $md_inst/ti99sim-sdl -f %ROM%; popd" "TI99" ".ctg .CTG"
+    addSystem "ti99"
 }

--- a/scriptmodules/emulators/ti99sim.sh
+++ b/scriptmodules/emulators/ti99sim.sh
@@ -38,6 +38,6 @@ function configure_ti99sim() {
     moveConfigDir "$home/.ti99sim" "$md_conf_root/ti99/"
     ln -sf "$biosdir/TI-994A.ctg" "$md_inst/TI-994A.ctg"
 
-    addEmulator 1 "$md_id" "ti99" "pushd $md_inst; $md_inst/ti99sim-sdl -f %ROM%; popd" "TI99" ".ctg .CTG"
+    addEmulator 1 "$md_id" "ti99" "pushd $md_inst; $md_inst/ti99sim-sdl -f %ROM%; popd"
     addSystem "ti99"
 }

--- a/scriptmodules/emulators/uae4all.sh
+++ b/scriptmodules/emulators/uae4all.sh
@@ -137,5 +137,6 @@ _EOF_
         rm -f "$biosdir/aros-amiga-m68k"*
     fi
 
-    addSystem 1 "$md_id" "amiga" "bash $romdir/amiga/+Start\ UAE4All.sh" "Amiga" ".sh"
+    addEmulator 1 "$md_id" "amiga" "bash $romdir/amiga/+Start\ UAE4All.sh" "Amiga" ".sh"
+    addSystem "amiga"
 }

--- a/scriptmodules/emulators/uae4all.sh
+++ b/scriptmodules/emulators/uae4all.sh
@@ -137,6 +137,6 @@ _EOF_
         rm -f "$biosdir/aros-amiga-m68k"*
     fi
 
-    addEmulator 1 "$md_id" "amiga" "bash $romdir/amiga/+Start\ UAE4All.sh" "Amiga" ".sh"
+    addEmulator 1 "$md_id" "amiga" "bash $romdir/amiga/+Start\ UAE4All.sh"
     addSystem "amiga"
 }

--- a/scriptmodules/emulators/uae4arm.sh
+++ b/scriptmodules/emulators/uae4arm.sh
@@ -67,6 +67,6 @@ _EOF_
     chmod a+x "$romdir/amiga/+Start UAE4Arm.sh"
     chown $user:$user "$romdir/amiga/+Start UAE4Arm.sh"
 
-    addEmulator 1 "$md_id" "amiga" "bash $romdir/amiga/+Start\ UAE4Arm.sh" "Amiga" ".sh"
+    addEmulator 1 "$md_id" "amiga" "bash $romdir/amiga/+Start\ UAE4Arm.sh"
     addSystem "amiga"
 }

--- a/scriptmodules/emulators/uae4arm.sh
+++ b/scriptmodules/emulators/uae4arm.sh
@@ -67,5 +67,6 @@ _EOF_
     chmod a+x "$romdir/amiga/+Start UAE4Arm.sh"
     chown $user:$user "$romdir/amiga/+Start UAE4Arm.sh"
 
-    addSystem 1 "$md_id" "amiga" "bash $romdir/amiga/+Start\ UAE4Arm.sh" "Amiga" ".sh"
+    addEmulator 1 "$md_id" "amiga" "bash $romdir/amiga/+Start\ UAE4Arm.sh" "Amiga" ".sh"
+    addSystem "amiga"
 }

--- a/scriptmodules/emulators/vice.sh
+++ b/scriptmodules/emulators/vice.sh
@@ -68,13 +68,14 @@ _EOF_
 
     mkRomDir "c64"
 
-    addSystem 1 "$md_id-x64" "c64" "$md_inst/bin/vice.sh x64 %ROM%"
-    addSystem 0 "$md_id-x64sc" "c64" "$md_inst/bin/vice.sh x64sc %ROM%"
-    addSystem 0 "$md_id-x128" "c64" "$md_inst/bin/vice.sh x128 %ROM%"
-    addSystem 0 "$md_id-xpet" "c64" "$md_inst/bin/vice.sh xpet %ROM%"
-    addSystem 0 "$md_id-xplus4" "c64" "$md_inst/bin/vice.sh xplus4 %ROM%"
-    addSystem 0 "$md_id-xvic" "c64" "$md_inst/bin/vice.sh xvic %ROM%"
-    addSystem 0 "$md_id-xvic-cart" "c64" "$md_inst/bin/vice.sh 'xvic -cartgeneric' %ROM%"
+    addEmulator 1 "$md_id-x64" "c64" "$md_inst/bin/vice.sh x64 %ROM%"
+    addEmulator 0 "$md_id-x64sc" "c64" "$md_inst/bin/vice.sh x64sc %ROM%"
+    addEmulator 0 "$md_id-x128" "c64" "$md_inst/bin/vice.sh x128 %ROM%"
+    addEmulator 0 "$md_id-xpet" "c64" "$md_inst/bin/vice.sh xpet %ROM%"
+    addEmulator 0 "$md_id-xplus4" "c64" "$md_inst/bin/vice.sh xplus4 %ROM%"
+    addEmulator 0 "$md_id-xvic" "c64" "$md_inst/bin/vice.sh xvic %ROM%"
+    addEmulator 0 "$md_id-xvic-cart" "c64" "$md_inst/bin/vice.sh 'xvic -cartgeneric' %ROM%"
+    addSystem "c64"
 
     [[ "$md_mode" == "remove" ]] && return
 

--- a/scriptmodules/emulators/xroar.sh
+++ b/scriptmodules/emulators/xroar.sh
@@ -49,7 +49,9 @@ function configure_xroar() {
 
     local params=(-fs)
     ! isPlatform "x11" && params+=(-vo sdl --ccr simple)
-    addSystem 1 "$md_id-dragon32" "dragon32" "$md_inst/bin/xroar ${params[*]} -machine dragon32 -run %ROM%"
-    addSystem 1 "$md_id-cocous" "coco" "$md_inst/bin/xroar ${params[*]} -machine cocous -run %ROM%"
-    addSystem 0 "$md_id-coco" "coco" "$md_inst/bin/xroar ${params[*]} -machine coco -run %ROM%"
+    addEmulator 1 "$md_id-dragon32" "dragon32" "$md_inst/bin/xroar ${params[*]} -machine dragon32 -run %ROM%"
+    addEmulator 1 "$md_id-cocous" "coco" "$md_inst/bin/xroar ${params[*]} -machine cocous -run %ROM%"
+    addEmulator 0 "$md_id-coco" "coco" "$md_inst/bin/xroar ${params[*]} -machine coco -run %ROM%"
+    addSystem "dragon32"
+    addSystem "coco"
 }

--- a/scriptmodules/emulators/zesarux.sh
+++ b/scriptmodules/emulators/zesarux.sh
@@ -87,7 +87,10 @@ _EOF_
 
     setDispmanx "$md_id" 1
 
-    addSystem 1 "$md_id" "zxspectrum" "bash $romdir/zxspectrum/+Start\ ZEsarUX.sh %ROM%"
-    addSystem 1 "$md_id" "samcoupe" "bash $romdir/zxspectrum/+Start\ ZEsarUX.sh --machine sam %ROM%"
-    addSystem 1 "$md_id" "amstradcpc" "bash $romdir/zxspectrum/+Start\ ZEsarUX.sh --machine CPC464 %ROM%"
+    addEmulator 1 "$md_id" "zxspectrum" "bash $romdir/zxspectrum/+Start\ ZEsarUX.sh %ROM%"
+    addEmulator 1 "$md_id" "samcoupe" "bash $romdir/zxspectrum/+Start\ ZEsarUX.sh --machine sam %ROM%"
+    addEmulator 1 "$md_id" "amstradcpc" "bash $romdir/zxspectrum/+Start\ ZEsarUX.sh --machine CPC464 %ROM%"
+    addSystem "zxspectrum"
+    addSystem "samcoupe"
+    addSystem "amstradcpc"
 }

--- a/scriptmodules/libretrocores/lr-4do.sh
+++ b/scriptmodules/libretrocores/lr-4do.sh
@@ -34,5 +34,6 @@ function configure_lr-4do() {
     mkRomDir "3do"
     ensureSystemretroconfig "3do"
 
-    addSystem 1 "$md_id" "3do" "$md_inst/4do_libretro.so"
+    addEmulator 1 "$md_id" "3do" "$md_inst/4do_libretro.so"
+    addSystem "3do"
 }

--- a/scriptmodules/libretrocores/lr-armsnes.sh
+++ b/scriptmodules/libretrocores/lr-armsnes.sh
@@ -35,5 +35,6 @@ function configure_lr-armsnes() {
     mkRomDir "snes"
     ensureSystemretroconfig "snes"
 
-    addSystem 0 "$md_id" "snes" "$md_inst/libpocketsnes.so"
+    addEmulator 0 "$md_id" "snes" "$md_inst/libpocketsnes.so"
+    addSystem "snes"
 }

--- a/scriptmodules/libretrocores/lr-beetle-lynx.sh
+++ b/scriptmodules/libretrocores/lr-beetle-lynx.sh
@@ -34,5 +34,6 @@ function configure_lr-beetle-lynx() {
     mkRomDir "atarilynx"
     ensureSystemretroconfig "atarilynx"
 
-    addSystem 0 "$md_id" "atarilynx" "$md_inst/mednafen_lynx_libretro.so"
+    addEmulator 0 "$md_id" "atarilynx" "$md_inst/mednafen_lynx_libretro.so"
+    addSystem "atarilynx"
 }

--- a/scriptmodules/libretrocores/lr-beetle-ngp.sh
+++ b/scriptmodules/libretrocores/lr-beetle-ngp.sh
@@ -36,11 +36,12 @@ function install_lr-beetle-ngp() {
 }
 
 function configure_lr-beetle-ngp() {
-    mkRomDir "ngp"
-    mkRomDir "ngpc"
-    ensureSystemretroconfig "ngp"
-    ensureSystemretroconfig "ngpc"
+    local system
+    for system in ngp ngpc; do
+        mkRomDir "$system"
+        ensureSystemretroconfig "$system"
+        addEmulator 1 "$md_id" "$system" "$md_inst/mednafen_ngp_libretro.so"
+        addSystem "$system"
+    done
 
-    addSystem 1 "$md_id" "ngp" "$md_inst/mednafen_ngp_libretro.so"
-    addSystem 1 "$md_id" "ngpc" "$md_inst/mednafen_ngp_libretro.so"
 }

--- a/scriptmodules/libretrocores/lr-beetle-pce-fast.sh
+++ b/scriptmodules/libretrocores/lr-beetle-pce-fast.sh
@@ -40,5 +40,6 @@ function configure_lr-beetle-pce-fast() {
     mkRomDir "pcengine"
     ensureSystemretroconfig "pcengine"
 
-    addSystem 1 "$md_id" "pcengine" "$md_inst/mednafen_pce_fast_libretro.so"
+    addEmulator 1 "$md_id" "pcengine" "$md_inst/mednafen_pce_fast_libretro.so"
+    addSystem "pcengine"
 }

--- a/scriptmodules/libretrocores/lr-beetle-pcfx.sh
+++ b/scriptmodules/libretrocores/lr-beetle-pcfx.sh
@@ -34,5 +34,6 @@ function configure_lr-beetle-pcfx() {
     mkRomDir "pcfx"
     ensureSystemretroconfig "pcfx"
 
-    addSystem 1 "$md_id" "pcfx" "$md_inst/mednafen_pcfx_libretro.so"
+    addEmulator 1 "$md_id" "pcfx" "$md_inst/mednafen_pcfx_libretro.so"
+    addSystem "pcfx"
 }

--- a/scriptmodules/libretrocores/lr-beetle-psx.sh
+++ b/scriptmodules/libretrocores/lr-beetle-psx.sh
@@ -35,5 +35,6 @@ function configure_lr-beetle-psx() {
     mkRomDir "psx"
     ensureSystemretroconfig "psx"
 
-    addSystem 0 "$md_id" "psx" "$md_inst/mednafen_psx_libretro.so"
+    addEmulator 0 "$md_id" "psx" "$md_inst/mednafen_psx_libretro.so"
+    addSystem "psx"
 }

--- a/scriptmodules/libretrocores/lr-beetle-supergrafx.sh
+++ b/scriptmodules/libretrocores/lr-beetle-supergrafx.sh
@@ -34,5 +34,6 @@ function configure_lr-beetle-supergrafx() {
     mkRomDir "pcengine"
     ensureSystemretroconfig "pcengine"
 
-    addSystem 0 "$md_id" "pcengine" "$md_inst/mednafen_supergrafx_libretro.so"
+    addEmulator 0 "$md_id" "pcengine" "$md_inst/mednafen_supergrafx_libretro.so"
+    addSystem "pcengine"
 }

--- a/scriptmodules/libretrocores/lr-beetle-vb.sh
+++ b/scriptmodules/libretrocores/lr-beetle-vb.sh
@@ -37,5 +37,6 @@ function configure_lr-beetle-vb() {
     mkRomDir "virtualboy"
     ensureSystemretroconfig "virtualboy"
 
-    addSystem 1 "$md_id" "virtualboy" "$md_inst/mednafen_vb_libretro.so"
+    addEmulator 1 "$md_id" "virtualboy" "$md_inst/mednafen_vb_libretro.so"
+    addSystem "virtualboy"
 }

--- a/scriptmodules/libretrocores/lr-beetle-wswan.sh
+++ b/scriptmodules/libretrocores/lr-beetle-wswan.sh
@@ -41,6 +41,8 @@ function configure_lr-beetle-wswan() {
     ensureSystemretroconfig "wonderswan"
     ensureSystemretroconfig "wonderswancolor"
 
-    addSystem 1 "$md_id" "wonderswan" "$md_inst/mednafen_wswan_libretro.so"
-    addSystem 1 "$md_id" "wonderswancolor" "$md_inst/mednafen_wswan_libretro.so"
+    addEmulator 1 "$md_id" "wonderswan" "$md_inst/mednafen_wswan_libretro.so"
+    addEmulator 1 "$md_id" "wonderswancolor" "$md_inst/mednafen_wswan_libretro.so"
+    addSystem "wonderswan"
+    addSystem "wonderswancolor"
 }

--- a/scriptmodules/libretrocores/lr-bluemsx.sh
+++ b/scriptmodules/libretrocores/lr-bluemsx.sh
@@ -42,5 +42,6 @@ function configure_lr-bluemsx() {
 
     wget -q -O- "$__archive_url/bluemsxroms.tar.gz" | tar -xvz -C "$biosdir/Machines/Shared Roms/"
 
-    addSystem 1 "$md_id" "msx" "$md_inst/bluemsx_libretro.so"
+    addEmulator 1 "$md_id" "msx" "$md_inst/bluemsx_libretro.so"
+    addSystem "msx"
 }

--- a/scriptmodules/libretrocores/lr-bsnes.sh
+++ b/scriptmodules/libretrocores/lr-bsnes.sh
@@ -36,5 +36,6 @@ function configure_lr-bsnes() {
     mkRomDir "snes"
     ensureSystemretroconfig "snes"
 
-    addSystem 1 "$md_id" "snes" "$md_inst/bsnes_accuracy_libretro.so"
+    addEmulator 1 "$md_id" "snes" "$md_inst/bsnes_accuracy_libretro.so"
+    addSystem "snes"
 }

--- a/scriptmodules/libretrocores/lr-caprice32.sh
+++ b/scriptmodules/libretrocores/lr-caprice32.sh
@@ -38,5 +38,6 @@ function configure_lr-caprice32() {
     setRetroArchCoreOption "cap32_Model" "6128"
     setRetroArchCoreOption "cap32_Ram" "128"
 
-    addSystem 1 "$md_id" "amstradcpc" "$md_inst/cap32_libretro.so"
+    addEmulator 1 "$md_id" "amstradcpc" "$md_inst/cap32_libretro.so"
+    addSystem "amstradcpc"
 }

--- a/scriptmodules/libretrocores/lr-desmume.sh
+++ b/scriptmodules/libretrocores/lr-desmume.sh
@@ -37,5 +37,6 @@ function configure_lr-desmume() {
     mkRomDir "nds"
     ensureSystemretroconfig "nds"
 
-    addSystem 0 "$md_id" "nds" "$md_inst/desmume_libretro.so"
+    addEmulator 0 "$md_id" "nds" "$md_inst/desmume_libretro.so"
+    addSystem "nds"
 }

--- a/scriptmodules/libretrocores/lr-fbalpha.sh
+++ b/scriptmodules/libretrocores/lr-fbalpha.sh
@@ -57,5 +57,5 @@ function configure_lr-fbalpha() {
     isPlatform "armv6" && def=0
     addSystem 0 "$md_id" "arcade" "$md_inst/fbalpha_libretro.so"
     addSystem $def "$md_id" "neogeo" "$md_inst/fbalpha_libretro.so"
-    addSystem $def "$md_id" "fba arcade" "$md_inst/fbalpha_libretro.so"
+    addSystem $def "$md_id" "fba" "$md_inst/fbalpha_libretro.so"
 }

--- a/scriptmodules/libretrocores/lr-fbalpha.sh
+++ b/scriptmodules/libretrocores/lr-fbalpha.sh
@@ -55,7 +55,10 @@ function configure_lr-fbalpha() {
 
     local def=1
     isPlatform "armv6" && def=0
-    addSystem 0 "$md_id" "arcade" "$md_inst/fbalpha_libretro.so"
-    addSystem $def "$md_id" "neogeo" "$md_inst/fbalpha_libretro.so"
-    addSystem $def "$md_id" "fba" "$md_inst/fbalpha_libretro.so"
+    addEmulator 0 "$md_id" "arcade" "$md_inst/fbalpha_libretro.so"
+    addEmulator $def "$md_id" "neogeo" "$md_inst/fbalpha_libretro.so"
+    addEmulator $def "$md_id" "fba" "$md_inst/fbalpha_libretro.so"
+    addSystem "arcade"
+    addSystem "neogeo"
+    addSystem "fba"
 }

--- a/scriptmodules/libretrocores/lr-fbalpha2012.sh
+++ b/scriptmodules/libretrocores/lr-fbalpha2012.sh
@@ -53,5 +53,5 @@ function configure_lr-fbalpha2012() {
 
     addSystem 0 "$md_id" "arcade" "$md_inst/fbalpha2012_libretro.so"
     addSystem 0 "$md_id" "neogeo" "$md_inst/fbalpha2012_libretro.so"
-    addSystem 0 "$md_id" "fba arcade" "$md_inst/fbalpha2012_libretro.so"
+    addSystem 0 "$md_id" "fba" "$md_inst/fbalpha2012_libretro.so"
 }

--- a/scriptmodules/libretrocores/lr-fbalpha2012.sh
+++ b/scriptmodules/libretrocores/lr-fbalpha2012.sh
@@ -44,14 +44,11 @@ function install_lr-fbalpha2012() {
 }
 
 function configure_lr-fbalpha2012() {
-    mkRomDir "arcade"
-    mkRomDir "fba"
-    mkRomDir "neogeo"
-    ensureSystemretroconfig "arcade"
-    ensureSystemretroconfig "fba"
-    ensureSystemretroconfig "neogeo"
-
-    addSystem 0 "$md_id" "arcade" "$md_inst/fbalpha2012_libretro.so"
-    addSystem 0 "$md_id" "neogeo" "$md_inst/fbalpha2012_libretro.so"
-    addSystem 0 "$md_id" "fba" "$md_inst/fbalpha2012_libretro.so"
+    local system
+    for system in arcade fba neogeo; do
+        mkRomDir "$system"
+        ensureSystemretroconfig "$system"
+        addEmulator 0 "$md_id" "$system" "$md_inst/fbalpha2012_libretro.so"
+        addSystem "$system"
+    done
 }

--- a/scriptmodules/libretrocores/lr-fceumm.sh
+++ b/scriptmodules/libretrocores/lr-fceumm.sh
@@ -40,7 +40,8 @@ function configure_lr-fceumm() {
     mkRomDir "fds"
     ensureSystemretroconfig "nes"
     ensureSystemretroconfig "fds"
-
-    addSystem 1 "$md_id" "nes" "$md_inst/fceumm_libretro.so"
-    addSystem 0 "$md_id" "fds" "$md_inst/fceumm_libretro.so"
+    addEmulator 1 "$md_id" "nes" "$md_inst/fceumm_libretro.so"
+    addEmulator 0 "$md_id" "fds" "$md_inst/fceumm_libretro.so"
+    addSystem "nes"
+    addSystem "fds"
 }

--- a/scriptmodules/libretrocores/lr-fmsx.sh
+++ b/scriptmodules/libretrocores/lr-fmsx.sh
@@ -57,5 +57,6 @@ function configure_lr-fmsx() {
     cp "$md_inst/"{*.ROM,*.FNT,*.SHA} "$biosdir/"
     chown $user:$user "$biosdir/"{*.ROM,*.FNT,*.SHA}
 
-    addSystem 0 "$md_id" "msx" "$md_inst/fmsx_libretro.so"
+    addEmulator 0 "$md_id" "msx" "$md_inst/fmsx_libretro.so"
+    addSystem "msx"
 }

--- a/scriptmodules/libretrocores/lr-fuse.sh
+++ b/scriptmodules/libretrocores/lr-fuse.sh
@@ -39,5 +39,6 @@ function configure_lr-fuse() {
     # default to 128k spectrum
     setRetroArchCoreOption "fuse_machine" "Spectrum 128K"
 
-    addSystem 1 "$md_id" "zxspectrum" "$md_inst/fuse_libretro.so"
+    addEmulator 1 "$md_id" "zxspectrum" "$md_inst/fuse_libretro.so"
+    addSystem "zxspectrum"
 }

--- a/scriptmodules/libretrocores/lr-gambatte.sh
+++ b/scriptmodules/libretrocores/lr-gambatte.sh
@@ -44,7 +44,8 @@ function configure_lr-gambatte() {
     mkRomDir "gb"
     ensureSystemretroconfig "gb"
     ensureSystemretroconfig "gbc"
-
-    addSystem 1 "$md_id" "gb" "$md_inst/gambatte_libretro.so"
-    addSystem 1 "$md_id" "gbc" "$md_inst/gambatte_libretro.so"
+    addEmulator 1 "$md_id" "gb" "$md_inst/gambatte_libretro.so"
+    addEmulator 1 "$md_id" "gbc" "$md_inst/gambatte_libretro.so"
+    addSystem "gb"
+    addSystem "gbc"
 }

--- a/scriptmodules/libretrocores/lr-genesis-plus-gx.sh
+++ b/scriptmodules/libretrocores/lr-genesis-plus-gx.sh
@@ -41,6 +41,7 @@ function configure_lr-genesis-plus-gx() {
         [[ "$system" == "gamegear" || "$system" == "sg-1000" ]] && def=1
         mkRomDir "$system"
         ensureSystemretroconfig "$system"
-        addSystem "$def" "$md_id" "$system" "$md_inst/genesis_plus_gx_libretro.so"
+        addEmulator "$def" "$md_id" "$system" "$md_inst/genesis_plus_gx_libretro.so"
+        addSystem "$system"
     done
 }

--- a/scriptmodules/libretrocores/lr-glupen64.sh
+++ b/scriptmodules/libretrocores/lr-glupen64.sh
@@ -49,5 +49,6 @@ function configure_lr-glupen64() {
     mkRomDir "n64"
     ensureSystemretroconfig "n64"
 
-    addSystem 0 "$md_id" "n64" "$md_inst/glupen64_libretro.so"
+    addEmulator 0 "$md_id" "n64" "$md_inst/glupen64_libretro.so"
+    addSystem "n64"
 }

--- a/scriptmodules/libretrocores/lr-gpsp.sh
+++ b/scriptmodules/libretrocores/lr-gpsp.sh
@@ -44,5 +44,6 @@ function configure_lr-gpsp() {
 
     local def=0
     isPlatform "armv6" && def=1
-    addSystem $def "$md_id" "gba" "$md_inst/gpsp_libretro.so"
+    addEmulator $def "$md_id" "gba" "$md_inst/gpsp_libretro.so"
+    addSystem "gba"
 }

--- a/scriptmodules/libretrocores/lr-gw.sh
+++ b/scriptmodules/libretrocores/lr-gw.sh
@@ -36,6 +36,6 @@ function configure_lr-gw() {
     mkRomDir "gameandwatch"
     ensureSystemretroconfig "gameandwatch"
 
-    addEmulator 1 "$md_id" "gameandwatch" "$md_inst/gw_libretro.so" "Game and Watch" ".mgw"
+    addEmulator 1 "$md_id" "gameandwatch" "$md_inst/gw_libretro.so"
     addSystem "gameandwatch"
 }

--- a/scriptmodules/libretrocores/lr-gw.sh
+++ b/scriptmodules/libretrocores/lr-gw.sh
@@ -36,5 +36,6 @@ function configure_lr-gw() {
     mkRomDir "gameandwatch"
     ensureSystemretroconfig "gameandwatch"
 
-    addSystem 1 "$md_id" "gameandwatch" "$md_inst/gw_libretro.so" "Game and Watch" ".mgw"
+    addEmulator 1 "$md_id" "gameandwatch" "$md_inst/gw_libretro.so" "Game and Watch" ".mgw"
+    addSystem "gameandwatch"
 }

--- a/scriptmodules/libretrocores/lr-handy.sh
+++ b/scriptmodules/libretrocores/lr-handy.sh
@@ -35,5 +35,6 @@ function configure_lr-handy() {
     mkRomDir "atarilynx"
     ensureSystemretroconfig "atarilynx"
 
-    addSystem 1 "$md_id" "atarilynx" "$md_inst/handy_libretro.so"
+    addEmulator 1 "$md_id" "atarilynx" "$md_inst/handy_libretro.so"
+    addSystem "atarilynx"
 }

--- a/scriptmodules/libretrocores/lr-hatari.sh
+++ b/scriptmodules/libretrocores/lr-hatari.sh
@@ -48,7 +48,8 @@ function configure_lr-hatari() {
     # move any old configs to new location
     moveConfigDir "$home/.hatari" "$md_conf_root/atarist"
 
-    addSystem 1 "$md_id" "atarist" "$md_inst/hatari_libretro.so"
+    addEmulator 1 "$md_id" "atarist" "$md_inst/hatari_libretro.so"
+    addSystem "atarist"
 
     # add LD_LIBRARY_PATH='$md_inst' to start of launch command
     iniConfig " = " '"' "$configdir/atarist/emulators.cfg"

--- a/scriptmodules/libretrocores/lr-imame4all.sh
+++ b/scriptmodules/libretrocores/lr-imame4all.sh
@@ -34,11 +34,11 @@ function install_lr-imame4all() {
 }
 
 function configure_lr-imame4all() {
-    mkRomDir "arcade"
-    mkRomDir "mame-mame4all"
-    ensureSystemretroconfig "arcade"
-    ensureSystemretroconfig "mame-mame4all"
-
-    addSystem 0 "$md_id" "arcade" "$md_inst/mame2000_libretro.so"
-    addSystem 0 "$md_id" "mame-mame4all" "$md_inst/mame2000_libretro.so"
+    local system
+    for system in arcade mame-libretro; do
+        mkRomDir "$system"
+        ensureSystemretroconfig "$system"
+        addEmulator 0 "$md_id" "$system" "$md_inst/mame2000_libretro.so"
+        addSystem "$system"
+    done
 }

--- a/scriptmodules/libretrocores/lr-imame4all.sh
+++ b/scriptmodules/libretrocores/lr-imame4all.sh
@@ -40,5 +40,5 @@ function configure_lr-imame4all() {
     ensureSystemretroconfig "mame-mame4all"
 
     addSystem 0 "$md_id" "arcade" "$md_inst/mame2000_libretro.so"
-    addSystem 0 "$md_id" "mame-mame4all arcade mame" "$md_inst/mame2000_libretro.so"
+    addSystem 0 "$md_id" "mame-mame4all" "$md_inst/mame2000_libretro.so"
 }

--- a/scriptmodules/libretrocores/lr-mame.sh
+++ b/scriptmodules/libretrocores/lr-mame.sh
@@ -46,5 +46,5 @@ function configure_lr-mame() {
     ensureSystemretroconfig "mame-libretro"
 
     addSystem 0 "$md_id" "arcade" "$md_inst/mamearcade_libretro.so"
-    addSystem 0 "$md_id" "mame-libretro arcade mame" "$md_inst/mamearcade_libretro.so"
+    addSystem 0 "$md_id" "mame-libretro" "$md_inst/mamearcade_libretro.so"
 }

--- a/scriptmodules/libretrocores/lr-mame.sh
+++ b/scriptmodules/libretrocores/lr-mame.sh
@@ -40,11 +40,11 @@ function install_lr-mame() {
 }
 
 function configure_lr-mame() {
-    mkRomDir "arcade"
-    mkRomDir "mame-libretro"
-    ensureSystemretroconfig "arcade"
-    ensureSystemretroconfig "mame-libretro"
-
-    addSystem 0 "$md_id" "arcade" "$md_inst/mamearcade_libretro.so"
-    addSystem 0 "$md_id" "mame-libretro" "$md_inst/mamearcade_libretro.so"
+    local system
+    for system in arcade mame-libretro; do
+        mkRomDir "$system"
+        ensureSystemretroconfig "$system"
+        addEmulator 0 "$md_id" "$system" "$md_inst/mamearcade_libretro.so"
+        addSystem "$system"
+    done
 }

--- a/scriptmodules/libretrocores/lr-mame2003.sh
+++ b/scriptmodules/libretrocores/lr-mame2003.sh
@@ -62,5 +62,5 @@ function configure_lr-mame2003() {
     setRetroArchCoreOption "mame2003-samples" "enabled"
 
     addSystem 0 "$md_id" "arcade" "$md_inst/mame2003_libretro.so"
-    addSystem 1 "$md_id" "mame-libretro arcade mame" "$md_inst/mame2003_libretro.so"
+    addSystem 1 "$md_id" "mame-libretro" "$md_inst/mame2003_libretro.so"
 }

--- a/scriptmodules/libretrocores/lr-mame2003.sh
+++ b/scriptmodules/libretrocores/lr-mame2003.sh
@@ -61,6 +61,8 @@ function configure_lr-mame2003() {
     setRetroArchCoreOption "mame2003-dcs-speedhack" "enabled"
     setRetroArchCoreOption "mame2003-samples" "enabled"
 
-    addSystem 0 "$md_id" "arcade" "$md_inst/mame2003_libretro.so"
-    addSystem 1 "$md_id" "mame-libretro" "$md_inst/mame2003_libretro.so"
+    addEmulator 0 "$md_id" "arcade" "$md_inst/mame2003_libretro.so"
+    addEmulator 1 "$md_id" "mame-libretro" "$md_inst/mame2003_libretro.so"
+    addSystem "arcade"
+    addSystem "mame-libretro"
 }

--- a/scriptmodules/libretrocores/lr-mame2010.sh
+++ b/scriptmodules/libretrocores/lr-mame2010.sh
@@ -45,5 +45,5 @@ function configure_lr-mame2010() {
     ensureSystemretroconfig "mame-libretro"
 
     addSystem 0 "$md_id" "arcade" "$md_inst/mame2010_libretro.so"
-    addSystem 0 "$md_id" "mame-libretro arcade mame" "$md_inst/mame2010_libretro.so"
+    addSystem 0 "$md_id" "mame-libretro" "$md_inst/mame2010_libretro.so"
 }

--- a/scriptmodules/libretrocores/lr-mame2010.sh
+++ b/scriptmodules/libretrocores/lr-mame2010.sh
@@ -39,11 +39,11 @@ function install_lr-mame2010() {
 }
 
 function configure_lr-mame2010() {
-    mkRomDir "arcade"
-    mkRomDir "mame-libretro"
-    ensureSystemretroconfig "arcade"
-    ensureSystemretroconfig "mame-libretro"
-
-    addSystem 0 "$md_id" "arcade" "$md_inst/mame2010_libretro.so"
-    addSystem 0 "$md_id" "mame-libretro" "$md_inst/mame2010_libretro.so"
+    local system
+    for system in arcade mame-libretro; do
+        mkRomDir "$system"
+        ensureSystemretroconfig "$system"
+        addEmulator 0 "$md_id" "$system" "$md_inst/mame2010_libretro.so"
+        addSystem "$system"
+    done
 }

--- a/scriptmodules/libretrocores/lr-mame2014.sh
+++ b/scriptmodules/libretrocores/lr-mame2014.sh
@@ -34,11 +34,11 @@ function install_lr-mame2014() {
 }
 
 function configure_lr-mame2014() {
-    mkRomDir "arcade"
-    mkRomDir "mame-libretro"
-    ensureSystemretroconfig "arcade"
-    ensureSystemretroconfig "mame-libretro"
-
-    addSystem 0 "$md_id" "arcade" "$md_inst/mame2014_libretro.so"
-    addSystem 0 "$md_id" "mame-libretro" "$md_inst/mame2014_libretro.so"
+    local system
+    for system in arcade mame-libretro; do
+        mkRomDir "$system"
+        ensureSystemretroconfig "$system"
+        addEmulator 0 "$md_id" "$system" "$md_inst/mame2014_libretro.so"
+        addSystem "$system"
+    done
 }

--- a/scriptmodules/libretrocores/lr-mame2014.sh
+++ b/scriptmodules/libretrocores/lr-mame2014.sh
@@ -40,5 +40,5 @@ function configure_lr-mame2014() {
     ensureSystemretroconfig "mame-libretro"
 
     addSystem 0 "$md_id" "arcade" "$md_inst/mame2014_libretro.so"
-    addSystem 0 "$md_id" "mame-libretro arcade mame" "$md_inst/mame2014_libretro.so"
+    addSystem 0 "$md_id" "mame-libretro" "$md_inst/mame2014_libretro.so"
 }

--- a/scriptmodules/libretrocores/lr-mess.sh
+++ b/scriptmodules/libretrocores/lr-mess.sh
@@ -34,16 +34,13 @@ function install_lr-mess() {
 }
 
 function configure_lr-mess() {
-    mkRomDir "nes"
-    mkRomDir "gameboy"
-    mkRomDir "coleco"
-    mkRomDir "arcadia"
-    mkRomDir "crvision"
-    ensureSystemretroconfig "nes"
-    ensureSystemretroconfig "gameboy"
-    ensureSystemretroconfig "coleco"
-    ensureSystemretroconfig "arcadia"
-    ensureSystemretroconfig "crvision"
+    local system
+    for system in nes gameboy coleco arcadia crvision; do
+        mkRomDir "$system"
+        ensureSystemretroconfig "$system"
+        addEmulator 0 "$md_id" "$system" "$md_inst/mess_libretro.so"
+        addSystem "$system"
+    done
 
     setRetroArchCoreOption "mame_softlists_enable" "enabled"
     setRetroArchCoreOption "mame_softlists_auto_media" "enabled"
@@ -52,9 +49,4 @@ function configure_lr-mess() {
     mkdir "$biosdir/mame"
     cp -rv "$md_build/hash" "$biosdir/mame/"
     chown -R $user:$user "$biosdir/mame"
-    addSystem 0 "$md_id" "nes" "$md_inst/mess_libretro.so"
-    addSystem 0 "$md_id" "gameboy" "$md_inst/mess_libretro.so"
-    addSystem 0 "$md_id" "coleco" "$md_inst/mess_libretro.so"
-    addSystem 0 "$md_id" "arcadia" "$md_inst/mess_libretro.so"
-    addSystem 0 "$md_id" "crvision" "$md_inst/mess_libretro.so"
 }

--- a/scriptmodules/libretrocores/lr-mgba.sh
+++ b/scriptmodules/libretrocores/lr-mgba.sh
@@ -44,5 +44,6 @@ function configure_lr-mgba() {
 
     local def=1
     isPlatform "armv6" && def=0
-    addSystem $def "$md_id" "gba" "$md_inst/mgba_libretro.so"
+    addEmulator $def "$md_id" "gba" "$md_inst/mgba_libretro.so"
+    addSystem "gba"
 }

--- a/scriptmodules/libretrocores/lr-mupen64plus.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus.sh
@@ -151,5 +151,6 @@ target FPS=25
 _EOF_
     chown $user:$user "$biosdir/gles2n64rom.conf"
 
-    addSystem 0 "$md_id" "n64" "$md_inst/mupen64plus_libretro.so"
+    addEmulator 0 "$md_id" "n64" "$md_inst/mupen64plus_libretro.so"
+    addSystem "n64"
 }

--- a/scriptmodules/libretrocores/lr-nestopia.sh
+++ b/scriptmodules/libretrocores/lr-nestopia.sh
@@ -48,6 +48,8 @@ function configure_lr-nestopia() {
 
     cp NstDatabase.xml "$biosdir/"
 
-    addSystem 0 "$md_id" "nes" "$md_inst/nestopia_libretro.so"
-    addSystem 1 "$md_id" "fds" "$md_inst/nestopia_libretro.so"
+    addEmulator 0 "$md_id" "nes" "$md_inst/nestopia_libretro.so"
+    addEmulator 1 "$md_id" "fds" "$md_inst/nestopia_libretro.so"
+    addSystem "nes"
+    addSystem "fds"
 }

--- a/scriptmodules/libretrocores/lr-o2em.sh
+++ b/scriptmodules/libretrocores/lr-o2em.sh
@@ -35,5 +35,6 @@ function configure_lr-o2em() {
     mkRomDir "videopac"
     ensureSystemretroconfig "videopac"
 
-    addSystem 1 "$md_id" "videopac" "$md_inst/o2em_libretro.so"
+    addEmulator 1 "$md_id" "videopac" "$md_inst/o2em_libretro.so"
+    addSystem "videopac"
 }

--- a/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
+++ b/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
@@ -45,5 +45,6 @@ function configure_lr-pcsx-rearmed() {
     mkRomDir "psx"
     ensureSystemretroconfig "psx"
 
-    addSystem 1 "$md_id" "psx" "$md_inst/libretro.so"
+    addEmulator 1 "$md_id" "psx" "$md_inst/libretro.so"
+    addSystem "psx"
 }

--- a/scriptmodules/libretrocores/lr-picodrive.sh
+++ b/scriptmodules/libretrocores/lr-picodrive.sh
@@ -42,17 +42,11 @@ function install_lr-picodrive() {
 }
 
 function configure_lr-picodrive() {
-    mkRomDir "megadrive"
-    mkRomDir "mastersystem"
-    mkRomDir "segacd"
-    mkRomDir "sega32x"
-    ensureSystemretroconfig "megadrive"
-    ensureSystemretroconfig "mastersystem"
-    ensureSystemretroconfig "segacd"
-    ensureSystemretroconfig "sega32x"
-
-    addSystem 1 "$md_id" "mastersystem" "$md_inst/picodrive_libretro.so"
-    addSystem 1 "$md_id" "megadrive" "$md_inst/picodrive_libretro.so"
-    addSystem 1 "$md_id" "segacd" "$md_inst/picodrive_libretro.so"
-    addSystem 1 "$md_id" "sega32x" "$md_inst/picodrive_libretro.so"
+    local system
+    for system in megadrrive mastersystem segacd sega32x; do
+        mkRomDir "$system"
+        ensureSystemretroconfig "$system"
+        addEmulator 1 "$md_id" "$system" "$md_inst/picodrive_libretro.so"
+        addSystem "$system"
+    done
 }

--- a/scriptmodules/libretrocores/lr-picodrive.sh
+++ b/scriptmodules/libretrocores/lr-picodrive.sh
@@ -43,7 +43,7 @@ function install_lr-picodrive() {
 
 function configure_lr-picodrive() {
     local system
-    for system in megadrrive mastersystem segacd sega32x; do
+    for system in megadrive mastersystem segacd sega32x; do
         mkRomDir "$system"
         ensureSystemretroconfig "$system"
         addEmulator 1 "$md_id" "$system" "$md_inst/picodrive_libretro.so"

--- a/scriptmodules/libretrocores/lr-ppsspp.sh
+++ b/scriptmodules/libretrocores/lr-ppsspp.sh
@@ -68,5 +68,6 @@ function configure_lr-ppsspp() {
         chown -R $user:$user "$biosdir/PPSSPP"
     fi
 
-    addSystem 1 "$md_id" "psp" "$md_inst/ppsspp_libretro.so"
+    addEmulator 1 "$md_id" "psp" "$md_inst/ppsspp_libretro.so"
+    addSystem "psp"
 }

--- a/scriptmodules/libretrocores/lr-prosystem.sh
+++ b/scriptmodules/libretrocores/lr-prosystem.sh
@@ -38,5 +38,6 @@ function configure_lr-prosystem() {
 
     ensureSystemretroconfig "atari7800"
 
-    addSystem 1 "$md_id" "atari7800" "$md_inst/prosystem_libretro.so"
+    addEmulator 1 "$md_id" "atari7800" "$md_inst/prosystem_libretro.so"
+    addSystem "atari7800"
 }

--- a/scriptmodules/libretrocores/lr-quicknes.sh
+++ b/scriptmodules/libretrocores/lr-quicknes.sh
@@ -34,5 +34,6 @@ function configure_lr-quicknes() {
     mkRomDir "nes"
     ensureSystemretroconfig "nes"
 
-    addSystem 0 "$md_id" "nes" "$md_inst/quicknes_libretro.so"
+    addEmulator 0 "$md_id" "nes" "$md_inst/quicknes_libretro.so"
+    addSystem "nes"
 }

--- a/scriptmodules/libretrocores/lr-reicast.sh
+++ b/scriptmodules/libretrocores/lr-reicast.sh
@@ -43,5 +43,6 @@ function configure_lr-reicast() {
     iniConfig " = " "" "$configdir/dreamcast/retroarch.cfg"
     iniSet "video_shared_context" "true"
 
-    addSystem 0 "$md_id" "dreamcast" "$md_inst/reicast_libretro.so"
+    addEmulator 0 "$md_id" "dreamcast" "$md_inst/reicast_libretro.so"
+    addSystem "dreamcast"
 }

--- a/scriptmodules/libretrocores/lr-snes9x.sh
+++ b/scriptmodules/libretrocores/lr-snes9x.sh
@@ -43,5 +43,6 @@ function configure_lr-snes9x() {
     mkRomDir "snes"
     ensureSystemretroconfig "snes"
 
-    addSystem 0 "$md_id" "snes" "$md_inst/snes9x_libretro.so"
+    addEmulator 0 "$md_id" "snes" "$md_inst/snes9x_libretro.so"
+    addSystem "snes"
 }

--- a/scriptmodules/libretrocores/lr-snes9x2002.sh
+++ b/scriptmodules/libretrocores/lr-snes9x2002.sh
@@ -43,5 +43,6 @@ function configure_lr-snes9x2002() {
 
     local def=0
     isPlatform "armv6" && def=1
-    addSystem $def "$md_id" "snes" "$md_inst/snes9x2002_libretro.so"
+    addEmulator $def "$md_id" "snes" "$md_inst/snes9x2002_libretro.so"
+    addSystem "snes"
 }

--- a/scriptmodules/libretrocores/lr-snes9x2005.sh
+++ b/scriptmodules/libretrocores/lr-snes9x2005.sh
@@ -39,5 +39,6 @@ function configure_lr-snes9x2005() {
     mkRomDir "snes"
     ensureSystemretroconfig "snes"
 
-    addSystem 0 "$md_id" "snes" "$md_inst/snes9x2005_libretro.so"
+    addEmulator 0 "$md_id" "snes" "$md_inst/snes9x2005_libretro.so"
+    addSystem "snes"
 }

--- a/scriptmodules/libretrocores/lr-snes9x2010.sh
+++ b/scriptmodules/libretrocores/lr-snes9x2010.sh
@@ -49,5 +49,6 @@ function configure_lr-snes9x2010() {
 
     local def=1
     isPlatform "armv6" && def=0
-    addSystem $def "$md_id" "snes" "$md_inst/snes9x2010_libretro.so"
+    addEmulator $def "$md_id" "snes" "$md_inst/snes9x2010_libretro.so"
+    addSystem "snes"
 }

--- a/scriptmodules/libretrocores/lr-stella.sh
+++ b/scriptmodules/libretrocores/lr-stella.sh
@@ -35,5 +35,6 @@ function configure_lr-stella() {
     mkRomDir "atari2600"
     ensureSystemretroconfig "atari2600"
 
-    addSystem 1 "$md_id" "atari2600" "$md_inst/stella_libretro.so"
+    addEmulator 1 "$md_id" "atari2600" "$md_inst/stella_libretro.so"
+    addSystem "atari2600"
 }

--- a/scriptmodules/libretrocores/lr-tgbdual.sh
+++ b/scriptmodules/libretrocores/lr-tgbdual.sh
@@ -39,6 +39,8 @@ function configure_lr-tgbdual() {
     # enable dual / link by default
     setRetroArchCoreOption "tgbdual_gblink_enable" "enabled"
 
-    addSystem 0 "$md_id" "gb" "$md_inst/tgbdual_libretro.so"
-    addSystem 0 "$md_id" "gbc" "$md_inst/tgbdual_libretro.so"
+    addEmulator 0 "$md_id" "gb" "$md_inst/tgbdual_libretro.so"
+    addEmulator 0 "$md_id" "gbc" "$md_inst/tgbdual_libretro.so"
+    addSystem "gb"
+    addSystem "gbc"
 }

--- a/scriptmodules/libretrocores/lr-vba-next.sh
+++ b/scriptmodules/libretrocores/lr-vba-next.sh
@@ -39,5 +39,6 @@ function configure_lr-vba-next() {
     mkRomDir "gba"
     ensureSystemretroconfig "gba"
 
-    addSystem 0 "$md_id" "gba" "$md_inst/vba_next_libretro.so"
+    addEmulator 0 "$md_id" "gba" "$md_inst/vba_next_libretro.so"
+    addSystem "gba"
 }

--- a/scriptmodules/libretrocores/lr-vecx.sh
+++ b/scriptmodules/libretrocores/lr-vecx.sh
@@ -41,5 +41,6 @@ function configure_lr-vecx() {
     cp -v "$md_inst/"{fast.bin,skip.bin,system.bin} "$biosdir/"
     chown $user:$user "$biosdir/"{fast.bin,skip.bin,system.bin}
 
-    addSystem 1 "$md_id" "vectrex" "$md_inst/vecx_libretro.so"
+    addEmulator 1 "$md_id" "vectrex" "$md_inst/vecx_libretro.so"
+    addSystem "vectrex"
 }

--- a/scriptmodules/libretrocores/lr-virtualjaguar.sh
+++ b/scriptmodules/libretrocores/lr-virtualjaguar.sh
@@ -36,5 +36,6 @@ function configure_lr-virtualjaguar() {
     mkRomDir "atarijaguar"
     ensureSystemretroconfig "atarijaguar"
 
-    addSystem 1 "$md_id" "atarijaguar" "$md_inst/virtualjaguar_libretro.so"
+    addEmulator 1 "$md_id" "atarijaguar" "$md_inst/virtualjaguar_libretro.so"
+    addSystem "atarijaguar"
 }

--- a/scriptmodules/libretrocores/lr-yabause.sh
+++ b/scriptmodules/libretrocores/lr-yabause.sh
@@ -47,5 +47,6 @@ function configure_lr-yabause() {
     mkRomDir "saturn"
     ensureSystemretroconfig "saturn"
 
-    addSystem 1 "$md_id" "saturn" "$md_inst/yabause_libretro.so"
+    addEmulator 1 "$md_id" "saturn" "$md_inst/yabause_libretro.so"
+    addSystem "saturn"
 }

--- a/scriptmodules/ports/love.sh
+++ b/scriptmodules/ports/love.sh
@@ -58,7 +58,7 @@ function configure_love() {
 
     mkRomDir "love"
 
-    addSystem 1 "$md_id" "love" "$md_inst/bin/love %ROM%" "Love" ".love"
+    addEmulator 1 "$md_id" "love" "$md_inst/bin/love %ROM%" "Love" ".love"
 
     [[ "$md_mode" == "install" ]] && game_data_love
 }

--- a/scriptmodules/ports/love.sh
+++ b/scriptmodules/ports/love.sh
@@ -58,7 +58,8 @@ function configure_love() {
 
     mkRomDir "love"
 
-    addEmulator 1 "$md_id" "love" "$md_inst/bin/love %ROM%" "Love" ".love"
+    addEmulator 1 "$md_id" "love" "$md_inst/bin/love %ROM%"
+    addSystem "love"
 
     [[ "$md_mode" == "install" ]] && game_data_love
 }

--- a/scriptmodules/ports/tyrquake.sh
+++ b/scriptmodules/ports/tyrquake.sh
@@ -41,7 +41,7 @@ function install_tyrquake() {
 function add_games_tyrquake() {
     _add_games_lr-tyrquake "$md_inst/bin/tyr-quake -basedir $romdir/ports/quake -game %QUAKEDIR%"
     if isPlatform "x11"; then
-        addSystem 1 "$md_id-gl" "quake pc ports" "$md_inst/bin/tyr-glquake -basedir $romdir/ports/quake -game %QUAKEDIR%"
+        addSystem 1 "$md_id-gl" "quake ports" "$md_inst/bin/tyr-glquake -basedir $romdir/ports/quake -game %QUAKEDIR%"
     fi
 }
 

--- a/scriptmodules/ports/tyrquake.sh
+++ b/scriptmodules/ports/tyrquake.sh
@@ -41,7 +41,7 @@ function install_tyrquake() {
 function add_games_tyrquake() {
     _add_games_lr-tyrquake "$md_inst/bin/tyr-quake -basedir $romdir/ports/quake -game %QUAKEDIR%"
     if isPlatform "x11"; then
-        addSystem 1 "$md_id-gl" "quake ports" "$md_inst/bin/tyr-glquake -basedir $romdir/ports/quake -game %QUAKEDIR%"
+        addEmulator 1 "$md_id-gl" "quake ports" "$md_inst/bin/tyr-glquake -basedir $romdir/ports/quake -game %QUAKEDIR%"
     fi
 }
 

--- a/scriptmodules/supplementary/limelight.sh
+++ b/scriptmodules/supplementary/limelight.sh
@@ -50,7 +50,8 @@ function configure_limelight() {
     mkRomDir "limelight"
 
     # Add System to es_system.cfg
-    addSystem 1 "$md_id" "limelight" "%ROM%" "Limelight Game Streaming" ".sh .SH"
+    addEmulator 1 "$md_id" "limelight" "%ROM%" "Limelight Game Streaming" ".sh .SH"
+    addSystem "limelight"
 
     [[ "$md_mode" == "remove" ]] && return
 

--- a/scriptmodules/supplementary/limelight.sh
+++ b/scriptmodules/supplementary/limelight.sh
@@ -50,8 +50,8 @@ function configure_limelight() {
     mkRomDir "limelight"
 
     # Add System to es_system.cfg
-    addEmulator 1 "$md_id" "limelight" "%ROM%" "Limelight Game Streaming" ".sh .SH"
-    addSystem "limelight"
+    addEmulator 1 "$md_id" "limelight" "%ROM%"
+    addSystem "limelight" "Limelight Game Streaming" ".sh"
 
     [[ "$md_mode" == "remove" ]] && return
 


### PR DESCRIPTION
Currently we have just addSystem which is used to add emulators and systems all at the same time. This is fine, except in some cases where we have multiple calls - eg for fuse where we have a 48k and 128k "emulator" (calling fuse with different parameters etc). Right now this causes the frontend system to be updated twice. 

Now we have other frontends, it would be better to just try and add a system once as needed. Also since the addSystem call handled the removal, we would also try and "remove" it multiple times when there was more than one emulator entry for that module.

By splitting it, we can now just add multiple emulators, and then add the system afterwards (it has to be in the order due to when in removal mode - system must be removed last).

As well as avoiding adding/updating a system multiple times it makes the code cleaner as the functions do what the name suggests, rather than one function that does multiple tasks.

Note backward compatibility is included for 3rd party repos like @zerojay 's - but they should be updated soon as it may be removed in the future.

This is quite a large patchset and there may be bugs, so I will give it some more testing before merging - feel free to test.