### PR TITLE
Updated esthemes.sh with a new vertical only ES theme for mame roms

### DIFF
--- a/scriptmodules/supplementary/esthemes.sh
+++ b/scriptmodules/supplementary/esthemes.sh
@@ -144,6 +144,7 @@ function gui_esthemes() {
         'RetroHursty69 infinity'
         'RetroHursty69 neogeo_only'
         'RetroHursty69 boxcity'
+        'RetroHursty69 vertical_arcade'
         'Saracade scv720'
         'chicueloarcade Chicuelo'
         'SuperMagicom nostalgic'


### PR DESCRIPTION
This theme is designed to be used with your screen rotated to landscape. You will need to add a line of code to the boot/config.txt file. 'display_rotate=3' (or =1 depending on which way you want to rotate). The theme only covers mame/arcade and relevant collections like capcom, data east etc. No consoles, PC or handhelds are covered.