### PR TITLE
Automatically place the lr-fbalpha hiscore.dat in the appropriate pla…

### DIFF
--- a/scriptmodules/libretrocores/lr-fbalpha.sh
+++ b/scriptmodules/libretrocores/lr-fbalpha.sh
@@ -37,6 +37,7 @@ function install_lr-fbalpha() {
         'gamelist.txt'
         'whatsnew.html'
         'preset-example.zip'
+        'metadata'
     )
 }
 
@@ -50,6 +51,10 @@ function configure_lr-fbalpha() {
     # Create samples directory
     mkUserDir "$biosdir/fba"
     mkUserDir "$biosdir/fba/samples"
+
+    # copy hiscore.dat
+    cp "$md_inst/metadata/hiscore.dat" "$biosdir/fba/"
+    chown $user:$user "$biosdir/fba/hiscore.dat"
 
     # Set core options
     setRetroArchCoreOption "fba-diagnostic-input" "Hold Start"


### PR DESCRIPTION
…ces.

Similar to https://github.com/RetroPie/RetroPie-Setup/commit/de59962c2ef7db8b223e7c264244bc27ba2b0147.

Note, lr-fbalpha needs it to be in the SAVE_DIRECTORY (`/roms/fba/` or `/roms/arcade/` or `/roms/neogeo/` directories for us), rather than the SYSTEM_DIRECTORY (`/BIOS/` for us). This ends up with 3 copies of the same 231KB file. Potentially you could have it in one place and symlink, but maybe that's over-engineering it. Also I seem to recall symlinks don't work properly in FAT32 (USB drives, etc)?

...or we could see if lr-fbalpha would first accept a PR to move the hiscore path to the SYSTEM_DIRECTORY path.