### PR TITLE
Update dosbox & add experimental sdl2-only version

### DIFF
--- a/scriptmodules/emulators/dosbox-sdl2.sh
+++ b/scriptmodules/emulators/dosbox-sdl2.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="dosbox-sdl2"
+rp_module_desc="DOS emulator (enhanced DOSBox fork)"
+rp_module_help="ROM Extensions: .bat .com .exe .sh .conf\n\nCopy your DOS games to $romdir/pc"
+rp_module_licence="GPL2 https://sourceforge.net/p/dosbox/code-0/HEAD/tree/dosbox/trunk/COPYING"
+rp_module_section="exp"
+rp_module_flags="!mali !kms"
+
+function depends_dosbox-sdl2() {
+    depends_dosbox libsdl2-dev libsdl2-net-dev libfluidsynth-dev fluid-soundfont-gm
+}
+
+function sources_dosbox-sdl2() {
+    gitPullOrClone "$md_build" "https://github.com/duganchen/dosbox.git"
+    # use custom config filename & path to allow coexistence with regular dosbox
+    sed -i "src/misc/cross.cpp" -e 's/~\/.dosbox/~\/.'$md_id'/g' \
+       -e 's/DEFAULT_CONFIG_FILE "dosbox-"/DEFAULT_CONFIG_FILE "'$md_id'-"/g'
+}
+
+function build_dosbox-sdl2() {
+    build_dosbox
+}
+
+function install_dosbox-sdl2() {
+    install_dosbox
+}
+
+function configure_dosbox-sdl2() {
+    configure_dosbox
+    if [[ "$md_mode" == "install" ]]; then
+        local config_path=$(su "$user" -c "\"$md_inst/bin/dosbox\" -printconf")
+        if [[ -f "$config_path" ]]; then
+            iniConfig "=" "" "$config_path"
+            iniSet "fluid.driver" "alsa"
+            iniSet "fluid.soundfont" "/usr/share/sounds/sf2/FluidR3_GM.sf2"
+            iniSet "fullresolution" "desktop"
+            iniSet "fullscreen" "true"
+            iniSet "mididevice" "fluidsynth"
+            iniSet "output" "texture"
+            iniDel "usescancodes"
+        fi
+    fi
+}

