### PR TITLE
Do not enable PowerBlock and ControlBlock service with installation

### DIFF
--- a/scriptmodules/supplementary/controlblock.sh
+++ b/scriptmodules/supplementary/controlblock.sh
@@ -13,6 +13,7 @@ rp_module_id="controlblock"
 rp_module_desc="ControlBlock Driver"
 rp_module_section="driver"
 rp_module_flags="noinstclean"
+rp_module_help="Please note that you need to manually enable or disable the ControlBlock Service in the Configuration section. IMPORTANT: If the service is enabled and the power switch functionality is enabled (which is the default setting) in the config file, you need to have a switch connected to the ControlBlock."
 
 function depends_controlblock() {
     local depends=(cmake doxygen)
@@ -39,7 +40,6 @@ function install_controlblock() {
     # install from there to system folders
     cd "$md_inst/build"
     make install
-    [[ ! -f "$md_inst/disabled" ]] && make installservice
 }
 
 function gui_controlblock() {
@@ -54,12 +54,10 @@ function gui_controlblock() {
         case "$choice" in
             1)
                 make -C "$md_inst/build" installservice
-                rm "$md_inst/disabled"
                 printMsgs "dialog" "Enabled ControlBlock driver."
                 ;;
             2)
                 make -C "$md_inst/build" uninstallservice
-                touch "$md_inst/disabled"
                 printMsgs "dialog" "Disabled ControlBlock driver."
                 ;;
         esac

--- a/scriptmodules/supplementary/powerblock.sh
+++ b/scriptmodules/supplementary/powerblock.sh
@@ -13,6 +13,7 @@ rp_module_id="powerblock"
 rp_module_desc="PowerBlock Driver"
 rp_module_section="driver"
 rp_module_flags="noinstclean"
+rp_module_help="Please note that you need to manually enable or disable the PowerBlock Service in the Configuration section. IMPORTANT: If the service is enabled and the power switch functionality is enabled (which is the default setting) in the config file, you need to have a switch connected to the PowerBlock."
 
 function depends_powerblock() {
     local depends=(cmake doxygen)
@@ -39,7 +40,6 @@ function install_powerblock() {
     # install from there to system folders
     cd "$md_inst/build"
     make install
-    [[ ! -f "$md_inst/disabled" ]] && make installservice
 }
 
 function gui_powerblock() {
@@ -54,12 +54,10 @@ function gui_powerblock() {
         case "$choice" in
             1)
                 make -C "$md_inst/build" installservice
-                rm "$md_inst/disabled"
                 printMsgs "dialog" "Enabled PowerBlock driver."
                 ;;
             2)
                 make -C "$md_inst/build" uninstallservice
-                touch "$md_inst/disabled"
                 printMsgs "dialog" "Disabled PowerBlock driver."
                 ;;
         esac


### PR DESCRIPTION
With this pull request the services are not enabled with the installation anymore. This addresses the reboot issue as discussed at #2156.