### PR TITLE
Cross compiler

### DIFF
--- a/scriptmodules/admin/builder.sh
+++ b/scriptmodules/admin/builder.sh
@@ -62,3 +62,45 @@ function upload_builder() {
 function clean_archives_builder() {
     rm -rfv "$__tmpdir/archives"
 }
+
+function chroot_build_builder() {
+    rp_callModule image depends
+    mkdir -p "$md_build"
+
+    # get current host ip for the distcc in the emulated chroot to connect to
+    local ip="$(ip route get 8.8.8.8 2>/dev/null | awk '{print $NF; exit}')"
+
+    local use_distcc=0
+    [[ -d "$rootdir/admin/crosscomp/$dist" ]] && use_distcc=1
+
+    local dist
+    local sys
+
+    for dist in jessie stretch; do
+        [[ "$use_distcc" -eq 1 ]] && rp_callModule crosscomp switch_distcc "$dist"
+        rp_callModule image create_chroot "$dist" "$md_build/$dist"
+        git clone "$HOME/RetroPie-Setup" "$md_build/$dist/home/pi/RetroPie-Setup"
+        cat > "$md_build/$dist/home/pi/install.sh" <<_EOF_
+#!/bin/bash
+cd
+sudo apt-get update
+sudo apt-get install -y git
+if [[ "$use_distcc" -eq 1 ]]; then
+    sudo apt-get install -y distcc
+    sudo sed -i s/\+zeroconf/$ip/ /etc/distcc/hosts;
+fi
+_EOF_
+        rp_callModule image chroot "$md_build/$dist" bash /home/pi/install.sh
+
+        for sys in rpi1 rpi2; do
+            rp_callModule image chroot "$md_build/$dist" \
+                sudo \
+                PATH="/usr/lib/distcc:$PATH" \
+                MAKEFLAGS="-j4 PATH=/usr/lib/distcc:$PATH" \
+                __platform="$sys" \
+                /home/pi/RetroPie-Setup/retropie_packages.sh builder "$@"
+        done
+
+        rsync -av "$md_build/$dist/home/pi/RetroPie-Setup/tmp/archives/" "$HOME/RetroPie-Setup/tmp/archives/"
+    done
+}

--- a/scriptmodules/admin/crosscomp.sh
+++ b/scriptmodules/admin/crosscomp.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="crosscomp"
+rp_module_desc="Create am arm cross compiler env - based on examples from http://preshing.com/20141119/how-to-build-a-gcc-cross-compiler"
+rp_module_help="Can be used via distcc to build RetroPie binaries"
+rp_module_section=""
+rp_module_flags="!arm"
+
+function _default_dist_crosscomp() {
+    echo "stretch"
+}
+
+function depends_crosscomp() {
+    getDepends distcc
+}
+
+function sources_crosscomp() {
+    local dist="$1"
+    [[ -z "$dist" ]] && return
+
+    declare -A pkgs
+    case "$dist" in
+        jessie)
+            pkgs=(
+                [binutils]=2.25
+                [cloog]=0.18.1
+                [gcc]=4.9.4
+                [glibc]=2.19
+                [gmp]=6.0.0a
+                [isl]=0.12.2
+                [kernel]=4.9.35
+                [mpfr]=3.1.2
+                [mpc]=1.0.2
+            )
+            ;;
+        stretch)
+            pkgs=(
+                [binutils]=2.28
+                [cloog]=0.18.4
+                [gcc]=6.4.0
+                [glibc]=2.24
+                [gmp]=6.1.2
+                [isl]=0.18
+                [kernel]=4.9.80
+                [mpfr]=3.1.5
+                [mpc]=1.0.3
+            )
+            ;;
+        *)
+            md_ret_errors+=("Unsupported distribution $dist")
+            return 1
+            ;;
+    esac
+
+    downloadAndExtract "ftp://gcc.gnu.org/pub/gcc/infrastructure/isl-${pkgs[isl]}.tar.bz2" isl 1
+    downloadAndExtract "http://www.bastoul.net/cloog/pages/download/count.php3?url=./cloog-${pkgs[cloog]}.tar.gz" cloog 1
+
+    downloadAndExtract "https://ftp.gnu.org/gnu/binutils/binutils-${pkgs[binutils]}.tar.gz" binutils 1
+
+    downloadAndExtract "https://ftp.gnu.org/gnu/mpfr/mpfr-${pkgs[mpfr]}.tar.gz" mpfr 1
+    downloadAndExtract "https://ftp.gnu.org/gnu/gmp/gmp-${pkgs[gmp]}.tar.bz2" gmp 1
+    downloadAndExtract "https://ftp.gnu.org/gnu/mpc/mpc-${pkgs[mpc]}.tar.gz" mpc 1
+
+    downloadAndExtract "https://ftp.gnu.org/gnu/glibc/glibc-${pkgs[glibc]}.tar.bz2" glibc 1
+    downloadAndExtract "https://ftp.gnu.org/gnu/gcc/gcc-${pkgs[gcc]}/gcc-${pkgs[gcc]}.tar.gz" gcc 1
+
+    downloadAndExtract "https://www.kernel.org/pub/linux/kernel/v4.x/linux-${pkgs[kernel]}.tar.gz" linux 1
+
+    local pkg
+    for pkg in cloog gmp isl mpc mpfr; do
+        ln -sf "../$pkg" "gcc/$pkg"
+    done
+}
+
+function build_crosscomp() {
+    local dist="$1"
+    [[ -z "$dist" ]] && return
+
+    # remove old build directories
+    rm -rf "$md_build/build-"*
+
+    local params=(--with-arch=armv6 --with-fpu=vfp --with-float=hard)
+    local target=arm-linux-gnueabihf
+    local dest="$md_inst/$dist"
+
+    export PATH="$dest/bin:$PATH"
+    export CFLAGS=""
+    export CXXFLAGS=""
+
+    # binutils
+    printHeading "Building binutils"
+    mkdir -p build-binutils
+    cd build-binutils
+    ../binutils/configure --prefix="$dest" --target="$target" "${params[@]}"
+    make
+    make install
+    cd ..
+
+    # kernel headers
+    printHeading "Installing kernel headers"
+    cd linux
+    make ARCH=arm INSTALL_HDR_PATH="$dest/$target" headers_install
+    cd ..
+
+    # gcc
+    printHeading "Building gcc"
+    mkdir -p build-gcc
+    cd build-gcc
+    ../gcc/configure --prefix="$dest" --target="$target" --enable-languages=c,c++ --disable-multilib --disable-werror "${params[@]}" 
+    make all-gcc
+    make install-gcc
+    cd ..
+
+    # glibc
+    printHeading "Building glibc"
+    mkdir -p build-glibc
+    cd build-glibc
+    ../glibc/configure --prefix="$dest/$target" --build="$MACHTYPE" --host="$target" --target="$target" --with-headers="$dest/$target/include" libc_cv_forced_unwind=yes
+    make install-bootstrap-headers=yes install-headers
+    make csu/subdir_lib
+    install csu/crt1.o csu/crti.o csu/crtn.o "$dest/$target/lib"
+
+    "$target-gcc" -nostdlib -nostartfiles -shared -x c /dev/null -o "$dest/$target/lib/libc.so"
+    touch "$dest/$target/include/gnu/stubs.h"
+    cd ..
+
+    # compiler support library
+    printHeading "Building libgcc"
+    cd build-gcc
+    make all-target-libgcc
+    make install-target-libgcc
+    cd ..
+
+    # standard c library
+    printHeading "Building glibc (2)"
+    cd build-glibc
+    make
+    make install
+    cd ..
+
+    # standard c++ library
+    printHeading "Building libcpp"
+    cd build-gcc
+    make all
+    make install
+    cd ..
+}
+
+function setup_crosscomp() {
+    local dist="$1"
+    [[ -z "$dist" ]] && dist="$(_default_dist_crosscomp)"
+    
+    if rp_callModule crosscomp sources "$dist"; then
+        rp_callModule crosscomp build "$dist"
+        rp_callModule crosscomp switch_distcc "$dist"
+    fi
+}
+
+function setup_all_crosscomp() {
+    local dist
+    for dist in jessie stretch; do
+        setup_crosscomp "$dist"
+    done
+}
+
+function switch_distcc_crosscomp() {
+    local dist="$1"
+    [[ -z "$dist" ]] && return 1
+
+    bins="$md_inst/bin"
+    mkdir -p "$bins"
+
+    # symlink the gcc/g++ binaries that match the distro we are cross compiling for
+    local name
+    for name in cc gcc arm-linux-gnueabihf-gcc; do
+        ln -sfv "$md_inst/$dist/bin/arm-linux-gnueabihf-gcc" "$bins/$name"
+    done
+
+    for name in c++ g++ arm-linux-gnueabihf-g++; do
+        ln -sfv "$md_inst/$dist/bin/arm-linux-gnueabihf-g++" "$bins/$name"
+    done
+
+    # make sure the path added to the distcc init.d script
+    sed -i "s#^PATH=.*#PATH=$bins:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin#" /etc/init.d/distcc
+
+    # restart distcc
+    systemctl daemon-reload
+    service distcc restart
+}

