### PR TITLE
zdoom: extend support to Strife, Chex 3 & isolate supported ports

### DIFF
--- a/scriptmodules/libretrocores/lr-prboom.sh
+++ b/scriptmodules/libretrocores/lr-prboom.sh
@@ -46,10 +46,17 @@ function _add_games_lr-prboom() {
         ['doom2']="Doom 2"
         ['tnt']="TNT - Evilution"
         ['plutonia']="The Plutonia Experiment"
-        ['heretic']="Heretic - Shadow of the Serpent Riders"
-        ['hexen']="Hexen - Beyond Heretic"
-        ['hexdd']="Hexen - Deathkings of the Dark Citadel"
     )
+
+    if [[ "$md_id" == "zdoom" ]]; then
+        games+=(
+            ['heretic']="Heretic - Shadow of the Serpent Riders"
+            ['hexen']="Hexen - Beyond Heretic"
+            ['hexdd']="Hexen - Deathkings of the Dark Citadel"
+            ['chex3']="Chex Quest 3"
+            ['strife1']="Strife"
+        )
+    fi
     local game
     local doswad
     local wad


### PR DESCRIPTION
* lr-pboom does not support Hexen/Heretic/Strife/Chex, so isolate these
  to zdoom's configuration instance.
* Omit Chex 1/2, as Chex 2 requires special arguments to load chex.wad, and
  Chex 3 (freeware) includes remastered versions of the previous two episodes.

--

This should cover zdoom's list of supported commercial ports (keeping in mind that Chex 3 is a remaster, but includes the originals).
