### PR TITLE
use mame2003 rungun memory patch to bypass stalling point

### DIFF
--- a/scriptmodules/libretrocores/lr-mame2003.sh
+++ b/scriptmodules/libretrocores/lr-mame2003.sh
@@ -57,6 +57,10 @@ function configure_lr-mame2003() {
         for mame_sub_dir in cfg ctrlr diff hi inp memcard nvram snap; do
             mkRomDir "$mame_dir/$name/$mame_sub_dir"
         done
+        
+        # copy nvram patches - currently only rungun.nv
+        cp "$md_inst/metadata/*.nv" "$mame_dir/$name/$nvram"
+        chown $user:$user "$mame_dir/$name/$nvram/*.*"
     done
 
     mkUserDir "$biosdir/$name"


### PR DESCRIPTION
Based on @grant2258 's research into Run and Gun I created this tiny .nvram memory patch to that gets `rungun` past it's stalling point. It was added to mame2003-libretro here https://github.com/libretro/mame2003-libretro/pull/346 . 

In brief: This is a cruder implementation of what mame2010 and later do.
At some point we could BUILD_BIN2C this into the mame2003 binary like the builtin hiscore.dat, but I digress. Maybe one day.

This PR should make the game start fine for RetroPie users in the meantime. I don't have a RetroPie environment to test on, however.