### PR TITLE
Joy2Key-related fixes

### DIFF
--- a/scriptmodules/emulators/fs-uae/fs-uae.sh
+++ b/scriptmodules/emulators/fs-uae/fs-uae.sh
@@ -21,7 +21,7 @@ kickfile="$biosdir/kick13.rom"
 source "$rootdir/lib/archivefuncs.sh"
 
 if [[ ! -f "$kickfile" ]]; then
-    dialog --msgbox "You need to copy the Amiga kickstart file (kick13.rom) to the folder $biosdir to boot the Amiga emulator." 22 76
+    dialog --no-cancel --pause "You need to copy the Amiga kickstart file (kick13.rom) to the folder $biosdir to boot the Amiga emulator." 22 76 15
     exit 1
 fi
 

--- a/scriptmodules/emulators/reicast/reicast.sh
+++ b/scriptmodules/emulators/reicast/reicast.sh
@@ -73,7 +73,7 @@ function mapInput() {
 }
 
 if [[ ! -f "$HOME/RetroPie/BIOS/dc_boot.bin" ]]; then
-    dialog --msgbox "You need to copy the Dreamcast BIOS files (dc_boot.bin and dc_flash.bin) to the folder $biosdir to boot the Dreamcast emulator." 22 76
+    dialog --no-cancel --pause "You need to copy the Dreamcast BIOS files (dc_boot.bin and dc_flash.bin) to the folder $biosdir to boot the Dreamcast emulator." 22 76 15
     exit 1
 fi
 

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -1029,8 +1029,8 @@ function joy2keyStart() {
 ## @brief Stop previously started joy2key.py process.
 function joy2keyStop() {
     if [[ -n $__joy2key_pid ]]; then
-        kill -INT $__joy2key_pid 2>/dev/null
-        sleep 1
+        kill -USR1 $__joy2key_pid
+        wait $__joy2key_pid 2>/dev/null
     fi
 }
 

--- a/scriptmodules/libretrocores/lr-nxengine.sh
+++ b/scriptmodules/libretrocores/lr-nxengine.sh
@@ -37,7 +37,7 @@ function configure_lr-nxengine() {
     addPort "$md_id" "cavestory" "Cave Story" "$md_inst/nxengine_libretro.so" << _EOF_
 #!/bin/bash
 if [[ ! -f "$romdir/ports/CaveStory/Doukutsu.exe" ]]; then
-    dialog --msgbox "$md_help" 22 76
+    dialog --no-cancel --pause "$md_help" 22 76 15
 else
     "$rootdir/supplementary/runcommand/runcommand.sh" 0 _PORT_ cavestory "$romdir/ports/CaveStory/Doukutsu.exe"
 fi

--- a/scriptmodules/supplementary/runcommand/joy2key.py
+++ b/scriptmodules/supplementary/runcommand/joy2key.py
@@ -212,6 +212,8 @@ def process_event(event):
     return False
 
 signal.signal(signal.SIGINT, signal_handler)
+signal.signal(signal.SIGTERM, signal_handler)
+signal.signal(signal.SIGUSR1, signal_handler)
 
 js_button_codes = {}
 button_codes = []

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -123,7 +123,8 @@ function start_joy2key() {
 
 function stop_joy2key() {
     if [[ -n "$JOY2KEY_PID" ]]; then
-        kill -INT "$JOY2KEY_PID"
+        kill -USR1 "$JOY2KEY_PID"
+        wait "$JOY2KEY_PID" 2>/dev/null
     fi
 }
 


### PR DESCRIPTION
Although you've re-arranged the start/stop invocations to avoid the process remaining in most cases, I thought you might want to consider switching to the USR1 signal to solve the orphaned process issue fully.

Additionally, I identified a few cases in which scripts will display a dialog without joy2key running, leaving users without a keyboard stuck. I considered adapting the scripts like so:

```
scriptdir=$scriptdir (needed for joy2keyStart to function; actual name should be replaced by sed or through substitution when creating new files)
source "$scriptdir/scriptmodules/helpers.sh"
joy2keyStart
dialog [...]
joy2keyStop
```
...but I think it might be a bit overkill, so I figured that changing these to pause dialogs with a 15 second timeout might work better.

Edit: the reicast warning is not visible with or without this PR. A different issue that needs checking, but it doesn't stall indefinitely with this PR, at least.