### PR TITLE
retroarch: switch to xmb menu driver & disable xmb icon shadows

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -110,6 +110,9 @@ function configure_retroarch() {
     # install shaders by default
     update_shaders_retroarch
 
+    # install assets by default (needed for xmb menu driver)
+    update_assets_retroarch
+
     local config="$(mktemp)"
 
     cp "$md_inst/retroarch.cfg" "$config"
@@ -169,19 +172,14 @@ function configure_retroarch() {
     iniSet "input_joypad_driver" "udev"
     iniSet "all_users_control_menu" "true"
 
-    # rgui by default
-    iniSet "menu_driver" "rgui"
+    # disable xmb menu driver's icon shadows
+    iniSet "xmb_shadows_enable" "false"
 
     copyDefaultConfig "$config" "$configdir/all/retroarch.cfg"
     rm "$config"
 
-    # if no menu_driver is set, force RGUI, as the default has now changed to XMB.
-    iniConfig " = " '"' "$configdir/all/retroarch.cfg"
-    iniGet "menu_driver"
-    [[ -z "$ini_value" ]] && iniSet "menu_driver" "rgui"
-
     # if no menu_unified_controls is set, force it on so that keyboard player 1 can control
-    # the RGUI menu which is important for arcade sticks etc that map to keyboard inputs
+    # the GUI menu which is important for arcade sticks etc that map to keyboard inputs
     iniGet "menu_unified_controls"
     [[ -z "$ini_value" ]] && iniSet "menu_unified_controls" "true"
 


### PR DESCRIPTION
* Switch back to retroarch's new default xmb menu driver
* Disable xmb icon shadows (this was causing performance issues)
* Install retroarch assets by default (needed for xmb)

Things to consider for pull request:
* The xmb driver menu has very choppy scrolling with default settings on RPi3, but the menu icon shadow setting appears to have been the sole culprit of the performance issue. With this setting disabled (in this patch), the menu scrolling is now 100% smooth for me, but I can't say the same for older Pi revisions.
* Retropie assets (needed for xmb) occupy ~148MB in /opt/retropie/configs/all/retroarch/assets.
* I've seen reports in an old pull request that the xmb driver was causing segfaults for N64 cores when threaded video is enabled, but I can't reproduce the issue on my system (tested lr-mupen64plus and lr-parallel-n64). See: https://github.com/RetroPie/RetroPie-Setup/pull/1674
* One cosmetic "issue" with the xmb driver is that the background does not become transparent unless you disable "Pause when menu activated". However, I submitted a patch for this issue which has been merged upstream, so the behaviour will change in later retroarch releases: https://github.com/libretro/RetroArch/commit/57503051ea33c619a92d9f795708e710897a338b

