### PR TITLE
Added lr-x1 - X Millenium/Sharp X1 libretro core

### DIFF
--- a/scriptmodules/libretrocores/lr-x1.sh
+++ b/scriptmodules/libretrocores/lr-x1.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-x1"
+rp_module_desc="Sharp X1 emulator - X Millenium port for libretro"
+rp_module_help="ROM Extensions: .dx1 .zip .2d .2hd .tfd .d88 .88d .hdm .xdf .dup .cmd\n\nCopy your X1 roms to $romdir/x1\n\nCopy the required BIOS files IPLROM.X1 and IPLROM.X1T to $biosdir"
+rp_module_section="exp"
+
+function sources_lr-x1() {
+    gitPullOrClone "$md_build" https://github.com/r-type/xmil-libretro.git
+}
+
+function build_lr-x1() {
+    cd libretro
+    make clean
+    make
+    md_ret_require="$md_build/libretro/x1_libretro.so"
+}
+
+function install_lr-x1() {
+    md_ret_files=(
+        'libretro/x1_libretro.so'
+    )
+}
+
+function configure_lr-x1() {
+    mkRomDir "x1"
+    ensureSystemretroconfig "x1"
+
+    addEmulator 1 "$md_id" "x1" "$md_inst/x1_libretro.so"
+    addSystem "x1"
+}


### PR DESCRIPTION
Yet another obscure Japanese home computer!  This one requires two BIOS files in `/home/pi/RetroPie/BIOS/xmil`, named IPLROM.X1 [CRC32 7B28D9DE] and IPLROM.X1T [CRC32 2E8B767C].  Tested and works on a Raspberry Pi 3B without overclocking.

Since the makefile is within the `libretro` folder, rather than at the root of the source files, I added `/libretro/` wherever needed.  Little bit hacky, but it works well enough and doesn't seem to cause any issues [I'm not sure if this is the preferred way to handle this however].