### PR TITLE
Quick fix for non ascii bluetooth device name

### DIFF
--- a/scriptmodules/supplementary/bluetooth/bluez-test-device
+++ b/scriptmodules/supplementary/bluetooth/bluez-test-device
@@ -5,6 +5,8 @@ from __future__ import absolute_import, print_function, unicode_literals
 from optparse import OptionParser, make_option
 import re
 import sys
+reload(sys)
+sys.setdefaultencoding('utf-8')
 import dbus
 import dbus.mainloop.glib
 try:


### PR DESCRIPTION
Bluetooth devices that have names with non-ascii characters won't connect. I experienced this with the Xiaomi Bluetooth game controller.

[The fix](https://retropie.org.uk/forum/topic/4804/xiaomi-bluetooth-gamepad-after-4-0-6-update/4) in the forum solves it, so I though it might as well become part of the code base.