### PR TITLE
Add missing fonts-freefont-ttf dependency

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -17,7 +17,7 @@ rp_module_section="main"
 rp_module_flags="!mali !kms"
 
 function depends_mupen64plus() {
-    local depends=(cmake libsamplerate0-dev libspeexdsp-dev libsdl2-dev libpng12-dev)
+    local depends=(cmake libsamplerate0-dev libspeexdsp-dev libsdl2-dev libpng12-dev fonts-freefont-ttf)
     isPlatform "x11" && depends+=(libglew-dev libglu1-mesa-dev libboost-filesystem-dev)
     isPlatform "x86" && depends+=(nasm)
     getDepends "${depends[@]}"


### PR DESCRIPTION
Needed by GlideN64: https://github.com/gonetz/GLideN64/blob/dfada113d35ebea131a13fa629512dc8852b0ad5/src/TextDrawer.cpp#L207