### PR TITLE
Deprecate stdin usage (fixes #2467)

### DIFF
--- a/scriptmodules/emulators/atari800.sh
+++ b/scriptmodules/emulators/atari800.sh
@@ -25,32 +25,7 @@ function depends_atari800() {
 function sources_atari800() {
     downloadAndExtract "$__archive_url/atari800-3.1.0.tar.gz" "$md_build" 1
     if isPlatform "rpi"; then
-        applyPatch rpi_fixes.diff <<\_EOF_
---- a/src/configure.ac
-+++ b/src/configure.ac
-@@ -136,7 +136,8 @@ if [[ "$a8_target" = "ps2" ]]; then
-     LDFLAGS="$LDFLAGS -L${PS2SDK}/ports/lib"
- fi
- if [[ "$a8_target" = "rpi" ]]; then
--    CC="${RPI_SDK}/bin/arm-linux-gnueabihf-gcc"
-+    [[ -z "$RPI_SDK" ]] && RPI_SDK="/opt/vc"
-+    CC="gcc"
-     CFLAGS="$CFLAGS -I${RPI_SDK}/include -I${RPI_SDK}/include/SDL -I${RPI_SDK}/include/interface/vmcs_host/linux -I${RPI_SDK}/include/interface/vcos/pthreads"
-     LDFLAGS="$LDFLAGS -Wl,--unresolved-symbols=ignore-in-shared-libs -L${RPI_SDK}/lib"
- fi
-@@ -309,8 +310,9 @@ dnl BeOS has a real issue with redundant-decls
-         AC_DEFINE(SUPPORTS_PLATFORM_CONFIGURE,1,[Additional config file options.])
-         AC_DEFINE(SUPPORTS_PLATFORM_CONFIGSAVE,1,[Save additional config file options.])
-         AC_DEFINE(SUPPORTS_PLATFORM_PALETTEUPDATE,1,[Update the Palette if it changed.])
--        A8_NEED_LIB(GLESv2)
--        A8_NEED_LIB(EGL)
-+        AC_DEFINE(PLATFORM_MAP_PALETTE,1,[Platform-specific mapping of RGB palette to display surface.])
-+        A8_NEED_LIB(brcmGLESv2)
-+        A8_NEED_LIB(brcmEGL)
-         A8_NEED_LIB(SDL)
-         A8_NEED_LIB(bcm_host)
-         OBJS="atari_rpi.o gles2/video.o sdl/main.o sdl/input.o"
-_EOF_
+        applyPatch "$md_data/01_rpi_fixes.diff"
     fi
 }
 

--- a/scriptmodules/emulators/atari800/01_rpi_fixes.diff
+++ b/scriptmodules/emulators/atari800/01_rpi_fixes.diff
@@ -1,0 +1,24 @@
+--- a/src/configure.ac	2014-04-12 13:58:16.000000000 +0000
++++ b/src/configure.ac	2018-08-22 13:51:47.998493324 +0000
+@@ -136,7 +136,8 @@
+     LDFLAGS="$LDFLAGS -L${PS2SDK}/ports/lib"
+ fi
+ if [[ "$a8_target" = "rpi" ]]; then
+-    CC="${RPI_SDK}/bin/arm-linux-gnueabihf-gcc"
++    [[ -z "$RPI_SDK" ]] && RPI_SDK="/opt/vc"
++    CC="gcc"
+     CFLAGS="$CFLAGS -I${RPI_SDK}/include -I${RPI_SDK}/include/SDL -I${RPI_SDK}/include/interface/vmcs_host/linux -I${RPI_SDK}/include/interface/vcos/pthreads"
+     LDFLAGS="$LDFLAGS -Wl,--unresolved-symbols=ignore-in-shared-libs -L${RPI_SDK}/lib"
+ fi
+@@ -309,8 +310,9 @@
+         AC_DEFINE(SUPPORTS_PLATFORM_CONFIGURE,1,[Additional config file options.])
+         AC_DEFINE(SUPPORTS_PLATFORM_CONFIGSAVE,1,[Save additional config file options.])
+         AC_DEFINE(SUPPORTS_PLATFORM_PALETTEUPDATE,1,[Update the Palette if it changed.])
+-        A8_NEED_LIB(GLESv2)
+-        A8_NEED_LIB(EGL)
++        AC_DEFINE(PLATFORM_MAP_PALETTE,1,[Platform-specific mapping of RGB palette to display surface.])
++        A8_NEED_LIB(brcmGLESv2)
++        A8_NEED_LIB(brcmEGL)
+         A8_NEED_LIB(SDL)
+         A8_NEED_LIB(bcm_host)
+         OBJS="atari_rpi.o gles2/video.o sdl/main.o sdl/input.o"

--- a/scriptmodules/emulators/fuse.sh
+++ b/scriptmodules/emulators/fuse.sh
@@ -25,17 +25,7 @@ function sources_fuse() {
     mkdir libspectrum
     downloadAndExtract "$__archive_url/libspectrum-1.4.1.tar.gz" "$md_build/libspectrum" 1
     if ! isPlatform "x11"; then
-        applyPatch cursor.diff <<\_EOF_
---- a/ui/sdl/sdldisplay.c	2015-02-18 22:39:05.631516602 +0000
-+++ b/ui/sdl/sdldisplay.c	2015-02-18 22:39:08.407506296 +0000
-@@ -411,7 +411,7 @@
-     SDL_ShowCursor( SDL_DISABLE );
-     SDL_WarpMouse( 128, 128 );
-   } else {
--    SDL_ShowCursor( SDL_ENABLE );
-+    SDL_ShowCursor( SDL_DISABLE );
-   }
-_EOF_
+        applyPatch "$md_data/01_disable_cursor.diff"
     fi
 }
 

--- a/scriptmodules/emulators/fuse/01_disable_cursor.diff
+++ b/scriptmodules/emulators/fuse/01_disable_cursor.diff
@@ -1,0 +1,11 @@
+--- a/ui/sdl/sdldisplay.c	2017-07-02 05:36:42.000000000 +0000
++++ b/ui/sdl/sdldisplay.c	2018-08-22 13:55:03.474702732 +0000
+@@ -412,7 +412,7 @@
+     SDL_ShowCursor( SDL_DISABLE );
+     SDL_WarpMouse( 128, 128 );
+   } else {
+-    SDL_ShowCursor( SDL_ENABLE );
++    SDL_ShowCursor( SDL_DISABLE );
+   }
+ 
+   fuse_emulation_unpause();

