### PR TITLE
helpers - ensureFBMode(): no-op if /etc/fb.modes doesn't exist

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -981,6 +981,7 @@ function downloadAndExtract() {
 ## were not set to use the dispmanx SDL1 backend would just show in a small
 ## area of the screen.
 function ensureFBMode() {
+    [[ ! -f /etc/fb.modes ]] && return
     local res_x="$1"
     local res_y="$2"
     local res="${res_x}x${res_y}"


### PR DESCRIPTION
In the case that /etc/fb.modes doesn't already exists,
ensureFBMode() will create an empty file only containing the
custom RetroPie video mode entry.

The above is problematic for example when `fbset` is not installed
beforehand. The package installation will detect the modified
version of /etc/fb.modes as user-customised and will prompt the user
what to do with the conflict, e.g. use the maintainer's version
(that doesn't include the RetroPie video mode entry) or keep the
modified version (that doesn't include the stock entries).

The safest solution is for ensureFBMode() to simply do nothing if
/etc/fb.modes doesn't exist already. After installing `fbset`, the
file will exist and ensureFBMode() will add the custom video mode
alongside the stock entries as expected.