### PR TITLE
Full game description in .rvm for scraper to hash

### DIFF
--- a/scriptmodules/emulators/residualvm.sh
+++ b/scriptmodules/emulators/residualvm.sh
@@ -77,9 +77,8 @@ game="\$2"
 [[ "\$game" =~ ^\+ ]] && game=""
 pushd "$romdir/residualvm" >/dev/null
 $md_inst/bin/residualvm --renderer=\$renderer --fullscreen --joystick=0 --extrapath="$md_inst/extra" \$game
-while read line; do
-    id=(\$line);
-    touch "$romdir/residualvm/\$id.rvm"
+while read id desc; do
+    echo "\$desc" > "$romdir/residualvm/\$id.rvm"
 done < <($md_inst/bin/residualvm --list-targets | tail -n +3)
 popd >/dev/null
 _EOF_


### PR DESCRIPTION
This change makes the script write the full game descrption (e.g. "Grim Fandango (Windows/English)") into the .rvm files that ES uses to generate the gamelist. The intent is to give .rvm files unique hashes that can be used by scrapers. Exactly the same as recent PR to scummvm.sh.