### PR TITLE
Add some mupen64plus optimizations

### DIFF
--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -322,7 +322,7 @@ function autoset() {
         1080
         starcraft
         wipeout
-        darkness
+        dark
     )
 
     for game in "${highres[@]}"; do

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -240,7 +240,7 @@ function testCompatibility() {
             fi
             iniConfig " = " "" "$config"
             # Settings version. Don't touch it.
-            local config_version="17"
+            local config_version="20"
             if [[ -f "$configdir/n64/GLideN64_config_version.ini" ]]; then
                 config_version=$(<"$configdir/n64/GLideN64_config_version.ini")
             fi

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -283,6 +283,15 @@ function testCompatibility() {
             done
             ;;
     esac
+
+    # fix Audio-SDL crackle
+    iniConfig " = " "\"" "$config"
+    # create section if necessary
+    if ! grep -q "\[Audio-SDL\]" "$config"; then
+        echo "[Audio-SDL]" >> "$config"
+        echo "Version = 1" >> "$config"
+    fi
+    iniSet "RESAMPLE" "src-sinc-fastest"
 }
 
 function useTexturePacks() {

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -173,7 +173,6 @@ function testCompatibility() {
     
     # these games need RSP-LLE
     local blacklist=(
-        gauntlet
         naboo
         body
         infernal
@@ -189,6 +188,7 @@ function testCompatibility() {
         beetle
         rogue
         squadron
+        gauntlet
     )
 
     # these games do not run with rice
@@ -196,6 +196,7 @@ function testCompatibility() {
         yoshi
         rogue
         squadron
+        gauntlet
     )
 
     # these games have massive glitches if legacy blending is enabled

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -212,6 +212,12 @@ function testCompatibility() {
         majora
     )
 
+    # these games have major problems with GLideN64
+    local gliden64_blacklist=(
+        zelda
+        conker
+    )
+
     # these games crash if audio-omx is selected
     local AudioOMX_blacklist=(
         pokemon
@@ -267,6 +273,11 @@ function testCompatibility() {
                 if [[ "${ROM,,}" == *"$game"* ]]; then
                     iniSet "EnableLegacyBlending" "False"
                     break
+                fi
+            done
+            for game in "${gliden64_blacklist[@]}"; do
+                if [[ "${ROM,,}" == *"$game"* ]]; then
+                    VIDEO_PLUGIN="mupen64plus-video-rice"
                 fi
             done
             ;;


### PR DESCRIPTION
-use default "Video-Rice" for Conker and Zelda games. These game have problems if GLideN64 is used (translucent and missing textures).
-remove Gauntlet Legends from blacklist
-use better Audio-SDL resampler (less crackle)
-fix Perfect Dark highres autosetting