--- a/scriptmodules/emulators/dosbox.sh
+++ b/scriptmodules/emulators/dosbox.sh
@@ -59,11 +59,17 @@ function install_dosbox() {
 }
 
 function configure_dosbox() {
-    local def="1"
-    local launcher_name="+Start DOSBox.sh"
-    # needs software synth for midi; limit to Pi for now
-    if isPlatform "rpi"; then
-        local needs_synth="1"
+    if [[ "$md_id" == "dosbox-sdl2" ]]; then
+        local def="0"
+        local launcher_name="+Start DOSBox-SDL2.sh"
+        local needs_synth="0"
+    else
+        local def="1"
+        local launcher_name="+Start DOSBox.sh"
+        # needs software synth for midi; limit to Pi for now
+        if isPlatform "rpi"; then
+            local needs_synth="1"
+        fi
     fi
 
     mkRomDir "pc"

--- a/scriptmodules/emulators/dosbox.sh
+++ b/scriptmodules/emulators/dosbox.sh
@@ -11,24 +11,31 @@
 
 rp_module_id="dosbox"
 rp_module_desc="DOS emulator"
-rp_module_help="ROM Extensions: .bat .com .exe .sh\n\nCopy your DOS games to $romdir/pc"
+rp_module_help="ROM Extensions: .bat .com .exe .sh .conf\n\nCopy your DOS games to $romdir/pc"
 rp_module_licence="GPL2 https://sourceforge.net/p/dosbox/code-0/HEAD/tree/dosbox/trunk/COPYING"
 rp_module_section="opt"
 rp_module_flags="dispmanx !mali !kms"
 
 function depends_dosbox() {
-    local depends=(libsdl1.2-dev libsdl-net1.2-dev libsdl-sound1.2-dev libasound2-dev libpng12-dev automake autoconf zlib1g-dev)
+    local depends=(libsdl1.2-dev libsdl-net1.2-dev libsdl-sound1.2-dev libasound2-dev libpng12-dev automake autoconf zlib1g-dev subversion "$@")
     isPlatform "rpi" && depends+=(timidity freepats)
     getDepends "${depends[@]}"
 }
 
 function sources_dosbox() {
-    downloadAndExtract "$__archive_url/dosbox-r3876.tar.gz" "$md_build" 1
+    local revision="$1"
+    [[ -z "$revision" ]] && revision="4006"
+
+    svn checkout https://svn.code.sf.net/p/dosbox/code-0/dosbox/trunk "$md_build" -r "$revision"
 }
 
 function build_dosbox() {
     local params=()
+
     ! isPlatform "x11" && params+=(--disable-opengl)
+    # add or override params from calling function
+    params+=("$@")
+
     ./autogen.sh
     ./configure --prefix="$md_inst" "${params[@]}"
     if isPlatform "arm"; then
@@ -52,14 +59,17 @@ function install_dosbox() {
 }
 
 function configure_dosbox() {
-    local needs_synth
-
-    # needs software synth for midi
-    isPlatform "rpi" && needs_synth=1
+    local def="1"
+    local launcher_name="+Start DOSBox.sh"
+    # needs software synth for midi; limit to Pi for now
+    if isPlatform "rpi"; then
+        local needs_synth="1"
+    fi
 
     mkRomDir "pc"
-    rm -f "$romdir/pc/Start DOSBox.sh"
-    cat > "$romdir/pc/+Start DOSBox.sh" << _EOF_
+    rm -f "$romdir/pc/$launcher_name"
+    if [[ "$md_mode" == "install" ]]; then
+        cat > "$romdir/pc/$launcher_name" << _EOF_
 #!/bin/bash
 
 [[ ! -n "\$(aconnect -o | grep -e TiMidity -e FluidSynth)" ]] && needs_synth="$needs_synth"
@@ -86,7 +96,9 @@ params=("\$@")
 if [[ -z "\${params[0]}" ]]; then
     params=(-c "@MOUNT C $romdir/pc" -c "@C:")
 elif [[ "\${params[0]}" == *.sh ]]; then
+    midi_synth start
     bash "\${params[@]}"
+    midi_synth stop
     exit
 elif [[ "\${params[0]}" == *.conf ]]; then
     params=(-userconf -conf "\${params[@]}")
@@ -98,24 +110,25 @@ midi_synth start
 "$md_inst/bin/dosbox" "\${params[@]}"
 midi_synth stop
 _EOF_
-    chmod +x "$romdir/pc/+Start DOSBox.sh"
-    chown $user:$user "$romdir/pc/+Start DOSBox.sh"
+        chmod +x "$romdir/pc/$launcher_name"
+        chown $user:$user "$romdir/pc/$launcher_name"
 
-    local config_path=$(su "$user" -c "\"$md_inst/bin/dosbox\" -printconf")
-    if [[ -f "$config_path" ]]; then
-        iniConfig "=" "" "$config_path"
-        iniSet "usescancodes" "false"
-        iniSet "core" "dynamic"
-        iniSet "cycles" "max"
-        iniSet "scaler" "none"
-        if isPlatform "rpi" || [[ -n "$(aconnect -o | grep -e TiMidity -e FluidSynth)" ]]; then
-            iniSet "mididevice" "alsa"
-            iniSet "midiconfig" "128:0"
+        local config_path=$(su "$user" -c "\"$md_inst/bin/dosbox\" -printconf")
+        if [[ -f "$config_path" ]]; then
+            iniConfig "=" "" "$config_path"
+            iniSet "usescancodes" "false"
+            iniSet "core" "dynamic"
+            iniSet "cycles" "max"
+            iniSet "scaler" "none"
+            if isPlatform "rpi" || [[ -n "$(aconnect -o | grep -e TiMidity -e FluidSynth)" ]]; then
+                iniSet "mididevice" "alsa"
+                iniSet "midiconfig" "128:0"
+            fi
         fi
     fi
 
-    moveConfigDir "$home/.dosbox" "$md_conf_root/pc"
+    moveConfigDir "$home/.$md_id" "$md_conf_root/pc"
 
-    addEmulator 1 "$md_id" "pc" "bash $romdir/pc/+Start\ DOSBox.sh %ROM%"
+    addEmulator "$def" "$md_id" "pc" "bash $romdir/pc/${launcher_name// /\\ } %ROM%"
     addSystem "pc"
 }


### PR DESCRIPTION
Testing a newer revision of the SDL2 patch as discussed previously: https://github.com/RetroPie/RetroPie-Setup/issues/1350

The new revision of vanilla DOSbox seems to work OK. I decided to update it so that we have an equal baseline for comparison with the SDL2 version. I also added some minor cleanups and a fix to ensure that the midi synth is launched for .sh script content.

I've done some testing of the SDL2 build - performance is almost identical, but there is a noticeable reduction in screen tearing, better scaling to fit the entire screen, and mapper colours are OK. The splash screen, windowed mode and the mapper doesn't scale to the full screen properly, and while SDL_VIDEO_RPI_SCALE_MODE=1 does scale the window, the mouse cursor's bounding appears limited to the unscaled resolution, making it impossible to navigate on parts of the screen, so I left that out. I'm guessing that the dispmanx patch in the SDL2 source would need updating so that the cursor bounds reflect the scaled window size instead of the original.

I'm sending the PR since you already expressed interest in testing SDL2, but I've no expectation for anyone to even so much as take a look until after the holidays :).