### PR TITLE
retroarch: disable xmb menu icon shadows

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -172,6 +172,9 @@ function configure_retroarch() {
     # rgui by default
     iniSet "menu_driver" "rgui"
 
+    # disable xmb menu driver icon shadows
+    iniSet "xmb_shadows_enable" "false"
+
     copyDefaultConfig "$config" "$configdir/all/retroarch.cfg"
     rm "$config"
 


### PR DESCRIPTION
This causes choppy scrolling performance even on a RPi3, so disable it by
default to benefit users who manually switch to the xmb menu driver.