### PR TITLE
wolf4sdl: fix spear of destiny mission support

### DIFF
--- a/scriptmodules/ports/wolf4sdl.sh
+++ b/scriptmodules/ports/wolf4sdl.sh
@@ -68,12 +68,17 @@ function game_data_wolf4sdl() {
 function configure_wolf4sdl() {
     local bin
     local bins
+    local mission=0
     while read -r bin; do
         bins+=("$bin")
     done < <(get_bins_wolf4sdl)
     # called outside of above loop to avoid problems with addPort and stdin
     for bin in "${bins[@]}"; do
-        addPort "$bin" "wolf3d" "Wolfenstein 3D" "$md_inst/bin/$bin"
+        [[ "$bin" != "wolf4sdl-spear" ]] && addPort "$bin" "wolf3d" "Wolfenstein 3D" "$md_inst/bin/$bin"
+    done
+    for bin in "wolf4sdl-spear" "wolf4sdl-spear2" "wolf4sdl-spear3"; do
+        ((mission++))
+        addPort "$bin" "wolf3d" "Wolfenstein 3D" "$md_inst/bin/wolf4sdl-spear --mission $mission"
     done
 
     mkRomDir "ports/wolf3d"


### PR DESCRIPTION
The previous wolf4sdl-spear default to mission 3 when executed with
no arguments. Fix and add ports for the other two missions.

Fixes #1507.