### PR TITLE
Removing .git directories from ES themes

### DIFF
--- a/scriptmodules/supplementary/esthemes.sh
+++ b/scriptmodules/supplementary/esthemes.sh
@@ -33,6 +33,7 @@ function install_theme_esthemes() {
     fi
     mkdir -p "/etc/emulationstation/themes"
     gitPullOrClone "/etc/emulationstation/themes/$theme" "https://github.com/$repo/es-theme-$theme.git"
+    rm -rf "/etc/emulationstation/themes/$theme/.git"
 }
 
 function uninstall_theme_esthemes() {


### PR DESCRIPTION
The files in `/etc/emulationstation/themes/$theme/.git` are unnecessary and can occupy dozens of MB.

Example:
```
[prompt] $ ls /etc/emulationstation/themes/
carbon/  ComicBook/  nes-mini/  pixel/  Retrorama/
[prompt] $ du -hs /etc/emulationstation/themes/
257M    /etc/emulationstation/themes/

# went to RetroPie-Setup -> esthemes and updated all installed themes:

[prompt] $ du -hs /etc/emulationstation/themes/
138M    /etc/emulationstation/themes/
```