### PR TITLE
properly add libraspberrypi-bin depedency handling

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -18,7 +18,7 @@ rp_module_flags="!mali !kms"
 
 function depends_mupen64plus() {
     local depends=(cmake libsamplerate0-dev libspeexdsp-dev libsdl2-dev libpng12-dev fonts-freefont-ttf)
-    isPlatform "rpi" && depends+=(libraspberrypi-dev)
+    isPlatform "rpi" && depends+=(libraspberrypi-bin libraspberrypi-dev)
     isPlatform "x11" && depends+=(libglew-dev libglu1-mesa-dev libboost-filesystem-dev)
     isPlatform "x86" && depends+=(nasm)
     isPlatform "vero4k" && depends+=(vero3-userland-dev-osmc libboost-all-dev)

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -204,6 +204,10 @@ function getDepends() {
     for required in $@; do
 
         # workaround for different package names on osmc / xbian
+        if [[ "$required" == "libraspberrypi-bin" ]]; then
+            isPlatform "osmc" && required="rbp-userland-osmc"
+            isPlatform "xbian" && required="xbian-package-firmware"
+        fi
         if [[ "$required" == "libraspberrypi-dev" ]]; then
             isPlatform "osmc" && required="rbp-userland-dev-osmc"
             isPlatform "xbian" && required="xbian-package-firmware"

--- a/scriptmodules/supplementary/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand.sh
@@ -20,7 +20,7 @@ function _update_hook_runcommand() {
 
 function depends_runcommand() {
     local depends=()
-    isPlatform "rpi" && depends+=(fbi fbset)
+    isPlatform "rpi" && depends+=(fbi fbset libraspberrypi-bin)
     isPlatform "x11" && depends+=(feh)
     getDepends "${depends[@]}"
 }


### PR DESCRIPTION
As discussed in PR #2461 , there was a problem with `libraspberrypi-bin` changing name in different OSs (OSMC and Xbian). This revised PR handles the issue similarly to how it is already handled for `librasperrypi-dev`. With this, we can now safely add `libraspberrypi-bin` as dependency for mupen64plus and runcommand.
Again, sorry for the previous broken PR, hopefully this one is trouble-free.