### PR TITLE
Add DraStic DS Emulator

### DIFF
--- a/scriptmodules/emulators/drastic.sh
+++ b/scriptmodules/emulators/drastic.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="drastic"
+rp_module_desc="NDS emu - DraStic"
+rp_module_help="ROM Extensions: .nds .zip\n\nCopy your Nintendo DS roms to $romdir/nds"
+rp_module_section="exp"
+rp_module_flags="!mali !x86 !armv6"
+
+function install_bin_drastic() {
+    wget -O- -q http://drastic-ds.com/drastic_rpi.tar.bz2 | tar -xvj --strip-components=1 -C "$md_inst"
+}
+
+function configure_drastic() {
+    mkRomDir "nds"
+    ensureSystemretroconfig "nds"
+
+    addEmulator 0 "$md_id" "nds" "$md_inst/drastic %ROM%"
+    addSystem "nds"
+}


### PR DESCRIPTION
The person who did the RPI port recently put out the link to the test port on [this forum post](https://pyra-handheld.com/boards/threads/drastic-nintendo-ds-emulator.73431/page-83#post-1403469), and it's actually playable!

Tested:
- using a Pi 3
- using the Super Mario 64 DS (USA version) ROM
- using the Pokémon HeartGold (USA version) ROM

Results:
- Game speed is usually around 100%
- Smooth, continuous sound

Bugs:
- After you exit the emulator, you can't start anymore applications or else the Pi freezes... The only way around this (at least right now) is to restart the Pi.