### PR TITLE
Mupen64plus more opts

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -124,7 +124,7 @@ function install_mupen64plus() {
         if [[ -f "$source/projects/unix/Makefile" ]]; then
             # optflags is needed due to the fact the core seems to rebuild 2 files and relink during install stage most likely due to a buggy makefile
             local params=()
-            isPlatform "rpi1" && params+=("VFP=1" "VFP_HARD=1" "HOST_CPU=armv6")
+            isPlatform "armv6" && params+=("VFP=1" "HOST_CPU=armv6")
             isPlatform "rpi" && params+=("VC=1")
             isPlatform "neon" && params+=("NEON=1")
             isPlatform "x86" && params+=("SSE=SSSE3")

--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -210,6 +210,10 @@ function configure_mupen64plus() {
         iniSet "UseNativeResolutionFactor" "1"
         # Enable legacy blending
         iniSet "EnableLegacyBlending" "True"
+        # Enable FPS Counter. Fixes zelda depth issue
+        iniSet "ShowFPS " "True"
+        iniSet "fontSize" "14"
+        iniSet "fontColor" "1F1F1F"
 
         # Disable gles2n64 autores feature and use dispmanx upscaling
         iniConfig " = " "" "$md_conf_root/n64/gles2n64.conf"

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -20,6 +20,7 @@ RSP_PLUGIN="$4"
 rootdir="/opt/retropie"
 configdir="$rootdir/configs"
 config="$configdir/n64/mupen64plus.cfg"
+inputconfig="$configdir/n64/InputAutoCfg.ini"
 datadir="$HOME/RetroPie"
 romdir="$datadir/roms"
 
@@ -362,6 +363,39 @@ iniConfig " = " "\"" "$config"
 iniSet "ScreenshotPath" "$romdir/n64"
 iniSet "SaveStatePath" "$romdir/n64"
 iniSet "SaveSRAMPath" "$romdir/n64"
+
+# add default keyboard configuration if InputAutoCFG.ini is missing
+if [[ ! -f "$inputconfig" ]]; then
+    cat > "$inputconfig" << _EOF_
+; InputAutoCfg.ini for Mupen64Plus SDL Input plugin
+
+; Keyboard_START
+[Keyboard]
+plugged = True
+plugin = 2
+mouse = False
+DPad R = key(100)
+DPad L = key(97)
+DPad D = key(115)
+DPad U = key(119)
+Start = key(13)
+Z Trig = key(122)
+B Button = key(306)
+A Button = key(304)
+C Button R = key(108)
+C Button L = key(106)
+C Button D = key(107)
+C Button U = key(105)
+R Trig = key(99)
+L Trig = key(120)
+Mempak switch = key(44)
+Rumblepak switch = key(46)
+X Axis = key(276,275)
+Y Axis = key(273,274)
+; Keyboard_END
+
+_EOF_
+fi
 
 getAutoConf mupen64plus_hotkeys && remap
 getAutoConf mupen64plus_audio && setAudio

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -243,6 +243,7 @@ function testCompatibility() {
             # Enable FPS Counter. Fixes zelda depth issue
             iniSet "ShowFPS " "True"
             iniSet "fontSize" "14"
+            iniSet "fontColor" "1F1F1F"
             # Enable FBEmulation if necessary
             iniSet "EnableFBEmulation" "True"
             # Set native resolution factor of 1


### PR DESCRIPTION
-GLideN64: make fps counter grey so it is less noticeable
-add defaut keyboard config if InputAutoCfg.ini is missing
-replace platform rpi1 with armv6