### PR TITLE
joy2key starters get button mappings from retroarch-joypads cfgs

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -105,26 +105,93 @@ function get_config() {
 
 function start_joy2key() {
     [[ "$DISABLE_JOYSTICK" -eq 1 ]] && return
-    # get the first joystick device (if not already set)
+ 
+    # get all joystick devices, if not already set
     if [[ -c "$__joy2key_dev" ]]; then
         JOY2KEY_DEV="$__joy2key_dev"
     else
-        JOY2KEY_DEV="/dev/input/jsX"
+        JOY2KEY_DEV=$(find /dev/input -name "js*")
     fi
-    # if joy2key.py is installed run it with cursor keys for axis, and enter + tab for buttons 0 and 1
-    if [[ -f "$ROOTDIR/supplementary/runcommand/joy2key.py" && -n "$JOY2KEY_DEV" ]] && ! pgrep -f joy2key.py >/dev/null; then
 
-        # call joy2key.py: arguments are curses capability names or hex values starting with '0x'
-        # see: http://pubs.opengroup.org/onlinepubs/7908799/xcurses/terminfo.html
-        "$ROOTDIR/supplementary/runcommand/joy2key.py" "$JOY2KEY_DEV" kcub1 kcuf1 kcuu1 kcud1 0x0a 0x09 &
-        JOY2KEY_PID=$!
+    # if joy2key.py is installed run it with cursor keys for axis, and enter + tab for buttons A and B
+    if [[ -f "$ROOTDIR/supplementary/runcommand/joy2key.py" && -n "$JOY2KEY_DEV" ]] && ! pgrep -f joy2key.py >/dev/null; then
+        local params=()
+        local dev
+
+        for dev in $JOY2KEY_DEV ; do
+            # joy2key.py: arguments are curses capability names or hex values starting with '0x'
+            # see: http://pubs.opengroup.org/onlinepubs/7908799/xcurses/terminfo.html
+            params=( $(joy2key_input_config) )
+            [[ -z "$params" ]] && params=(kcub1 kcuf1 kcuu1 kcud1 0x0a 0x09)
+
+            "$ROOTDIR/supplementary/runcommand/joy2key.py" "$dev" "${params[@]}" &
+            JOY2KEY_PID+=($!)
+        done
     fi
 }
 
 function stop_joy2key() {
-    if [[ -n "$JOY2KEY_PID" ]]; then
-        kill -INT "$JOY2KEY_PID"
+    if [[ "${#JOY2KEY_PID[@]}" -gt 0 ]]; then
+        kill -INT "${JOY2KEY_PID[@]}"
     fi
+}
+
+function joy2key_input_config() {
+    local retroarchcfg="$CONFIGDIR/all/retroarch.cfg"
+    local joypadcfg
+    local enter_btn=a
+    local enter_btn_num
+    local tab_btn=b
+    local tab_btn_num
+    local dev_name
+    local dev_path
+    local biggest_num
+    local i
+
+    iniGet menu_swap_ok_cancel_buttons "$retroarchcfg"
+    if [[ "$ini_value" == true ]]; then
+        enter_btn=b
+        tab_btn=a
+    fi
+
+    # "inspired" on configedit.sh code
+    if udevadm info --name=$dev | grep -q "ID_INPUT_JOYSTICK=1"; then
+        dev_path="$(udevadm info --name=$dev | grep DEVPATH | cut -d= -f2)"
+        dev_name="$(</$(dirname sys$dev_path)/name)"
+
+        # get the retroarch config file for this joypad
+        joypadcfg="$(grep -l "input_device *= *\"$dev_name\"" "$CONFIGDIR/all/retroarch-joypads/"*.cfg)"
+        [[ -f "$joypadcfg" ]] || return 1
+        iniGet input_device "$joypadcfg"
+        [[ "$ini_value" != "$dev_name" ]] && return 1
+
+        enter_btn_num=$(get_btn_number "$enter_btn") || return 1
+        tab_btn_num=$(get_btn_number "$tab_btn") || return 1
+
+        biggest_num=$tab_btn_num
+        [[ "$tab_btn_num" -lt "$enter_btn_num" ]] && biggest_num=$enter_btn_num
+
+        params="kcub1 kcuf1 kcuu1 kcud1"
+        for i in $(seq 0 $biggest_num); do
+            case $i in
+                $enter_btn_num) params+=" 0x0a" ;;
+                $tab_btn_num)   params+=" 0x09" ;;
+                *)              params+=" ''" ;;
+            esac
+        done
+
+        echo "$params"
+    fi
+}
+
+function get_btn_number() {
+    local btn="$1"
+    iniGet input_${btn}_btn "$joypadcfg"
+    if [[ -z "$ini_value" ]]; then
+        iniGet input_player1_${btn}_btn "$joypadcfg"
+        [[ -z "$ini_value" ]] && return 1
+    fi
+    echo "$ini_value"
 }
 
 function get_params() {


### PR DESCRIPTION
@joolswills 
Not sure if you'll want to merge it the way I'm doing here, but I'm submitting this PR so we can talk about the method I used to achiev what we were talking [in this forum topic](https://retropie.org.uk/forum/post/70225)...

Summarizing what the function `joy2key_input_config()` in runcommand.sh does:

1. gets the name of `/dev/input/jsN` device.
2. checks if there's a `retroarch-joypads/JOYSTICK.cfg` for the respective device.
3. gets the **A** and **B** button number.
4. echoes the parameters needed for joy2key.py setting the **A** for `<enter>` and **B** for `<tab>`.
  4.1. if the global retroarch.cfg has `menu_swap_ok_cancel_buttons = true`, **A** is set to `<tab>` and **B** to `<enter>`.
5. If the function fails in any of the steps above the default behavior is button 0 = `<enter>` and button 1 = `<tab>`.

**Some notes:**

- The main thing to note is that in `start_joy2key()` I'm launching one instance of joy2key.py for each `/dev/input/jsN` device, but I'm keeping track of all the PIDs to kill them in `stop_joy2key()`.

- The function `joy2keyInputConfig()` in helpers.sh works similarly, but using `<space>` rather than `<tab>`.

- The function `joy2keyStart()` in helpers.sh has a feature that let the caller explicitly set the parameters for joy2key, I'm being careful to not break this feature. When the caller explicitly sets those params, `joy2keyStart()` does **NOT** get the retroarch joypad configs. (AFAIK the wikiview.sh is the only `joy2keyStart`'s client that use it this way.)

- I tested both retropie_setup and runcommand here with 3 different controllers, tried different mappings in `retroarch-joypads/JOYSTICK.cfg` for each controller, tested the `menu_swap_ok_cancel_buttons` thing, all of it several times, etc. and everything seems to be fine. **But I didn't test it with those bluetooth joysticks with weird button numbers yet** (don't have one at hand currently).