### PR TITLE
Add initial support for Pegasus frontend

### DIFF
--- a/scriptmodules/supplementary/pegasus-fe.sh
+++ b/scriptmodules/supplementary/pegasus-fe.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="pegasus-fe"
+rp_module_desc="Pegasus: A cross platform, customizable graphical frontend (latest alpha release)"
+rp_module_licence="GPL3+ https://raw.githubusercontent.com/mmatyas/pegasus-frontend/master/LICENSE.md"
+rp_module_section="exp"
+rp_module_flags="!mali frontend"
+
+function depends_pegasus-fe() {
+    local depends=(
+        fontconfig
+        gstreamer1.0-alsa
+        gstreamer1.0-libav
+        gstreamer1.0-plugins-good
+        jq
+        policykit-1
+    )
+
+    getDepends "${depends[@]}"
+}
+
+function install_bin_pegasus-fe() {
+    # get all asset urls for the latest continuous release
+    local all_assets
+    all_assets="$(wget -q -O - https://api.github.com/repos/mmatyas/pegasus-frontend/releases/tags/continuous)" || return
+    all_assets="$(echo "${all_assets}" | jq -r '.assets[] | .browser_download_url')"
+
+    printMsgs "console" "Available releases:"
+    printMsgs "console" "${all_assets}"
+
+    # find out which platform's package we'll need
+    local platform
+    isPlatform "x11" && platform="x11"
+    if isPlatform "rpi"; then
+        if isPlatform "armv6"; then
+            platform="rpi1"
+        else
+            platform="rpi2"
+        fi
+    fi
+    if [[ -z "${platform}" ]]; then
+        md_ret_errors+=("Sorry, Pegasus is not yet available for this platform. Consider reporting this on the forum!")
+        return
+    fi
+
+    printMsgs "console" "Package platform: ${platform}"
+
+    # select the url for the platform
+    local asset_url
+    asset_url="$(echo "${all_assets}" | grep ${platform})"
+
+    if [[ -z "${asset_url}" ]]; then
+        md_ret_errors+=("Looks like the latest Pegasus release is not yet available for this platform. This happens when the build is so fresh it's being uploaded right now, or when there's a technical problem on the download server. Either way, this is a temporary problem, so please try again in 1-2 minutes. If the problem persists, consider reporting it on the forum!")
+        return
+    fi
+
+    # download and extract the package
+    printMsgs "console" "Download URL: ${asset_url}"
+    downloadAndExtract "${asset_url}" "$md_inst"
+}
+
+function configure_pegasus-fe() {
+    moveConfigDir "$home/.config/pegasus-frontend" "$md_conf_root/all/pegasus-fe"
+
+    # create external directories
+    mkUserDir "$md_conf_root/all/pegasus-fe/scripts"
+    mkUserDir "$md_conf_root/all/pegasus-fe/themes"
+}


### PR DESCRIPTION
This patch adds initial/experimental support for the [pegasus-frontend](http://github.com/mmatyas/pegasus-frontend). The script downloads and extracts the [latest automatic build](https://github.com/mmatyas/pegasus-frontend/releases/tag/continuous) for the current platform (there are RPi and X11 builds). At the moment it uses the ES2 config files, so probably no additional configuration steps are necessary.