### PR TITLE
retroarch - updated to v1.7.3

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -37,13 +37,14 @@ function depends_retroarch() {
 }
 
 function sources_retroarch() {
-    gitPullOrClone "$md_build" https://github.com/libretro/RetroArch.git v1.7.1
+    gitPullOrClone "$md_build" https://github.com/libretro/RetroArch.git v1.7.3
     applyPatch "$md_data/01_hotkey_hack.diff"
     applyPatch "$md_data/02_disable_search.diff"
+    applyPatch "$md_data/03_disable_udev_sort.diff"
 }
 
 function build_retroarch() {
-    local params=(--disable-sdl --enable-sdl2 --disable-oss --disable-al --disable-jack)
+    local params=(--disable-sdl --enable-sdl2 --disable-oss --disable-al --disable-jack --disable-qt)
     ! isPlatform "x11" && params+=(--disable-x11 --disable-pulse)
     if compareVersions "$__os_debian_ver" lt 9; then
         params+=(--disable-ffmpeg)

--- a/scriptmodules/emulators/retroarch/03_disable_udev_sort.diff
+++ b/scriptmodules/emulators/retroarch/03_disable_udev_sort.diff
@@ -1,0 +1,15 @@
+diff --git a/input/drivers_joypad/udev_joypad.c b/input/drivers_joypad/udev_joypad.c
+index 4475c62..865431c 100644
+--- a/input/drivers_joypad/udev_joypad.c
++++ b/input/drivers_joypad/udev_joypad.c
+@@ -588,8 +588,8 @@ static bool udev_joypad_init(void *data)
+ 
+    /* Sort the udev entries by devnode name so that they are
+     * created in the proper order */
+-   qsort(sorted, sorted_count,
+-         sizeof(struct joypad_udev_entry), sort_devnodes);
++   //qsort(sorted, sorted_count,
++   //      sizeof(struct joypad_udev_entry), sort_devnodes);
+ 
+    for (i = 0; i < sorted_count; i++)
+    {


### PR DESCRIPTION
 * add --disable-qt configure flag
 * disable udev sort as it the changed behaviour may cause more problems than it solves - https://retropie.org.uk/forum/topic/17276/usb-ports-no-longer-determine-player-number-retroarch-1-7-1