### PR TITLE
Add support for tinker for few emulator

### DIFF
--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -23,10 +23,18 @@ function depends_ppsspp() {
 }
 
 function sources_ppsspp() {
-    gitPullOrClone "$md_build/ppsspp" https://github.com/hrydgard/ppsspp.git v1.5.4
+    if isPlatform "tinker"; then
+        gitPullOrClone "$md_build/ppsspp" https://github.com/hrydgard/ppsspp.git
+    else
+        gitPullOrClone "$md_build/ppsspp" https://github.com/hrydgard/ppsspp.git v1.5.4
+    fi
     cd ppsspp
 
-    applyPatch "$md_data/01_egl_name.diff"
+    if isPlatform "tinker"; then
+        applyPatch "$md_data/02_tinker_options.diff"
+    else
+        applyPatch "$md_data/01_egl_name.diff"
+    fi
 
     # remove the lines that trigger the ffmpeg build script functions - we will just use the variables from it
     sed -i "/^build_ARMv6$/,$ d" ffmpeg/linux_arm.sh
@@ -123,6 +131,8 @@ function build_ppsspp() {
         fi
     elif isPlatform "mali"; then
         params+=(-DUSING_GLES2=ON -DUSING_FBDEV=ON)
+    elif isPlatform "tinker"; then
+        params+=(-DCMAKE_TOOLCHAIN_FILE="$md_data/tinker.armv7.cmake")
     fi
     "$cmake" "${params[@]}" .
     make clean
@@ -146,6 +156,10 @@ function configure_ppsspp() {
     mkUserDir "$md_conf_root/psp/PSP"
     ln -snf "$romdir/psp" "$md_conf_root/psp/PSP/GAME"
 
-    addEmulator 0 "$md_id" "psp" "$md_inst/PPSSPPSDL %ROM%"
+    if isPlatform "tinker"; then
+        addEmulator 0 "$md_id" "psp" "$md_inst/PPSSPPSDL --fulscreen %ROM%"
+    else
+        addEmulator 0 "$md_id" "psp" "$md_inst/PPSSPPSDL %ROM%"
+    fi
     addSystem "psp"
 }

--- a/scriptmodules/emulators/ppsspp/02_tinker_options.diff
+++ b/scriptmodules/emulators/ppsspp/02_tinker_options.diff
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e26ebe2227..d4384f8a94 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -57,7 +57,7 @@ endif()
+ 
+ if(NOT ANDROID AND NOT IOS)
+ 	if(ARM OR SIMULATOR)
+-		set(USING_EGL ON)
++		set(USING_EGL OFF)
+ 	endif()
+ endif()
+ 
+@@ -76,7 +76,7 @@ endif()
+ 
+ # We only support Vulkan on Unix, Android and Windows.
+ if(ANDROID OR WIN32 OR (UNIX AND NOT APPLE))
+-  set(VULKAN ON)
++  set(VULKAN OFF)
+ else()
+   add_definitions(-DNO_VULKAN)
+ endif()

--- a/scriptmodules/emulators/ppsspp/tinker.armv7.cmake
+++ b/scriptmodules/emulators/ppsspp/tinker.armv7.cmake
@@ -1,0 +1,13 @@
+include_directories(SYSTEM
+  /usr/local/include
+  /usr/include
+)
+
+set(ARCH_FLAGS "-O2 -marm -march=armv7-a -mfpu=neon-vfpv4 -mtune=cortex-a17 -mfloat-abi=hard -ftree-vectorize -funsafe-math-optimizations -pipe")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ARCH_FLAGS}"  CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ARCH_FLAGS}" CACHE STRING "" FORCE)
+set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${ARCH_FLAGS}" CACHE STRING "" FORCE)
+
+set(OPENGL_LIBRARIES GLESv2)
+set(ARMV7 ON)
+set(USING_GLES2 ON)

--- a/scriptmodules/emulators/reicast.sh
+++ b/scriptmodules/emulators/reicast.sh
@@ -14,7 +14,7 @@ rp_module_desc="Dreamcast emulator Reicast"
 rp_module_help="ROM Extensions: .cdi .gdi\n\nCopy your Dremcast roms to $romdir/dreamcast\n\nCopy the required BIOS files dc_boot.bin and dc_flash.bin to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/reicast/reicast-emulator/master/LICENSE"
 rp_module_section="opt"
