### PR TITLE
fbalpha - enable neocd subsystem / add .cue and .iso extensions

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -13,7 +13,7 @@ amstradcpc_fullname="Amstrad CPC"
 apple2_exts=".po .dsk .nib"
 apple2_fullname="Apple II"
 
-arcade_exts=".7z .fba .zip"
+arcade_exts=".7z .cue .fba .iso .zip"
 arcade_fullname="Arcade"
 
 arcadia_exts=".bin .zip"
@@ -63,7 +63,7 @@ dragon32_fullname="Dragon 32"
 dreamcast_exts=".cdi .chd .gdi .sh"
 dreamcast_fullname="Dreamcast"
 
-fba_exts=".7z .fba .zip"
+fba_exts=".7z .cue .fba .iso .zip"
 fba_fullname="Final Burn Alpha"
 fba_platform="arcade"
 
@@ -132,7 +132,7 @@ n64_fullname="Nintendo 64"
 nds_exts=".nds .zip"
 nds_fullname="Nintendo DS"
 
-neogeo_exts=".7z .fba .zip"
+neogeo_exts=".7z .cue .fba .iso .zip"
 neogeo_fullname="Neo Geo"
 
 nes_exts=".7z .nes .zip"

--- a/scriptmodules/libretrocores/lr-fbalpha.sh
+++ b/scriptmodules/libretrocores/lr-fbalpha.sh
@@ -62,8 +62,11 @@ function configure_lr-fbalpha() {
     local def=1
     isPlatform "armv6" && def=0
     addEmulator 0 "$md_id" "arcade" "$md_inst/fbalpha_libretro.so"
+    addEmulator 0 "$md_id-neocd" "arcade" "$md_inst/fbalpha_libretro.so --subsystem neocd"
     addEmulator $def "$md_id" "neogeo" "$md_inst/fbalpha_libretro.so"
+    addEmulator 0 "$md_id-neocd" "neogeo" "$md_inst/fbalpha_libretro.so --subsystem neocd"
     addEmulator $def "$md_id" "fba" "$md_inst/fbalpha_libretro.so"
+    addEmulator 0 "$md_id-neocd" "fba" "$md_inst/fbalpha_libretro.so --subsystem neocd"
     addSystem "arcade"
     addSystem "neogeo"
     addSystem "fba"


### PR DESCRIPTION
 * fbalpha now has neogeo cd support - see https://github.com/libretro/fbalpha/issues/4