### PR TITLE
iniProcess returns 0 if not editing retroarch.cfg

### DIFF
--- a/scriptmodules/inifuncs.sh
+++ b/scriptmodules/inifuncs.sh
@@ -86,6 +86,7 @@ function iniProcess() {
     fi
 
     [[ "$file" =~ retroarch\.cfg$ ]] && retroarchIncludeToEnd "$file"
+    return 0
 }
 
 ## @fn iniUnset()


### PR DESCRIPTION
The test `[[ "$file" =~ retroarch\.cfg$ ]]` in the end of iniProcess was making the function always return a non-zero (fail) when not editing a retroarch.cfg file, even if everything was fine in iniProcess.

This change makes iniProcess return zero after that test.