### PR TITLE
ps3controller: add insserv to depends

### DIFF
--- a/scriptmodules/supplementary/ps3controller.sh
+++ b/scriptmodules/supplementary/ps3controller.sh
@@ -16,7 +16,7 @@ rp_module_section="driver"
 
 function depends_ps3controller() {
     depends_bluetooth
-    local depends=(checkinstall libusb-dev libbluetooth-dev joystick)
+    local depends=(checkinstall libusb-dev libbluetooth-dev joystick insserv)
     getDepends "${depends[@]}"
 }
 


### PR DESCRIPTION
This is not present on the default stretch lite installation, leading
to the service not being enabled correctly.

(Let me know if you want me to convert to a systemd service... however, the service does autostart correctly as long as insserv is installed, unlike asplashscreen).