### PR TITLE
Added common screenshot directory (~/RetroPie/screenshots/) for mupen…

### DIFF
--- a/retropie_packages.sh
+++ b/retropie_packages.sh
@@ -25,6 +25,7 @@ biosdir="$datadir/BIOS"
 romdir="$datadir/roms"
 emudir="$rootdir/emulators"
 configdir="$rootdir/configs"
+screenshotsdir="$datadir/screenshots"
 
 scriptdir="$(dirname "$0")"
 scriptdir="$(cd "$scriptdir" && pwd)"

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -23,6 +23,7 @@ config="$configdir/n64/mupen64plus.cfg"
 inputconfig="$configdir/n64/InputAutoCfg.ini"
 datadir="$HOME/RetroPie"
 romdir="$datadir/roms"
+screenshotsdir="$datadir/screenshots"
 
 source "$rootdir/lib/inifuncs.sh"
 
@@ -361,7 +362,7 @@ if ! grep -q "\[Core\]" "$config"; then
     echo "Version = 1.010000" >> "$config"
 fi
 iniConfig " = " "\"" "$config"
-iniSet "ScreenshotPath" "$romdir/n64"
+iniSet "ScreenshotPath" "$screenshotsdir"
 iniSet "SaveStatePath" "$romdir/n64"
 iniSet "SaveSRAMPath" "$romdir/n64"
 

--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -127,6 +127,7 @@ function configure_retroarch() {
     iniConfig " = " '"' "$config"
     iniSet "cache_directory" "/tmp/retroarch"
     iniSet "system_directory" "$biosdir"
+    iniSet "screenshot_directory" "$screenshotsdir"
     iniSet "config_save_on_exit" "false"
     iniSet "video_aspect_ratio_auto" "true"
     iniSet "video_smooth" "false"

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -356,6 +356,7 @@ function setupDirectories() {
     mkUserDir "$biosdir"
     mkUserDir "$configdir"
     mkUserDir "$configdir/all"
+    mkUserDir "$screenshotsdir"
 
     # make sure we have inifuncs.sh in place and that it is up to date
     mkdir -p "$rootdir/lib"


### PR DESCRIPTION
…64plus and libretro (lr-) emulators.

* This solves the annoyance of having screenshots saved all over the place, and libretro ones being stored in the hidden `/home/pi/.config` path.
* I've only done this for cores I use/can test. Are there others that store screenshots in customizable locations?
* It might also make sense to save them in the `/rom/<system>/` directory, but for this isn't possible via changing the retroarch.cfg file (I think you'd have to add `screenshot_directory = "/home/pi/RetroPie/roms/<system>` to every single `/<system>/retroarch.cfg`). I'm open to that, though, if that is the preference?
* unrelated, but mupen64plus.sh defines the directory paths internally. I wonder if there's a way of getting it to use those in retropie_packages.sh? 