### PR TITLE
ps3controller: clarify Bluetooth stack compatibility

### DIFF
--- a/scriptmodules/supplementary/bluetooth.sh
+++ b/scriptmodules/supplementary/bluetooth.sh
@@ -405,7 +405,7 @@ function gui_bluetooth() {
             esac
         else
             # restart sixad (if running)
-            service sixad status >/dev/null && service sixad restart
+            service sixad status >/dev/null && service sixad restart && printMsgs "dialog" "NOTICE: The ps3controller driver was temporarily interrupted in order to allow compatibility with standard Bluetooth peripherals. Please re-pair your Dual Shock controller to continue (or disregard this message if currently using another controller)."
             break
         fi
     done

--- a/scriptmodules/supplementary/ps3controller.sh
+++ b/scriptmodules/supplementary/ps3controller.sh
@@ -94,7 +94,7 @@ function gui_ps3controller() {
     drivers["gasia-only"]="gasia only"
     drivers["shanwan"]="clone support shanwan"
 
-    printMsgs "dialog" "NOTE: You cannot currently use PS3 controllers with other bluetooth devices. The PS3 controller driver disables the standard bluetooth stack. If you want to use a wireless keyboard along with your PS3 controllers you can use 2.4ghz wireless devices that come with their own dongle."
+    printMsgs "dialog" "WARNING: The ps3controller driver partially disables the standard Bluetooth stack so that Dual Shock controllers can pair correctly. Although the Bluetooth stack is temporarily re-enabled inside Retropie's Bluetooth menu to allow compatibility with standard Bluetooth peripherals, any other software that relies on the full Bluetooth stack will not work correctly while the ps3controller driver is active."
     local cmd=(dialog --backtitle "$__backtitle" --menu "Choose an option" 22 76 16)
     while true; do
         local i=1


### PR DESCRIPTION
* Remove obsolete information that driver breaks Bluetooth and replace
  with warning that Bluetooth pairing works in RetroPie menu, but cannot
  be guaranteed elsewhere.
* Add notice after exiting Bluetooth menu (only when sixad is running)
  informing users to re-pair controller, to hopefully reduce confusion.