### PR TITLE
retroarch: Install minimal assets (6MB) needed for xmb menu driver

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -15,7 +15,7 @@ rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/RetroArch/mas
 rp_module_section="core"
 
 function depends_retroarch() {
-    local depends=(libudev-dev libxkbcommon-dev libsdl2-dev libasound2-dev libusb-1.0-0-dev)
+    local depends=(libudev-dev libxkbcommon-dev libsdl2-dev libasound2-dev libusb-1.0-0-dev subversion)
     isPlatform "rpi" && depends+=(libraspberrypi-dev)
     isPlatform "mali" && depends+=(mali-fbdev)
     isPlatform "x11" && depends+=(libx11-xcb-dev libpulse-dev libavcodec-dev libavformat-dev libavdevice-dev)
@@ -86,6 +86,17 @@ function update_assets_retroarch() {
     chown -R $user:$user "$dir"
 }
 
+function update_xmbassets_retroarch() {
+    local dir="$configdir/all/retroarch/assets"
+    local path="xmb/monochrome"
+    # export files only if full assets are missing
+    if [ ! -d "$dir/.git" ]; then
+        rm -rf "$dir/$path"
+        svnExport "$dir/$path" https://github.com/libretro/retroarch-assets.git "$path"
+        chown -R $user:$user "$dir"
+    fi
+}
+
 function configure_retroarch() {
     [[ "$md_mode" == "remove" ]] && return
 
@@ -103,6 +114,9 @@ function configure_retroarch() {
 
     # install shaders by default
     update_shaders_retroarch
+
+    # install minimal xmb assets by default
+    update_xmbassets_retroarch
 
     local config="$(mktemp)"
 
@@ -287,6 +301,7 @@ function gui_retroarch() {
                         ;;
                     2)
                         rm -rf "$configdir/all/retroarch/$dir"
+                        [[ ! -d "$configdir/all/retroarch/assets" ]] && update_xmbassets_retroarch
                         ;;
                     *)
                         continue

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -347,6 +347,22 @@ function gitPullOrClone() {
     fi
 }
 
+## @fn svnExport()
+## @param dest destination directory
+## @param repo repository to export from
+## @param path to export files from
+## @param branch branch to export from (optional)
+## @brief Export a working copy of files from svn or git repository
+function svnExport() {
+    local dir="$1"
+    local repo="$2"
+    local path="$3"
+    local branch="$4"
+    [[ -z "$branch" ]] && branch="trunk"
+
+    runCmd svn export $repo/$branch/$path $dir/
+}
+
 # @fn setupDirectories()
 # @brief Makes sure some required retropie directories and files are created.
 function setupDirectories() {


### PR DESCRIPTION
For your consideration, two changes to enable fetching of minimal assets required for the xmb menu driver to function. The download and total occupied space is a mere 6MB for assets and a few extra megabytes (2MB packed) due to the additional subversion dependency.

"svn export" allows fetching of specific data from a folder of a git repository without downloading or storing the entire .git repository. This seems ideal for our purposes.

Note: "git archive" could probably achieve a similar result, but unfortunately, the github servers don't support this functionality over the https protocol.