### PR TITLE
loadModuleConfig's value can have spaces

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -866,7 +866,7 @@ function loadModuleConfig() {
     for option in "${options[@]}"; do
         option=(${option/=/ })
         key="${option[0]}"
-        value="${option[1]}"
+        value="${option[@]:1}"
         iniGet "$key"
         if [[ -z "$ini_value" ]]; then
             iniSet "$key" "$value"


### PR DESCRIPTION
I was having problems when using loadModuleConfig and the variable's value has spaces.
Example: when using `loading_text="NOW LOADING"`, loadModuleConfig was getting `key=loading_text` and `value=NOW`. After this change it's getting `value="NOW LOADING"`.

I've tested `scraper.sh` with this change to make sure it don't break anything and everything runs fine.

**Note**: the use of quotes on variable definitions should be avoided (maybe prohibited?), like this: `loading_text=NOW LOADING`.
If using `loading_text="NOW LOADING"` it will save this in the ini file:
```
loading_text = ""NOW LOADING""
```
And this excess of quotes symbols with `eval` (in scriptmodules) are a dangerous combination.