### PR TITLE
system: skip GCC ABI compatibility workaround on stretch

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -95,7 +95,7 @@ function get_os_version() {
 
             # workaround for GCC ABI incompatibility with threaded armv7+ C++ apps built
             # on Raspbian's armv6 userland https://github.com/raspberrypi/firmware/issues/491
-            if [[ "$__os_id" == "Raspbian" ]]; then
+            if [[ "$__os_id" == "Raspbian" ]] && compareVersions "$__os_release" lt 9; then
                 __default_cxxflags+=" -U__GCC_HAVE_SYNC_COMPARE_AND_SWAP_2"
             fi
 


### PR DESCRIPTION
I tested a build of PPSSPP with the flag removed for jessie, but it still seems to be broken on jessie's gcc 4.9:

```
07:56:474 Core/Config.cpp:1024 I[LOADER]: Loading controller config: /home/pi/.config/ppsspp/PSP/SYSTEM/controls.ini
Pixels: 1366 x 768
Virtual pixels: 1366 x 768
I: gpu_features.cpp:136: GPU Vendor : Broadcom ; renderer: VideoCore IV HW version str: OpenGL ES 2.0 ; GLSL version str: OpenGL ES GLSL ES 1.00
glGetError 0x500
I: thin3d_gl.cpp:280: Shader module created (0xf55198)
I: thin3d_gl.cpp:280: Shader module created (0xf5eb80)
I: thin3d_gl.cpp:280: Shader module created (0xf59c70)
I: thin3d_gl.cpp:280: Shader module created (0xf59f58)
I: NativeApp.cpp:603: NativeInitGraphics
I: NativeApp.cpp:682: NativeInitGraphics completed
pure virtual method called
terminate called without an active exception
Aborted
```
