### PR TITLE
system - remove default gcc functions which were needed for Raspbian Wheezy

### DIFF
--- a/scriptmodules/libretrocores/lr-mame.sh
+++ b/scriptmodules/libretrocores/lr-mame.sh
@@ -22,7 +22,7 @@ function _get_params_lr-mame() {
 }
 
 function depends_lr-mame() {
-    if compareVersions $(gcc -dumpversion) lt 5.0.0; then
+    if compareVersions $__gcc_version lt 5.0.0; then
         md_ret_errors+=("Sorry, you need an OS with gcc 5.0 or newer to compile lr-mame")
         return 1
     fi

--- a/scriptmodules/ports/cgenius.sh
+++ b/scriptmodules/ports/cgenius.sh
@@ -22,7 +22,7 @@ function sources_cgenius() {
     gitPullOrClone "$md_build" https://github.com/gerstrong/Commander-Genius.git
 
     # use -O2 on older GCC due to segmentation fault when compiling with -O3
-    if compareVersions $(gcc -dumpversion) lt 6.0.0; then
+    if compareVersions $__gcc_version lt 6.0.0; then
         sed -i "s/ADD_DEFINITIONS(-O3)/ADD_DEFINITIONS(-O2)/" src/CMakeLists.txt
     fi
 }


### PR DESCRIPTION
 * use __gcc_version to avoid calling gcc -dumpversion multiple times in the code