### PR TITLE
joy2key: normalize device path & check parent directory

### DIFF
--- a/scriptmodules/supplementary/runcommand/joy2key.py
+++ b/scriptmodules/supplementary/runcommand/joy2key.py
@@ -66,7 +66,9 @@ def get_button_codes(dev_path):
     dev_button_codes = list(default_button_codes)
 
     for device in Context().list_devices(DEVNAME=dev_path):
-        sysdev_path = '/sys' + os.path.dirname(device.get('DEVPATH')) + '/'
+        sysdev_path = os.path.normpath('/sys' + device.get('DEVPATH')) + '/'
+        if not os.path.isfile(sysdev_path + 'name'):
+            sysdev_path = os.path.normpath(sysdev_path + '/../') + '/'
         # getting joystick name
         dev_name = sysdev_get('name', sysdev_path)
         # getting joystick vendor ID


### PR DESCRIPTION
The location of the name, id/vendor & id/product descriptors are not
consistent with udev's DEVPATH for every kernel driver.

Fix this by properly normalizing the path correctly, then shift to the parent
directory if the "name" file does not exist.

Fixes the hid_sony driver.