### PR TITLE
Commander Genius now uses the stable branch instead of a fixed tag

### DIFF
--- a/scriptmodules/ports/cgenius.sh
+++ b/scriptmodules/ports/cgenius.sh
@@ -19,7 +19,7 @@ function depends_cgenius() {
 }
 
 function sources_cgenius() {
-    gitPullOrClone "$md_build" https://github.com/gerstrong/Commander-Genius.git v2.2.2
+    gitPullOrClone "$md_build" https://github.com/gerstrong/Commander-Genius.git stable
 
     # use -O2 on older GCC due to segmentation fault when compiling with -O3
     if compareVersions $__gcc_version lt 6.0.0; then


### PR DESCRIPTION
Use stable branch instead of a version