### PR TITLE
Enable PowerBlock and ControlBlock drivers with installation

### DIFF
--- a/scriptmodules/supplementary/controlblock.sh
+++ b/scriptmodules/supplementary/controlblock.sh
@@ -39,6 +39,7 @@ function install_controlblock() {
     # install from there to system folders
     cd "$md_inst/build"
     make install
+    make installservice
 }
 
 function gui_controlblock() {

--- a/scriptmodules/supplementary/powerblock.sh
+++ b/scriptmodules/supplementary/powerblock.sh
@@ -39,6 +39,7 @@ function install_powerblock() {
     # install from there to system folders
     cd "$md_inst/build"
     make install
+    make installservice
 }
 
 function gui_powerblock() {


### PR DESCRIPTION
Some users stumbled over the current modules implementation that the ControlBlock and PowerBlock  drivers are not enabled with the installation, but needed to be enabled in another step after the installation. The drivers are enabled with the installation now.