### PR TITLE
Add gzdoom port to experimental, .pk3, Brutal Doom & Freedoom support

### DIFF
--- a/scriptmodules/libretrocores/lr-prboom.sh
+++ b/scriptmodules/libretrocores/lr-prboom.sh
@@ -35,34 +35,45 @@ function game_data_lr-prboom() {
     if [[ ! -f "$romdir/ports/doom/doom1.wad" ]]; then
         # download doom 1 shareware
         wget -nv -O "$romdir/ports/doom/doom1.wad" "$__archive_url/doom1.wad"
-        chown $user:$user "$romdir/ports/doom/doom1.wad"
     fi
+
+    if [[ ! -f "$romdir/ports/doom/freedoom1.wad" ]]; then
+        # download freedoom
+        downloadAndExtract "https://github.com/freedoom/freedoom/releases/download/v0.11.3/freedoom-0.11.3.zip" "$romdir/ports/doom/" "-j -LL"
+    fi
+
+    chown -R $user:$user "$romdir/ports/doom"
 }
 
 function _add_games_lr-prboom() {
-    local cmd="$1"
+    local cmd="${@}"
     declare -A games=(
-        ['doom1']="Doom"
-        ['doom2']="Doom 2"
-        ['tnt']="TNT - Evilution"
-        ['plutonia']="The Plutonia Experiment"
+        ['doom1.wad']="Doom"
+        ['doom2.wad']="Doom II"
+        ['doomu.wad']="The Ultimate Doom"
+        ['freedoom1.wad']="Freedoom - Phase I"
+        ['freedoom2.wad']="Freedoom - Phase II"
+        ['tnt.wad']="TNT - Evilution"
+        ['plutonia.wad']="The Plutonia Experiment"
     )
 
-    if [[ "$md_id" == "zdoom" ]]; then
+    if [[ "$md_id" =~ "zdoom" ]]; then
         games+=(
-            ['heretic']="Heretic - Shadow of the Serpent Riders"
-            ['hexen']="Hexen - Beyond Heretic"
-            ['hexdd']="Hexen - Deathkings of the Dark Citadel"
-            ['chex3']="Chex Quest 3"
-            ['strife1']="Strife"
+            ['bd21testfeb24.pk3']="Brutal Doom v21 Beta"
+            ['heretic.wad']="Heretic - Shadow of the Serpent Riders"
+            ['hexen.wad']="Hexen - Beyond Heretic"
+            ['hexdd.wad']="Hexen - Deathkings of the Dark Citadel"
+            ['chex3.wad']="Chex Quest 3"
+            ['strife1.wad']="Strife"
         )
     fi
+
     local game
     local doswad
     local wad
     for game in "${!games[@]}"; do
-        doswad="$romdir/ports/doom/${game^^}.WAD"
-        wad="$romdir/ports/doom/$game.wad"
+        doswad="$romdir/ports/doom/${game^^}"
+        wad="$romdir/ports/doom/$game"
         if [[ -f "$doswad" ]]; then
             mv "$doswad" "$wad"
         fi

--- a/scriptmodules/ports/gzdoom.sh
+++ b/scriptmodules/ports/gzdoom.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="gzdoom"
+rp_module_desc="gzdoom - Enhanced port of the official DOOM source"
+rp_module_licence="GPL3 https://raw.githubusercontent.com/coelckers/gzdoom/master/docs/licenses/README.TXT"
+rp_module_section="exp"
+rp_module_flags=""
+
+function depends_gzdoom() {
+    local depends=(libgme-dev libsdl2-dev libsndfile1-dev)
+
+    depends_zdoom "${depends[@]}"
+}
+
+function sources_gzdoom() {
+    gitPullOrClone "$md_build" https://github.com/coelckers/gzdoom
+}
+
+function build_gzdoom() {
+    rm -rf release
+    mkdir -p release
+    cd release
+    local params=(-DCMAKE_INSTALL_PREFIX="$md_inst" -DCMAKE_BUILD_TYPE=Release)
+    if isPlatform "armv8"; then
+        params+=(-DUSE_ARMV8=On)
+    fi
+    cmake "${params[@]}" ..
+    make
+    md_ret_require="$md_build/release/gzdoom"
+}
+
+function install_gzdoom() {
+    md_ret_files=(
+        'release/brightmaps.pk3'
+        'release/gzdoom'
+        'release/gzdoom.pk3'
+        'release/lights.pk3'
+        'release/zd_extra.pk3'
+        'README.md'
+    )
+}
+
+function add_games_gzdoom() {
+    local params=("+set fullscreen 1")
+    if isPlatform "gles"; then
+        params+=("+set vid_renderer 0")
+    fi
+    _add_games_lr-prboom "$md_inst/gzdoom.sh %ROM% ${params[@]}"
+}
+
+function configure_gzdoom() {
+    configure_zdoom
+}


### PR DESCRIPTION
* Implement gzdoom support. Supports OpenGL or software rendering via
  SDL2 (the latter used by GLES targets, including Pi).
* Extend support for .pk3 format paks in zdoom and gzdoom.
* Add port launcher for The Ultimate Doom & rename Doom 2 -> II.
* Add port launchers for Freedoom & automatically download game data.
* Add port launcher for Brutal Doom v21 (Public Beta Feb 24 2018).
* For .pk3 support, use doom2 base wad with fallback to freedoom2 if needed.

Performance of gzdoom on Pi is satisfactory for the original games, but more
complex mods such as Brutal Doom will work better in zdoom.