### PR TITLE
add gvfs to pixel desktop

### DIFF
--- a/scriptmodules/supplementary/raspbiantools.sh
+++ b/scriptmodules/supplementary/raspbiantools.sh
@@ -21,7 +21,7 @@ function apt_upgrade_raspbiantools() {
 
 function lxde_raspbiantools() {
     aptInstall --no-install-recommends lxde
-    aptInstall xorg raspberrypi-ui-mods rpi-chromium-mods
+    aptInstall xorg raspberrypi-ui-mods rpi-chromium-mods gvfs
     setConfigRoot "ports"
     addPort "lxde" "lxde" "Desktop" "startx"
     enable_autostart


### PR DESCRIPTION
should fix the whole wastebasket not showing up, mounts, etc.

post for reference:

https://retropie.org.uk/forum/topic/7538/installing-pixel/10