### PR TITLE
splashscreen: ensure splash is set to default if needed

### DIFF
--- a/scriptmodules/supplementary/splashscreen.sh
+++ b/scriptmodules/supplementary/splashscreen.sh
@@ -293,7 +293,7 @@ function gui_splashscreen() {
                         disable_splashscreen
                         printMsgs "dialog" "Disabled splashscreen on boot."
                     else
-                        [[ ! -f /etc/splashscreen.list ]] && rp_CallModule splashscreen default
+                        [[ ! -f /etc/splashscreen.list ]] && rp_callModule splashscreen default
                         enable_splashscreen
                         printMsgs "dialog" "Enabled splashscreen on boot."
                     fi


### PR DESCRIPTION
If /etc/splashscreen.list is not present during enable, default will
not be set correctly due to typo in function called.