### PR TITLE
Hook ODROID-C1 into lr-mupen64plus.sh properly

### DIFF
--- a/scriptmodules/libretrocores/lr-mupen64plus.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus.sh
@@ -21,7 +21,7 @@ function sources_lr-mupen64plus() {
 function build_lr-mupen64plus() {
     rpSwap on 750
     make clean
-    if isPlatform "rpi"; then
+    if isPlatform "rpi" || isPlatform "odroid-c1"; then
         make platform="$__platform"
     else
         make


### PR DESCRIPTION
This fix builds lr-mupen64plus properly on ODROID-C1. I have a C2 on the way, and it looks like the fix will be the same for it. If there's a better way to fix this, please let me know and I'll roll it properly, then submit another pull request.