### PR TITLE
emulationstation: sync A/B swap configuration to retroarch config

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -114,6 +114,10 @@ function configure_retroarch() {
 
     cp "$md_inst/retroarch.cfg" "$config"
 
+    # query ES A/B key swap configuration
+    local es_swap="false"
+    getAutoConf "es_swap_a_b" && es_swap="true"
+
     # configure default options
     iniConfig " = " '"' "$config"
     iniSet "cache_directory" "/tmp/retroarch"
@@ -174,6 +178,9 @@ function configure_retroarch() {
 
     # disable xmb menu driver icon shadows
     iniSet "xmb_shadows_enable" "false"
+
+    # swap A/B buttons based on ES configuration
+    iniSet "menu_swap_ok_cancel_buttons" "$es_swap"
 
     copyDefaultConfig "$config" "$configdir/all/retroarch.cfg"
     rm "$config"

--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -325,6 +325,9 @@ function gui_emulationstation() {
             3)
                 es_swap="$((es_swap ^ 1))"
                 setAutoConf "es_swap_a_b" "$es_swap"
+                local ra_swap="false"
+                getAutoConf "es_swap_a_b" && ra_swap="true"
+                iniSet "menu_swap_ok_cancel_buttons" "$ra_swap" "$configdir/all/retroarch.cfg"
                 printMsgs "dialog" "You will need to reconfigure you controller in Emulation Station for the changes to take effect."
                 ;;
         esac


### PR DESCRIPTION
When configuring "Swap A/B buttons in ES", users will most likely
need to enable the equivalent option (menu_swap_ok_cancel_buttons)
in RetroArch. Do this automatically to minimize user confusion.