### PR TITLE
Add .car files to Atari800

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -22,7 +22,7 @@ atari5200_fullname="Atari 5200"
 atari7800_exts=".a78 .bin .zip"
 atari7800_fullname="Atari 7800 ProSystem"
 
-atari800_exts=".bas .bin .com .xex .atr .xfd .dcm .atr.gz .xfd.gz"
+atari800_exts=".bas .bin .car .com .xex .atr .xfd .dcm .atr.gz .xfd.gz"
 atari800_fullname="Atari 800"
 
 atarilynx_exts=".lnx .zip"

--- a/scriptmodules/emulators/atari800.sh
+++ b/scriptmodules/emulators/atari800.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="atari800"
 rp_module_desc="Atari 8-bit/800/5200 emulator"
-rp_module_help="ROM Extensions: .a52 .bas .bin .xex .atr .xfd .dcm .atr.gz .xfd.gz\n\nCopy your Atari800 roms to $romdir/atari800\n\nCopy your Atari 5200 roms to $romdir/atari5200 You need to copy the Atari 800/5200 BIOS files (5200.ROM, ATARIBAS.ROM, ATARIOSB.ROM and ATARIXL.ROM) to the folder $biosdir and then on first launch configure it to scan that folder for roms (F1 -> Emulator Configuration -> System Rom Settings)"
+rp_module_help="ROM Extensions: .a52 .bas .bin .car .xex .atr .xfd .dcm .atr.gz .xfd.gz\n\nCopy your Atari800 roms to $romdir/atari800\n\nCopy your Atari 5200 roms to $romdir/atari5200 You need to copy the Atari 800/5200 BIOS files (5200.ROM, ATARIBAS.ROM, ATARIOSB.ROM and ATARIXL.ROM) to the folder $biosdir and then on first launch configure it to scan that folder for roms (F1 -> Emulator Configuration -> System Rom Settings)"
 rp_module_section="opt"
 rp_module_flags="!mali"
 


### PR DESCRIPTION
.car files are Atari 8-bit cart images created from .bin files by the
Atari800 Emulator itself. They add a metadata header telling Atari800
what type of cart it is and saving the user from entering it manually.
TOSEC managed to scramble some carts by just renaming the .car files to
.bin in a lot of cases, not realising there was a difference. In
retropie, using a .car file in preference to a .bin file will save a
step for the user.