### PR TITLE
Implement configKernelModule helper

### DIFF
--- a/scriptmodules/supplementary/gamecondriver.sh
+++ b/scriptmodules/supplementary/gamecondriver.sh
@@ -52,19 +52,12 @@ function install_bin_gamecondriver() {
 }
 
 function remove_gamecondriver() {
-    sed -i "/gamecon_gpio_rpi/d" /etc/modules
-    rm -f /etc/modprobe.d/gamecon.conf
+    configKernelModule "remove" "gamecon_gpio_rpi" "gamecon"
     aptRemove db9-gpio-rpi-dkms gamecon-gpio-rpi-dkms
 }
 
 function configure_gamecondriver() {
     [[ "$md_mode" == "remove" ]] && return
-
-    if ! grep -q "gamecon_gpio_rpi" /etc/modules; then
-        addLineToFile "gamecon_gpio_rpi" /etc/modules
-    elif grep -q "gamecon_gpio_rpi.*map" /etc/modules; then
-        sed -i "s/gamecon_gpio_rpi.*/gamecon_gpio_rpi/" /etc/modules
-    fi
 }
 
 function dual_snes_gamecondriver() {
@@ -79,13 +72,10 @@ function dual_snes_gamecondriver() {
     esac
 
     if [[ "$gpio_rev" == 1 ]]; then
-        echo "options gamecon_gpio_rpi map=0,1,1,0" >/etc/modprobe.d/gamecon.conf
+        configKernelModule "install" "gamecon_gpio_rpi" "gamecon" "options gamecon_gpio_rpi map=0,1,1,0"
     else
-        echo "options gamecon_gpio_rpi map=0,0,1,0,0,1" >/etc/modprobe.d/gamecon.conf
+        configKernelModule "install" "gamecon_gpio_rpi" "gamecon" "options gamecon_gpio_rpi map=0,0,1,0,0,1"
     fi
-
-    [[ -n "$(lsmod | grep gamecon_gpio_rpi)" ]] && rmmod gamecon_gpio_rpi
-    modprobe gamecon_gpio_rpi
 
     iniConfig " = " "" "$configdir/all/retroarch.cfg"
 

--- a/scriptmodules/supplementary/mkarcadejoystick.sh
+++ b/scriptmodules/supplementary/mkarcadejoystick.sh
@@ -48,24 +48,16 @@ function build_mkarcadejoystick() {
 }
 
 function remove_mkarcadejoystick() {
-    [[ -n "$(lsmod | grep mk_arcade_joystick_rpi)" ]] && rmmod mk_arcade_joystick_rpi
+    configKernelModule "remove" "mk_arcade_joystick_rpi"
     _dkms_remove_mkarcadejoystick
     rm -rf /usr/src/mk_arcade_joystick_rpi-0.1.5
-    rm -f /etc/modprobe.d/mk_arcade_joystick_rpi.conf
-    sed -i "/mk_arcade_joystick_rpi/d" /etc/modules
 }
 
 function configure_mkarcadejoystick() {
     [[ "$md_mode" == "remove" ]] && return
 
-    if ! grep -q "mk_arcade_joystick_rpi" /etc/modules; then
-        addLineToFile "mk_arcade_joystick_rpi" /etc/modules
-    fi
-
     if [[ ! -f /etc/modprobe.d/mk_arcade_joystick_rpi.conf ]]; then
-        echo "options mk_arcade_joystick_rpi map=1" >/etc/modprobe.d/mk_arcade_joystick_rpi.conf
+        local parameter="options mk_arcade_joystick_rpi map=1"
     fi
-
-    [[ -n "$(lsmod | grep mk_arcade_joystick_rpi)" ]] && rmmod mk_arcade_joystick_rpi
-    modprobe mk_arcade_joystick_rpi
-} 
+    configKernelModule "install" "mk_arcade_joystick_rpi" "mk_arcade_joystick_rpi" "$parameter"
+}

--- a/scriptmodules/supplementary/raspbiantools.sh
+++ b/scriptmodules/supplementary/raspbiantools.sh
@@ -39,18 +39,12 @@ function disable_blanker_raspbiantools() {
 }
 
 function enable_modules_raspbiantools() {
-    sed -i '/snd_bcm2835/d' /etc/modules
+    local modules=("uinput")
+    local parameters=("")
+    local index
 
-    local modules=(uinput)
-
-    local module
-    for module in "${modules[@]}"; do
-        modprobe $module
-        if ! grep -q "$module" /etc/modules; then
-            addLineToFile "$module" "/etc/modules"
-        else
-            echo "$module module already contained in /etc/modules"
-        fi
+    for index in "${!modules[@]}"; do
+        configKernelModule "install" "${modules[index]}" "retropie" "${parameters[index]}"
     done
 }
 

--- a/scriptmodules/supplementary/xpad.sh
+++ b/scriptmodules/supplementary/xpad.sh
@@ -71,11 +71,13 @@ function build_xpad() {
 function remove_xpad() {
     dkms remove -m xpad -v 0.4 --all
     rm -rf /usr/src/xpad-0.4
-    rm -f /etc/modprobe.d/xpad.conf
+    configKernelModule "remove" "xpad"
 }
 
 function configure_xpad() {
+    [[ "$md_mode" == "remove" ]] && return
     if [[ ! -f /etc/modprobe.d/xpad.conf ]]; then
-        echo "options xpad triggers_to_buttons=1" >/etc/modprobe.d/xpad.conf
+        local parameter="options xpad triggers_to_buttons=1"
     fi
+    configKernelModule "install" "xpad" "xpad" "$parameter"
 }


### PR DESCRIPTION
Apologies for dumping this all of a sudden. @joolswills and I briefly discussed the possibility of adding software midi daemon function to runcommand for use with AGS (and dosbox), but I don't think he was happy with the idea :). Instead of doing that, I can just add the daemon to a script for AGS, just as DOSbox currently does. The problem, however, is that AGS requires a raw midi device in order to function, so a non-standard kernel module needs to be loaded in order for it to work.

Since AGS will need a kernel to be loaded with custom parameters for MIDI support, I've written a new helper function to manage install & configuration of kernel modules. I tried to keep it as concise as possible, but I've commented the important lines to help illustrate its function.

It adds some extra bloat to the code, but makes module management more consistent between the projects, has better systemd support, and does a better job at cleaning up on uninstall. I'm only sending the PR to see if you would find this acceptable for inclusion; depending on your decision, my AGS PR (which I still need time to work on) will either utilize this function, or else will have to re-use the same code that's duplicated between gamecondriver/xpad etc. for configuring the required module (snd-virmidi).