### PR TITLE
retropiemenu: quit joy2key for RetroArch case

### DIFF
--- a/scriptmodules/supplementary/retropiemenu.sh
+++ b/scriptmodules/supplementary/retropiemenu.sh
@@ -133,6 +133,7 @@ function launch_retropiemenu() {
     joy2keyStart
     case $basename in
         retroarch.rp)
+            joy2keyStop
             cp "$configdir/all/retroarch.cfg" "$configdir/all/retroarch.cfg.bak"
             chown $user:$user "$configdir/all/retroarch.cfg.bak"
             su $user -c "\"$emudir/retroarch/bin/retroarch\" --menu --config \"$configdir/all/retroarch.cfg\""


### PR DESCRIPTION
P.S. The small interval between start/stop should no longer matter now that the python is killed before script processing completes, via the USR1 signal. I've tested several times and never saw an orphaned process before exiting retroarch, but even so, the second invocation of joy2keyStop after exiting retroarch would probably catch it.