### PR TITLE
Bluetooth: enhance sixad compatibility

### DIFF
--- a/scriptmodules/supplementary/bluetooth.sh
+++ b/scriptmodules/supplementary/bluetooth.sh
@@ -377,6 +377,8 @@ function gui_bluetooth() {
 
         local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
         if [[ -n "$choice" ]]; then
+            # temporarily restore Bluetooth stack (if needed)
+            service sixad status >/dev/null && sixad -r
             case $choice in
                 R)
                     register_bluetooth
@@ -402,6 +404,8 @@ function gui_bluetooth() {
                     ;;
             esac
         else
+            # restart sixad (if running)
+            service sixad status >/dev/null && service sixad restart
             break
         fi
     done


### PR DESCRIPTION
Re-enable bluetoooth stack in Bluetooth dialog menu, and restart
sixad daemon upon exit.

This allows standard BT device pair/unpair management with DS3
controller fully working in-menu. The only drawback is that
your PS3 controller will turn off upon exiting the menu due to the
daemon restart.