### PR TITLE
switch to newer package name libpng-dev over libpng12-dev for dependencies

### DIFF
--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -17,7 +17,7 @@ rp_module_section="opt"
 rp_module_flags="!x86"
 
 function depends_amiberry() {
-    local depends=(libpng12-dev libmpeg2-4-dev zlib1g-dev)
+    local depends=(libpng-dev libmpeg2-4-dev zlib1g-dev)
     if ! isPlatform "rpi" || isPlatform "kms" || isPlatform "vero4k"; then
         depends+=(libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev)
     fi

--- a/scriptmodules/emulators/atari800.sh
+++ b/scriptmodules/emulators/atari800.sh
@@ -17,7 +17,7 @@ rp_module_section="opt"
 rp_module_flags="!mali !kms"
 
 function depends_atari800() {
-    local depends=(libsdl1.2-dev autoconf zlib1g-dev libpng12-dev)
+    local depends=(libsdl1.2-dev autoconf zlib1g-dev libpng-dev)
     isPlatform "rpi" && depends+=(libraspberrypi-dev)
     getDepends "${depends[@]}"
 }

--- a/scriptmodules/emulators/capricerpi.sh
+++ b/scriptmodules/emulators/capricerpi.sh
@@ -17,7 +17,7 @@ rp_module_section="opt"
 rp_module_flags="dispmanx !x86 !mali !kms"
 
 function depends_capricerpi() {
-    getDepends libsdl1.2-dev libsdl-image1.2-dev libsdl-ttf2.0-dev zlib1g-dev libpng12-dev
+    getDepends libsdl1.2-dev libsdl-image1.2-dev libsdl-ttf2.0-dev zlib1g-dev libpng-dev
 }
 
 function sources_capricerpi() {

--- a/scriptmodules/emulators/dosbox.sh
+++ b/scriptmodules/emulators/dosbox.sh
@@ -17,7 +17,7 @@ rp_module_section="opt"
 rp_module_flags="dispmanx !mali !kms"
 
 function depends_dosbox() {
-    local depends=(libsdl1.2-dev libsdl-net1.2-dev libsdl-sound1.2-dev libasound2-dev libpng12-dev automake autoconf zlib1g-dev subversion "$@")
+    local depends=(libsdl1.2-dev libsdl-net1.2-dev libsdl-sound1.2-dev libasound2-dev libpng-dev automake autoconf zlib1g-dev subversion "$@")
     isPlatform "rpi" && depends+=(timidity freepats)
     getDepends "${depends[@]}"
 }

--- a/scriptmodules/emulators/fuse.sh
+++ b/scriptmodules/emulators/fuse.sh
@@ -17,7 +17,7 @@ rp_module_section="opt"
 rp_module_flags="dispmanx !mali"
 
 function depends_fuse() {
-    getDepends libsdl1.2-dev libpng12-dev zlib1g-dev libbz2-dev libaudiofile-dev bison flex
+    getDepends libsdl1.2-dev libpng-dev zlib1g-dev libbz2-dev libaudiofile-dev bison flex
 }
 
 function sources_fuse() {

--- a/scriptmodules/emulators/hatari.sh
+++ b/scriptmodules/emulators/hatari.sh
@@ -17,7 +17,7 @@ rp_module_section="opt"
 rp_module_flags=""
 
 function depends_hatari() {
-    getDepends libsdl2-dev zlib1g-dev libpng12-dev cmake libreadline-dev portaudio19-dev
+    getDepends libsdl2-dev zlib1g-dev libpng-dev cmake libreadline-dev portaudio19-dev
 }
 
 function _sources_libcapsimage_hatari() {

--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -17,7 +17,7 @@ rp_module_section="main"
 rp_module_flags="!mali !kms"
 
 function depends_mupen64plus() {
-    local depends=(cmake libsamplerate0-dev libspeexdsp-dev libsdl2-dev libpng12-dev fonts-freefont-ttf)
+    local depends=(cmake libsamplerate0-dev libspeexdsp-dev libsdl2-dev libpng-dev fonts-freefont-ttf)
     isPlatform "rpi" && depends+=(libraspberrypi-bin libraspberrypi-dev)
     isPlatform "x11" && depends+=(libglew-dev libglu1-mesa-dev libboost-filesystem-dev)
     isPlatform "x86" && depends+=(nasm)

--- a/scriptmodules/emulators/pcsx-rearmed.sh
+++ b/scriptmodules/emulators/pcsx-rearmed.sh
@@ -17,7 +17,7 @@ rp_module_section="opt"
 rp_module_flags="dispmanx !x86 !mali !kms"
 
 function depends_pcsx-rearmed() {
-    getDepends libsdl1.2-dev libasound2-dev libpng12-dev libx11-dev
+    getDepends libsdl1.2-dev libasound2-dev libpng-dev libx11-dev
 }
 
 function sources_pcsx-rearmed() {

--- a/scriptmodules/emulators/residualvm.sh
+++ b/scriptmodules/emulators/residualvm.sh
@@ -19,7 +19,7 @@ rp_module_flags="dispmanx !mali !kms"
 function depends_residualvm() {
     local depends=(
         libsdl2-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev
-        libpng12-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev
+        libpng-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev
         zlib1g-dev libjpeg-dev
     )
     isPlatform "x11" && depends+=(libglew-dev)

--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -17,7 +17,7 @@ rp_module_section="opt"
 rp_module_flags=""
 
 function depends_scummvm() {
-    local depends=(libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng12-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev libjpeg-dev)
+    local depends=(libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev libjpeg-dev)
     if isPlatform "vero4k"; then
         depends+=(vero3-userland-dev-osmc)
     fi

--- a/scriptmodules/emulators/stella.sh
+++ b/scriptmodules/emulators/stella.sh
@@ -17,7 +17,7 @@ rp_module_section="opt"
 rp_module_flags=""
 
 function depends_stella() {
-    getDepends libsdl2-dev libpng12-dev zlib1g-dev xz-utils
+    getDepends libsdl2-dev libpng-dev zlib1g-dev xz-utils
 }
 
 function sources_stella() {

--- a/scriptmodules/emulators/stratagus.sh
+++ b/scriptmodules/emulators/stratagus.sh
@@ -17,7 +17,7 @@ rp_module_section="opt"
 rp_module_flags="!mali !kms"
 
 function depends_stratagus() {
-    getDepends libsdl1.2-dev libbz2-dev libogg-dev libvorbis-dev libtheora-dev libpng12-dev liblua5.1-0-dev libtolua++5.1-dev libfluidsynth-dev libmikmod-dev
+    getDepends libsdl1.2-dev libbz2-dev libogg-dev libvorbis-dev libtheora-dev libpng-dev liblua5.1-0-dev libtolua++5.1-dev libfluidsynth-dev libmikmod-dev
 }
 
 function sources_stratagus() {

--- a/scriptmodules/emulators/vice.sh
+++ b/scriptmodules/emulators/vice.sh
@@ -17,7 +17,7 @@ rp_module_section="opt"
 rp_module_flags=""
 
 function depends_vice() {
-    local depends=(libsdl2-dev libmpg123-dev libpng12-dev zlib1g-dev libasound2-dev libvorbis-dev libflac-dev libpcap-dev automake checkinstall bison flex subversion libjpeg-dev portaudio19-dev texinfo xa65)
+    local depends=(libsdl2-dev libmpg123-dev libpng-dev zlib1g-dev libasound2-dev libvorbis-dev libflac-dev libpcap-dev automake checkinstall bison flex subversion libjpeg-dev portaudio19-dev texinfo xa65)
     isPlatform "x11" && depends+=(libpulse-dev)
     getDepends "${depends[@]}"
 }

--- a/scriptmodules/emulators/xm7.sh
+++ b/scriptmodules/emulators/xm7.sh
@@ -17,7 +17,7 @@ rp_module_section="exp"
 rp_module_flags="dispmanx !mali !kms"
 
 function depends_xm7() {
-    getDepends libjpeg-dev libsdl1.2-dev libsdl-mixer1.2-dev libtool libpng12-dev libuim-dev libfreetype6-dev libfontconfig1-dev gawk fonts-takao libxinerama-dev libx11-dev imagemagick
+    getDepends libjpeg-dev libsdl1.2-dev libsdl-mixer1.2-dev libtool libpng-dev libuim-dev libfreetype6-dev libfontconfig1-dev gawk fonts-takao libxinerama-dev libx11-dev imagemagick
 }
 
 function sources_xm7() {

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -213,9 +213,15 @@ function getDepends() {
             isPlatform "xbian" && required="xbian-package-firmware"
         fi
 
-        # map libpng12-dev to libpng-dev for Ubuntu 16.10+
+        # map libpng12-dev to libpng-dev for Stretch+
         if [[ "$required" == "libpng12-dev" ]] && compareVersions "$__os_debian_ver" ge 9;  then
             required="libpng-dev"
+            printMsgs "console" "RetroPie module references libpng12-dev and should be changed to libpng-dev"
+        fi
+
+        # map libpng-dev to libpng12-dev for Jessie
+        if [[ "$required" == "libpng-dev" ]] && compareVersions "$__os_debian_ver" lt 9; then
+            required="libpng12-dev"
         fi
 
         if [[ "$md_mode" == "install" ]]; then

--- a/scriptmodules/libretrocores/lr-mupen64plus.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus.sh
@@ -30,7 +30,7 @@ function _update_hook_lr-mupen64plus() {
 }
 
 function depends_lr-mupen64plus() {
-    local depends=(flex bison libpng12-dev)
+    local depends=(flex bison libpng-dev)
     isPlatform "x11" && depends+=(libglew-dev libglu1-mesa-dev)
     isPlatform "x86" && depends+=(nasm)
     isPlatform "rpi" && depends+=(libraspberrypi-dev)

--- a/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
+++ b/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
@@ -16,7 +16,7 @@ rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/pcsx_rearmed/
 rp_module_section="main"
 
 function depends_lr-pcsx-rearmed() {
-    local depends=(libpng12-dev)
+    local depends=(libpng-dev)
     isPlatform "x11" && depends+=(libx11-dev)
     getDepends "${depends[@]}"
 }

--- a/scriptmodules/ports/eduke32.sh
+++ b/scriptmodules/ports/eduke32.sh
@@ -16,7 +16,7 @@ rp_module_section="opt"
 
 function depends_eduke32() {
     local depends=(
-        subversion flac libflac-dev libvorbis-dev libpng12-dev libvpx-dev freepats
+        subversion flac libflac-dev libvorbis-dev libpng-dev libvpx-dev freepats
         libsdl2-dev libsdl2-mixer-dev
     )
 

--- a/scriptmodules/ports/gemrb.sh
+++ b/scriptmodules/ports/gemrb.sh
@@ -15,7 +15,7 @@ rp_module_licence="GPL2 https://raw.githubusercontent.com/gemrb/gemrb/master/COP
 rp_module_section="exp"
 
 function depends_gemrb() {
-    getDepends python-dev libopenal-dev libsdl1.2-dev cmake libpng12-dev libfreetype6-dev
+    getDepends python-dev libopenal-dev libsdl1.2-dev cmake libpng-dev libfreetype6-dev
 }
 
 function sources_gemrb() {

--- a/scriptmodules/ports/openbor.sh
+++ b/scriptmodules/ports/openbor.sh
@@ -17,7 +17,7 @@ rp_module_section="exp"
 rp_module_flags="!mali !x11 !kms"
 
 function depends_openbor() {
-    getDepends libsdl1.2-dev libsdl-gfx1.2-dev libogg-dev libvorbisidec-dev libvorbis-dev libpng12-dev zlib1g-dev
+    getDepends libsdl1.2-dev libsdl-gfx1.2-dev libogg-dev libvorbisidec-dev libvorbis-dev libpng-dev zlib1g-dev
 }
 
 function sources_openbor() {


### PR DESCRIPTION
 * allow modules to still use libpng12-dev but show a message for them to be updated
 * change libpng-dev dependency to libpng12-dev for Jessie and older

@zerojay - if any modules in your extras repo use libpng12-dev they should be updated to libpng-dev after this PR is accepted although they will still work but will throw a warning on install.