### PR TITLE
love - allow installation of v0.10.2 in addition to latest version

### DIFF
--- a/scriptmodules/ports/love-0.10.2.sh
+++ b/scriptmodules/ports/love-0.10.2.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="love-0.10.2"
+rp_module_desc="Love - 2d Game Engine v0.10.2"
+rp_module_help="Copy your Love games to $romdir/love"
+rp_module_licence="GPL3 https://bitbucket.org/rude/love/raw/7b520c437317626da2102de1aafdad0e67b54bf5/license.txt"
+rp_module_section="opt"
+rp_module_flags="!aarch64"
+
+function depends_love-0.10.2() {
+    depends_love
+}
+
+function sources_love-0.10.2() {
+    hg clone https://bitbucket.org/rude/love/#0.10.2 "$md_build"
+}
+
+function build_love-0.10.2() {
+    build_love
+}
+
+function install_love-0.10.2() {
+    install_love
+}
+
+function game_data_love-0.10.2() {
+    game_data_love
+}
+
+function configure_love-0.10.2() {
+    configure_love
+}


### PR DESCRIPTION
Many games for Love are incompatible with the latest version (v11). For example, the bundled game [Mari0](http://stabyourself.net/mari0/) requires v0.10.2, and the amazing game [Not Tetris](http://stabyourself.net/nottetris2/) requires 0.7.2.

With this PR, I am trying to add the option to install versions 0.10.2 and 0.7.2 as additional emulators for the system "love". I looked at advmame-x.xx as examples how this might work.

The goal is to allow users to use the runcommand menu to choose the version of Love on a per-game basis, similar to how it works with Advmame. The choices should be love (latest version, currently v11.1, the default), love-0.10.2, or love-0.7.2.

I am pretty sure I probably forgot something in this PR. I just copy-pasted from love.sh and made the obvious adjustments.

Can someone who is more familiar with RetroPie-Setup look over my first attempt and see if I forgot something before merging this?

Thank you!