### PR TITLE
Fix multiple matching device filenames 

### DIFF
--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -113,7 +113,7 @@ function remap() {
         bind=""
         for device_num in "${!devices[@]}"; do
             # get name of retroarch auto config file
-            file=$(grep --exclude=*.bak -rl "$configdir/all/retroarch-joypads/" -e "\"${devices[$device_num]}\"")
+            file=`grep --exclude=*.bak -rl "$configdir/all/retroarch-joypads/" -e "\"${devices[$device_num]}\"" | awk '{n=gsub("/","/",$0);printf "%d/%s\n",n,$0}' | sort -t/ | sed 's|[^/]*/||' | head -n1`
             atebitdo_hack=0
             [[ "$file" == *8Bitdo* ]] && getAutoConf "8bitdo_hack" && atebitdo_hack=1
             if [[ -f "$file" ]]; then

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -113,7 +113,7 @@ function remap() {
         bind=""
         for device_num in "${!devices[@]}"; do
             # get name of retroarch auto config file
-            file=$(grep --exclude=*.bak -rl "$configdir/all/retroarch-joypads/" -e "\"${devices[$device_num]}\"" | awk '{n=gsub("/","/",$0);printf "%d/%s\n",n,$0}' | sort -t/ | sed 's|[^/]*/||' | head -n1)
+            file=$(grep -lF "\"${devices[$device_num]}\"" "$configdir/all/retroarch-joypads/"*.cfg)
             atebitdo_hack=0
             [[ "$file" == *8Bitdo* ]] && getAutoConf "8bitdo_hack" && atebitdo_hack=1
             if [[ -f "$file" ]]; then

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -113,7 +113,7 @@ function remap() {
         bind=""
         for device_num in "${!devices[@]}"; do
             # get name of retroarch auto config file
-            file=`grep --exclude=*.bak -rl "$configdir/all/retroarch-joypads/" -e "\"${devices[$device_num]}\"" | awk '{n=gsub("/","/",$0);printf "%d/%s\n",n,$0}' | sort -t/ | sed 's|[^/]*/||' | head -n1`
+            file=$(grep --exclude=*.bak -rl "$configdir/all/retroarch-joypads/" -e "\"${devices[$device_num]}\"" | awk '{n=gsub("/","/",$0);printf "%d/%s\n",n,$0}' | sort -t/ | sed 's|[^/]*/||' | head -n1)
             atebitdo_hack=0
             [[ "$file" == *8Bitdo* ]] && getAutoConf "8bitdo_hack" && atebitdo_hack=1
             if [[ -f "$file" ]]; then


### PR DESCRIPTION
$ cat /sys/class/input/js0/device/name
> Microsoft X-Box 360 pad

$ grep --exclude=*.bak -rl "/opt/retropie/configs/all/retroarch-joypads/" -e "Microsoft X-Box 360 pad"
> /opt/retropie/configs/all/retroarch-joypads/udev/Microsoft_X-Box_360_pad.cfg
> /opt/retropie/configs/all/retroarch-joypads/Microsoft X-Box 360 pad.cfg
> /opt/retropie/configs/all/retroarch-joypads/android/Microsoft_XBOX_360_Controller_USB.cfg

-sort and awk ensures breadth first as to comply with joypad config