--- a/scriptmodules/emulators/scummvm-sdl1.sh
+++ b/scriptmodules/emulators/scummvm-sdl1.sh
@@ -21,21 +21,11 @@ function depends_scummvm-sdl1() {
 }
 
 function sources_scummvm-sdl1() {
-    sources_scummvm
+    # sources_scummvm() expects $md_data to be ../scummvm
+    # the following only modifies $md_data for the function call
+    md_data="$md_data/../scummvm" sources_scummvm
     if isPlatform "rpi"; then
-        applyPatch rpi-sdl1.diff <<\_EOF_
---- a/configure
-+++ b/configure
-@@ -2807,7 +2807,7 @@ if test -n "$_host"; then
- 			# We prefer SDL2 on the Raspberry Pi: acceleration now depends on it
- 			# since SDL2 manages dispmanx/GLES2 very well internally.
- 			# SDL1 is bit-rotten on this platform.
--			_sdlconfig=sdl2-config
-+			_sdlconfig=sdl-config
- 			# OpenGL ES support is mature enough as to be the best option on
- 			# the Raspberry Pi, so it's enabled by default.
- 			# The Raspberry Pi always supports OpenGL ES 2.0 contexts, thus we
-_EOF_
+        applyPatch "$md_data/01_rpi_sdl1.diff"
     fi
 }
 

--- a/scriptmodules/emulators/scummvm-sdl1/01_rpi_sdl1.diff
+++ b/scriptmodules/emulators/scummvm-sdl1/01_rpi_sdl1.diff
@@ -1,0 +1,11 @@
+--- a/configure	2018-08-22 14:35:59.974063916 +0000
++++ b/configure	2018-08-22 14:36:36.379862346 +0000
+@@ -2917,7 +2917,7 @@
+ 			# We prefer SDL2 on the Raspberry Pi: acceleration now depends on it
+ 			# since SDL2 manages dispmanx/GLES2 very well internally.
+ 			# SDL1 is bit-rotten on this platform.
+-			_sdlconfig=sdl2-config
++			_sdlconfig=sdl-config
+ 			# OpenGL ES support is mature enough as to be the best option on
+ 			# the Raspberry Pi, so it's enabled by default.
+ 			# The Raspberry Pi always supports OpenGL ES 2.0 contexts, thus we

