### PR TITLE
Dolphin libretro core is missing sources

### DIFF
--- a/scriptmodules/libretrocores/lr-dolphin.sh
+++ b/scriptmodules/libretrocores/lr-dolphin.sh
@@ -18,6 +18,7 @@ rp_module_flags="!arm !aarch64"
 
 function sources_lr-dolphin() {
     depends_dolphin
+    gitPullOrClone "$md_build" https://github.com/libretro/dolphin
 }
 
 function build_lr-dolphin() {


### PR DESCRIPTION
Small fix to actually pull the Dolphin core sources before building them.