### PR TITLE
Fix lr-fbalpha build on unrecognized neon platforms

### DIFF
--- a/scriptmodules/libretrocores/lr-fbalpha.sh
+++ b/scriptmodules/libretrocores/lr-fbalpha.sh
@@ -26,7 +26,11 @@ function sources_lr-fbalpha() {
 
 function build_lr-fbalpha() {
     make -f makefile.libretro clean
-    make -f makefile.libretro
+    if isPlatform "neon"; then
+        make -f makefile.libretro HAVE_NEON=1
+    else
+        make -f makefile.libretro
+    fi
     md_ret_require="$md_build/fbalpha_libretro.so"
 }
 


### PR DESCRIPTION
Fix for neon platforms not recognized by lr-fbalpha makefile.

See Issue: https://github.com/libretro/fbalpha/issues/249