### PR TITLE
mupen64plus: add some improvements

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -79,7 +79,7 @@ function build_mupen64plus() {
     # build GLideN64
     "$md_build/GLideN64/src/getRevision.sh"
     pushd "$md_build/GLideN64/projects/cmake"
-    params=("-DMUPENPLUSAPI=On" "-DUSE_SYSTEM_LIBS=On")
+    params=("-DMUPENPLUSAPI=On" "-DUSE_SYSTEM_LIBS=On" "-DVEC4_OPT=On")
     isPlatform "neon" && params+=("-DNEON_OPT=On")
     if isPlatform "rpi3"; then 
         params+=("-DCRC_ARMV8=On")

--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -52,8 +52,6 @@ function sources_mupen64plus() {
         gitPullOrClone "$dir" https://github.com/${repo[0]}/mupen64plus-${repo[1]} ${repo[2]}
     done
     gitPullOrClone "$md_build/GLideN64" https://github.com/gonetz/GLideN64.git
-    # fix for static x86_64 libs found in repo which are not usefull if target is i686
-    isPlatform "x11" && sed -i "s/BCMHOST/UNIX/g" GLideN64/src/GLideNHQ/CMakeLists.txt
     
     local config_version=$(grep -oP '(?<=CONFIG_VERSION_CURRENT ).+?(?=U)' GLideN64/src/Config.h)
     echo "$config_version" > "$md_build/GLideN64_config_version.ini"
@@ -81,7 +79,7 @@ function build_mupen64plus() {
     # build GLideN64
     "$md_build/GLideN64/src/getRevision.sh"
     pushd "$md_build/GLideN64/projects/cmake"
-    params=("-DMUPENPLUSAPI=On")
+    params=("-DMUPENPLUSAPI=On" "-DUSE_SYSTEM_LIBS=On")
     isPlatform "neon" && params+=("-DNEON_OPT=On")
     if isPlatform "rpi3"; then 
         params+=("-DCRC_ARMV8=On")

--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -219,6 +219,7 @@ function configure_mupen64plus() {
     fi
 
     addAutoConf mupen64plus_hotkeys 1
+    addAutoConf mupen64plus_texture_packs 1
 
     chown -R $user:$user "$md_conf_root/n64"
 }

--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -83,7 +83,11 @@ function build_mupen64plus() {
     pushd "$md_build/GLideN64/projects/cmake"
     params=("-DMUPENPLUSAPI=On")
     isPlatform "neon" && params+=("-DNEON_OPT=On")
-    isPlatform "rpi3" && params+=("-DCRC_ARMV8=On")
+    if isPlatform "rpi3"; then 
+        params+=("-DCRC_ARMV8=On")
+    else
+        params+=("-DCRC_OPT=On")
+    fi
     cmake "${params[@]}" ../../src/
     make
     popd

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -281,6 +281,27 @@ function testCompatibility() {
     esac
 }
 
+function useTexturePacks() {
+    # video-GLideN64
+    if ! grep -q "\[Video-GLideN64\]" "$config"; then
+        echo "[Video-GLideN64]" >> "$config"
+    fi
+    iniConfig " = " "" "$config"
+    # Settings version. Don't touch it.
+    local config_version="17"
+    if [[ -f "$configdir/n64/GLideN64_config_version.ini" ]]; then
+        config_version=$(<"$configdir/n64/GLideN64_config_version.ini")
+    fi
+    iniSet "configVersion" "$config_version"
+    iniSet "txHiresEnable" "True"
+
+    # video-rice
+    if ! grep -q "\[Video-Rice\]" "$config"; then
+        echo "[Video-Rice]" >> "$config"
+    fi
+    iniSet "LoadHiResTextures" "True"
+}
+
 if ! grep -q "\[Core\]" "$config"; then
     echo "[Core]" >> "$config"
     echo "Version = 1.010000" >> "$config"
@@ -293,6 +314,7 @@ iniSet "SaveSRAMPath" "$romdir/n64"
 getAutoConf mupen64plus_hotkeys && remap
 getAutoConf mupen64plus_compatibility_check && testCompatibility
 getAutoConf mupen64plus_audio && setAudio
+getAutoConf mupen64plus_texture_packs && useTexturePacks
 
 if [[ "$(sed -n '/^Hardware/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo)" == BCM* ]]; then
     # If a raspberry pi is used lower resolution to 320x240 and enable SDL dispmanx scaling mode 1


### PR DESCRIPTION
-use new CRC optimization if platform is not rpi3. rpi3 has a fast hardware crc32 implementation.
-use texture packs if available.
-remove GLideN64 system lib fix.
-use VEC4 OPT again and enable more NEON optimizations.
    