### PR TITLE
add support for Devuan (fully Debian compatible)

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -87,6 +87,12 @@ function get_os_version() {
                 __platform_flags+=" xbian"
             fi
             ;;
+         Devuan)
+            # Devuan 1 === Debian 8 Jessie, with the only modification
+            # of a different init system (it gets rid of systemD)
+            # so any Devuan version meets the requeriments
+            foo=bar
+            ;;
         LinuxMint)
             if compareVersions "$__os_release" lt 17; then
                 error="You need Linux Mint 17 or newer"


### PR DESCRIPTION
Devuan 1 is a fully compliant Debian 8 Jessie, with the only modification of the init system (it gets rid of systemD).
100% working at the time of submitting.