### PR TITLE
Amiga: remove emulator ROM scripts correctly on uninstall

### DIFF
--- a/scriptmodules/emulators/uae4all.sh
+++ b/scriptmodules/emulators/uae4all.sh
@@ -118,6 +118,7 @@ function configure_uae4all() {
     fi
     moveConfigDir "$md_inst/kickstarts" "$biosdir"
 
+    rm -f "$romdir/amiga/+Start UAE4All.sh"
     if [[ "$md_mode" == "install" ]]; then
         if [[ ! -f "$biosdir/aros-amiga-m68k-ext.bin" ]]; then
             # unpack aros kickstart

--- a/scriptmodules/emulators/uae4arm.sh
+++ b/scriptmodules/emulators/uae4arm.sh
@@ -89,12 +89,15 @@ function configure_uae4arm() {
 
     local script="+Start UAE4Arm.sh"
     [[ "$md_id" == "amiberry" ]] && script="+Start Amiberry.sh"
-    cat > "$romdir/amiga/$script" << _EOF_
+    rm -f "$romdir/amiga/$script"
+    if [[ "$md_mode" == "install" ]]; then
+        cat > "$romdir/amiga/$script" << _EOF_
 #!/bin/bash
 "$md_inst/$md_id.sh"
 _EOF_
-    chmod a+x "$romdir/amiga/$script"
-    chown $user:$user "$romdir/amiga/$script"
+        chmod a+x "$romdir/amiga/$script"
+        chown $user:$user "$romdir/amiga/$script"
+    fi
 
     addEmulator 1 "$md_id" "amiga" "$md_inst/$md_id.sh auto %ROM%"
     addEmulator 1 "$md_id-a500" "amiga" "$md_inst/$md_id.sh rp-a500.uae %ROM%"


### PR DESCRIPTION
Applies to uae4all, uae4arm & amiberry scripts.