### PR TITLE
Workaround for cgenius build error

### DIFF
--- a/scriptmodules/ports/cgenius.sh
+++ b/scriptmodules/ports/cgenius.sh
@@ -15,7 +15,7 @@ rp_module_licence="GPL2 https://raw.githubusercontent.com/gerstrong/Commander-Ge
 rp_module_section="exp"
 
 function depends_cgenius() {
-    getDepends build-essential libvorbis-dev libogg-dev libsdl2-dev libsdl2-image-dev libboost-dev
+    getDepends build-essential clang-3.9 libvorbis-dev libogg-dev libsdl2-dev libsdl2-image-dev libboost-dev
 }
 
 function sources_cgenius() {
@@ -24,7 +24,7 @@ function sources_cgenius() {
 
 function build_cgenius() {
     cd $md_build
-    cmake -DUSE_SDL2=yes -DCMAKE_INSTALL_PREFIX="$md_inst"
+    CC=clang-3.9 CXX=clang++-3.9 cmake -DUSE_SDL2=yes -DCMAKE_INSTALL_PREFIX="$md_inst"
     make
     md_ret_require="$md_build"
 }


### PR DESCRIPTION
As discussed in #2074 and #2099, building Commander Genius using the stock Debian GCC currently fails due to an internal compiler error. As a workaround, this patch installs and uses Clang 3.9 to build the program. The bug doesn't seem to occur with later GCC releases, so these changes can be rolled out after the upgrade to Stretch.