### PR TITLE
pegasus-fe: patch vendor graphics libraries

### DIFF
--- a/scriptmodules/supplementary/pegasus-fe.sh
+++ b/scriptmodules/supplementary/pegasus-fe.sh
@@ -66,6 +66,7 @@ function install_bin_pegasus-fe() {
     # download and extract the package
     printMsgs "console" "Download URL: ${asset_url}"
     downloadAndExtract "${asset_url}" "$md_inst"
+    patchVendorGraphics "$md_inst/pegasus-fe"
 }
 
 function configure_pegasus-fe() {


### PR DESCRIPTION
Needed until binary packages are updated to link against the correct
libbrcm*.so libraries from new firmware revisions.

(Hopefully doesn't need merging if the author can fix the binaries soon)