### PR TITLE
add .zip extension to n64 platform for lr-mupen64plus

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -126,7 +126,7 @@ megadrive_platform="megadrive"
 msx_exts=".rom .mx1 .mx2 .col .dsk .zip .m3u"
 msx_fullname="MSX"
 
-n64_exts=".z64 .n64 .v64"
+n64_exts=".z64 .n64 .v64 .zip"
 n64_fullname="Nintendo 64"
 
 nds_exts=".nds .zip"


### PR DESCRIPTION
The `lr-mupen64plus` retroarch core does support zip files, add them as supported files for Nintendo 64.
Tested and working.