### PR TITLE
Update lr-fbalpha.sh

### DIFF
--- a/scriptmodules/libretrocores/lr-fbalpha.sh
+++ b/scriptmodules/libretrocores/lr-fbalpha.sh
@@ -26,7 +26,7 @@ function sources_lr-fbalpha() {
 
 function build_lr-fbalpha() {
     make -f makefile.libretro clean
-    make -f makefile.libretro profile=performance
+    make -f makefile.libretro
     md_ret_require="$md_build/fbalpha_libretro.so"
 }
 
@@ -38,6 +38,7 @@ function install_lr-fbalpha() {
         'whatsnew.html'
         'preset-example.zip'
         'metadata'
+        'dats'
     )
 }
 


### PR DESCRIPTION
`profile=performance` argument doesn't do anything (it disappeared ~2 years ago), also, considering you keep dat files in pifba, perhaps you should do the same here.
Also, you don't plan to include the other subsystems ? Considering fbalpha run properly some games that won't on picodrive/genplus_gx, it's kinda sad.