### PR TITLE
retroarch - bump to v1.6.9

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -33,7 +33,7 @@ function depends_retroarch() {
 }
 
 function sources_retroarch() {
-    gitPullOrClone "$md_build" https://github.com/libretro/RetroArch.git v1.6.7
+    gitPullOrClone "$md_build" https://github.com/libretro/RetroArch.git v1.6.9
     applyPatch "$md_data/01_hotkey_hack.diff"
     applyPatch "$md_data/02_disable_search.diff"
 }


### PR DESCRIPTION
I compiled 1.6.9 here and everything seems to be working just fine.

And now we have RetroAchievements Leaderboards support! :D