### PR TITLE
Prevent Bash parameter expansion in filenames passed to retroarch

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -878,8 +878,8 @@ function get_sys_command() {
     COMMAND="$(default_emulator get emu_cmd)"
 
     # replace tokens
-    COMMAND="${COMMAND//\%ROM\%/\"$ROM\"}"
-    COMMAND="${COMMAND//\%BASENAME\%/\"$ROM_BN\"}"
+    COMMAND="${COMMAND//\%ROM\%/\'$ROM\'}"
+    COMMAND="${COMMAND//\%BASENAME\%/\'$ROM_BN\'}"
 
     # special case to get the last 2 folders for quake games for the -game parameter
     # remove everything up to /quake/

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -878,8 +878,8 @@ function get_sys_command() {
     COMMAND="$(default_emulator get emu_cmd)"
 
     # replace tokens
-    COMMAND="${COMMAND//\%ROM\%/\'$ROM\'}"
-    COMMAND="${COMMAND//\%BASENAME\%/\'$ROM_BN\'}"
+    COMMAND="${COMMAND//\%ROM\%/$(printf '%q' "$ROM")}"
+    COMMAND="${COMMAND//\%BASENAME\%/$(printf '%q' "$ROM_BN")}"
 
     # special case to get the last 2 folders for quake games for the -game parameter
     # remove everything up to /quake/


### PR DESCRIPTION
When attempting to launch a ROM with a "$" in the filename, runcommand.sh passes the filename to retroarch in a way that allows for Bash parameter expansion. I encountered this in the wild when trying to run "WarioWare, Inc. - Mega Microgame$!": the $! is a valid Bash parameter and was expanded.