### PR TITLE
Sixaxis groundwork

### DIFF
--- a/scriptmodules/supplementary/bluetooth.sh
+++ b/scriptmodules/supplementary/bluetooth.sh
@@ -80,9 +80,15 @@ function bluez_cmd_bluetooth() {
 function list_available_bluetooth() {
     local mac_address
     local device_name
+    local info_text="\n\nSearching ..."
 
-    dialog --backtitle "$__backtitle" --infobox "\nSearching ..." 5 40 >/dev/tty
+    # sixaxis: add USB pairing information
+    [[ -n "$(lsmod | grep hid_sony)" ]] && info_text="Searching ...\n\n(To register a DualShock controller, please unplug and replug your controller while this text is visible...)"
+
+    dialog --backtitle "$__backtitle" --infobox "$info_text" 7 60 >/dev/tty
     if hasPackage bluez 5; then
+        # sixaxis: reply to authorization challenge on USB cable connect
+        [[ -n "$(lsmod | grep hid_sony)" ]] && bluez_cmd_bluetooth "default-agent" "10" "Authorize" "yes" >/dev/null &
         while read mac_address; read device_name; do
             echo "$mac_address"
             echo "$device_name"

--- a/scriptmodules/supplementary/customhidsony/0001-hidsony-nomotionsensors.diff
+++ b/scriptmodules/supplementary/customhidsony/0001-hidsony-nomotionsensors.diff
@@ -1,0 +1,23 @@
+diff --git a/drivers/hid/hid-sony.c b/drivers/hid/hid-sony.c
+index b9dc3ac..2020524 100644
+--- a/drivers/hid/hid-sony.c
++++ b/drivers/hid/hid-sony.c
+@@ -868,7 +868,7 @@ static void sixaxis_parse_report(struct sony_sc *sc, u8 *rd, int size)
+ 	sc->battery_charging = battery_charging;
+ 	spin_unlock_irqrestore(&sc->lock, flags);
+ 
+-	if (sc->quirks & SIXAXIS_CONTROLLER) {
++	if (sc->sensor_dev && sc->quirks & SIXAXIS_CONTROLLER) {
+ 		int val;
+ 
+ 		offset = SIXAXIS_INPUT_REPORT_ACC_X_OFFSET;
+@@ -1310,6 +1310,9 @@ static void sony_unregister_touchpad(struct sony_sc *sc)
+ 
+ static int sony_register_sensors(struct sony_sc *sc)
+ {
++	if (sc->quirks & SIXAXIS_CONTROLLER)
++		return 0;
++
+ 	size_t name_sz;
+ 	char *name;
+ 	int ret;


### PR DESCRIPTION
Due to the new kernel 4.14, we now have different button maps for the DS3's USB connection (via hid-sony) compared to both the 4.9 kernel version's driver as well as the current ps3controller driver. In order to at least maintain consistency with the native driver, I've split the sixaxis PR into two. 

This "groundwork" PR does two things: 
* bring the ```customhidsony``` driver into sync with the default 4.14 kernel driver so it has the same new mappings; the only difference between rpi-4.14.y and rpi-4.15.y version of hid_sony will be the Shanwan vibration fix (as well as my change to disable motion sensors).
* add basic bluetooth pairing support.

Neither of these changes will break ps3controller, but will allow people the option to use the native driver via Bluetooth (as long as they understand that it will not yet have an inactivity timeout) - and helps lay the groundwork for future inclusion of the sixaxis helper.

The original PR now only has only the major changes - the helper and custom Bluez module. Those require more time and proper review, and thus can wait until much later.