### PR TITLE
Add Amiga file extension ".uae" to platforms.cfg

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -1,7 +1,7 @@
 3do_exts=".iso"
 3do_fullname="3DO Interactive Multiplayer"
 
-amiga_exts=".adf .adz .dms .ipf .zip"
+amiga_exts=".adf .adz .dms .ipf .uae .zip"
 amiga_fullname="Commodore Amiga"
 
 amstradcpc_exts=".cdt .cpc .dsk"


### PR DESCRIPTION
In addition to the existing disk image extensions such as .adf and dms, the emulator configuration file extension .uae/.UAE is necessary to boot into hard disk images and whdload packages. This way the emulator can be launched with a .uae configuration file containing the path to the hard disk image and any special configurations that image may require.

Whdload packages are often fixed to have less strict hardware/bios requirements and removes the need to swap disks as all files are located in one hard disk image.

An example where .uae is required is the whdload booter for RetroPie: 
http://www.ultimateamiga.co.uk/index.php?topic=9930.0

Adding .uae to the emulators default extensions does not automatically make whdload booting work but makes it simpler - without adverse effects for those using traditional disk images such as .adf and .dms.