### PR TITLE
lr-bluemsx - added colecovision support - fixes #2032

### DIFF
--- a/scriptmodules/libretrocores/lr-bluemsx.sh
+++ b/scriptmodules/libretrocores/lr-bluemsx.sh
@@ -10,8 +10,8 @@
 #
 
 rp_module_id="lr-bluemsx"
-rp_module_desc="MSX/MSX2 emu - blueMSX port for libretro"
-rp_module_help="ROM Extensions: .rom .mx1 .mx2 .col .dsk .zip\n\nCopy your MSX/MSX2 games to $romdir/msx"
+rp_module_desc="MSX/MSX2/Colecovision emu - blueMSX port for libretro"
+rp_module_help="ROM Extensions: .rom .mx1 .mx2 .col .dsk .zip\n\nCopy your MSX/MSX2 games to $romdir/msx\nCopy your Colecovision games to $romdir/coleco\n\nlr-bluemsx requires the BIOS files from the full standalone package of BlueMSX to be copied to '$biosdir/Machines' folder.\nColecovision BIOS needs to be copied to '$biosdir/Machines/COL - ColecoVision\coleco.rom'"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/blueMSX-libretro/master/license.txt"
 rp_module_section="opt"
 
@@ -38,9 +38,22 @@ function configure_lr-bluemsx() {
     mkRomDir "msx"
     ensureSystemretroconfig "msx"
 
+    mkRomDir "coleco"
+    ensureSystemretroconfig "coleco"
+
+    # force colecovision system
+    local core_config="$md_conf_root/coleco/retroarch-core-options.cfg"
+    iniConfig " = " '"' "$md_conf_root/coleco/retroarch.cfg"
+    iniSet "core_options_path" "$core_config"
+    iniSet "bluemsx_msxtype" "ColecoVision" "$core_config"
+    chown $user:$user "$core_config"
+
     cp -rv "$md_inst/"{Databases,Machines} "$biosdir/"
     chown -R $user:$user "$biosdir/"{Databases,Machines}
 
     addEmulator 1 "$md_id" "msx" "$md_inst/bluemsx_libretro.so"
     addSystem "msx"
+
+    addEmulator 1 "$md_id" "coleco" "$md_inst/bluemsx_libretro.so"
+    addSystem "coleco"
 }


### PR DESCRIPTION
 * document msx/colecovision bios / rom locations
 * added to coleco system
 * use a separate retroarch-core-options.cfg so as to force the colecovision system

This needs some testing. I think the retroarch input configuration might need switching/changing to work also with this.