### PR TITLE
Removed references to imame4all, and re-worded

### DIFF
--- a/scriptmodules/libretrocores/lr-mame2000.sh
+++ b/scriptmodules/libretrocores/lr-mame2000.sh
@@ -10,8 +10,8 @@
 #
 
 rp_module_id="lr-mame2000"
-rp_module_desc="Arcade emu - iMAME4all (based on MAME 0.37b5) port for libretro"
-rp_module_help="ROM Extension: .zip\n\nCopy your iMAME4all roms to either $romdir/mame-mame4all or\n$romdir/arcade"
+rp_module_desc="Arcade emu - MAME 0.37b5 port for libretro"
+rp_module_help="ROM Extension: .zip\n\nCopy your MAME 0.37b5 roms to either $romdir/mame-mame4all or\n$romdir/arcade"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/mame2000-libretro/master/readme.txt"
 rp_module_section="main"
 


### PR DESCRIPTION
imame4all is the old name. This is the only remaining reference to it. As well as removing it, I adjusted the wording to read similarly to https://github.com/RetroPie/RetroPie-Setup/blob/master/scriptmodules/libretrocores/lr-mame2003.sh