### PR TITLE
overload license and changelog filenames for mame2003-plus

### DIFF
--- a/scriptmodules/libretrocores/lr-mame2003-plus.sh
+++ b/scriptmodules/libretrocores/lr-mame2003-plus.sh
@@ -12,11 +12,20 @@
 rp_module_id="lr-mame2003-plus"
 rp_module_desc="Arcade emu - updated MAME 0.78 port for libretro with added game support"
 rp_module_help="ROM Extension: .zip\n\nCopy your MAME roms to either $romdir/mame-libretro or\n$romdir/arcade"
-rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/mame2003-plus-libretro/master/docs/mame.txt"
+rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/mame2003-plus-libretro/master/LICENSE.md"
 rp_module_section="exp"
 
 function sources_lr-mame2003-plus() {
     gitPullOrClone "$md_build" https://github.com/libretro/mame2003-plus-libretro.git
+}
+
+function install_lr-mame2003() {
+    md_ret_files=(
+        "$(_get_name_lr-mame2003)_libretro.so"
+        'README.md'
+        'CHANGELOG.md'
+        'metadata'
+    )
 }
 
 function build_lr-mame2003-plus() {


### PR DESCRIPTION
If I understand the function of this script, the PR will point `lr-mame2003-plus.sh` to the location of the changelog without having to re-implement any more of the underling `lr-mame2003.sh` script.

Because twinaphex merged the PR which reformated and relocated these files in mame2003-plus it's a fair bet that this change will eventually work it's way back to mame2003 as well but who knows when.