### PR TITLE
Add lr-81: libretro core for Sinclair ZX81

### DIFF
--- a/scriptmodules/libretrocores/lr-81.sh
+++ b/scriptmodules/libretrocores/lr-81.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-81"
+rp_module_desc="Sinclair ZX81 emulator - EightyOne port for libretro"
+rp_module_help="ROM Extensions: .p .tzx .t81\n\nCopy your ZX81 roms to $romdir/zx81"
+rp_module_licence="GPL3 https://github.com/libretro/81-libretro/blob/master/LICENSE"
+rp_module_section="opt"
+
+function sources_lr-81() {
+    gitPullOrClone "$md_build" https://github.com/libretro/81-libretro.git
+}
+
+function build_lr-81() {
+    make clean
+    make
+    md_ret_require="$md_build/81_libretro.so"
+}
+
+function install_lr-81() {
+    md_ret_files=(
+        'README.md'
+        '81_libretro.so'
+    )
+}
+
+function configure_lr-81() {
+    mkRomDir "zx81"
+    ensureSystemretroconfig "zx81"
+
+    addEmulator 1 "$md_id" "zx81" "$md_inst/81_libretro.so"
+    addSystem "zx81"
+}

--- a/scriptmodules/libretrocores/lr-81.sh
+++ b/scriptmodules/libretrocores/lr-81.sh
@@ -13,7 +13,7 @@ rp_module_id="lr-81"
 rp_module_desc="Sinclair ZX81 emulator - EightyOne port for libretro"
 rp_module_help="ROM Extensions: .p .tzx .t81\n\nCopy your ZX81 roms to $romdir/zx81"
 rp_module_licence="GPL3 https://github.com/libretro/81-libretro/blob/master/LICENSE"
-rp_module_section="opt"
+rp_module_section="exp"
 
 function sources_lr-81() {
     gitPullOrClone "$md_build" https://github.com/libretro/81-libretro.git


### PR DESCRIPTION
I noticed this core sitting in the RetroArch repository, and decided to try compiling it on the Pi and seeing how well it works.  Since it ended up working more-or-less perfectly from the look of things, and because the ZX81 isn't available at all in RetroPie yet, I decided to write a script module for it.

Due to some control-related issues (specifically having to set player 2's controller type to "Sinclair Keyboard" in order to get inputs to work), I put the core in the Experimental section.  The RetroArch page also didn't mention whether or not .zip or .7z files work, so I excluded them for the time being.

I should also note that some colorized ROM files are present within the repository's `colorized` folder for use with the core's Chroma feature.  However, the author of the ROMs appear to have given permission to redistribute the files on the repository (plus they're redistributed on his website), so I'm not sure if they should be excluded or not.