### PR TITLE
update Devuan versions in build scripts

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -109,6 +109,15 @@ function get_os_version() {
                 jessie)
                     __os_debian_ver="8"
                     ;;
+                ascii)
+                    __os_debian_ver="9"
+                    ;;
+                beowolf)
+                    __os_debian_ver="10"
+                    ;;
+                ceres)
+                    __os_debian_ver="11"
+                    ;;
             esac
             ;;
         LinuxMint)


### PR DESCRIPTION
added `os_codename` versions for Devuan; ASCII, Beowolf, and Ceres