### PR TITLE
Adding ability to override user during setup

### DIFF
--- a/retropie_packages.sh
+++ b/retropie_packages.sh
@@ -17,9 +17,14 @@ __version="4.2.20"
 rootdir="/opt/retropie"
 
 user="$SUDO_USER"
+[[ -n "$RETROPIE_USER" ]] && user=$RETROPIE_USER
 [[ -z "$user" ]] && user="$(id -un)"
 
 home="$(eval echo ~$user)"
+if [[ $home == ~* ]]; then
+    echo "User $user does not seem to exist"
+    exit 1
+fi
 datadir="$home/RetroPie"
 biosdir="$datadir/BIOS"
 romdir="$datadir/roms"


### PR DESCRIPTION
instead of assuming retropie will be setup under the SUDO_USER account,
there is now a way to override it using the RETORPIE_USER environment
variable.

For example:
sudo RETROPIE_USER=pi bash retropie_packages.sh setup basic_install