### PR TITLE
Misc platform fixes

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -70,6 +70,9 @@ fba_platform="arcade"
 fds_exts=".7z .nes .fds .zip"
 fds_fullname="Famicom Disk System"
 
+fm7_exts=".d77 .t77 .d88 .2d"
+fm7_fullname="Fujitsu FM-7 Series"
+
 gameandwatch_exts=".mgw"
 gameandwatch_fullname="Game and Watch"
 

--- a/platforms.cfg
+++ b/platforms.cfg
@@ -91,7 +91,7 @@ gbc_fullname="Game Boy Color"
 gc_exts=".ciso .gcm .gcz .iso"
 gc_fullname="Nintendo Gamecube"
 
-intellivision_exts=".int .bin"
+intellivision_exts=".bin .int .itv .rom"
 intellivision_fullname="Intellivision"
 
 love_exts=".love"

--- a/platforms.cfg
+++ b/platforms.cfg
@@ -16,6 +16,9 @@ apple2_fullname="Apple II"
 arcade_exts=".7z .fba .zip"
 arcade_fullname="Arcade"
 
+arcadia_exts=".bin .zip"
+arcadia_fullname="Arcadia 2001"
+
 atari2600_exts=".7z .a26 .bin .rom .zip .gz"
 atari2600_fullname="Atari 2600"
 
@@ -47,6 +50,9 @@ coleco_exts=".bin .col .rom .zip"
 coleco_fullname="ColecoVision"
 coleco_theme="colecovision"
 coleco_platform="colecovision"
+
+crvision_exts=".rom .zip"
+crvision_fullname="CreatiVision"
 
 daphne_exts=".daphne"
 daphne_fullname="Daphne"

--- a/scriptmodules/libretrocores/lr-mess.sh
+++ b/scriptmodules/libretrocores/lr-mess.sh
@@ -45,7 +45,7 @@ function configure_lr-mess() {
     [[ -z "$module" ]] && module="mess_libretro.so"
 
     local system
-    for system in nes gameboy coleco arcadia crvision; do
+    for system in nes gb coleco arcadia crvision; do
         mkRomDir "$system"
         ensureSystemretroconfig "$system"
         addEmulator 0 "$md_id" "$system" "$md_inst/$module"


### PR DESCRIPTION
Mostly to silence EmulationStation warnings printed in framebuffer during startup.

Note that lr-mess is currently a total... mess. The core doesn't load correctly as it seems to expect the driver name to be specified as the first argument:
```
[libretro INFO] Starting game from command line:/home/pi/RetroPie/roms/gb/Bionic Commando (USA).zip
[libretro INFO] ARGUV[0]=/home/pi/RetroPie/roms/gb/Bionic
[libretro WARN] Driver /home/pi/RetroPie/roms/gb/Bionic not found -1
[libretro WARN] Game not found: (USA)
[libretro INFO] RES:-2
```

After poking around a bit with strace and specifying the driver, the core will only load the bios from ```gameboy/dmg_boot.bin``` relative to the current path, so it won't read the bios files in the roms or bios folders. I don't have a desktop Linux installation & the program is prohibitively large to recompile for testing on Pi, so for now, the objective is just to silence the EmulationStation warnings. 