### PR TITLE
lr-px68k

### DIFF
--- a/scriptmodules/emulators/px68k.sh
+++ b/scriptmodules/emulators/px68k.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="px68k"
 rp_module_desc="SHARP X68000 Emulator"
-rp_module_help="You need to copy the X68000 bios files plrom30.dat, iplromco.dat, iplrom.dat, iplromxv.dat, and the font file cgrom.dat to $romdir/BIOS. Use F12 to access the in emulator menu."
+rp_module_help="You need to copy a X68000 bios file (iplrom30.dat, iplromco.dat, iplrom.dat, or iplromxv.dat), and the font file (cgrom.dat or cgrom.tmp) to $romdir/BIOS/keropi. Use F12 to access the in emulator menu."
 rp_module_section="exp"
 rp_module_flags="!mali"
 
@@ -40,10 +40,14 @@ function configure_px68k() {
     mkRomDir "x68000"
 
     moveConfigDir "$home/.keropi" "$md_conf_root/x68000"
+    mkUserDir "$biosdir/keropi"
 
     local bios
-    for bios in cgrom.dat plrom30.dat iplromco.dat iplrom.dat iplromxv.dat; do
-        ln -sf "$biosdir/$bios" "$md_conf_root/x68000/$bios"
+    for bios in cgrom.dat iplrom30.dat iplromco.dat iplrom.dat iplromxv.dat; do
+        if [[ -f "$biosdir/$bios" ]]; then
+            mv "$biosdir/$bios" "$biosdir/keropi/$bios"
+        fi
+        ln -sf "$biosdir/keropi/$bios" "$md_conf_root/x68000/$bios"
     done
 
     setDispmanx "$md_id" 0

--- a/scriptmodules/libretrocores/lr-px68k.sh
+++ b/scriptmodules/libretrocores/lr-px68k.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-px68k"
+rp_module_desc="SHARP X68000 Emulator"
+rp_module_help="You need to copy a X68000 bios file (iplrom30.dat, iplromco.dat, iplrom.dat, or iplromxv.dat), and the font file (cgrom.dat or cgrom.tmp) to $romdir/BIOS/keropi. Use F12 to access the in emulator menu."
+rp_module_section="exp"
+rp_module_flags=""
+
+function sources_lr-px68k() {
+    gitPullOrClone "$md_build" https://github.com/libretro/px68k-libretro.git
+}
+
+function build_lr-px68k() {
+    make clean
+    make
+    md_ret_require="$md_build/px68k_libretro.so"
+}
+
+function install_lr-px68k() {
+    md_ret_files=(
+        'px68k_libretro.so'
+        'README.MD'
+        'readme.txt'
+    )
+}
+
+function configure_lr-px68k() {
+    mkRomDir "x68000"
+    ensureSystemretroconfig "x68000"
+
+    mkUserDir "$biosdir/keropi"
+
+    addEmulator 1 "$md_id" "x68000" "$md_inst/px68k_libretro.so"
+    addSystem "x68000"
+}


### PR DESCRIPTION
libretro port of px68k https://github.com/hissorii/px68k with backported c68k core from https://github.com/kenyahiro/px68k/ fork

Updated px68k to match bios locations.

Will look to switch standalone px68k to the fork also - after testing on the rpi.