### PR TITLE
Unblank framebuffer on setup, runcommand and joypad inputs

### DIFF
--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -486,6 +486,7 @@ function reboot_setup()
 # retropie-setup main menu
 function gui_setup() {
     depends_setup
+    [[ "$TERM" == "linux" ]] && setterm --blank poke
     joy2keyStart
     local default
     while true; do

--- a/scriptmodules/supplementary/runcommand/joy2key.py
+++ b/scriptmodules/supplementary/runcommand/joy2key.py
@@ -31,6 +31,8 @@ JS_EVENT_BUTTON = 0x01
 JS_EVENT_AXIS = 0x02
 JS_EVENT_INIT = 0x80
 
+FB_UNBLANK = '\033[13]'
+
 CONFIG_DIR = '/opt/retropie/configs/'
 RETROARCH_CFG = CONFIG_DIR + 'all/retroarch.cfg'
 
@@ -194,6 +196,9 @@ def process_event(event):
     if hex_chars:
         for c in hex_chars:
             fcntl.ioctl(tty_fd, termios.TIOCSTI, c)
+        if os.getenv('TERM') == 'linux':
+            sys.stdout.write(FB_UNBLANK)
+            sys.stdout.flush()
         return True
 
     return False

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -1025,9 +1025,10 @@ function runcommand() {
         exit 1
     fi
 
-    # turn off cursor and clear screen
+    # turn off cursor, clear screen and unblank
     tput civis
     clear
+    [[ "$TERM" == "linux" ]] && setterm --blank poke
 
     rm -f "$LOG"
     echo -e "$SYSTEM\n$EMULATOR\n$ROM\n$COMMAND" >/dev/shm/runcommand.info


### PR DESCRIPTION
Raspbian stretch uses a very short framebuffer timeout. While good to avoid
burn-in when users leave an active console displayed, this interferes with
script and runcommand visibility. Solve the issue by unblanking on first
invocation of scripts, and also trigger unblank on every joypad input.

* Unblank framebuffer on RetroPie-Setup and runcommand launch.
* Avoid unnecessary unblank invocation on pseudoterminals.
* Modify joy2key to send ANSI setterm code ESC [13] (unblank framebuffer)
  to simulate regular wakeup on key press.