### PR TITLE
RPi stretch binary-only compatibility patching

### DIFF
--- a/scriptmodules/emulators/coolcv.sh
+++ b/scriptmodules/emulators/coolcv.sh
@@ -22,6 +22,7 @@ function depends_coolcv() {
 
 function install_bin_coolcv() {
     downloadAndExtract "$__archive_url/coolcv.tar.gz" "$md_inst" 1
+    patchVendorGraphics "$md_inst/coolcv_pi"
 }
 
 function configure_coolcv() {

--- a/scriptmodules/emulators/drastic.sh
+++ b/scriptmodules/emulators/drastic.sh
@@ -18,6 +18,7 @@ rp_module_flags="!mali !x86 !armv6 !kms"
 
 function install_bin_drastic() {
     downloadAndExtract "http://drastic-ds.com/drastic_rpi.tar.bz2" "$md_inst" 1
+    patchVendorGraphics "$md_inst/drastic"
 }
 
 function configure_drastic() {

--- a/scriptmodules/emulators/rpix86.sh
+++ b/scriptmodules/emulators/rpix86.sh
@@ -20,6 +20,7 @@ function install_bin_rpix86() {
     downloadAndExtract "$__archive_url/rpix86.tar.gz" "$md_inst"
     # install 4DOS.com
     downloadAndExtract "$__archive_url/4dos.zip" "$md_inst"
+    patchVendorGraphics "$md_inst/rpix86"
 }
 
 function configure_rpix86() {

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -1281,3 +1281,20 @@ function delEmulator() {
         done
     fi
 }
+
+## @fn patchVendorGraphics()
+## @param filename file to patch
+## @details replace declared dependencies of old vendor graphics libraries with new names
+## Temporary compatibility workaround for legacy software to work on new Raspberry Pi firmwares.
+function patchVendorGraphics() {
+    local filename="$1"
+
+    getDepends patchelf
+    printMsgs "console" "Applying vendor graphics patch: $filename"
+    patchelf --replace-needed libEGL.so libbrcmEGL.so \
+             --replace-needed libGLES_CM.so libbrcmGLESv2.so \
+             --replace-needed libGLESv1_CM.so libbrcmGLESv2.so \
+             --replace-needed libGLESv2.so libbrcmGLESv2.so \
+             --replace-needed libOpenVG.so libbrcmOpenVG.so \
+             --replace-needed libWFC.so libbrcmWFC.so "$filename"
+}

--- a/scriptmodules/ports/giana.sh
+++ b/scriptmodules/ports/giana.sh
@@ -20,6 +20,7 @@ function depends_giana() {
 
 function install_bin_giana() {
     downloadAndExtract "http://www.retroguru.com/gianas-return/gianas-return-v.latest-raspberrypi.zip" "$md_inst"
+    patchVendorGraphics "$md_inst/giana_rpi"
 }
 
 function configure_giana() {


### PR DESCRIPTION
Hi @joolswills,

This seems like the ideal solution for our legacy/binary only items. I've confirmed that giana, rpix86 and coolcv work perfectly on stretch after patching with this PR.

This PR can be expanded to all other binary packages. Can you let me know what other binary-only software is distributed by the script and thus may potentially need patching?

Should help towards resolving #2091.