### PR TITLE
mupen64plus: workaround GLideN64 shader cache crash

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -52,7 +52,10 @@ function sources_mupen64plus() {
         gitPullOrClone "$dir" https://github.com/${repo[0]}/mupen64plus-${repo[1]} ${repo[2]}
     done
     gitPullOrClone "$md_build/GLideN64" https://github.com/gonetz/GLideN64.git
-    
+
+    # workaround for shader cache crash issue on Raspbian stretch. See: https://github.com/gonetz/GLideN64/issues/1665
+    applyPatch "$md_data/0001-GLideN64-use-emplace.patch"
+
     local config_version=$(grep -oP '(?<=CONFIG_VERSION_CURRENT ).+?(?=U)' GLideN64/src/Config.h)
     echo "$config_version" > "$md_build/GLideN64_config_version.ini"
 }

--- a/scriptmodules/emulators/mupen64plus/0001-GLideN64-use-emplace.patch
+++ b/scriptmodules/emulators/mupen64plus/0001-GLideN64-use-emplace.patch
@@ -1,0 +1,13 @@
+diff --git a/GLideN64/src/Combiner.cpp b/GLideN64/src/Combiner.cpp
+index f724cc0..0141f6c 100644
+--- a/GLideN64/src/Combiner.cpp
++++ b/GLideN64/src/Combiner.cpp
+@@ -295,7 +295,7 @@ void CombinerInfo::setCombine(u64 _mux )
+ 	} else {
+ 		m_pCurrent = Combiner_Compile(key);
+ 		m_pCurrent->update(true);
+-		m_combiners[m_pCurrent->getKey()] = m_pCurrent;
++		m_combiners.emplace(m_pCurrent->getKey(), m_pCurrent);
+ 	}
+ 	m_bChanged = true;
+ }


### PR DESCRIPTION
Crash seems reproducible only on gcc 6.3.0 via Rasbian stretch, but the
workaround should not negatively impact other systems.

See: https://github.com/gonetz/GLideN64/issues/1665