### PR TITLE
Newbcrmlibs

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -14,7 +14,7 @@ rp_module_desc="N64 emulator MUPEN64Plus"
 rp_module_help="ROM Extensions: .z64 .n64 .v64\n\nCopy your N64 roms to $romdir/n64"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/mupen64plus/mupen64plus-core/master/LICENSES"
 rp_module_section="main"
-rp_module_flags="!mali"
+rp_module_flags="!mali newbrcmlibs"
 
 function depends_mupen64plus() {
     local depends=(cmake libsamplerate0-dev libspeexdsp-dev libsdl2-dev libpng12-dev)

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -228,6 +228,14 @@ function rp_callModule() {
             elif fnExists "install_bin_${md_id}"; then
                 "install_bin_${md_id}" "$@"
             fi
+            # if the module has the newbrcmlibs it means it is linked against the
+            # renamed videocore libbrcm* libraries. We record this so we can
+            # switch library names for SDL in runcommand for software using the
+            # older names (the new SDL 2.0.6 requires applications to also use
+            # the new libraries by default)
+            if isPlatform "rpi" && hasFlag "$md_flags" "newbrcmlibs"; then
+                touch "$md_inst/RP-NEWBRCMLIBS"
+            fi
             ;;
         install_bin)
             if fnExists "install_bin_${md_id}"; then

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -900,6 +900,13 @@ function get_sys_command() {
     if [[ -n "$TTY" && "$COMMAND" =~ ^(startx|xinit) ]]; then
         COMMAND+=" -- vt$TTY -keeptty"
     fi
+
+    # if on RPI and there is no RP-NEWBRCMLIBS file present then use old library names for SDL
+    if [[ "$(sed -n '/^Hardware/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo)" == BCM* && "$COMMAND" =~ $ROOTDIR/[^/]*/[^/]* ]]; then
+        if [[ ! -f "${BASH_REMATCH[0]}/RP-NEWBRCMLIBS" ]]; then
+            COMMAND="SDL_VIDEO_EGL_DRIVER=/opt/vc/lib/libEGL.so SDL_VIDEO_GL_DRIVER=/opt/vc/lib/libGLESv2.so $COMMAND"
+        fi
+    fi
 }
 
 function show_launch() {

--- a/scriptmodules/supplementary/sdl2.sh
+++ b/scriptmodules/supplementary/sdl2.sh
@@ -16,11 +16,11 @@ rp_module_section=""
 rp_module_flags=""
 
 function get_ver_sdl2() {
-    echo "2.0.5"
+    echo "2.0.6"
 }
 
 function get_pkg_ver_sdl2() {
-    local ver="$(get_ver_sdl2)+5"
+    local ver="$(get_ver_sdl2)+1"
     isPlatform "rpi" && ver+="rpi"
     isPlatform "mali" && ver+="mali"
     echo "$ver"
@@ -33,7 +33,7 @@ function get_arch_sdl2() {
 function depends_sdl2() {
     # Dependencies from the debian package control + additional dependencies for the pi (some are excluded like dpkg-dev as they are
     # already covered by the build-essential package retropie relies on.
-    local depends=(devscripts debhelper dh-autoreconf libasound2-dev libudev-dev libibus-1.0-dev libdbus-1-dev libx11-dev libxcursor-dev libxext-dev libxi-dev libxinerama-dev libxrandr-dev libxss-dev libxt-dev libxxf86vm-dev libgl1-mesa-dev)
+    local depends=(devscripts debhelper dh-autoreconf libasound2-dev libudev-dev libibus-1.0-dev libdbus-1-dev libx11-dev libxcursor-dev libxext-dev libxi-dev libxinerama-dev libxrandr-dev libxss-dev libxt-dev libxxf86vm-dev libgl1-mesa-dev fcitx-libs-dev)
     isPlatform "rpi" && depends+=(libraspberrypi-dev)
     isPlatform "mali" && depends+=(mali-fbdev)
     isPlatform "x11" && depends+=(libpulse-dev)
@@ -45,7 +45,7 @@ function sources_sdl2() {
     local pkg_ver="$(get_pkg_ver_sdl2)"
 
     local branch="release-$ver"
-    isPlatform "rpi" && branch="retropie-$ver"
+    isPlatform "rpi" && branch="rpi-$ver"
     isPlatform "mali" && branch="mali-$ver"
 
     gitPullOrClone "$md_build/$pkg_ver" https://github.com/RetroPie/SDL-mirror.git "$branch"


### PR DESCRIPTION
@psyke83 this is how I would like to handle it - should help with most cases, and fixes mupen64plus for now (plus we get the new sdl library)

We still may need to handle RetroArch manually, but are there any affected modules apart from lr-ppsspp ? as we control that, we can just do it at the same time as RetroArch update.