### PR TITLE
KDE Neon is now based on Ubuntu 18.04 LTS.

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -154,7 +154,12 @@ function get_os_version() {
             __os_debian_ver="8"
             ;;
         neon)
-             __os_ubuntu_ver="$__os_release"
+            __os_ubuntu_ver="$__os_release"
+            if compareVersions "$__os_release" lt 16.10; then
+                __os_debian_ver="8"
+            else
+                __os_debian_ver="9"
+            fi
             ;;
         *)
             error="Unsupported OS"


### PR DESCRIPTION
We need to set `__os_debian_ver="9"` as KDE Neon is now based on Ubuntu 18.04
LTS and we need the little libpng-dev trick.
Old KDE Neon use Ubuntu 16.04 LTS.