### PR TITLE
Mupen64plus improvements

### DIFF
--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -170,7 +170,6 @@ function testCompatibility() {
     # some roms lead to a black screen of death
     local game
     local blacklist=(
-        resident
         gauntlet
         rogue
         squadron

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -212,6 +212,7 @@ function testCompatibility() {
         beetle
         donkey
         zelda
+        bomberman
     )
 
     local GLideN64NativeResolution_blacklist=(

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -221,6 +221,7 @@ function testCompatibility() {
 
     local AudioOMX_blacklist=(
         pokemon
+        resident
     )
 
     for game in "${blacklist[@]}"; do

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -219,9 +219,19 @@ function testCompatibility() {
         majora
     )
 
+    local AudioOMX_blacklist=(
+        pokemon
+    )
+
     for game in "${blacklist[@]}"; do
         if [[ "${ROM,,}" == *"$game"* ]]; then
             exit
+        fi
+    done
+
+    for game in "${AudioOMX_blacklist[@]}"; do
+        if [[ "${ROM,,}" == *"$game"* ]]; then
+            AUDIO_PLUGIN="mupen64plus-audio-sdl"
         fi
     done
 
@@ -313,8 +323,8 @@ iniSet "SaveStatePath" "$romdir/n64"
 iniSet "SaveSRAMPath" "$romdir/n64"
 
 getAutoConf mupen64plus_hotkeys && remap
-getAutoConf mupen64plus_compatibility_check && testCompatibility
 getAutoConf mupen64plus_audio && setAudio
+getAutoConf mupen64plus_compatibility_check && testCompatibility
 getAutoConf mupen64plus_texture_packs && useTexturePacks
 
 if [[ "$(sed -n '/^Hardware/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo)" == BCM* ]]; then


### PR DESCRIPTION
-fix bomberman 64: disable legacy blending.
-fix resident evil 2: use AUDIO-SDL. AUDIO-OMX crashs emulator at startup.
-fix pokemon stadium 2: use AUDIO-SDL. AUDIO-OMX crashs emulator at startup.