### PR TITLE
Full game description in .svm for scraper to hash

### DIFF
--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -89,9 +89,9 @@ function configure_scummvm() {
 game="\$1"
 pushd "$romdir/scummvm" >/dev/null
 $md_inst/bin/scummvm --fullscreen --joystick=0 --extrapath="$md_inst/extra" \$game
-while read line; do
-    id=(\$line);
+while read id desc; do
     touch "$romdir/scummvm/\$id.svm"
+	if [[ ! -s "$romdir/scummvm/\$id.svm" ]]; then echo \$desc >> "$romdir/scummvm/\$id.svm"; fi
 done < <($md_inst/bin/scummvm --list-targets | tail -n +3)
 popd >/dev/null
 _EOF_


### PR DESCRIPTION
This change makes the script write the full game descrption (e.g. "The Secret of Monkey Island (CD/DOS/English)") into the .svm files that ES uses to generate the gamelist.

The purpose of this change is to make the .svm files unique and not empty so that scrapers can hash the .svm files and match them to the actual games. This is how, for example, screenscraper.fr and Recalbox handle ScummVM scraping. 

Attempting to hash on the real game files is problematic because of the number of different variations of files that make up a ScummVM title - files can be modified or compressed and still be valid, resulting in a virtually unlimited number of possible hash values. This change allows each game title to have exactly one hash value.

Someone with some actual bash knowledge should review this; I am a bash newbie.