### PR TITLE
retroarch - refresh patches

### DIFF
--- a/scriptmodules/emulators/retroarch/01_hotkey_hack.diff
+++ b/scriptmodules/emulators/retroarch/01_hotkey_hack.diff
@@ -1,8 +1,8 @@
 diff --git a/input/input_driver.c b/input/input_driver.c
-index 3d5ee6ca73..c9b58a6f1f 100644
+index f49fd82..d13ba8e 100644
 --- a/input/input_driver.c
 +++ b/input/input_driver.c
-@@ -380,6 +380,10 @@ static unsigned input_driver_max_users            = 0;
+@@ -413,6 +413,10 @@ static unsigned input_driver_max_users            = 0;
  static const void *hid_data                       = NULL;
  #endif
  
@@ -13,7 +13,7 @@ index 3d5ee6ca73..c9b58a6f1f 100644
  /**
   * check_input_driver_block_hotkey:
   *
-@@ -1057,9 +1061,16 @@ void input_keys_pressed(void *data, retro_bits_t* p_new_state)
+@@ -1118,9 +1122,16 @@ void input_keys_pressed(void *data, input_bits_t *p_new_state)
              && current_input->input_state(
                 current_input_data, joypad_info, &binds, 0,
                 RETRO_DEVICE_JOYPAD, 0, RARCH_ENABLE_HOTKEY))
@@ -32,4 +32,4 @@ index 3d5ee6ca73..c9b58a6f1f 100644
 +      }
     }
  
-    game_focus_toggle_valid                      = binds[RARCH_GAME_FOCUS_TOGGLE].valid;
+    if (binds[RARCH_GAME_FOCUS_TOGGLE].valid)

--- a/scriptmodules/emulators/retroarch/02_disable_search.diff
+++ b/scriptmodules/emulators/retroarch/02_disable_search.diff
@@ -1,8 +1,8 @@
 diff --git a/menu/widgets/menu_entry.c b/menu/widgets/menu_entry.c
-index ea5be0c4cc..846f662c8f 100644
+index a5e83ab..ade921b 100644
 --- a/menu/widgets/menu_entry.c
 +++ b/menu/widgets/menu_entry.c
-@@ -474,7 +474,7 @@ int menu_entry_action(menu_entry_t *entry, unsigned i, enum menu_action action)
+@@ -476,7 +476,7 @@ int menu_entry_action(menu_entry_t *entry, unsigned i, enum menu_action action)
                    entry->label, entry->type, i);
           break;
        case MENU_ACTION_SEARCH:


### PR DESCRIPTION
The following patches for `retroarch` needed a rebase after the recent update to `v1.7.5`:

* `01_hotkey_hack.diff`
* `02_disable_search.diff`

This PR refreshes them so they apply cleanly when compiling from source.