### PR TITLE
Add Deepin to supported OS

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -132,6 +132,12 @@ function get_os_version() {
             fi
             __os_ubuntu_ver="$__os_release"
             ;;
+        Deepin)
+            if compareVersions "$__os_release" lt 15.5; then
+                error="You need Deepin OS 15.5 or newer"
+            fi
+            __os_debian_ver="9"
+            ;;
         elementary)
             if compareVersions "$__os_release" lt 0.3; then
                 error="You need Elementary OS 0.3 or newer"


### PR DESCRIPTION
As Deepin is now based in Debian, is just needed a little entry in the system.sh script to support the last version of this distribution without problems.
https://www.deepin.org/es/

Testing environment:
OS:  Deepin 15.5 Desktop
Processor: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
Ram: 16GB
Kernel: 4.9.0-deepin13-amd64 #1 SMP PREEMPT Deepin 4.9.57-1 (2017-10-19) x86_64 GNU/Linux
