### PR TITLE
Update lr-mame2016.sh

### DIFF
--- a/scriptmodules/libretrocores/lr-mame2016.sh
+++ b/scriptmodules/libretrocores/lr-mame2016.sh
@@ -22,8 +22,8 @@ function sources_lr-mame2016() {
 function build_lr-mame2016() {
     rpSwap on 1200
     local params=($(_get_params_lr-mame) SUBTARGET=arcade)
-    make clean
-    make "${params[@]}"
+    make -f Makefile.libretro clean
+    make -f Makefile.libretro "${params[@]}"
     rpSwap off
     md_ret_require="$md_build/mamearcade2016_libretro.so"
 }


### PR DESCRIPTION
Building fails with the normal `makefile`, i can build successfully with `Makefile.libretro`, except if i use a high `-jX` setting