### PR TITLE
Move .desktop and icon to existing folders

### DIFF
--- a/scriptmodules/supplementary/autostart.sh
+++ b/scriptmodules/supplementary/autostart.sh
@@ -54,7 +54,7 @@ function enable_autostart() {
 
     if isPlatform "x11"; then
         mkUserDir "$home/.config/autostart"
-        ln -sf "/usr/local/share/applications/retropie.desktop" "$home/.config/autostart/"
+        ln -sf "/usr/share/applications/retropie.desktop" "$home/.config/autostart/"
     else
         if [[ "$__os_id" == "Raspbian" ]]; then
             if [[ "$__chroot" -eq 1 ]]; then

--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -228,9 +228,10 @@ _EOF_
     chmod +x /usr/bin/emulationstation
 
     if isPlatform "x11"; then
-        mkdir -p /usr/local/share/{icons,applications}
-        cp "$scriptdir/scriptmodules/$md_type/emulationstation/retropie.svg" "/usr/local/share/icons/"
-        cat > /usr/local/share/applications/retropie.desktop << _EOF_
+        mkdir -p /usr/share/applications
+        mkdir -p /usr/share/icons/hicolor/scalable/apps/
+        cp "$scriptdir/scriptmodules/$md_type/emulationstation/retropie.svg" "/usr/share/icons/hicolor/scalable/apps/"
+        cat > /usr/share/applications/retropie.desktop << _EOF_
 [Desktop Entry]
 Type=Application
 Exec=gnome-terminal --full-screen --hide-menubar -e emulationstation
@@ -241,7 +242,7 @@ Name[de_DE]=RetroPie
 Name=rpie
 Comment[de_DE]=RetroPie
 Comment=retropie
-Icon=/usr/local/share/icons/retropie.svg
+Icon=/usr/share/icons/hicolor/scalable/apps/retropie.svg
 Categories=Game
 _EOF_
     fi
@@ -255,7 +256,7 @@ function clear_input_emulationstation() {
 function remove_emulationstation() {
     rm -f "/usr/bin/emulationstation"
     if isPlatform "x11"; then
-        rm -rfv "/usr/local/share/icons/retropie.svg" "/usr/local/share/applications/retropie.desktop"
+        rm -rfv "/usr/share/icons/hicolor/scalable/apps/retropie.svg" "/usr/share/applications/retropie.desktop"
     fi
 }
 


### PR DESCRIPTION
I was just investigating where RetroPie was placing the .desktop and icon in my PC, and for some reason, they were using non default folders.

I'm updating to use the same Debian/Ubuntu existing folders.