### PR TITLE
Incorporate Herb's mkdocs work into a module

### DIFF
--- a/scriptmodules/admin/apidocs.sh
+++ b/scriptmodules/admin/apidocs.sh
@@ -9,19 +9,19 @@
 # at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
 #
 
-rp_module_id="docs"
+rp_module_id="apidocs"
 rp_module_desc="Generate developer documentation"
 rp_module_section=""
 
-function depends_docs() {
+function depends_apidocs() {
     getDepends doxygen graphviz
 }
 
-function sources_docs() {
+function sources_apidocs() {
     gitPullOrClone "$md_build" https://github.com/Anvil/bash-doxygen.git
 }
 
-function build_docs() {
+function build_apidocs() {
     local config="Doxyfile"
     rm -f "$config"
     doxygen -g "$config" >/dev/null
@@ -40,12 +40,12 @@ function build_docs() {
     doxygen "$config"
 }
 
-function install_docs() {
+function install_apidocs() {
     rm -rf "$scriptdir/docs"
     cp -R "$md_build/html" "$scriptdir/docs"
     chown -R $user:$user "$scriptdir/docs"
 }
 
-function upload_docs() {
+function upload_apidocs() {
     rsync -av --delete "$scriptdir/docs/" "retropie@$__binary_host:retropie-setup-api/"
 }

--- a/scriptmodules/admin/apidocs.sh
+++ b/scriptmodules/admin/apidocs.sh
@@ -41,11 +41,10 @@ function build_apidocs() {
 }
 
 function install_apidocs() {
-    rm -rf "$scriptdir/docs"
-    cp -R "$md_build/html" "$scriptdir/docs"
-    chown -R $user:$user "$scriptdir/docs"
+    rsync -a --delete "$md_build/html/" "$__tmpdir/apidocs/"
+    chown -R $user:$user "$__tmpdir/apidocs"
 }
 
 function upload_apidocs() {
-    rsync -av --delete "$scriptdir/docs/" "retropie@$__binary_host:retropie-setup-api/"
+    rsync -av --delete "$__tmpdir/apidocs/" "retropie@$__binary_host:api/"
 }

--- a/scriptmodules/admin/wikidocs.sh
+++ b/scriptmodules/admin/wikidocs.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="wikidocs"
+rp_module_desc="Generate mkdocs documentation from wiki"
+rp_module_section=""
+
+function depends_wikidocs() {
+    getDepends python3 python3-pip
+    pip3 install --upgrade mkdocs mkdocs-material
+}
+
+function sources_wikidocs() {
+    gitPullOrClone "$md_build" https://github.com/RetroPie/RetroPie-Docs.git
+    gitPullOrClone "$md_build/docs" https://github.com/RetroPie/retropie-setup.wiki.git
+
+    cp -v "docs/Home.md" "docs/index.md"
+    cp -R "$md_build/"{images,stylesheets} "docs/"
+}
+
+function build_wikidocs() {
+    mkdocs build
+}
+
+function install_wikidocs() {
+    rsync -a --delete "$md_build/site/" "$__tmpdir/wikidocs/"
+    chown -R $user:$user "$__tmpdir/wikidocs"
+}
+
+function upload_wikidocs() {
+    rsync -av --delete "$__tmpdir/wikidocs/" "retropie@$__binary_host:docs/"
+}
+


### PR DESCRIPTION
Renamed existing docs module to apidocs.
Added this one as wikidocs.

```
sudo ./retropie_packages.sh wikidocs
```

to generate

```
sudo ./retropie_packages.sh wikidocs upload
```

to push to the site (requires your ssh public key in retropie account on our server - we can sort that if you want to test).

docs end up here

https://retropie.org.uk/wikidocs/

thanks for your work on this