### PR TITLE
dosbox: implement support for launching via .conf files

### DIFF
--- a/scriptmodules/emulators/dosbox.sh
+++ b/scriptmodules/emulators/dosbox.sh
@@ -88,6 +88,8 @@ if [[ -z "\${params[0]}" ]]; then
 elif [[ "\${params[0]}" == *.sh ]]; then
     bash "\${params[@]}"
     exit
+elif [[ "\${params[0]}" == *.conf ]]; then
+    params=(-userconf -conf "\${params[@]}")
 else
     params+=(-exit)
 fi


### PR DESCRIPTION
This allows users to override the default dosbox configuration,
but the most likely use is to configure the autoexec, such as:

[autoexec]
MOUNT C /home/pi/RetroPie/roms/pc
C:
CD PROGRAM/
LAUNCH.EXE
EXIT

This is the recommend way to configure content, and should also
work with lr-dosbox.