### PR TITLE
zdoom: add support for Hexen 1 Series & Heretic

### DIFF
--- a/scriptmodules/libretrocores/lr-prboom.sh
+++ b/scriptmodules/libretrocores/lr-prboom.sh
@@ -46,11 +46,19 @@ function _add_games_lr-prboom() {
         ['doom2']="Doom 2"
         ['tnt']="TNT - Evilution"
         ['plutonia']="The Plutonia Experiment"
+        ['heretic']="Heretic - Shadow of the Serpent Riders"
+        ['hexen']="Hexen - Beyond Heretic"
+        ['hexdd']="Hexen - Deathkings of the Dark Citadel"
     )
     local game
+    local doswad
     local wad
     for game in "${!games[@]}"; do
+        doswad="$romdir/ports/doom/${game^^}.WAD"
         wad="$romdir/ports/doom/$game.wad"
+        if [[ -f "$doswad" ]]; then
+            mv "$doswad" "$wad"
+        fi
         if [[ -f "$wad" ]]; then
             addPort "$md_id" "doom" "${games[$game]}" "$cmd" "$wad"
         fi

--- a/scriptmodules/ports/zdoom.sh
+++ b/scriptmodules/ports/zdoom.sh
@@ -46,7 +46,7 @@ function install_zdoom() {
 }
 
 function add_games_zdoom() {
-    _add_games_lr-prboom "$md_inst/zdoom +set fullscreen 1 -iwad %ROM%"
+    _add_games_lr-prboom "DOOMWADDIR=$romdir/ports/doom $md_inst/zdoom +set fullscreen 1 -iwad %ROM%"
 }
 
 function configure_zdoom() {


### PR DESCRIPTION
Requires the following wads:
* Hexen: ```hexen.wad```
* Hexen Deathkings: ```hexen.wad``` & ```hexdd.wad```
* Heretic: ```heretic.wad```

Additionally, the scriptmodule will automatically rename supported wad
files to lowercase if necessary.

Tested and confirmed as working after ripping the necessary .wad files from my Steam installation.

Just a note on the added invocation of pushd/popd: the Hexen Deathkings file is actually a pwad that depends on ```hexen.wad``` to be present in order to launch correctly. If zdoom doesn't find hexen.wad in the current directory, the expansion won't be able to launch unless its location is specified via the additional argument ```-file /path/to/hexdd.wad``` -  but that must be invoked with ```-iwad /path/to/hexen.wad```. If you prefer to make a wrapper script that handles this complexity instead, let me know and I can update the PR.