-rp_module_flags="!armv6 !mali !kms"
+rp_module_flags="!armv6 !mali"
 
 function depends_reicast() {
     getDepends libsdl1.2-dev python-dev python-pip alsa-oss python-setuptools libevdev-dev
@@ -35,6 +35,9 @@ function build_reicast() {
     if isPlatform "rpi"; then
         make platform=rpi2 clean
         make platform=rpi2
+    elif isPlatform "tinker"; then
+        make USE_GLES=1 USE_SDL=1 clean
+        make USE_GLES=1 USE_SDL=1
     else
         make clean
         make
@@ -46,6 +49,8 @@ function install_reicast() {
     cd shell/linux
     if isPlatform "rpi"; then
         make platform=rpi2 PREFIX="$md_inst" install
+    elif isPlatform "tinker"; then
+        make USE_GLES=1 USE_SDL=1 PREFIX="$md_inst" install
     else
         make PREFIX="$md_inst" install
     fi

--- a/scriptmodules/libretrocores/lr-mupen64plus.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus.sh
@@ -54,6 +54,7 @@ function build_lr-mupen64plus() {
         isPlatform "arm" && params+=(WITH_DYNAREC=arm)
         isPlatform "neon" && params+=(HAVE_NEON=1)
         isPlatform "gles" && params+=(FORCE_GLES=1)
+        isPlatform "kms" && params+=(FORCE_GLES3=1)
     fi
     make clean
     make "${params[@]}"

--- a/scriptmodules/libretrocores/lr-parallel-n64.sh
+++ b/scriptmodules/libretrocores/lr-parallel-n64.sh
@@ -29,13 +29,18 @@ function sources_lr-parallel-n64() {
 }
 
 function build_lr-parallel-n64() {
-    rpSwap on 750
+    rpSwap on 1000
     make clean
+    local params=()
     if isPlatform "rpi" || isPlatform "odroid-c1"; then
-        make platform="$__platform"
-    else
-        make
+        params+=(platform="$__platform")
+    elif isPlatform "tinker"; then
+        params+=(platform="kms")
+        params+=("CPUFLAGS=-DNO_ASM -DARM -D__arm__ -DARM_ASM -D__NEON_OPT -DNOSSE")
+        params+=("GLES=1 HAVE_NEON=1 WITH_DYNAREC=arm")
+        params+=("GL_LIB:=-lGLESv2")
     fi
+    make "${params[@]}"
     rpSwap off
     md_ret_require="$md_build/parallel_n64_libretro.so"
 }
@@ -52,9 +57,9 @@ function configure_lr-parallel-n64() {
     ensureSystemretroconfig "n64"
 
     # Set core options
-    setRetroArchCoreOption "mupen64-gfxplugin" "rice"
-    setRetroArchCoreOption "mupen64-gfxplugin-accuracy" "low"
-    setRetroArchCoreOption "mupen64-screensize" "640x480"
+    setRetroArchCoreOption "parallel-n64-gfxplugin" "auto"
+    setRetroArchCoreOption "parallel-n64-gfxplugin-accuracy" "low"
+    setRetroArchCoreOption "parallel-n64-screensize" "640x480"
 
     # Copy config files
     cat > $home/RetroPie/BIOS/gles2n64rom.conf << _EOF_

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -310,7 +310,7 @@ function platform_odroid-xu() {
 }
 
 function platform_tinker() {
-    __default_cflags="-O2 -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard -ftree-vectorize -funsafe-math-optimizations"
+    __default_cflags="-O2 -marm -march=armv7-a -mtune=cortex-a17 -mfpu=neon-vfpv4 -mfloat-abi=hard -ftree-vectorize -funsafe-math-optimizations"
     # required for mali headers to define GL functions
     __default_cflags+=" -DGL_GLEXT_PROTOTYPES"
     __default_asflags=""


### PR DESCRIPTION
Hello,

The changes made make it possible to have a support on the emulators concerned. We are working on an image based on Armbian Stretch with the supplied 4.4.120-rockchip kernel. The changes also work on the ISO TinkerOS provided by ASUS.
If you want to do the tests on an armbian image we have a script that automates all the part of the dependencies etc.

https://github.com/Tinkerpie/Armbian-Setup