### PR TITLE
kill "feh" when invoking runcommand menu

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -903,6 +903,7 @@ function check_menu() {
     # check for key pressed to enter configuration
     IFS= read -s -t 2 -N 1 key </dev/tty
     if [[ -n "$key" ]]; then
+        [[ -n "$IMG_PID" ]] && kill -SIGINT "$IMG_PID"
         if [[ "$HAS_TVS" -eq 1 ]]; then
             get_all_modes
         fi


### PR DESCRIPTION
When running under X and showing the launching image with `feh`, if the user "press a button" to access the runcommand menu, the image stays in front of the terminal. This change kills the `feh` if the user "press a button".