### PR TITLE
Fix lr-parallel-n64 build from source on tinker platform

### DIFF
--- a/scriptmodules/libretrocores/lr-parallel-n64.sh
+++ b/scriptmodules/libretrocores/lr-parallel-n64.sh
@@ -35,10 +35,9 @@ function build_lr-parallel-n64() {
     if isPlatform "rpi" || isPlatform "odroid-c1"; then
         params+=(platform="$__platform")
     elif isPlatform "tinker"; then
-        params+=(platform="kms")
-        params+=("CPUFLAGS=-DNO_ASM -DARM -D__arm__ -DARM_ASM -D__NEON_OPT -DNOSSE")
-        params+=("GLES=1 HAVE_NEON=1 WITH_DYNAREC=arm")
-        params+=("GL_LIB:=-lGLESv2")
+        params+=(CPUFLAGS="-DNO_ASM -DARM -D__arm__ -DARM_ASM -D__NEON_OPT -DNOSSE")
+        params+=(GLES=1 HAVE_NEON=1 WITH_DYNAREC=arm)
+        params+=(GL_LIB:=-lGLESv2)
     fi
     make "${params[@]}"
     rpSwap off


### PR DESCRIPTION
Hi, I wanted to test the lr-parallel-n64 core on my TinkerBoard (with Armbian 5.59, kern 4.14) but was unable to get it to build.  I was able to build it with these changes.

When building with platform="kms" the makefile exits immediately. 

I'm guessing eventually the lr-parallel-n64 Makefile will understand "kms" ?

The arguments inside the params array also need their quoting fixed, so that the variables in the makefile get set correctly when the array is expanded.



