### PR TITLE
runcommand - use existing VIDEO_CONF variable

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -299,7 +299,7 @@ function default_mode() {
             key="${SAVE_EMU}_render"
             ;;
     esac
-    default_process "$CONFIGDIR/all/videomodes.cfg" "$mode" "$key" "$value"
+    default_process "$VIDEO_CONF" "$mode" "$key" "$value"
 }
 
 function default_emulator() {


### PR DESCRIPTION
Another small fix:
* The `VIDEO_CONF` variable is initialised at the beginning of the script with the appropiate file path. However, the `default_mode()` function does not use it and instead hard-codes the file path.