### PR TITLE
Fix to enable compilation on ubuntu 17.10

### DIFF
--- a/scriptmodules/emulators/advmame.sh
+++ b/scriptmodules/emulators/advmame.sh
@@ -37,7 +37,7 @@ function sources_advmame() {
 }
 
 function build_advmame() {
-    ./configure --prefix="$md_inst"
+    CFLAGS="-fno-stack-protector" ./configure --prefix="$md_inst"
     make clean
     make
 }


### PR DESCRIPTION
As newer versions of GCC have stack protection turned on by default, this change is necessary. If stack protection is on by default, the resulting binary will crash with stack protection errors. By setting stack protection off, then advmame will compile and work without issue.