### PR TITLE
bluetooth: fix bluez 5.43 compatibility

### DIFF
--- a/scriptmodules/supplementary/bluetooth.sh
+++ b/scriptmodules/supplementary/bluetooth.sh
@@ -56,7 +56,7 @@ function list_available_bluetooth() {
         mkfifo "$fifo"
         exec 3<>"$fifo"
         local line
-        while read -r -n12 line; do
+        while read -r -n18 line; do
             if [[ "$line" == *"[bluetooth]"* ]]; then
                 echo "scan on" >&3
                 read -r line


### PR DESCRIPTION
It's necessary to read more characters per line to match the "[bluetooth]" string due to commit:
https://git.kernel.org/pub/scm/bluetooth/bluez.git/commit/?id=6fd2662dc96ccf5fc194c53d5c6f90431ba9f8a5

Fixes bluetooth on stretch.