### PR TITLE
Update lr-desmume and split 2015 version

### DIFF
--- a/scriptmodules/libretrocores/lr-desmume2015.sh
+++ b/scriptmodules/libretrocores/lr-desmume2015.sh
@@ -9,32 +9,32 @@
 # at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
 #
 
-rp_module_id="lr-desmume"
-rp_module_desc="NDS emu - DESMUME"
+rp_module_id="lr-desmume2015"
+rp_module_desc="NDS emu - DESMUME (2015 version)"
 rp_module_help="ROM Extensions: .nds .zip\n\nCopy your Nintendo DS roms to $romdir/nds"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/desmume/master/desmume/COPYING"
 rp_module_section="exp"
 
-function sources_lr-desmume() {
-    gitPullOrClone "$md_build" https://github.com/libretro/desmume.git
+function sources_lr-desmume2015() {
+    gitPullOrClone "$md_build" https://github.com/libretro/desmume2015.git
 }
 
-function build_lr-desmume() {
-    cd desmume/src/frontend/libretro
+function build_lr-desmume2015() {
+    cd desmume
     local params=()
     isPlatform "arm" && params+=("platform=armvhardfloat")
-    make clean
-    make "${params[@]}"
-    md_ret_require="$md_build/desmume/src/frontend/libretro/desmume_libretro.so"
+    make -f Makefile.libretro clean
+    make -f Makefile.libretro "${params[@]}"
+    md_ret_require="$md_build/desmume/desmume2015_libretro.so"
 }
 
-function install_lr-desmume() {
+function install_lr-desmume2015() {
     md_ret_files=(
-        'desmume/src/frontend/libretro/desmume_libretro.so'
+        'desmume/desmume2015_libretro.so'
     )
 }
 
-function configure_lr-desmume() {
+function configure_lr-desmume2015() {
     mkRomDir "nds"
     ensureSystemretroconfig "nds"
 


### PR DESCRIPTION
Fix build for new upstream rebase, and split off old version into
lr-desmume2015 scriptmodule to correspond to its new name.

Fixes #2314.

N.B. The new fork of upstream (now "lr-desmume") will not build correctly until this is merged: https://github.com/libretro/desmume/pull/4. The new version seems to launch OK, but it's still slow on Pi 3.