### PR TITLE
Solarus update to 1.5.3

### DIFF
--- a/scriptmodules/ports/solarus.sh
+++ b/scriptmodules/ports/solarus.sh
@@ -16,14 +16,14 @@ rp_module_section="opt"
 rp_module_flags="noinstclean !aarch64"
 
 function depends_solarus() {
-    getDepends cmake libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libluajit-5.1-dev libphysfs-dev libopenal-dev libmodplug-dev libvorbis-dev zip unzip
+    getDepends cmake libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libluajit-5.1-dev libphysfs-dev libopenal-dev libmodplug-dev libvorbis-dev zip unzip qtbase5-dev qttools5-dev-tools
 }
 
 function sources_solarus() {
-    downloadAndExtract "http://www.solarus-games.org/downloads/solarus/solarus-1.4.5-src.tar.gz" "$md_build" 1
-    downloadAndExtract "http://www.zelda-solarus.com/downloads/zsdx/zsdx-1.10.3.tar.gz" "$md_build"
-    downloadAndExtract "http://www.zelda-solarus.com/downloads/zsxd/zsxd-1.10.3.tar.gz" "$md_build"
-    downloadAndExtract "http://www.zelda-solarus.com/downloads/zelda-roth-se/zelda-roth-se-1.0.8.tar.gz" "$md_build"
+    downloadAndExtract "http://www.solarus-games.org/downloads/solarus/solarus-1.5.3-src.tar.gz" "$md_build" 1
+    downloadAndExtract "http://www.zelda-solarus.com/downloads/zsdx/zsdx-1.11.0.tar.gz" "$md_build"
+    downloadAndExtract "http://www.zelda-solarus.com/downloads/zsxd/zsxd-1.11.0.tar.gz" "$md_build"
+downloadAndExtract "http://www.zelda-solarus.com/downloads/zelda-roth-se/zelda-roth-se-1.1.0.tar.gz" "$md_build"
 }
 
 function build_solarus() {
@@ -31,41 +31,42 @@ function build_solarus() {
     cd build
     cmake .. -DCMAKE_INSTALL_PREFIX="$md_inst"
     make
-    cd ../zsdx-1.10.3
+    cd ../zsdx-1.11.0
     cmake . -DCMAKE_INSTALL_PREFIX="$md_inst"
     make
-    cd ../zsxd-1.10.3
+    cd ../zsxd-1.11.0
     cmake . -DCMAKE_INSTALL_PREFIX="$md_inst"
     make
-    cd ../zelda-roth-se-1.0.8
+    cd ../zelda-roth-se-1.1.0
     cmake . -DCMAKE_INSTALL_PREFIX="$md_inst"
     make
     md_ret_require=(
-        "$md_build/build/solarus_run"
-        "$md_build/zsdx-1.10.3/data.solarus"
-        "$md_build/zsxd-1.10.3/data.solarus"
-        "$md_build/zelda-roth-se-1.0.8/data.solarus"
+        "$md_build/build/solarus-run"
+        "$md_build/zsdx-1.11.0/data.solarus"
+        "$md_build/zsxd-1.11.0/data.solarus"
+        "$md_build/zelda-roth-se-1.1.0/data.solarus"
     )
 }
 
 function install_solarus() {
     cd build
     make install
-    cd ../zsdx-1.10.3/
+    cd ../zsdx-1.11.0/
     make install
-    cd ../zsxd-1.10.3/
+    cd ../zsxd-1.11.0/
     make install
-    cd ../zelda-roth-se-1.0.8/
+    cd ../zelda-roth-se-1.1.0/
     make install
 }
 
 function configure_solarus() {
-    addPort "$md_id" "zsdx" "Solarus Engine - Zelda Mystery of Solarus DX" "LD_LIBRARY_PATH=$md_inst/lib $md_inst/bin/solarus_run $md_inst/share/solarus/zsdx/"
-    addPort "$md_id" "zsxd" "Solarus Engine - Zelda Mystery of Solarus XD" "LD_LIBRARY_PATH=$md_inst/lib $md_inst/bin/solarus_run $md_inst/share/solarus/zsxd/"
-    addPort "$md_id" "zelda_roth_se" "Solarus Engine - Zelda Return of the Hylian SE" "LD_LIBRARY_PATH=$md_inst/lib $md_inst/bin/solarus_run $md_inst/share/solarus/zelda_roth_se/"
+    addPort "$md_id" "zsdx" "Solarus Engine - Zelda Mystery of Solarus DX" "LD_LIBRARY_PATH=$md_inst/lib $md_inst/bin/solarus-run $md_inst/share/solarus/zsdx/"
+    addPort "$md_id" "zsxd" "Solarus Engine - Zelda Mystery of Solarus XD" "LD_LIBRARY_PATH=$md_inst/lib $md_inst/bin/solarus-run $md_inst/share/solarus/zsxd/"
+    addPort "$md_id" "zelda_roth_se" "Solarus Engine - Zelda Return of the Hylian SE" "LD_LIBRARY_PATH=$md_inst/lib $md_inst/bin/solarus-run $md_inst/share/solarus/zelda_roth_se/"
 
     # symlink the library so it can be found on all platforms
     ln -sf "$md_inst"/lib/*/libsolarus.so "$md_inst/lib"
+    ln -sf "$md_inst"/lib/*/libsolarus.so.1 "$md_inst/lib"
 
     moveConfigDir "$home/.solarus" "$md_conf_root/solarus"
 


### PR DESCRIPTION
Updated Solarus and games to 1.5.3

Besides updating sources, qtbase5-dev and qttools5-dev-tools were added as dependencies, probably used by Solarus's GUI launcher.

A syslink was also added to link libsolarus.so.1 to solarus/lib/