### PR TITLE
Support for Git repositories that use Submodules, drivers module for ControlBlock

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -327,9 +327,10 @@ function gitPullOrClone() {
     if [[ -d "$dir/.git" ]]; then
         pushd "$dir" > /dev/null
         git pull > /dev/null
+        git submodule update --init --recursive
         popd > /dev/null
     else
-        local git="git clone"
+        local git="git clone --recursive"
         if [[ "$__persistent_repos" -ne 1 ]]; then
             [[ "$repo" =~ github ]] && git+=" --depth 1"
         fi

--- a/scriptmodules/supplementary/controlblock.sh
+++ b/scriptmodules/supplementary/controlblock.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="controlblock"
+rp_module_desc="ControlBlock Driver"
+rp_module_section="driver"
+rp_module_flags="noinstclean"
+
+function depends_controlblock() {
+    local depends=(cmake doxygen)
+    isPlatform "rpi" && depends+=(libraspberrypi-dev)
+
+    getDepends "${depends[@]}"
+}
+
+function sources_controlblock() {
+    gitPullOrClone "$md_inst" https://github.com/petrockblog/ControlBlockService2.git
+}
+
+function build_controlblock() {
+    cd "$md_inst"
+    rm -rf "build"
+    mkdir build
+    cd build
+    cmake ..
+    make
+    md_ret_require="$md_inst/build/controlblock"
+}
+
+function install_controlblock() {
+    # install from there to system folders
+    cd "$md_inst/build"
+    make install
+}
+
+function gui_controlblock() {
+    cmd=(dialog --backtitle "$__backtitle" --menu "Choose an option." 22 86 16)
+    options=(
+        1 "Enable ControlBlock driver"
+        2 "Disable ControlBlock driver"
+
+    )
+    choices=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
+    if [[ -n "$choices" ]]; then
+        case $choices in
+            1)
+                make -C "$md_inst/build" installservice
+                printMsgs "dialog" "Enabled ControlBlock driver."
+                ;;
+            2)
+                make -C "$md_inst/build" uninstallservice
+                printMsgs "dialog" "Disabled ControlBlock driver."
+                ;;
+        esac
+    fi
+}
+
+function remove_controlblock() {
+    make -C "$md_inst/build" uninstallservice
+    make -C "$md_inst/build" uninstall
+}


### PR DESCRIPTION
I have added support for Git repository that use Git submodules. Also, I have added a driver module for the ControlBlock hardware, which is similar to the PowerBlock module.