### PR TITLE
Allow multiple instances of the same token in an emulator command.

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -877,15 +877,15 @@ function get_sys_command() {
     COMMAND="$(default_emulator get emu_cmd)"
 
     # replace tokens
-    COMMAND="${COMMAND/\%ROM\%/\"$ROM\"}"
-    COMMAND="${COMMAND/\%BASENAME\%/\"$ROM_BN\"}"
+    COMMAND="${COMMAND//\%ROM\%/\"$ROM\"}"
+    COMMAND="${COMMAND//\%BASENAME\%/\"$ROM_BN\"}"
 
     # special case to get the last 2 folders for quake games for the -game parameter
     # remove everything up to /quake/
     local quake_dir="${ROM##*/quake/}"
     # remove filename
     quake_dir="${quake_dir%/*}"
-    COMMAND="${COMMAND/\%QUAKEDIR\%/\"$quake_dir\"}"
+    COMMAND="${COMMAND//\%QUAKEDIR\%/\"$quake_dir\"}"
 
     # if it starts with CON: it is a console application (so we don't redirect stdout later)
     if [[ "$COMMAND" == CON:* ]]; then


### PR DESCRIPTION
This allows a token to be reused more than once in an emulator command, e.g. attaching a disk image and a snapshot in VICE:

```
vice-x64-snap-disk = "/opt/retropie/emulators/vice/bin/x86 -8 %ROM%.d64 %ROM%"
```

Where there are a pair of files in the ROM directory:

```
romname.vsf
romname.vsf.d64
```