--- a/scriptmodules/admin/image.sh
+++ b/scriptmodules/admin/image.sh
@@ -18,13 +18,17 @@ function depends_image() {
     getDepends kpartx unzip qemu-user-static rsync parted squashfs-tools dosfstools e2fsprogs
 }
 
-function chroot_image() {
+function create_chroot_image() {
     local version="$1"
     [[ -z "$version" ]] && version="stretch"
 
+    local chroot="$2"
+    [[ -z "$chroot" ]] && chroot="$md_build/chroot"
+
     mkdir -p "$md_build"
     pushd "$md_build"
-    mkdir -p mnt/boot chroot
+
+    mkdir -p "$chroot"
 
     local url
     local image
@@ -36,7 +40,7 @@ function chroot_image() {
             url="https://downloads.raspberrypi.org/raspbian_lite_latest"
             ;;
         *)
-            printMsgs "console" "Unknown/unsupported Raspbian version"
+            md_ret_errors+=("Unknown/unsupported Raspbian version")
             return 1
             ;;
     esac
@@ -53,14 +57,18 @@ function chroot_image() {
     # mount image
     kpartx -s -a "$image"
 
-    mount /dev/mapper/loop0p2 mnt
-    mount /dev/mapper/loop0p1 mnt/boot
+    local tmp="$(mktemp -d -p "$md_build")"
+    mkdir -p "$tmp/boot"
 
-    printMsgs "console" "Creating chroot"
-    rsync -aAHX --numeric-ids --delete mnt/ chroot/
+    mount /dev/mapper/loop0p2 "$tmp"
+    mount /dev/mapper/loop0p1 "$tmp/boot"
 
-    umount -l mnt/boot mnt
-    rm -rf mnt
+    printMsgs "console" "Creating chroot from $image ..."
+    rsync -aAHX --numeric-ids --delete "$tmp/" "$chroot/"
+
+    umount -l "$tmp/boot" "$tmp"
+    rm -rf "tmp"
+
     kpartx -d "$image"
 
     popd
@@ -70,38 +78,24 @@ function install_rp_image() {
     local platform="$1"
     [[ -z "$platform" ]] && return
 
-    mkdir -p "$md_build"
-    pushd "$md_build"
-
-    # unmount on ctrl+c
-    trap _umount_chroot INT
-
-    # mount special filesytems to chroot
-    mkdir -p chroot/dev/pts
-    mount none -t devpts chroot/dev/pts
-    mount -t proc /proc chroot/proc
-
-    # required for emulated chroot
-    cp "/usr/bin/qemu-arm-static" chroot/usr/bin/
-
-    # so we can resolve inside the chroot
-    echo "nameserver 192.168.1.1" >chroot/etc/resolv.conf
+    local chroot="$2"
+    [[ -z "$chroot" ]] && chroot="$md_build/chroot"
 
     # hostname to retropie
-    echo "retropie" >chroot/etc/hostname
-    sed -i "s/raspberrypi/retropie/" chroot/etc/hosts
+    echo "retropie" >"$chroot/etc/hostname"
+    sed -i "s/raspberrypi/retropie/" "$chroot/etc/hosts"
 
     # quieter boot / disable plymouth (as without the splash parameter it
     # causes all boot messages to be displayed and interferes with people
     # using tty3 to make the boot even quieter)
-    if ! grep -q consoleblank chroot/boot/cmdline.txt; then
+    if ! grep -q consoleblank "$chroot/boot/cmdline.txt"; then
         # extra quiet as the raspbian usr/lib/raspi-config/init_resize.sh does
         # sed -i 's/ quiet init=.*$//' /boot/cmdline.txt so this will remove the last quiet
         # and the init line but leave ours intact
-        sed -i "s/quiet/quiet loglevel=3 consoleblank=0 plymouth.enable=0 quiet/" chroot/boot/cmdline.txt
+        sed -i "s/quiet/quiet loglevel=3 consoleblank=0 plymouth.enable=0 quiet/" "$chroot/boot/cmdline.txt"
     fi
 
-    cat > chroot/home/pi/install.sh <<_EOF_
+    cat > "$chroot/home/pi/install.sh" <<_EOF_
 #!/bin/bash
 cd
 sudo apt-get update
@@ -131,36 +125,68 @@ sudo apt-get clean
 _EOF_
 
     # chroot and run install script
-    HOME="/home/pi" chroot --userspec 1000:1000 chroot bash /home/pi/install.sh
+    rp_callModule image chroot "$chroot" bash /home/pi/install.sh
 
-    _umount_chroot
-
-    >chroot/etc/resolv.conf
-    rm chroot/home/pi/install.sh
+    rm "$chroot/home/pi/install.sh"
 
     # remove any ssh host keys that may have been generated during any ssh package upgrades
-    rm -f chroot/etc/ssh/ssh_host*
-
-    popd
+    rm -f "$chroot/etc/ssh/ssh_host"*
 }
 
-function _umount_chroot() {
+function _init_chroot_image() {
+    # unmount on ctrl+c
+    trap "_trap_chroot_image '$chroot'" INT
+
+    # mount special filesytems to chroot
+    mkdir -p "$chroot"/dev/pts
+    mount none -t devpts "$chroot"/dev/pts
+    mount -t proc /proc "$chroot"/proc
+
+    # required for emulated chroot
+    cp "/usr/bin/qemu-arm-static" "$chroot"/usr/bin/
+
+    local nameserver="$(nmcli device show | grep IP4.DNS  | awk '{print $NF; exit}')"
+    # so we can resolve inside the chroot
+    echo "nameserver $nameserver" >"$chroot"/etc/resolv.conf
+}
+
+function _deinit_chroot_image() {
+    local chroot="$1"
+    [[ -z "$chroot" ]] && chroot="$md_build/chroot"
+
     trap "" INT
-    umount -l chroot/proc chroot/dev/pts
+    >"$chroot/etc/resolv.conf"
+    umount -l "$chroot/proc" "$chroot/dev/pts"
     trap INT
+}
+
+function _trap_chroot_image() {
+    _deinit_chroot_image "$1"
+    exit
+}
+
+function chroot_image() {
+    local chroot="$1"
+    [[ -z "$chroot" ]] && chroot="$md_build/chroot"
+    shift
+
+    printMsgs "console" "Chrooting to $chroot ..."
+    _init_chroot_image "$chroot"
+    HOME="/home/pi" chroot --userspec 1000:1000 "$chroot" "$@"
+    _deinit_chroot_image "$chroot"
 }
 
 function create_image() {
     local image="$1"
     [[ -z "$image" ]] && return 1
 
+    local chroot="$2"
+    [[ -z "$chroot" ]] && chroot="$md_build/chroot"
+
     image+=".img"
 
-    mkdir -p "$md_build"
-    pushd "$md_build"
-
     # make image size 300mb larger than contents of chroot
-    local mb_size=$(du -s --block-size 1048576 chroot 2>/dev/null | cut -f1)
+    local mb_size=$(du -s --block-size 1048576 $chroot 2>/dev/null | cut -f1)
     ((mb_size+=300))
 
     # create image
@@ -177,44 +203,50 @@ function create_image() {
 
     # format
     printMsgs "console" "Formatting $image ..."
-    kpartx -s -a "$image"
+
+    # change to the image folder as kpartx has problems removing the
+    # device mapper files when using a full path to the image
+    local image_path="${image%/*}"
+    local image_name="${image##*/}"
+    pushd "$image_path"
+
+    kpartx -s -a "$image_name"
 
     mkfs.vfat -F 16 -n boot /dev/mapper/loop0p1
     mkfs.ext4 -O ^metadata_csum,^huge_file -L retropie /dev/mapper/loop0p2
 
-    parted "$image" print
+    parted "$image_name" print
 
     # disable ctrl+c
     trap "" INT
 
     # mount
-    printMsgs "console" "Mounting $image ..."
-    mkdir -p mnt
-    mount /dev/mapper/loop0p2 mnt
-    mkdir -p mnt/boot
-    mount /dev/mapper/loop0p1 mnt/boot
+    printMsgs "console" "Mounting $image_name ..."
+    local tmp="$(mktemp -d -p "$md_build")"
+    mount /dev/mapper/loop0p2 "$tmp"
+    mkdir -p "$tmp/boot"
+    mount /dev/mapper/loop0p1 "$tmp/boot"
 
     # copy files
-    printMsgs "console" "Rsyncing chroot to $image ..."
-    rsync -aAHX --numeric-ids  chroot/ mnt/
+    printMsgs "console" "Rsyncing chroot to $image_name ..."
+    rsync -aAHX --numeric-ids "$chroot/" "$tmp/"
 
     # we need to fix up the UUIDS for /boot/cmdline.txt and /etc/fstab
-    local old_id="$(sed "s/.*PARTUUID=\([^-]*\).*/\1/" mnt/boot/cmdline.txt)"
+    local old_id="$(sed "s/.*PARTUUID=\([^-]*\).*/\1/" $tmp/boot/cmdline.txt)"
     local new_id="$(blkid -s PARTUUID -o value /dev/mapper/loop0p2 | cut -c -8)"
-    sed -i "s/$old_id/$new_id/" mnt/boot/cmdline.txt
-    sed -i "s/$old_id/$new_id/g" mnt/etc/fstab
+    sed -i "s/$old_id/$new_id/" "$tmp/boot/cmdline.txt"
+    sed -i "s/$old_id/$new_id/g" "$tmp/etc/fstab"
 
     # unmount
-    umount -l mnt/boot mnt
-    rm -rf mnt
-    kpartx -d "$image"
+    umount -l "$tmp/boot" "$tmp"
+    rm -rf "$tmp"
+
+    kpartx -d "$image_name"
 
     trap INT
 
     printMsgs "console" "Compressing $image ..."
     gzip -f "$image"
-
-    popd
 }
 
 # generate berryboot squashfs from filesystem
@@ -222,19 +254,18 @@ function create_bb_image() {
     local image="$1"
     [[ -z "$image" ]] && return 1
 
+    local chroot="$2"
+    [[ -z "$chroot" ]] && chroot="$md_build/chroot"
+
     image+="-berryboot.img256"
 
-    mkdir -p "$md_build"
-    pushd "$md_build"
-
     # replace fstab
-    echo "proc            /proc           proc    defaults          0       0" >chroot/etc/fstab
+    echo "proc            /proc           proc    defaults          0       0" >"$chroot/etc/fstab"
+
     # remove any earlier image
     rm -f "$image"
 
-    mksquashfs chroot "$image" -comp lzo -e boot -e lib/modules
-
-    popd
+    mksquashfs "$chroot" "$image" -comp lzo -e boot -e lib/modules
 }
 
 function all_image() {
@@ -248,17 +279,20 @@ function all_image() {
 
 function platform_image() {
     local platform="$1"
-    local version="$2"
+    local dist="$2"
     [[ -z "$platform" ]] && exit
+
+    local dest="$__tmpdir/images"
+    mkdir -p "$dest"
 
     local image
     if [[ "$platform" == "rpi1" ]]; then
-        image="retropie-${__version}-rpi1_zero"
+        image="$dest/retropie-${__version}-rpi1_zero"
     else
-        image="retropie-${__version}-rpi2_rpi3"
+        image="$dest/retropie-${__version}-rpi2_rpi3"
     fi
 
-    rp_callModule image chroot "$version"
+    rp_callModule image create_chroot "$dist"
     rp_callModule image install_rp "$platform"
     rp_callModule image create "$image"
     rp_callModule image create_bb "$image"


### PR DESCRIPTION
This code is added primarily to reduce the number of external scripts I have for maintenance, and to incorporate some of the admin functionality into the main RetroPie-Setup code (as was done for image building).

With these changes it is easier to install an arm targetting cross compiler set-up to be used with distcc. This is then used when building packages in an emulated chroot for faster compilation.

Am still doing a bit of final testing on it before merging.