### PR TITLE
mame2003 now already includes hiscore.dat

### DIFF
--- a/scriptmodules/libretrocores/lr-mame2003.sh
+++ b/scriptmodules/libretrocores/lr-mame2003.sh
@@ -57,8 +57,8 @@ function configure_lr-mame2003() {
     mkUserDir "$biosdir/mame2003/samples"
 
     # copy hiscore.dat
-    cp "$md_inst/metadata/"{hiscore.dat,cheat.dat} "$biosdir/mame2003/"
-    chown $user:$user "$biosdir/mame2003/"{hiscore.dat,cheat.dat}
+    cp "$md_inst/metadata/"{cheat.dat} "$biosdir/mame2003/"
+    chown $user:$user "$biosdir/mame2003/"{cheat.dat}
 
     # Set core options
     setRetroArchCoreOption "mame2003-skip_disclaimer" "enabled"


### PR DESCRIPTION
`hiscore.dat` is compiled into the mame2003 core itself starting with this commit: https://github.com/libretro/mame2003-libretro/commit/9e397494e0b55a1c11494959b0e23946508ab38b