### PR TITLE
Fix mk_arcade_joystick module building for the wrong kernel

### DIFF
--- a/scriptmodules/supplementary/mkarcadejoystick.sh
+++ b/scriptmodules/supplementary/mkarcadejoystick.sh
@@ -34,7 +34,7 @@ function build_mkarcadejoystick() {
     if dkms status | grep -q "^mk_arcade_joystick"; then
         _dkms_remove_mkarcadejoystick
     fi
-    dkms install -m mk_arcade_joystick_rpi -v 0.1.5 -k "$(ls -1 /lib/modules | tail -n -1)"
+    dkms install -m mk_arcade_joystick_rpi -v 0.1.5 -k "$(uname -r)"
     if dkms status | grep -q "^mk_arcade_joystick"; then
         md_ret_error+=("Failed to install $md_id")
         return 1


### PR DESCRIPTION
At least with the retropie image, the actual kernel isn't e.g. 4.9.35-v7+, but rather 4.9.35+. The line I changed never used the correct kernel name in use, hence it never worked in the first place and required a manual rebuild and installation every time