### PR TITLE
Stretch changes

### DIFF
--- a/scriptmodules/emulators/capricerpi.sh
+++ b/scriptmodules/emulators/capricerpi.sh
@@ -22,6 +22,7 @@ function depends_capricerpi() {
 
 function sources_capricerpi() {
     gitPullOrClone "$md_build" https://github.com/KaosOverride/CapriceRPI.git
+    sed -i "s/-lpng12/-lpng/" src/makefile
 }
 
 function build_capricerpi() {

--- a/scriptmodules/emulators/pcsx-rearmed.sh
+++ b/scriptmodules/emulators/pcsx-rearmed.sh
@@ -28,7 +28,7 @@ function build_pcsx-rearmed() {
     if isPlatform "neon"; then
         ./configure --sound-drivers=alsa --enable-neon
     else
-        ./configure --sound-drivers=alsa
+        ./configure --sound-drivers=alsa --disable-neon
     fi
     make clean
     make

--- a/scriptmodules/emulators/pisnes.sh
+++ b/scriptmodules/emulators/pisnes.sh
@@ -17,7 +17,7 @@ rp_module_section="opt"
 rp_module_flags="!x86 !mali !kms"
 
 function depends_pisnes() {
-    getDepends libasound2-dev libsdl1.2-dev libraspberrypi-dev
+    getDepends libasound2-dev libsdl1.2-dev libraspberrypi-dev libjpeg-dev
 }
 
 function sources_pisnes() {

--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -26,6 +26,8 @@ function sources_ppsspp() {
     gitPullOrClone "$md_build/ppsspp" https://github.com/hrydgard/ppsspp.git v1.5.4
     cd ppsspp
 
+    applyPatch "$md_data/01_egl_name.diff"
+
     # remove the lines that trigger the ffmpeg build script functions - we will just use the variables from it
     sed -i "/^build_ARMv6$/,$ d" ffmpeg/linux_arm.sh
 

--- a/scriptmodules/emulators/ppsspp/01_egl_name.diff
+++ b/scriptmodules/emulators/ppsspp/01_egl_name.diff
@@ -1,0 +1,28 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 628831ba30..7f998be6a3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -130,7 +130,10 @@ if(NOT OPENGL_LIBRARIES AND USING_GLES2)
+ endif()
+ 
+ if(USING_EGL)
+-	set(OPENGL_LIBRARIES ${OPENGL_LIBRARIES} EGL)
++	if(NOT EGL_LIBRARIES)
++		set(EGL_LIBRARIES EGL)
++	endif()
++	set(OPENGL_LIBRARIES ${OPENGL_LIBRARIES} ${EGL_LIBRARIES})
+ endif()
+ 
+ if(NOT OPENGL_LIBRARIES)
+@@ -748,10 +751,7 @@ elseif(TARGET SDL2::SDL2)
+ 		set(nativeExtra ${nativeExtra} SDL/SDLMain.h SDL/SDLMain.mm)
+ 		set(nativeExtraLibs ${nativeExtraLibs} ${COCOA_LIBRARY})
+ 	elseif(USING_EGL)
+-		if(NOT EGL_LIBRARIES)
+-			set(EGL_LIBRARIES EGL)
+-		endif()
+-		set(nativeExtraLibs ${nativeExtraLibs} pthread ${EGL_LIBRARIES})
++		set(nativeExtraLibs ${nativeExtraLibs} pthread)
+ 	endif()
+ 	set(TargetBin PPSSPPSDL)
+ elseif(WIN32)

--- a/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
+++ b/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
@@ -24,7 +24,11 @@ function sources_lr-pcsx-rearmed() {
 }
 
 function build_lr-pcsx-rearmed() {
-    ./configure --platform=libretro
+    if isPlatform "neon"; then
+        ./configure --platform=libretro --enable-neon
+    else
+        ./configure --platform=libretro --disable-neon
+    fi
     make clean
     make
     md_ret_require="$md_build/libretro.so"

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -76,10 +76,6 @@ function get_os_version() {
     local error=""
     case "$__os_id" in
         Raspbian|Debian)
-            if compareVersions "$__os_release" ge 9 && isPlatform "rpi"; then
-                error="Sorry - Raspbian/Debian Stretch (and newer) is not yet supported on the RPI"
-            fi
-
             if compareVersions "$__os_release" lt 8; then
                 error="You need Raspbian/Debian Jessie or newer"
             fi

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -90,8 +90,8 @@ function get_os_version() {
                 __platform_flags+=" xbian"
             fi
 
-            # we provide binaries for RPI on Raspbian < 9 only
-            if isPlatform "rpi" && compareVersions "$__os_release" lt 9; then
+            # we provide binaries for RPI on Raspbian < 10 only
+            if isPlatform "rpi" && compareVersions "$__os_release" lt 10; then
                 __has_binaries=1
             fi
 

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -256,7 +256,7 @@ function get_platform() {
 
 function platform_rpi1() {
     # values to be used for configure/make
-    __default_cflags="-O2 -mfpu=vfp -march=armv6j -mfloat-abi=hard"
+    __default_cflags="-O2 -mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard"
     __default_asflags=""
     __default_makeflags=""
     __platform_flags="arm armv6 rpi gles"


### PR DESCRIPTION
This PR adds some additional stretch support -

* Enables running retropie_setup on Stretch
* Enables binaries (Almost all binaries are now built)
* Fixes a few packages for Stretch

lr-armsnes does not currently build on gcc 6.0 , due to some inline asm. I believe it should be a simple fix, but I am considering removing this module. It's no longer developed upstream, and had very few optimisations over pocketsnes really.

I'm currently rebuilding all packages again to make sure there are no issues with the CPU flags changes for the rpi1.