### PR TITLE
lr-tyrquake: enable episode 5 (dopa) support

### DIFF
--- a/scriptmodules/libretrocores/lr-tyrquake.sh
+++ b/scriptmodules/libretrocores/lr-tyrquake.sh
@@ -57,6 +57,7 @@ function _add_games_lr-tyrquake() {
         ['id1']="Quake"
         ['hipnotic']="Quake Mission Pack 1 (hipnotic)"
         ['rogue']="Quake Mission Pack 2 (rogue)"
+        ['dopa']="Quake Episode 5 (dopa)"
     )
     local dir
     local pak


### PR DESCRIPTION
Will be recognized when dopa is located in roms/ports/quake/dopa/pak0.pak

Note: this contradicts the current information on the wiki (telling you to rename to pak2.pak and copy shareware/registered paks). All episodes seem to work in all quake clients with the files in the following locations:

ports/quake/hipnotic/pak0.pak
ports/quake/dopa/pak0.pak (dopa itself)
ports/quake/rogue/pak0.pak
ports/quake/id1/pak1.pak (registered)
ports/quake/id1/pak0.pak (shareware)
