### PR TITLE
Updating Dolphin extensions for GC and Wii

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -76,7 +76,7 @@ gb_fullname="Game Boy"
 gbc_exts=".7z .gbc .zip"
 gbc_fullname="Game Boy Color"
 
-gc_exts=".iso"
+gc_exts=".ciso .gcm .gcz .iso"
 gc_fullname="Nintendo Gamecube"
 
 intellivision_exts=".int .bin"
@@ -203,7 +203,7 @@ videopac_fullname="Videopac"
 virtualboy_exts=".7z .vb .zip"
 virtualboy_fullname="Virtual Boy"
 
-wii_exts=".iso"
+wii_exts=".ciso .gcm .gcz .iso .wbfs"
 wii_fullname="Nintendo Wii"
 
 wonderswan_exts=".7z .ws .zip"


### PR DESCRIPTION
Like described in https://dolphin-emu.org/docs/faq/#what-dump-formats-are-supported-dolphin. I didn't include `.wbfs` for Gamecube because I believe it's a Wii only format (while not specified in the Wiki).