### PR TITLE
Request to Add ComicBook_SE Themes

### DIFF
--- a/scriptmodules/supplementary/esthemes.sh
+++ b/scriptmodules/supplementary/esthemes.sh
@@ -89,6 +89,8 @@ function gui_esthemes() {
         'anthonycaccese crt-centered'
         'TMNTturtleguy ComicBook'
         'TMNTturtleguy ComicBook_4-3'
+        'TMNTturtleguy ComicBook_SE-Wheelart'
+        'TMNTturtleguy ComicBook_4-3_SE-Wheelart'
         'ChoccyHobNob cygnus'
         'dmmarti steampunk'
         'dmmarti hurstyblue'


### PR DESCRIPTION
I would like to request the addition of ComicBook_SE Themes for both the 16:9 and 4:3 versions of the theme.  This allows users with Marquee/Wheelart to display them above the video instead of the standard logos.  Due to the current ES restrictions, it is not possible to allow this to happen and still function for users without wheelart/marqueed scraped.