### PR TITLE
Add platform flags & pkgconfig

### DIFF
--- a/pkgconfig/bcm_host.pc
+++ b/pkgconfig/bcm_host.pc
@@ -1,0 +1,10 @@
+prefix=/opt/vc
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: bcm_host
+Description: Broadcom VideoCore host API library
+Version: 1
+Libs: -L${libdir} -lbcm_host -lvcos -lvchiq_arm -pthread
+Cflags: -I${includedir} -I${includedir}/interface/vmcs_host/linux -I${includedir}/interface/vcos/pthreads -DUSE_VCHIQ_ARM

--- a/pkgconfig/brcmegl.pc
+++ b/pkgconfig/brcmegl.pc
@@ -1,0 +1,13 @@
+prefix=/opt/vc
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: brcmEGL
+Description: Fake brcmEGL package for RPi
+Version: 10
+Requires: bcm_host
+Libs: -L${libdir} -lbrcmEGL -lbrcmGLESv2 -lbcm_host -lvchostif
+Cflags: -I${includedir} -I${includedir}/interface/vmcs_host/linux \
+        -I${includedir}/interface/vcos/pthreads
+

--- a/pkgconfig/brcmglesv2.pc
+++ b/pkgconfig/brcmglesv2.pc
@@ -1,0 +1,12 @@
+prefix=/opt/vc
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: brcmGLESv2
+Description: Fake brcmGLES2 package for RPi
+Version: 10
+Requires: bcm_host
+Libs: -L${libdir} -lbrcmGLESv2
+Cflags: -I${includedir}
+

--- a/pkgconfig/brcmvg.pc
+++ b/pkgconfig/brcmvg.pc
@@ -1,0 +1,11 @@
+prefix=/opt/vc
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: brcmOpenVG
+Description: Fake brcmOpenVG package for RPi
+Version: 10
+Requires: bcm_host
+Libs: -L${libdir} -lbrcmOpenVG
+Cflags: -I${includedir}

--- a/pkgconfig/mmal.pc
+++ b/pkgconfig/mmal.pc
@@ -1,0 +1,11 @@
+prefix=/opt/vc
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: MMAL
+Description: Multi-Media Abstraction Layer library for RPi
+Version: 1
+Requires: vcsm
+Libs: -L${libdir} -lmmal -lmmal_core -lmmal_util -lmmal_vc_client -lbcm_host
+Cflags: -I${includedir}

--- a/pkgconfig/vcsm.pc
+++ b/pkgconfig/vcsm.pc
@@ -1,0 +1,10 @@
+prefix=/opt/vc
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: VCSM
+Description: VideoCore Shared Memory library for RPi
+Version: 1
+Libs: -L${libdir} -lvcsm
+Cflags: -I${includedir}

--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -64,8 +64,9 @@ function depends_setup() {
         exec "$scriptdir/retropie_packages.sh" setup post_update gui_setup
     fi
 
-    if isPlatform "rpi" && [[ -f /boot/config.txt ]] && grep -q "^dtoverlay=vc4-kms-v3d" /boot/config.txt; then
-        printMsgs "dialog" "You have the experimental desktop GL driver enabled. This is NOT compatible with RetroPie, and Emulation Station as well as emulators will fail to launch. Please disable the experimental desktop GL driver from the raspi-config 'Advanced Options' menu."
+    if isPlatform "rpi" && isPlatform "mesa"; then
+        printMsgs "dialog" "ERROR: You have the experimental desktop GL driver enabled. This is NOT compatible with RetroPie, and Emulation Station as well as emulators will fail to launch.\n\nPlease disable the experimental desktop GL driver from the raspi-config 'Advanced Options' menu."
+        exit 1
     fi
 
     # make sure user has the correct group permissions

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -157,6 +157,9 @@ function get_os_version() {
 
     # add 32bit/64bit to platform flags
     __platform_flags+=" $(getconf LONG_BIT)bit"
+
+    # configure Raspberry Pi graphics stack
+    isPlatform "rpi" && get_rpi_video
 }
 
 function get_default_gcc() {
@@ -209,6 +212,21 @@ function get_retropie_depends() {
     if ! getDepends "${depends[@]}"; then
         fatalError "Unable to install packages required by $0 - ${md_ret_errors[@]}"
     fi
+}
+
+function get_rpi_video() {
+    local pkgconfig="/opt/vc/lib/pkgconfig"
+
+    # detect driver via inserted module / platform driver setup
+    if [[ -d "/sys/module/vc4" ]]; then
+        __platform_flags+=" mesa kms"
+        [[ "$(ls -A /sys/bus/platform/drivers/vc4_firmware_kms/*.firmwarekms 2>/dev/null)" ]] && __platform_flags+=" dispmanx"
+    else
+        __platform_flags+=" videocore dispmanx"
+    fi
+
+    # set pkgconfig path for vendor libraries
+    export PKG_CONFIG_PATH="$pkgconfig"
 }
 
 function get_platform() {

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -225,6 +225,9 @@ function get_rpi_video() {
         __platform_flags+=" videocore dispmanx"
     fi
 
+    # use our supplied fallback pkgconfig if necessary
+    [[ ! -d "$pkgconfig" ]] && pkgconfig="$scriptdir/pkgconfig"
+
     # set pkgconfig path for vendor libraries
     export PKG_CONFIG_PATH="$pkgconfig"
 }


### PR DESCRIPTION
* Add "mesa kms" flags when vc4 module is inserted.
* Add "dispmanx" flag if /sys/bus/platform/devices/*.firmwarekms is enumerated (fake kms).
* Fallback to "videocore dispmanx" if neither is detected.
* Put a hard block on script execution if VC4 driver is enabled.
* Set environment variable for PKGCONFIG (coming in next stretch firmware).
* Use fallback copy of pkgconfig if needed; useful for current stretch firmware that lacks pkgconfig & legacy jessie compatibility. Separate commit so that it can be cleanly reverted in future.