### PR TITLE
Revert "dependency fixes to helpers, runcommand and mupen64plus"

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -18,7 +18,7 @@ rp_module_flags="!mali !kms"
 
 function depends_mupen64plus() {
     local depends=(cmake libsamplerate0-dev libspeexdsp-dev libsdl2-dev libpng12-dev fonts-freefont-ttf)
-    isPlatform "rpi" && depends+=(libraspberrypi-dev libraspberrypi-bin)
+    isPlatform "rpi" && depends+=(libraspberrypi-dev)
     isPlatform "x11" && depends+=(libglew-dev libglu1-mesa-dev libboost-filesystem-dev)
     isPlatform "x86" && depends+=(nasm)
     isPlatform "vero4k" && depends+=(vero3-userland-dev-osmc libboost-all-dev)

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -981,7 +981,6 @@ function downloadAndExtract() {
 ## were not set to use the dispmanx SDL1 backend would just show in a small
 ## area of the screen.
 function ensureFBMode() {
-    [[ ! -f /etc/fb.modes ]] && return
     local res_x="$1"
     local res_y="$2"
     local res="${res_x}x${res_y}"

--- a/scriptmodules/supplementary/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand.sh
@@ -20,7 +20,7 @@ function _update_hook_runcommand() {
 
 function depends_runcommand() {
     local depends=()
-    isPlatform "rpi" && depends+=(fbi fbset libraspberrypi-bin)
+    isPlatform "rpi" && depends+=(fbi)
     isPlatform "x11" && depends+=(feh)
     getDepends "${depends[@]}"
 }


### PR DESCRIPTION
Reverts RetroPie/RetroPie-Setup#2455

Reverting due to OSMC dependency issue - no raspberrypi-bin on OSMC.