### PR TITLE
esthemes: added gbz35 and gbz35-dark themes

### DIFF
--- a/scriptmodules/supplementary/esthemes.sh
+++ b/scriptmodules/supplementary/esthemes.sh
@@ -94,6 +94,8 @@ function gui_esthemes() {
         'dmmarti hurstyblue'
         'dmmarti maximuspie'
         'lipebello Retrorama'
+        'rxbrad gbz35'
+        'rxbrad gbz35-dark'
     )
     while true; do
         local theme


### PR DESCRIPTION
These themes, from @rxbrad, are useful for small screens.

Forum topic:
https://retropie.org.uk/forum/topic/6383/gbz-3-5-theme

Repositories:
https://github.com/rxbrad/es-theme-gbz35
https://github.com/rxbrad/es-theme-gbz35-dark