### PR TITLE
dxx-rebirth: use master branch

### DIFF
--- a/scriptmodules/ports/dxx-rebirth.sh
+++ b/scriptmodules/ports/dxx-rebirth.sh
@@ -22,7 +22,7 @@ function depends_dxx-rebirth() {
 }
 
 function sources_dxx-rebirth() {
-    gitPullOrClone "$md_build" https://github.com/dxx-rebirth/dxx-rebirth "unification/master"
+    gitPullOrClone "$md_build" https://github.com/dxx-rebirth/dxx-rebirth "master"
 }
 
 function build_dxx-rebirth() {


### PR DESCRIPTION
The unification/master branch is no longer recommended by upstream,
and the master branch has support for the new vendor libraries (as
well as the experimental Mesa driver).