### PR TITLE
Adding ES OMX Player Experimental module

### DIFF
--- a/scriptmodules/supplementary/emulationstation-omx.sh
+++ b/scriptmodules/supplementary/emulationstation-omx.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="emulationstation-omx"
+rp_module_desc="EmulationStation with OMX Player and Screensaver, based on fieldofcows's OMX Player work, iterated on by pjft."
+rp_module_licence="MIT https://raw.githubusercontent.com/pjft/EmulationStation/master/LICENSE.md"
+rp_module_section="exp"
+
+function depends_emulationstation-omx() {
+    depends_emulationstation
+}
+
+function sources_emulationstation-omx() {
+    sources_emulationstation "https://github.com/pjft/EmulationStation" "ES-OMX-Master-Merged-Stable"
+}
+
+function build_emulationstation-omx() {
+    build_emulationstation
+}
+
+function install_emulationstation-omx() {
+    install_emulationstation
+}
+
+function configure_emulationstation-omx() {
+    configure_emulationstation
+}
+
+function gui_emulationstation-omx() {
+    gui_emulationstation
+}


### PR DESCRIPTION
Hi,

I have been maintaining a build based on @fieldofcows ' OMX Player and screensaver work, with a few other quality of life features, such as random game selection from the screensaver, captions for showing the screensaver game name.

Given that we're still a ways off from getting HW acceleration on VLC, this build is being used by a few people in the community, but it's kind of a suboptimal flow to update it.

I'm planning on keeping the source branch up-to-date with the master RetroPie/EmulationStation branch on a regular-ish basis (2 months, monthly, or on the odd occasion sooner if relevant), so that people can keep up with the majority of new developments but still keep OMX Player as an option, as well as having screensaver support.

Hence, I'd like to ask if it it's possible to add this to the experimental section of RetroPie-Setup. If so, I'll add it to the wiki then as a separate page, similar to the ES-Kids fork one.

Open to recommendations - and explicitly calling out @fieldofcows in case he has any further feedback, as well as in case the emails I have tried to reach out to him on aren't being monitored anymore. If you have any concerns or aren't supportive of this, I'm happy to withdraw this change, but it's an easier way for people to have access to this work.

Thanks.