### PR TITLE
[bluez-test-device] Fix indent style

### DIFF
--- a/scriptmodules/supplementary/bluetooth/bluez-test-device
+++ b/scriptmodules/supplementary/bluetooth/bluez-test-device
@@ -55,7 +55,7 @@ if (args[0] == "list"):
 		if properties["Adapter"] != adapter_path:
 			continue;
 		device_string = "%s %s" % (properties["Address"], properties["Alias"])
-                print(device_string.encode('ascii', 'ignore'))
+		print(device_string.encode('ascii', 'ignore'))
 
 	sys.exit(0)
 


### PR DESCRIPTION
The latest fix made to bluez-test-device did not respect the existing tabs styling present in the file. This commit uses tabs where necessary.