### PR TITLE
mupen64plus: fix ubuntu 16.04

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -80,8 +80,9 @@ function build_mupen64plus() {
     # build GLideN64
     "$md_build/GLideN64/src/getRevision.sh"
     pushd "$md_build/GLideN64/projects/cmake"
-    params=("-DMUPENPLUSAPI=On" "-DUSE_SYSTEM_LIBS=On" "-DVEC4_OPT=On")
+    params=("-DMUPENPLUSAPI=On" "-DVEC4_OPT=On")
     isPlatform "neon" && params+=("-DNEON_OPT=On")
+    isPlatform "rpi" && params+=("-DUSE_SYSTEM_LIBS=On")
     if isPlatform "rpi3"; then 
         params+=("-DCRC_ARMV8=On")
     else


### PR DESCRIPTION
GLideN64 needs libpng16-dev. Mupen64plus-core needs freetype and
ubuntu’s freetype needs libpng12-dev. libpng16-dev removes libpng12.
Fix: Use GLideN64 libpng16 libs and headers.