### PR TITLE
mupen64plus: use config version of branch "flicker fix"

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -193,7 +193,7 @@ function configure_mupen64plus() {
             echo "[Video-GLideN64]" >> "$config"
         fi
         # Settings version. Don't touch it.
-        iniSet "configVersion" "17"
+        iniSet "configVersion" "15"
         # Bilinear filtering mode (0=N64 3point, 1=standard)
         iniSet "bilinearMode" "1"
         # Size of texture cache in megabytes. Good value is VRAM*3/4

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -230,7 +230,7 @@ function testCompatibility() {
             fi
             iniConfig " = " "" "$config"
             # Settings version. Don't touch it.
-            iniSet "configVersion" "17"
+            iniSet "configVersion" "15"
             # Enable FBEmulation if necessary
             iniSet "EnableFBEmulation" "False"
             for game in "${GLideN64FBEMU_whitelist[@]}"; do


### PR DESCRIPTION
Use version 15 until we can use upstream again.
https://github.com/joolswills/GLideN64/blob/flicker_fix/src/Config.h#L7