### PR TITLE
runcommand - add fbset as dependency

### DIFF
--- a/scriptmodules/supplementary/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand.sh
@@ -20,7 +20,7 @@ function _update_hook_runcommand() {
 
 function depends_runcommand() {
     local depends=()
-    isPlatform "rpi" && depends+=(fbi)
+    isPlatform "rpi" && depends+=(fbi fbset)
     isPlatform "x11" && depends+=(feh)
     getDepends "${depends[@]}"
 }


### PR DESCRIPTION
The runcommand script uses the `fbset` binary and in some
systems this package might not be installed by default.