### PR TITLE
virtualgamepad: use nodesource if npm is not in distribution package

### DIFF
--- a/scriptmodules/supplementary/virtualgamepad.sh
+++ b/scriptmodules/supplementary/virtualgamepad.sh
@@ -17,8 +17,8 @@ rp_module_flags="noinstclean"
 
 function depends_virtualgamepad() {
     getDepends nodejs
-    # if the system version of nodejs is old, we will install manually for armv6 or use nodesource
-    if hasPackage nodejs 4.6 lt; then
+    # if the system version of nodejs is old or doesn't package npm, we will install manually for armv6 or use nodesource
+    if hasPackage nodejs 4.6 lt || ! which npm >/dev/null; then
         if isPlatform "armv6"; then
             getDepends npm
             if ! hasPackage node; then


### PR DESCRIPTION
It seems that Raspbian stretch splits npm into it's own package of the same name, but installing it would break libssl-dev:
```
The following additional packages will be installed:
  gyp javascript-common libjs-inherits libjs-jquery libjs-node-uuid libjs-underscore libssl1.0-dev libuv1-dev node-abbrev node-ansi node-ansi-color-table node-archy
  node-async node-balanced-match node-block-stream node-brace-expansion node-builtin-modules node-combined-stream node-concat-map node-cookie-jar node-delayed-stream
  node-forever-agent node-form-data node-fs.realpath node-fstream node-fstream-ignore node-github-url-from-git node-glob node-graceful-fs node-gyp
  node-hosted-git-info node-inflight node-inherits node-ini node-is-builtin-module node-isexe node-json-stringify-safe node-lockfile node-lru-cache node-mime
  node-minimatch node-mkdirp node-mute-stream node-node-uuid node-nopt node-normalize-package-data node-npmlog node-once node-osenv node-path-is-absolute
  node-pseudomap node-qs node-read node-read-package-json node-request node-retry node-rimraf node-semver node-sha node-slide node-spdx-correct
  node-spdx-expression-parse node-spdx-license-ids node-tar node-tunnel-agent node-underscore node-validate-npm-package-license node-which node-wrappy node-yallist
  nodejs-dev python-pkg-resources
Suggested packages:
  apache2 | lighttpd | httpd node-hawk node-aws-sign node-oauth-sign node-http-signature python-setuptools
The following packages will be REMOVED:
  libssl-dev
The following NEW packages will be installed:
  gyp javascript-common libjs-inherits libjs-jquery libjs-node-uuid libjs-underscore libssl1.0-dev libuv1-dev node-abbrev node-ansi node-ansi-color-table node-archy
  node-async node-balanced-match node-block-stream node-brace-expansion node-builtin-modules node-combined-stream node-concat-map node-cookie-jar node-delayed-stream
  node-forever-agent node-form-data node-fs.realpath node-fstream node-fstream-ignore node-github-url-from-git node-glob node-graceful-fs node-gyp
  node-hosted-git-info node-inflight node-inherits node-ini node-is-builtin-module node-isexe node-json-stringify-safe node-lockfile node-lru-cache node-mime
  node-minimatch node-mkdirp node-mute-stream node-node-uuid node-nopt node-normalize-package-data node-npmlog node-once node-osenv node-path-is-absolute
  node-pseudomap node-qs node-read node-read-package-json node-request node-retry node-rimraf node-semver node-sha node-slide node-spdx-correct
  node-spdx-expression-parse node-spdx-license-ids node-tar node-tunnel-agent node-underscore node-validate-npm-package-license node-which node-wrappy node-yallist
  nodejs-dev npm python-pkg-resources
0 upgraded, 73 newly installed, 1 to remove and 0 not upgraded.
Need to get 1,494 kB/3,288 kB of archives.
After this operation, 8,846 kB of additional disk space will be used.
```

Nodesource seems to support stretch and provides nodejs package version 4.8.7-1nodesource1, which includes npm as needed for virtualgamepad and mobilegamepad.