### PR TITLE
lr-beetle-psx: include hw core

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -18,7 +18,7 @@ function depends_retroarch() {
     local depends=(libudev-dev libxkbcommon-dev libsdl2-dev libasound2-dev libusb-1.0-0-dev)
     isPlatform "rpi" && depends+=(libraspberrypi-dev)
     isPlatform "mali" && depends+=(mali-fbdev)
-    isPlatform "x11" && depends+=(libx11-xcb-dev libpulse-dev libavcodec-dev libavformat-dev libavdevice-dev)
+    isPlatform "x11" && depends+=(libx11-xcb-dev libpulse-dev libavcodec-dev libavformat-dev libavdevice-dev libvulkan-dev)
 
     # only install nvidia-cg-toolkit if it is available (as the non-free repo may not be enabled)
     if isPlatform "x86"; then
@@ -47,6 +47,7 @@ function build_retroarch() {
     isPlatform "kms" && params+=(--enable-kms)
     isPlatform "arm" && params+=(--enable-floathard)
     isPlatform "neon" && params+=(--enable-neon)
+    isPlatform "x11" && params+=(--enable-vulkan)
     ./configure --prefix="$md_inst" "${params[@]}"
     make clean
     make

--- a/scriptmodules/libretrocores/lr-beetle-psx.sh
+++ b/scriptmodules/libretrocores/lr-beetle-psx.sh
@@ -16,19 +16,26 @@ rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/beetle-psx-li
 rp_module_section="opt"
 rp_module_flags="!arm"
 
+function depends_lr-beetle-psx() {
+    local depends=(libvulkan-dev libgl1-mesa-dev)
+    getDepends "${depends[@]}"
+}
+
 function sources_lr-beetle-psx() {
     gitPullOrClone "$md_build" https://github.com/libretro/beetle-psx-libretro.git
 }
 
 function build_lr-beetle-psx() {
     make clean
-    make
-    md_ret_require="$md_build/mednafen_psx_libretro.so"
+    make HAVE_HW=1
+    md_ret_require=(
+        'mednafen_psx_hw_libretro.so'
+    )
 }
 
 function install_lr-beetle-psx() {
     md_ret_files=(
-        'mednafen_psx_libretro.so'
+        'mednafen_psx_hw_libretro.so'
     )
 }
 
@@ -36,6 +43,6 @@ function configure_lr-beetle-psx() {
     mkRomDir "psx"
     ensureSystemretroconfig "psx"
 
-    addEmulator 0 "$md_id" "psx" "$md_inst/mednafen_psx_libretro.so"
+    addEmulator 0 "$md_id" "psx" "$md_inst/mednafen_psx_hw_libretro.so"
     addSystem "psx"
 }

--- a/scriptmodules/supplementary/configedit.sh
+++ b/scriptmodules/supplementary/configedit.sh
@@ -231,7 +231,7 @@ function advanced_configedit() {
         'input_overlay_enable true false'
         "input_overlay _file_ *.cfg $rootdir/emulators/retroarch/overlays"
         "audio_driver $audio_opts"
-        'video_driver gl dispmanx sdl2 vg'
+        'video_driver gl dispmanx sdl2 vg vulkan'
         'menu_driver rgui xmb'
         'video_fullscreen_x _string_'
         'video_fullscreen_y _string_'


### PR DESCRIPTION
Tagging @movisman - please test this PR and verify that the hw core builds & runs as expected.

As Jools has stated on the forum, it needs to be confirmed as working by someone in the project before being included. I currently don't have an x86 Linux installation available, and Jools is busy, so you'll need to be patient until I can sort out a testing environment.

Are you absolutely certain that Vulkan works? I would imagine that RetroArch itself needs to be built with Vulkan support enabled -  and we don't take any special steps to enable vulkan there.
