### PR TITLE
Add ODROID-XU4 to avoid constant "unknown __platform" errors.

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -267,7 +267,7 @@ function get_platform() {
             "Freescale i.MX6 Quad/DualLite (Device Tree)")
                 __platform="imx6"
                 ;;
-            ODROID-XU3)
+            ODROID-XU3|ODROID-XU4)
                 __platform="odroid-xu"
                 ;;
             *)


### PR DESCRIPTION
Fixes the constant complaints about __platform being unrecognized when using certain functions of RetroPie-Setup on ODROID-XU4 even with the script being launched with __platform set manually as the error tells you to do. This fixes a lot of submenus of the RetroPie-Setup script such as the Bluetooth configuration submenu which will not launch properly without this, even with __platform defined properly.