### PR TITLE
Add lr-pokemini: experimental libretro core for Pokemon Mini

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -166,7 +166,7 @@ pcengine_theme="pcengine"
 pcfx_exts=".pce .ccd .cue .iso .chd"
 pcfx_fullname="PC-FX"
 
-pokemini_exts=".min"
+pokemini_exts=".min .zip"
 pokemini_fullname="Pokemon Mini"
 
 ports_exts=".sh"

--- a/platforms.cfg
+++ b/platforms.cfg
@@ -166,6 +166,9 @@ pcengine_theme="pcengine"
 pcfx_exts=".pce .ccd .cue .iso .chd"
 pcfx_fullname="PC-FX"
 
+pokemini_exts=".min"
+pokemini_fullname="Pokemon Mini"
+
 ports_exts=".sh"
 ports_fullname="Ports"
 ports_platform="pc"

--- a/scriptmodules/libretrocores/lr-pokemini.sh
+++ b/scriptmodules/libretrocores/lr-pokemini.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-pokemini"
+rp_module_desc="Pokemon Mini emulator - PokeMini port for libretro"
+rp_module_help="ROM Extensions: .min .zip\n\nCopy your Pokemon Mini roms to $romdir/pokemini"
+rp_module_section="exp"
+
+function sources_lr-pokemini() {
+    gitPullOrClone "$md_build" https://github.com/libretro/pokemini.git
+}
+
+function build_lr-pokemini() {
+    make clean
+    make
+    md_ret_require="$md_build/pokemini_libretro.so"
+}
+
+function install_lr-pokemini() {
+    md_ret_files=(
+        'pokemini_libretro.so'
+    )
+}
+
+function configure_lr-pokemini() {
+    mkRomDir "pokemini"
+    ensureSystemretroconfig "pokemini"
+
+    addEmulator 1 "$md_id" "pokemini" "$md_inst/pokemini_libretro.so"
+    addSystem "pokemini"
+}


### PR DESCRIPTION
Title pretty much says it all.  I decided to take this opportunity to edit platforms.cfg to add Pokemon Mini platform definitions, since that seems to be how es_systems determines what file types to use.  (I might also submit a PR for the ZX81, as that script appears to not place file extensions otherwise, thus requiring the user to edit es_systems manually to add the extensions.)

I could just be misunderstanding how scriptmodules work, so feel free to change as you see fit.