### PR TITLE
runcommand: only look for art if delay is not zero

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -904,35 +904,37 @@ function get_sys_command() {
 function show_launch() {
     local images=()
 
-    if [[ "$IS_SYS" -eq 1 && "$USE_ART" -eq 1 ]]; then
-        # if using art look for images in paths for es art.
-        images+=(
-            "$HOME/RetroPie/roms/$SYSTEM/images/${ROM_BN}-image"
-            "$HOME/.emulationstation/downloaded_images/$SYSTEM/${ROM_BN}-image"
-        )
-    fi
+    if [[ "$IMAGE_DELAY" -ne 0 ]]; then
+        if [[ "$IS_SYS" -eq 1 && "$USE_ART" -eq 1 ]]; then
+            # if using art look for images in paths for es art.
+            images+=(
+                "$HOME/RetroPie/roms/$SYSTEM/images/${ROM_BN}-image"
+                "$HOME/.emulationstation/downloaded_images/$SYSTEM/${ROM_BN}-image"
+            )
+        fi
 
-    # look for custom launching images
-    if [[ "$IS_SYS" -eq 1 ]]; then
-        images+=(
-            "$HOME/RetroPie/roms/$SYSTEM/images/${ROM_BN}-launching"
-            "$CONF_ROOT/launching"
-        )
-    fi
-    [[ "$IS_PORT" -eq 1 ]] && images+=("$CONFIGDIR/ports/launching")
-    images+=("$CONFIGDIR/all/launching")
+        # look for custom launching images
+        if [[ "$IS_SYS" -eq 1 ]]; then
+            images+=(
+                "$HOME/RetroPie/roms/$SYSTEM/images/${ROM_BN}-launching"
+                "$CONF_ROOT/launching"
+            )
+        fi
+        [[ "$IS_PORT" -eq 1 ]] && images+=("$CONFIGDIR/ports/launching")
+        images+=("$CONFIGDIR/all/launching")
 
-    local image
-    local path
-    local ext
-    for path in "${images[@]}"; do
-        for ext in jpg png; do
-            if [[ -f "$path.$ext" ]]; then
-                image="$path.$ext"
-                break 2
-            fi
+        local image
+        local path
+        local ext
+        for path in "${images[@]}"; do
+            for ext in jpg png; do
+                if [[ -f "$path.$ext" ]]; then
+                    image="$path.$ext"
+                    break 2
+                fi
+            done
         done
-    done
+    fi
 
     if [[ -n "$image" ]]; then
         # if we are running under X use feh otherwise try and use fbi


### PR DESCRIPTION
@joolswills sorry for bothering again, but I've just noticed that there's no option to disable launching image in runcommand setup. The "Launch menu art" option is related to scraped art only.

Currently to disable launching image we **must** delete the `launching.png` file from `/opt/retropie/configs/$SYSTEM/`, which would be unwanted.

One solution I've found is to set the "Launch image delay in seconds" to zero.

The diff of this PR make it looks like I've made a lot of changes but it's because of indentation. I only added an `if [[ "$IMAGE_DELAY" -ne 0 ]]` before the logic that looks for the image file (and a closing `fi` at the end of the same logic).