### PR TITLE
Putting drastic back to RetroPie

### DIFF
--- a/scriptmodules/emulators/drastic.sh
+++ b/scriptmodules/emulators/drastic.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="drastic"
+rp_module_desc="NDS emu - DraStic"
+rp_module_help="ROM Extensions: .nds .zip\n\nCopy your Nintendo DS roms to $romdir/nds"
+rp_module_licence="PROP"
+rp_module_section="exp"
+rp_module_flags="!mali !x86 !armv6"
+
+function install_bin_drastic() {
+    wget -O- -q http://drastic-ds.com/drastic_rpi.tar.bz2 | tar -xvj --strip-components=1 -C "$md_inst"
+}
+
+function configure_drastic() {
+    mkRomDir "nds"
+
+    # wrong permissions on game_database.xml
+    chmod 644 "$md_inst/game_database.xml"
+
+    mkUserDir "$md_conf_root/nds/drastic"
+    mkUserDir "$md_conf_root/nds/drastic/system"
+
+    local file
+    for file in game_database.xml system/drastic_bios_arm7.bin system/drastic_bios_arm9.bin usrcheat.dat drastic_logo_0.raw drastic_logo_1.raw; do
+        ln -sfv "$md_inst/$file" "$md_conf_root/nds/drastic/$file"
+    done
+
+    addEmulator 1 "$md_id" "nds" "pushd $md_conf_root/nds/drastic; $md_inst/drastic %ROM%; popd"
+    addSystem "nds"
+}


### PR DESCRIPTION
This is the very same code as it was before being removed.

DraStic creator answered the @mediamogul message [here](http://www.drastic-ds.com/viewtopic.php?f=5&t=4307&sid=7bc928f81c7633d7c1577ad1bb1d3b19&start=10). This part of the message makes me believe that there's no problem to add DraStic to RetroPie-Setup again:

> I think at this point there's no real harm keeping it in there, if you don't have any misgivings doing so. I feel bad seeing it be released like this then taken away, and it's otherwise been out there so there's nothing to really hold back now.