### PR TITLE
Add lr-puae #1871

### DIFF
--- a/scriptmodules/libretrocores/lr-puae.sh
+++ b/scriptmodules/libretrocores/lr-puae.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-puae"
+rp_module_desc="P-UAE Amiga emulator port for libretro"
+rp_module_help="ROM Extensions: .adf .uae\n\nCopy your roms to $romdir/amiga and create configs as .uae"
+rp_module_section="exp"
+
+function sources_lr-puae() {
+    gitPullOrClone "$md_build" https://github.com/libretro/libretro-uae.git
+}
+
+function build_lr-puae() {
+    make
+    md_ret_require="$md_build/puae_libretro.so"
+}
+
+function install_lr-puae() {
+    md_ret_files=(
+        'puae_libretro.so'
+        'README'
+    )
+}
+
+function configure_lr-puae() {
+    mkRomDir "amiga"
+    ensureSystemretroconfig "amiga"
+    addEmulator 1 "$md_id" "amiga" "$md_inst/puae_libretro.so"
+    addSystem "amiga" "Commodore Amiga" ".uae"
+}


### PR DESCRIPTION
Initial pull request for code review, notes:
- No directory setup for kickstart or rom folders, I set that up with RetroPie assistant template and I can share that too if wanted
- Adding .uae extension (which can also be done by retropieassistant)
- Not verified with other arhitecture hence the restriction
- Save states doesn't work for me (Need to check with upstream maybe)