### PR TITLE
debian stretch support

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -18,8 +18,14 @@ function depends_retroarch() {
     local depends=(libudev-dev libxkbcommon-dev libsdl2-dev libasound2-dev libusb-1.0-0-dev)
     isPlatform "rpi" && depends+=(libraspberrypi-dev)
     isPlatform "mali" && depends+=(mali-fbdev)
-    isPlatform "x86" && depends+=(nvidia-cg-toolkit)
     isPlatform "x11" && depends+=(libpulse-dev libavcodec-dev libavformat-dev libavdevice-dev)
+
+    # only install nvidia-cg-toolkit if it is available (as the non-free repo may not be enabled)
+    if isPlatform "x86"; then
+        if [[ -n "$(apt-cache search --names-only nvidia-cg-toolkit)" ]]; then
+            depends+=(nvidia-cg-toolkit)
+        fi
+    fi
 
     getDepends "${depends[@]}"
 

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -213,7 +213,7 @@ function getDepends() {
         fi
 
         # map libpng12-dev to libpng-dev for Ubuntu 16.10+
-        if [[ "$required" == "libpng12-dev" && -n "$__os_ubuntu_ver" ]] && compareVersions "$__os_ubuntu_ver" ge 16.10;  then
+        if [[ "$required" == "libpng12-dev" ]] && compareVersions "$__os_debian_ver" ge 9;  then
             required="libpng-dev"
         fi
 

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -40,7 +40,7 @@ function setup_env() {
     __archive_url="http://files.retropie.org.uk/archives"
 
     # -pipe is faster but will use more memory - so let's only add it if we have more thans 256M free ram.
-    [[ $__memory_phys -ge 256 ]] && __default_cflags+=" -pipe"
+    [[ $__memory_phys -ge 512 ]] && __default_cflags+=" -pipe"
 
     [[ -z "${CFLAGS}" ]] && export CFLAGS="${__default_cflags}"
     [[ -z "${CXXFLAGS}" ]] && export CXXFLAGS="${__default_cxxflags}"
@@ -124,9 +124,12 @@ function get_os_version() {
         Ubuntu)
             if compareVersions "$__os_release" lt 14.04; then
                 error="You need Ubuntu 14.04 or newer"
+            elif compareVersions "$__os_release" lt 16.10; then
+                __os_debian_ver="8"
+            else
+                __os_debian_ver="9"
             fi
             __os_ubuntu_ver="$__os_release"
-            __os_debian_ver="8"
             ;;
         elementary)
             if compareVersions "$__os_release" lt 0.3; then
@@ -156,8 +159,8 @@ function get_default_gcc() {
     if [[ -z "$__default_gcc_version" ]]; then
         case "$__os_id" in
             Raspbian|Debian)
-                case "$__os_codename" in
-                    *)
+                case "$__os_debian_ver" in
+                    8)
                         __default_gcc_version="4.9"
                 esac
                 ;;


### PR DESCRIPTION
 * only force gcc version to 4.9 on debian/raspbian 8
 * use libpng-dev for debian 9+
 * set debian version to 9 for ubuntu 16.10 and above (for libpng naming).