### PR TITLE
system - add missing dependencies for get_retropie_depends()

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -166,7 +166,7 @@ function get_os_version() {
 }
 
 function get_retropie_depends() {
-    local depends=(git dialog wget gcc g++ build-essential unzip xmlstarlet python-pyudev)
+    local depends=(git ca-certificates dialog wget gcc g++ build-essential unzip xmlstarlet python-pyudev procps)
 
     if ! getDepends "${depends[@]}"; then
         fatalError "Unable to install packages required by $0 - ${md_ret_errors[@]}"


### PR DESCRIPTION
Just catched these missing deps too:

* `ca-certificates` is needed by `git` for https repositories
* `procps` is needed by `system.sh`:

      scriptmodules/system.sh: line 20: free: command not found
      scriptmodules/system.sh: line 21: free: command not found