### PR TITLE
lr-mgba.sh: enable lr-mgba for GB and GBC (SGB also supported)

### DIFF
--- a/scriptmodules/libretrocores/lr-mgba.sh
+++ b/scriptmodules/libretrocores/lr-mgba.sh
@@ -10,8 +10,8 @@
 #
 
 rp_module_id="lr-mgba"
-rp_module_desc="GBA emulator - MGBA (optimised) port for libretro"
-rp_module_help="ROM Extensions: .gba .zip\n\nCopy your Game Boy Advance roms to $romdir/gba\n\nCopy the required BIOS file gba_bios.bin to $biosdir"
+rp_module_desc="(Super) Game Boy Color/GBA emulator - MGBA (optimised) port for libretro"
+rp_module_help="ROM Extensions: .gb .gbc .gba .zip\n\nCopy your Game Boy roms to $romdir/gb\nGame Boy Color roms to $romdir/gbc\nGame Boy Advance roms to $romdir/gba\n\nCopy the recommended BIOS files gb_bios.bin, gbc_bios.bin, sgb_bios.bin and gba_bios.bin to $biosdir"
 rp_module_licence="MPL2 https://raw.githubusercontent.com/libretro/mgba/master/LICENSE"
 rp_module_section="main"
 rp_module_flags=""
@@ -40,11 +40,14 @@ function install_lr-mgba() {
 }
 
 function configure_lr-mgba() {
-    mkRomDir "gba"
-    ensureSystemretroconfig "gba"
-
-    local def=1
-    isPlatform "armv6" && def=0
-    addEmulator $def "$md_id" "gba" "$md_inst/mgba_libretro.so"
-    addSystem "gba"
+    local system
+    local def
+    for system in gb gbc gba; do
+        def=0
+        [[ "$system" == "gba" ]] && ! isPlatform "armv6" && def=1
+        mkRomDir "$system"
+        ensureSystemretroconfig "$system"
+        addEmulator "$def" "$md_id" "$system" "$md_inst/mgba_libretro.so"
+        addSystem "$system"
+    done
 }


### PR DESCRIPTION
As mentioned in #2295, `lr-mgba` is mature enough now to support GB/GBC/SGB as well as GBA.
I've been using it for several weeks now and all works fine. The emulator detects the system type automatically and can use all BIOSes available, even Super Gameboy.
The emulation speed in my standard-configured RPI3 is very satisfactory too.
This is for the `master` upstream repository of `lr-mgba`, used when you install it from source.
I strongly suggest the binary version in RetroPie is updated too to make all work out-of-the-box.

The following BIOS files were used for testing each system type:

    a860e8c0b6d573d191e4ec7db1b1e4f6  gba_bios.bin
    32fbbd84168d3482956eb3c5051637f5  gb_bios.bin
    dbfce9db9deaa2567f6a84fde55f9680  gbc_bios.bin
    d574d4f9c12f305074798f54c091a8b4  sgb_bios.bin

I kept the original logic used to set the emulator as default, e.g. set it as default in non `armv6` platforms.
This should keep users of slow hardware unaffected if they are using `lr-gambatte` already.