### PR TITLE
resolve error + one other update to mame2010 build

### DIFF
--- a/scriptmodules/libretrocores/lr-mame2010.sh
+++ b/scriptmodules/libretrocores/lr-mame2010.sh
@@ -34,7 +34,6 @@ function install_lr-mame2010() {
     md_ret_files=(
         'mame2010_libretro.so'
         'README.md'
-        'mame.ini'
     )
 }
 

--- a/scriptmodules/libretrocores/lr-mame2010.sh
+++ b/scriptmodules/libretrocores/lr-mame2010.sh
@@ -33,8 +33,7 @@ function build_lr-mame2010() {
 function install_lr-mame2010() {
     md_ret_files=(
         'mame2010_libretro.so'
-        'README.txt'
-        'whatsnew.txt'
+        'README.md'
         'mame.ini'
     )
 }


### PR DESCRIPTION
I updated the mame2010 readme and switched to markdown to enjoy some formatting. This creates an error as reported by @mediamogul here: https://retropie.org.uk/forum/post/133826

Pending the approval of my next PR ( https://github.com/libretro/mame2010-libretro/pull/94 ) mame2010 will autogenerate a mame.ini file if there isn't one -- therefore I'm suggesting that `mame.ini` from this script be removed as well.

In this PR I have also omitted the original mame 0.139 "whatsnew" file which seems out of place. No offense if you reject this change.