### PR TITLE
ags: add to platforms & enable DIGMID support

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -1,6 +1,9 @@
 3do_exts=".iso"
 3do_fullname="3DO Interactive Multiplayer"
 
+ags_exts=".exe"
+ags_fullname="Adventure Game Studio"
+
 amiga_exts=".adf .adz .dms .ipf .uae .zip .sh"
 amiga_fullname="Commodore Amiga"
 

--- a/scriptmodules/emulators/ags.sh
+++ b/scriptmodules/emulators/ags.sh
@@ -36,6 +36,9 @@ function install_ags() {
 function configure_ags() {
     mkRomDir "ags"
 
+    # install Eawpatches GUS patch set (see: http://liballeg.org/digmid.html)
+    [[ "$md_mode" == "install" ]] && wget -qO- "http://www.eglebbk.dds.nl/program/download/digmid.dat" | bzcat >"$md_inst/bin/patches.dat"
+
     if isPlatform "x11"; then
         addEmulator 1 "$md_id" "ags" "$md_inst/bin/ags --fullscreen %ROM%" "Adventure Game Studio" ".exe"
     else


### PR DESCRIPTION
Add Adventure Game Studio to platforms configuration and fetch
recommended GUS patch from http://liballeg.org/digmid.html.

Fixes MIDI playback on devices with no hardware MIDI support (such as
Raspberry Pi).

--

It's not easy to determine which games use MIDI sound, so to help test this PR, I recommend downloading this: http://www.g4g.it/2009/11/30/fullyramblomatic-special-editions-pack/. I can confirm that "5 Days Special Edition" plays midi sound on the title menu.

If you'd like to mirror the GUS patch file, let me know and I can update the PR once you've uploaded the file to the retropie server. The current "digmid.dat" file is actually bz2 compressed, which is why "downloadAndExtract" is not possible unless we mirror a properly compressed & named archive.