### PR TITLE
lr-tyrquake: correct mission pack paths

### DIFF
--- a/scriptmodules/libretrocores/lr-tyrquake.sh
+++ b/scriptmodules/libretrocores/lr-tyrquake.sh
@@ -55,8 +55,8 @@ function _add_games_lr-tyrquake() {
     local cmd="$1"
     declare -A games=(
         ['id1']="Quake"
-        ['id1/hipnotic']="Quake Mission Pack 1 (hipnotic)"
-        ['id1/rogue']="Quake Mission Pack 2 (rogue)"
+        ['hipnotic']="Quake Mission Pack 1 (hipnotic)"
+        ['rogue']="Quake Mission Pack 2 (rogue)"
     )
     local dir
     local pak


### PR DESCRIPTION
hipnotic and rogue folders should be parallel to id1, not subfolders.

Fixes #2006