--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -32,23 +32,7 @@ function depends_scummvm() {
 function sources_scummvm() {
     gitPullOrClone "$md_build" https://github.com/scummvm/scummvm.git "branch-2-0"
     if isPlatform "rpi"; then
-        applyPatch rpi_enable_scalers.diff <<\_EOF_
-diff --git a/configure b/configure
-index 31dbf5a..58e9563 100755
---- a/configure
-+++ b/configure
-@@ -2651,10 +2651,6 @@ if test -n "$_host"; then
- 			append_var LDFLAGS "-L$RPI_ROOT/opt/vc/lib"
- 			# This is so optional OpenGL ES includes are found.
- 			append_var CXXFLAGS "-I$RPI_ROOT/opt/vc/include"
--			_savegame_timestamp=no
--			_eventrec=no
--			_build_scalers=no
--			_build_hq_scalers=no
- 			# We prefer SDL2 on the Raspberry Pi: acceleration now depends on it
- 			# since SDL2 manages dispmanx/GLES2 very well internally.
- 			# SDL1 is bit-rotten on this platform.
-_EOF_
+        applyPatch "$md_data/01_rpi_enable_scalers.diff"
     fi
 }
 

--- a/scriptmodules/emulators/scummvm/01_rpi_enable_scalers.diff
+++ b/scriptmodules/emulators/scummvm/01_rpi_enable_scalers.diff
@@ -1,0 +1,13 @@
+--- a/configure
++++ b/configure
+@@ -2914,10 +2914,6 @@ if test -n "$_host"; then
+ 			append_var LDFLAGS "-L$RPI_ROOT/opt/vc/lib"
+ 			# This is so optional OpenGL ES includes are found.
+ 			append_var CXXFLAGS "-I$RPI_ROOT/opt/vc/include"
+-			_savegame_timestamp=no
+-			_eventrec=no
+-			_build_scalers=no
+-			_build_hq_scalers=no
+ 			# We prefer SDL2 on the Raspberry Pi: acceleration now depends on it
+ 			# since SDL2 manages dispmanx/GLES2 very well internally.
+ 			# SDL1 is bit-rotten on this platform.

--- a/scriptmodules/emulators/uae4all.sh
+++ b/scriptmodules/emulators/uae4all.sh
@@ -26,48 +26,7 @@ function sources_uae4all() {
     downloadAndExtract "$__archive_url/guichan-0.8.2.tar.gz" "$md_build/guichan" 1
     cd guichan
     # fix from https://github.com/sphaero/guichan
-    applyPatch guichan.diff <<\_EOF_
-diff --git a/src/widget.cpp b/src/widget.cpp
-index 7dfc7e1..97978a7 100644
---- a/src/widget.cpp
-+++ b/src/widget.cpp
-@@ -598,7 +598,8 @@ namespace gcn
-     {
-         if (mFocusHandler == NULL)
-         {
--            throw GCN_EXCEPTION("No focushandler set (did you add the widget to the gui?).");
-+            return false;
-+            //throw GCN_EXCEPTION("No focushandler set (isModalFocused: did you add the widget to the gui?).");
-         }
- 
-         if (getParent() != NULL)
-@@ -614,7 +615,8 @@ namespace gcn
-     {
-         if (mFocusHandler == NULL)
-         {
--            throw GCN_EXCEPTION("No focushandler set (did you add the widget to the gui?).");
-+            return false;
-+            //throw GCN_EXCEPTION("No focushandler set (isModalMouseInputFocused: did you add the widget to the gui?).");
-         }
- 
-         if (getParent() != NULL)
-diff --git a/src/widgets/tabbedarea.cpp b/src/widgets/tabbedarea.cpp
-index e07d14c..5ed9d39 100644
---- a/src/widgets/tabbedarea.cpp
-+++ b/src/widgets/tabbedarea.cpp
-@@ -317,6 +317,10 @@ namespace gcn
- 
-     void TabbedArea::logic()
-     {
-+        for (unsigned int i = 0; i < mTabs.size(); i++)
-+        {
-+                  mTabs[i].second->logic();
-+        }
-     }
- 
-     void TabbedArea::adjustSize()
-
-_EOF_
+    applyPatch "$md_data/01_guichan.diff"
 }
 
 function build_uae4all() {

--- a/scriptmodules/emulators/uae4all/01_guichan.diff
+++ b/scriptmodules/emulators/uae4all/01_guichan.diff
@@ -1,0 +1,39 @@
+diff --git a/src/widget.cpp b/src/widget.cpp
+index 7dfc7e1..97978a7 100644
+--- a/src/widget.cpp
++++ b/src/widget.cpp
+@@ -598,7 +598,8 @@ namespace gcn
+     {
+         if (mFocusHandler == NULL)
+         {
+-            throw GCN_EXCEPTION("No focushandler set (did you add the widget to the gui?).");
++            return false;
++            //throw GCN_EXCEPTION("No focushandler set (isModalFocused: did you add the widget to the gui?).");
+         }
+ 
+         if (getParent() != NULL)
+@@ -614,7 +615,8 @@ namespace gcn
+     {
+         if (mFocusHandler == NULL)
+         {
+-            throw GCN_EXCEPTION("No focushandler set (did you add the widget to the gui?).");
++            return false;
++            //throw GCN_EXCEPTION("No focushandler set (isModalMouseInputFocused: did you add the widget to the gui?).");
+         }
+ 
+         if (getParent() != NULL)
+diff --git a/src/widgets/tabbedarea.cpp b/src/widgets/tabbedarea.cpp
+index e07d14c..5ed9d39 100644
+--- a/src/widgets/tabbedarea.cpp
++++ b/src/widgets/tabbedarea.cpp
+@@ -317,6 +317,10 @@ namespace gcn
+ 
+     void TabbedArea::logic()
+     {
++        for (unsigned int i = 0; i < mTabs.size(); i++)
++        {
++                  mTabs[i].second->logic();
++        }
+     }
+ 
+     void TabbedArea::adjustSize()

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -1147,6 +1147,7 @@ function delSystem() {
 ## @param name display name for the launch script
 ## @param cmd commandline to launch
 ## @param game rom/game parameter (optional)
+## @param script launch script to use instead of the default (optional - requires game to be set)
 ## @brief Adds a port to the emulationstation ports menu.
 ## @details Adds an emulators.cfg entry as with addSystem but also creates a launch script in `$datadir/ports/$name.sh`.
 ##
@@ -1166,6 +1167,7 @@ function addPort() {
     local file="$romdir/ports/$3.sh"
     local cmd="$4"
     local game="$5"
+    local script="$6"
 
     # move configurations from old ports location
     if [[ -d "$configdir/$port" ]]; then
@@ -1185,13 +1187,13 @@ function addPort() {
 
     mkUserDir "$romdir/ports"
 
-    if [[ -t 0 ]]; then
+    if [[ -z "$script" ]]; then
         cat >"$file" << _EOF_
 #!/bin/bash
 "$rootdir/supplementary/runcommand/runcommand.sh" 0 _PORT_ "$port" "$game"
 _EOF_
     else
-        cat >"$file"
+        cat >"$file" <<< "$script"
     fi
 
     chown $user:$user "$file"

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -908,14 +908,10 @@ function applyPatch() {
     local patch="$1"
     local patch_applied="${patch##*/}.applied"
 
-    # patch is in stdin
-    if [[ ! -t 0 ]]; then
-        cat >"$patch"
-    fi
-
     if [[ ! -f "$patch_applied" ]]; then
         if patch -f -p1 <"$patch"; then
             touch "$patch_applied"
+            printMsgs "console" "Successfully applied patch: $patch"
         else
             md_ret_errors+=("$md_id patch $patch failed to apply")
             return 1

--- a/scriptmodules/libretrocores/lr-nxengine.sh
+++ b/scriptmodules/libretrocores/lr-nxengine.sh
@@ -32,9 +32,10 @@ function install_lr-nxengine() {
 }
 
 function configure_lr-nxengine() {
+    local script
     setConfigRoot "ports"
 
-    addPort "$md_id" "cavestory" "Cave Story" "$md_inst/nxengine_libretro.so" << _EOF_
+    read -r -d "" script << _EOF_
 #!/bin/bash
 if [[ ! -f "$romdir/ports/CaveStory/Doukutsu.exe" ]]; then
     dialog --no-cancel --pause "$md_help" 22 76 15
@@ -42,6 +43,7 @@ else
     "$rootdir/supplementary/runcommand/runcommand.sh" 0 _PORT_ cavestory "$romdir/ports/CaveStory/Doukutsu.exe"
 fi
 _EOF_
+    addPort "$md_id" "cavestory" "Cave Story" "$md_inst/nxengine_libretro.so" "" "$script"
 
     ensureSystemretroconfig "ports/cavestory"
 }

--- a/scriptmodules/ports/darkplaces-quake.sh
+++ b/scriptmodules/ports/darkplaces-quake.sh
@@ -24,7 +24,7 @@ function depends_darkplaces-quake() {
 function sources_darkplaces-quake() {
     gitPullOrClone "$md_build" https://github.com/xonotic/darkplaces.git
     if isPlatform "rpi"; then
-        applyPatch "$md_data/rpi.diff"
+        applyPatch "$md_data/01_rpi_fixes.diff"
     fi
 }
 

--- a/scriptmodules/ports/darkplaces-quake/01_rpi_fixes.diff
+++ b/scriptmodules/ports/darkplaces-quake/01_rpi_fixes.diff
@@ -1,10 +1,10 @@
 diff --git a/gl_textures.c b/gl_textures.c
-index 9e76ac9..ba491dc 100644
+index c970f8c..8ca9c10 100644
 --- a/gl_textures.c
 +++ b/gl_textures.c
-@@ -14,6 +14,10 @@ extern LPDIRECT3DDEVICE9 vid_d3d9dev;
- #define GL_TEXTURE_3D				0x806F
- #endif
+@@ -5,6 +5,10 @@
+ #include "image_png.h"
+ #include "intoverflow.h"
  
 +#define GL_RGBA32F				0x8814
 +#define GL_RGBA16F				0x881A
@@ -14,10 +14,10 @@ index 9e76ac9..ba491dc 100644
  cvar_t gl_max_lightmapsize = {CVAR_SAVE, "gl_max_lightmapsize", "1024", "maximum allowed texture size for lightmap textures, use larger values to improve rendering speed, as long as there is enough video memory available (setting it too high for the hardware will cause very bad performance)"};
  cvar_t gl_picmip = {CVAR_SAVE, "gl_picmip", "0", "reduces resolution of textures by powers of 2, for example 1 will halve width/height, reducing texture memory usage by 75%"};
 diff --git a/makefile b/makefile
-index 59504d1..73b3032 100644
+index d7f3e6d..1dd84a2 100644
 --- a/makefile
 +++ b/makefile
-@@ -128,6 +128,37 @@ ifeq ($(DP_MAKE_TARGET), linux)
+@@ -108,6 +108,37 @@ ifeq ($(DP_MAKE_TARGET), linux)
  	DP_LINK_CRYPTO_RIJNDAEL?=dlopen
  endif
  
@@ -54,15 +54,15 @@ index 59504d1..73b3032 100644
 +
  # Mac OS X configuration
  ifeq ($(DP_MAKE_TARGET), macosx)
- 	DEFAULT_SNDAPI=COREAUDIO
+ 	OBJ_ICON=
 diff --git a/makefile.inc b/makefile.inc
-index 9c66ed1..03fb7c5 100644
+index 326e3a4..bc80179 100644
 --- a/makefile.inc
 +++ b/makefile.inc
-@@ -434,8 +434,8 @@ bin-debug :
+@@ -372,8 +372,8 @@ bin-debug :
  	$(MAKE) prepare BUILD_DIR=build-obj/debug/$(EXE)
  	$(MAKE) -C build-obj/debug/$(EXE) $(EXE) \
- 		DP_MAKE_TARGET=$(DP_MAKE_TARGET) DP_SOUND_API=$(DP_SOUND_API) \
+ 		DP_MAKE_TARGET=$(DP_MAKE_TARGET) \
 -		CFLAGS='$(CFLAGS_COMMON) $(CFLAGS_FEATURES) $(CFLAGS_EXTRA) $(CFLAGS_DEBUG) $(OPTIM_DEBUG)'\
 -		LDFLAGS='$(LDFLAGS_DEBUG) $(LDFLAGS_COMMON)' LEVEL=2
 +		CFLAGS+='$(CFLAGS_COMMON) $(CFLAGS_FEATURES) $(CFLAGS_EXTRA) $(CFLAGS_DEBUG) $(OPTIM_DEBUG)'\
@@ -70,10 +70,10 @@ index 9c66ed1..03fb7c5 100644
  
  bin-profile :
  	$(CHECKLEVEL1)
-@@ -444,8 +444,8 @@ bin-profile :
+@@ -382,8 +382,8 @@ bin-profile :
  	$(MAKE) prepare BUILD_DIR=build-obj/profile/$(EXE)
  	$(MAKE) -C build-obj/profile/$(EXE) $(EXE) \
- 		DP_MAKE_TARGET=$(DP_MAKE_TARGET) DP_SOUND_API=$(DP_SOUND_API) \
+ 		DP_MAKE_TARGET=$(DP_MAKE_TARGET) \
 -		CFLAGS='$(CFLAGS_COMMON) $(CFLAGS_FEATURES) $(CFLAGS_EXTRA) $(CFLAGS_PROFILE) $(OPTIM_RELEASE)'\
 -		LDFLAGS='$(LDFLAGS_PROFILE) $(LDFLAGS_COMMON)' LEVEL=2
 +		CFLAGS+='$(CFLAGS_COMMON) $(CFLAGS_FEATURES) $(CFLAGS_EXTRA) $(CFLAGS_PROFILE) $(OPTIM_RELEASE)'\
@@ -81,10 +81,10 @@ index 9c66ed1..03fb7c5 100644
  
  bin-release :
  	$(CHECKLEVEL1)
-@@ -454,8 +454,8 @@ bin-release :
+@@ -392,8 +392,8 @@ bin-release :
  	$(MAKE) prepare BUILD_DIR=build-obj/release/$(EXE)
  	$(MAKE) -C build-obj/release/$(EXE) $(EXE) \
- 		DP_MAKE_TARGET=$(DP_MAKE_TARGET) DP_SOUND_API=$(DP_SOUND_API) \
+ 		DP_MAKE_TARGET=$(DP_MAKE_TARGET) \
 -		CFLAGS='$(CFLAGS_COMMON) $(CFLAGS_FEATURES) $(CFLAGS_EXTRA) $(CFLAGS_RELEASE) $(OPTIM_RELEASE)'\
 -		LDFLAGS='$(LDFLAGS_RELEASE) $(LDFLAGS_COMMON)' LEVEL=2
 +		CFLAGS+='$(CFLAGS_COMMON) $(CFLAGS_FEATURES) $(CFLAGS_EXTRA) $(CFLAGS_RELEASE) $(OPTIM_RELEASE)'\
@@ -92,10 +92,10 @@ index 9c66ed1..03fb7c5 100644
  	$(STRIP) $(EXE)
  
  bin-release-profile :
-@@ -465,8 +465,8 @@ bin-release-profile :
+@@ -403,8 +403,8 @@ bin-release-profile :
  	$(MAKE) prepare BUILD_DIR=build-obj/release-profile/$(EXE)
  	$(MAKE) -C build-obj/release-profile/$(EXE) $(EXE) \
- 		DP_MAKE_TARGET=$(DP_MAKE_TARGET) DP_SOUND_API=$(DP_SOUND_API) \
+ 		DP_MAKE_TARGET=$(DP_MAKE_TARGET) \
 -		CFLAGS='$(CFLAGS_COMMON) $(CFLAGS_FEATURES) $(CFLAGS_EXTRA) $(CFLAGS_RELEASE_PROFILE) $(OPTIM_RELEASE)'\
 -		LDFLAGS='$(LDFLAGS_RELEASE) $(LDFLAGS_COMMON)' LEVEL=2
 +		CFLAGS+='$(CFLAGS_COMMON) $(CFLAGS_FEATURES) $(CFLAGS_EXTRA) $(CFLAGS_RELEASE_PROFILE) $(OPTIM_RELEASE)'\

--- a/scriptmodules/supplementary/xpad.sh
+++ b/scriptmodules/supplementary/xpad.sh
@@ -28,37 +28,7 @@ function sources_xpad() {
     gitPullOrClone "$md_inst" https://github.com/paroj/xpad.git
     cd "$md_inst"
     # LED support (as disabled currently in packaged RPI kernel) and allow forcing MAP_TRIGGERS_TO_BUTTONS
-    applyPatch "retropie.diff" <<\_EOF_
-diff --git a/xpad.c b/xpad.c
-index e0de997..eba3a5c 100644
---- a/xpad.c
-+++ b/xpad.c
-@@ -86,6 +86,8 @@
- 
- #define XPAD_PKT_LEN 64
- 
-+#define CONFIG_JOYSTICK_XPAD_LEDS 1
-+
- /*
-  * xbox d-pads should map to buttons, as is required for DDR pads
-  * but we map them to axes when possible to simplify things
-@@ -1779,12 +1781,13 @@ static int xpad_probe(struct usb_interface *intf, const struct usb_device_id *id
- 
- 		if (dpad_to_buttons)
- 			xpad->mapping |= MAP_DPAD_TO_BUTTONS;
--		if (triggers_to_buttons)
--			xpad->mapping |= MAP_TRIGGERS_TO_BUTTONS;
- 		if (sticks_to_null)
- 			xpad->mapping |= MAP_STICKS_TO_NULL;
- 	}
- 
-+	if (triggers_to_buttons)
-+		xpad->mapping |= MAP_TRIGGERS_TO_BUTTONS;
-+
- 	if (xpad->xtype == XTYPE_XBOXONE &&
- 	    intf->cur_altsetting->desc.bInterfaceNumber != 0) {
- 		/*
-_EOF_
+    applyPatch "$md_data/01_enable_leds_and_trigmapping.diff"
 }
 
 function build_xpad() {

--- a/scriptmodules/supplementary/xpad/01_enable_leds_and_trigmapping.diff
+++ b/scriptmodules/supplementary/xpad/01_enable_leds_and_trigmapping.diff
@@ -1,0 +1,27 @@
+--- a/xpad.c	2018-08-22 14:49:37.237360461 +0000
++++ b/xpad.c	2018-08-22 14:49:37.293357132 +0000
+@@ -86,6 +86,8 @@
+ 
+ #define XPAD_PKT_LEN 64
+ 
++#define CONFIG_JOYSTICK_XPAD_LEDS 1
++
+ /*
+  * xbox d-pads should map to buttons, as is required for DDR pads
+  * but we map them to axes when possible to simplify things
+@@ -1782,12 +1784,13 @@
+ 
+ 		if (dpad_to_buttons)
+ 			xpad->mapping |= MAP_DPAD_TO_BUTTONS;
+-		if (triggers_to_buttons)
+-			xpad->mapping |= MAP_TRIGGERS_TO_BUTTONS;
+ 		if (sticks_to_null)
+ 			xpad->mapping |= MAP_STICKS_TO_NULL;
+ 	}
+ 
++	if (triggers_to_buttons)
++		xpad->mapping |= MAP_TRIGGERS_TO_BUTTONS;
++
+ 	if (xpad->xtype == XTYPE_XBOXONE &&
+ 	    intf->cur_altsetting->desc.bInterfaceNumber != 0) {
+ 		/*


### PR DESCRIPTION
As discussed in #2467, deprecate stdin usage in `applyPatch` / `addPort`.
This is a somewhat big PR, so I will summarise the commits here:

* a367202 and 9534c17 remove stdin functionality from `applyPatch` and `addPort`.
* 67cdb4f to a89c3f5 moves and rebases the in-line patches into files for affected modules.
* 4c3146c updates the only module using stdin with `addPort` to use new approach.

In the case of `applyPatch`, I did the following:

* Tested patching in every affected module and in every supported platform (see below).
* Rebased the patches so they apply cleanly into current source code. Some patches didn't even apply anymore due to being outdated, this is now fixed too.

In the case of `addPort`, I did the following:

* Changed the signature of the function to accept a custom script as a parameter instead of stdin.
* Checked and updated the only module using addPort with stdin and updated to new signature.
* Tested all modules using `addPort` and verify they are still creating launch scripts properly.

Because the change in `applyPatch` is sensitive, I wrote the following test and verified that there were no errors and all patches are applied cleanly:
```sh
#!/usr/bin/env bash

PLATFORMS=(
  rpi1 rpi2 rpi3
  odroid-c1 odroid-c2 odroid-xu
  tinker
  x86 generic-x11
  armv7-mali
  imx6
  vero4k
)

PACKAGES=(
  atari800 darkplaces-quake fuse
  mupen64plus scummvm scummvm-sdl1
  uae4all xpad
)

for platform in "${PLATFORMS[@]}"; do
  for package in "${PACKAGES[@]}"; do
    printf "Package '$package' in platform '$platform' ...\n\n"
    __platform=$platform ./retropie_packages.sh "$package" clean
    __platform=$platform ./retropie_packages.sh "$package" sources
    printf "\n"
  done
done
```

Take your time to review this PR and let me know if I'm missing something. I'm happy to help.
