### PR TITLE
Re-enabled online updater in RGUI (for cheats)

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -181,9 +181,11 @@ function configure_retroarch() {
     # rgui by default
     iniSet "menu_driver" "rgui"
 
-    # hide online updater menu options
+    # hide core updater menu option
     iniSet "menu_show_core_updater" "false"
-    iniSet "menu_show_online_updater" "false"
+    
+    # show online updater menu option (for cheats)
+    iniSet "menu_show_online_updater" "true"
 
     # disable unnecessary xmb menu tabs
     iniSet "xmb_show_add" "false"


### PR DESCRIPTION
Many reports of this:
https://www.reddit.com/r/RetroPie/comments/74fpcj/online_updater_missing_from_retroarch/
https://www.reddit.com/r/RetroPie/comments/6x9515/where_is_the_online_updater/
https://www.reddit.com/r/RetroPie/comments/72trxn/cheats_online_update_and_retropie_43/
https://www.reddit.com/r/RetroPie/comments/740ea1/no_online_updater_option_in_rgui/

and in our docs:
https://retropie.org.uk/docs/Cheats/