### PR TITLE
--frames isn't used by retroarch anymore

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -775,7 +775,7 @@ function retroarch_append_config() {
     # append any NETPLAY configuration
     if [[ "$NETPLAY" -eq 1 ]] && [[ -f "$RETRONETPLAY_CONF" ]]; then
         source "$RETRONETPLAY_CONF"
-        COMMAND+=" -$__netplaymode $__netplayhostip_cfile --port $__netplayport --frames $__netplayframes --nick $__netplaynickname"
+        COMMAND+=" -$__netplaymode $__netplayhostip_cfile --port $__netplayport --nick $__netplaynickname"
     fi
 }
 


### PR DESCRIPTION
This error is preventing netplay from working in recent release. --check-frames is new sort of similar(but not the same) option but isn't necessary to be adjusted if it works with default values.