### PR TITLE
added runcommand-onmenu feature

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -462,6 +462,10 @@ function main_menu() {
             options+=(Z "Launch with netplay enabled")
         fi
 
+        if [[ -f "$CONFIGDIR/all/runcommand-onmenu.sh" ]]; then
+            options+=(M "Execute runcommand-onmenu.sh")
+        fi
+        
         options+=(Q "Exit (without launching)")
 
         local temp_mode
@@ -533,6 +537,9 @@ function main_menu() {
             L)
                 COMMAND+=" --verbose"
                 return 0
+                ;;
+            M)
+                user_script "runcommand-onmenu.sh"
                 ;;
             Q)
                 return 1


### PR DESCRIPTION
`runcommand-onmenu.sh` is a script to be launched only if user invoke runcommand menu and choose the option to launch it.

I can see some use cases for this.