### PR TITLE
Autostart only on configured user

### DIFF
--- a/scriptmodules/supplementary/autostart.sh
+++ b/scriptmodules/supplementary/autostart.sh
@@ -38,14 +38,16 @@ _EOF_
     sed -i '/#auto/d' "$script"
     # make sure there is a newline
     sed -i '$a\' "$script"
+    echo "if \$(whoami) == \"${user}\"; then #auto" >> "$script"
     case "$mode" in
         kodi)
-            echo -e "kodi #auto\nemulationstation #auto" >>"$script"
+            echo -e "    kodi #auto\nemulationstation #auto" >>"$script"
             ;;
         es|*)
-            echo "emulationstation #auto" >>"$script"
+            echo "    emulationstation #auto" >>"$script"
             ;;
     esac
+    echo "fi #auto" >> "$script"
     chown $user:$user "$script"
 }
 

--- a/scriptmodules/supplementary/autostart.sh
+++ b/scriptmodules/supplementary/autostart.sh
@@ -38,10 +38,10 @@ _EOF_
     sed -i '/#auto/d' "$script"
     # make sure there is a newline
     sed -i '$a\' "$script"
-    echo "if \$(whoami) == \"${user}\"; then #auto" >> "$script"
+    echo "if [[ \"\$(whoami)\" == \"${user}\" ]]; then #auto" >> "$script"
     case "$mode" in
         kodi)
-            echo -e "    kodi #auto\nemulationstation #auto" >>"$script"
+            echo -e "    kodi #auto\n    emulationstation #auto" >>"$script"
             ;;
         es|*)
             echo "    emulationstation #auto" >>"$script"


### PR DESCRIPTION
Actually, the 10-autostart.sh script in profiles.d unconditionnaly runs kodi.

This versions tests the username which must be the same as the one used when installing RetroPie preventing kodi to start when switching to root, or emulationstation to start when switching user.

TODO: don't use username but uid, because if you rename your user, then you have to reinstall the script, as the `if` statement whould always be false.