### PR TITLE
retroarch - update to new version including modules that require new brcm library names - #2091

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -33,7 +33,7 @@ function depends_retroarch() {
 }
 
 function sources_retroarch() {
-    gitPullOrClone "$md_build" https://github.com/libretro/RetroArch.git v1.6.7
+    gitPullOrClone "$md_build" https://github.com/libretro/RetroArch.git v1.6.9
     applyPatch "$md_data/01_hotkey_hack.diff"
     applyPatch "$md_data/02_disable_search.diff"
 }

--- a/scriptmodules/libretrocores/lr-mupen64plus.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus.sh
@@ -38,6 +38,8 @@ function depends_lr-mupen64plus() {
 
 function sources_lr-mupen64plus() {
     gitPullOrClone "$md_build" https://github.com/libretro/mupen64plus-libretro.git
+    # needed until https://github.com/libretro/mupen64plus-libretro/pull/39 is accepted
+    isPlatform "rpi" && applyPatch "$md_data/01_new_lib_names.diff"
 }
 
 function build_lr-mupen64plus() {

--- a/scriptmodules/libretrocores/lr-mupen64plus/01_new_lib_names.diff
+++ b/scriptmodules/libretrocores/lr-mupen64plus/01_new_lib_names.diff
@@ -1,0 +1,66 @@
+diff --git a/Makefile b/Makefile
+index 2f248c1..ec72779 100644
+--- a/Makefile
++++ b/Makefile
+@@ -77,7 +77,8 @@ else ifneq (,$(findstring rpi,$(platform)))
+    else
+       LLE = 0
+       CPUFLAGS += -DVC
+-      GL_LIB := -L/opt/vc/lib -lGLESv2
++      GL_LIB := -L/opt/vc/lib -lbrcmGLESv2
++      EGL_LIB := -lbrcmEGL
+       INCFLAGS += -I/opt/vc/include -I/opt/vc/include/interface/vcos -I/opt/vc/include/interface/vcos/pthreads
+    endif
+    WITH_DYNAREC=arm
+diff --git a/Makefile.common b/Makefile.common
+index 4d36cba..4ae4325 100644
+--- a/Makefile.common
++++ b/Makefile.common
+@@ -301,9 +301,11 @@ else
+ 	SOURCES_CXX   += $(VIDEODIR_GLIDEN64)/src/3DMath.cpp
+ endif
+ 
++EGL_LIB ?= -lEGL
++
+ ifeq ($(GLES),1)
+ 	GLFLAGS += -DHAVE_OPENGLES -DHAVE_OPENGLES2 -DGLES2 -DUSE_DEPTH_RENDERBUFFER
+-	LDFLAGS += -lEGL
++	LDFLAGS += $(EGL_LIB)
+ 	SOURCES_C += $(LIBRETRO_COMM_DIR)/glsym/glsym_es2.c
+ 	SOURCES_CXX += $(VIDEODIR_GLIDEN64)/src/GLES2/GLSLCombiner_gles2.cpp
+ 	ifneq (,$(findstring android,$(platform)))
+@@ -312,7 +314,7 @@ ifeq ($(GLES),1)
+ 
+ else ifeq ($(GLES3),1)
+ 	GLFLAGS += -DHAVE_OPENGLES -DHAVE_OPENGLES3 -DGLES3
+-	LDFLAGS += -lEGL
++	LDFLAGS += $(EGL_LIB)
+ 	SOURCES_C += $(LIBRETRO_COMM_DIR)/glsym/glsym_es3.c
+ 	SOURCES_CXX +=  $(VIDEODIR_GLIDEN64)/src/OGL3X/GLSLCombiner_ogl3x.cpp \
+ 		$(VIDEODIR_GLIDEN64)/src/BufferCopy/ColorBufferToRDRAM_GL.cpp
+diff --git a/mupen64plus-core/projects/unix/Makefile b/mupen64plus-core/projects/unix/Makefile
+index 4a80335..a58fdeb 100755
+--- a/mupen64plus-core/projects/unix/Makefile
++++ b/mupen64plus-core/projects/unix/Makefile
+@@ -264,15 +264,16 @@ CFLAGS += $(SDL_CFLAGS)
+ LDLIBS += $(SDL_LDLIBS)
+ 
+ ifeq ($(VC), 1)
+-  CFLAGS += -DUSE_GLES -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/vmcs_host/linux
+-  LDLIBS += -L/opt/vc/lib -lGLESv2 -lEGL -lbcm_host -lvcos -lvchiq_arm
+-  # OSD uses non-ES code and breaks attribs of video plugins
+-  OSD=0
++  CFLAGS += -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/vmcs_host/linux
++  LDLIBS += -L/opt/vc/lib -lbrcmEGL -lbcm_host -lvcos -lvchiq_arm
++  GLES_LIB := -lbrcmGLESv2
++  USE_GLES := 1
+ endif
+ 
+ ifeq ($(USE_GLES), 1)
++  GLES_LIB ?= -lGLESv2
+   CFLAGS += -DUSE_GLES
+-  LDLIBS += -lGLESv2
++  LDLIBS += $(GLES_LIB)
+   # OSD uses non-ES code and breaks attribs of video plugins
+   OSD=0
+ endif

--- a/scriptmodules/libretrocores/lr-parallel-n64.sh
+++ b/scriptmodules/libretrocores/lr-parallel-n64.sh
@@ -17,6 +17,8 @@ rp_module_section="opt"
 
 function sources_lr-parallel-n64() {
     gitPullOrClone "$md_build" https://github.com/libretro/parallel-n64.git
+    # needed until https://github.com/libretro/parallel-n64/pull/469 is accepted
+    isPlatform "rpi" && sed -i "s#-L/opt/vc/lib -lGLESv2#-L/opt/vc/lib -lbrcmGLESv2#" Makefile
 }
 
 function build_lr-parallel-n64() {


### PR DESCRIPTION
 * include patches for lr-mupen64plus and lr-parallel-n64 until upstream accepts the PRs - https://github.com/libretro/mupen64plus-libretro/pull/39 / https://github.com/libretro/parallel-n64/pull/469

@psyke83 tagging you for review. 