### PR TITLE
Add more common filetypes for Sharp X68000

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -212,7 +212,7 @@ wonderswan_fullname="Wonderswan"
 wonderswancolor_exts=".7z .wsc .zip"
 wonderswancolor_fullname="Wonderswan Color"
 
-x68000_exts=".dim"
+x68000_exts=".dim .hdf .2hd .d88"
 x68000_fullname="X68000"
 
 zmachine_exts=".dat .zip .z1 .z2 .z3 .z4 .z5 .z6 .z7 .z8"


### PR DESCRIPTION
Including hard disk image support (hdf).