### PR TITLE
Allow `lr-mess` to finish building on the Raspberry Pi

### DIFF
--- a/scriptmodules/libretrocores/lr-mess.sh
+++ b/scriptmodules/libretrocores/lr-mess.sh
@@ -24,7 +24,7 @@ function sources_lr-mess() {
 }
 
 function build_lr-mess() {
-    rpSwap on 1400
+    rpSwap on 2000
     local params=($(_get_params_lr-mame) SUBTARGET=mess)
     make clean
     make "${params[@]}"


### PR DESCRIPTION
Based on the discussion in https://retropie.org.uk/forum/topic/18126/lr-mess-and-lr-mess2016-not-compiling/19.

* increase the total memory allocated to 2Gb
* limit the compilation to 2 processes, in the memory critical sections the system is just swapping anyway.