### PR TITLE
scriptmodules: RPI: move optional SDL2 applications to new library names

### DIFF
--- a/scriptmodules/emulators/advmame.sh
+++ b/scriptmodules/emulators/advmame.sh
@@ -14,7 +14,7 @@ rp_module_desc="AdvanceMAME v3.5"
 rp_module_help="ROM Extension: .zip\n\nCopy your AdvanceMAME roms to either $romdir/mame-advmame or\n$romdir/arcade"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/amadvance/advancemame/master/COPYING"
 rp_module_section="opt"
-rp_module_flags="!mali"
+rp_module_flags="!mali newbrcmlibs"
 
 function _update_hook_advmame() {
     # if the non split advmame is installed, make directories for 0.94 / 1.4 so they will be updated

--- a/scriptmodules/emulators/hatari.sh
+++ b/scriptmodules/emulators/hatari.sh
@@ -14,7 +14,7 @@ rp_module_desc="Atari emulator Hatari"
 rp_module_help="ROM Extensions: .st .stx .img .rom .raw .ipf .ctr\n\nCopy your Atari ST games to $romdir/atarist"
 rp_module_licence="GPL2 https://hg.tuxfamily.org/mercurialroot/hatari/hatari/file/9ee1235233e9/gpl.txt"
 rp_module_section="opt"
-rp_module_flags=""
+rp_module_flags="newbrcmlibs"
 
 function depends_hatari() {
     getDepends libsdl2-dev zlib1g-dev libpng12-dev cmake libreadline-dev portaudio19-dev

--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -14,7 +14,7 @@ rp_module_desc="ScummVM"
 rp_module_help="Copy your ScummVM games to $romdir/scummvm"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/scummvm/scummvm/master/COPYING"
 rp_module_section="opt"
-rp_module_flags="!mali"
+rp_module_flags="!mali newbrcmlibs"
 
 function depends_scummvm() {
     local depends=(libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng12-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev libjpeg-dev)

--- a/scriptmodules/emulators/stella.sh
+++ b/scriptmodules/emulators/stella.sh
@@ -14,7 +14,7 @@ rp_module_desc="Atari2600 emulator STELLA"
 rp_module_help="ROM Extensions: .a26 .bin .rom .zip .gz\n\nCopy your Atari 2600 roms to $romdir/atari2600"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/stella-emu/stella/master/License.txt"
 rp_module_section="opt"
-rp_module_flags=""
+rp_module_flags="newbrcmlibs"
 
 function depends_stella() {
     getDepends libsdl2-dev libpng12-dev zlib1g-dev xz-utils

--- a/scriptmodules/emulators/vice.sh
+++ b/scriptmodules/emulators/vice.sh
@@ -14,7 +14,7 @@ rp_module_desc="C64 emulator VICE"
 rp_module_help="ROM Extensions: .crt .d64 .g64 .prg .t64 .tap .x64 .zip .vsf\n\nCopy your Commodore 64 games to $romdir/c64"
 rp_module_licence="GPL2 http://svn.code.sf.net/p/vice-emu/code/trunk/vice/COPYING"
 rp_module_section="opt"
-rp_module_flags=""
+rp_module_flags="newbrcmlibs"
 
 function depends_vice() {
     local depends=(libsdl2-dev libmpg123-dev libpng12-dev zlib1g-dev libasound2-dev libvorbis-dev libflac-dev libpcap-dev automake checkinstall bison flex subversion libjpeg-dev portaudio19-dev texinfo xa65)

--- a/scriptmodules/ports/eduke32.sh
+++ b/scriptmodules/ports/eduke32.sh
@@ -13,6 +13,7 @@ rp_module_id="eduke32"
 rp_module_desc="Duke3D Port"
 rp_module_licence="GPL2 http://svn.eduke32.com/eduke32/package/common/gpl-2.0.txt"
 rp_module_section="opt"
+rp_module_flags="newbrcmlibs"
 
 function depends_eduke32() {
     local depends=(

--- a/scriptmodules/ports/love.sh
+++ b/scriptmodules/ports/love.sh
@@ -14,7 +14,7 @@ rp_module_desc="Love - 2d Game Engine"
 rp_module_help="Copy your Love games to $romdir/love"
 rp_module_licence="GPL3 https://bitbucket.org/rude/love/raw/7b520c437317626da2102de1aafdad0e67b54bf5/license.txt"
 rp_module_section="opt"
-rp_module_flags="!aarch64"
+rp_module_flags="!aarch64 newbrcmlibs"
 
 function depends_love() {
     local depends=(mercurial autotools-dev automake libtool pkg-config libdevil-dev libfreetype6-dev libluajit-5.1-dev libphysfs-dev libsdl2-dev libopenal-dev libogg-dev libtheora-dev libvorbis-dev libflac-dev libflac++-dev libmodplug-dev libmpg123-dev libmng-dev libjpeg-dev)

--- a/scriptmodules/ports/sdlpop.sh
+++ b/scriptmodules/ports/sdlpop.sh
@@ -13,6 +13,7 @@ rp_module_id="sdlpop"
 rp_module_desc="SDLPoP - Port of Prince of Persia"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/NagyD/SDLPoP/master/doc/gpl-3.0.txt"
 rp_module_section="opt"
+rp_module_flags="newbrcmlibs"
 
 function depends_sdlpop() {
     getDepends libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev

--- a/scriptmodules/ports/solarus.sh
+++ b/scriptmodules/ports/solarus.sh
@@ -13,7 +13,7 @@ rp_module_id="solarus"
 rp_module_desc="solarus - An Open Source Zelda LttP Engine"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/solarus-games/solarus/dev/license.txt"
 rp_module_section="opt"
-rp_module_flags="noinstclean !aarch64"
+rp_module_flags="noinstclean !aarch64 newbrcmlibs"
 
 function depends_solarus() {
     getDepends cmake libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libluajit-5.1-dev libphysfs-dev libopenal-dev libmodplug-dev libvorbis-dev zip unzip

--- a/scriptmodules/ports/tyrquake.sh
+++ b/scriptmodules/ports/tyrquake.sh
@@ -13,6 +13,7 @@ rp_module_id="tyrquake"
 rp_module_desc="Quake 1 engine - TyrQuake port"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/RetroPie/tyrquake/master/gnu.txt"
 rp_module_section="opt"
+rp_module_flags="newbrcmlibs"
 
 function depends_tyrquake() {
     getDepends libsdl2-dev

--- a/scriptmodules/ports/zdoom.sh
+++ b/scriptmodules/ports/zdoom.sh
@@ -13,7 +13,7 @@ rp_module_id="zdoom"
 rp_module_desc="ZDoom - Enhanced port of the official DOOM source"
 rp_module_licence="OTHER https://raw.githubusercontent.com/RetroPie/zdoom/master/docs/licenses/README.TXT"
 rp_module_section="opt"
-rp_module_flags=""
+rp_module_flags="newbrcmlibs"
 
 function depends_zdoom() {
     local depends=(


### PR DESCRIPTION
The following optional scriptmodules use SDL2 but do not link GLES or EGL
libraries:

* advmame
* eduke32
* hatari
* love
* scummvm
* sdlpop
* solarus
* stella
* tyrquake
* vice
* zdoom

These packages are safe to switch to the new library names on jessie,
with the added benefit of fixing stretch support.