### PR TITLE
Revert " helpers: joy2keyStop: wait for successful SIGINT"

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -1025,9 +1025,8 @@ function joy2keyStart() {
 ## @brief Stop previously started joy2key.py process.
 function joy2keyStop() {
     if [[ -n $__joy2key_pid ]]; then
-        while kill -INT $__joy2key_pid 2>/dev/null; do
-            sleep 0.1
-        done
+        kill -INT $__joy2key_pid 2>/dev/null
+        sleep 1
     fi
 }
 


### PR DESCRIPTION
Reverts RetroPie/RetroPie-Setup#2148

causes `Exception OSError: (9, 'Bad file descriptor') in <module 'threading' from '/usr/lib/python2.7/threading.pyc'> ignored` to be thrown by joy2key.