### PR TITLE
make sure xserver-xorg-legacy is not installed - fixes #2299

### DIFF
--- a/scriptmodules/supplementary/raspbiantools.sh
+++ b/scriptmodules/supplementary/raspbiantools.sh
@@ -20,8 +20,9 @@ function apt_upgrade_raspbiantools() {
 }
 
 function lxde_raspbiantools() {
-    aptInstall --no-install-recommends lxde
-    aptInstall xorg raspberrypi-ui-mods rpi-chromium-mods gvfs
+    aptInstall --no-install-recommends xorg lxde
+    aptInstall raspberrypi-ui-mods rpi-chromium-mods gvfs
+
     setConfigRoot "ports"
     addPort "lxde" "lxde" "Desktop" "startx"
     enable_autostart

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -167,6 +167,11 @@ function get_retropie_depends() {
     if ! getDepends "${depends[@]}"; then
         fatalError "Unable to install packages required by $0 - ${md_ret_errors[@]}"
     fi
+
+    # make sure we don't have xserver-xorg-legacy installed as it breaks launching x11 apps from ES
+    if ! isPlatform "x11" && hasPackage "xserver-xorg-legacy"; then
+        aptRemove xserver-xorg-legacy
+    fi
 }
 
 function get_rpi_video() {


### PR DESCRIPTION
 * remove package if installed when running retropie-setup for existing installs
 * install xorg without recommendations from raspbiantools so it wont be installed when installing the desktop