### PR TITLE
lr-nestopia - change ownership of installed database to $user:$user

### DIFF
--- a/scriptmodules/libretrocores/lr-nestopia.sh
+++ b/scriptmodules/libretrocores/lr-nestopia.sh
@@ -47,6 +47,7 @@ function configure_lr-nestopia() {
     ensureSystemretroconfig "fds"
 
     cp NstDatabase.xml "$biosdir/"
+    chown $user:$user "$biosdir/NstDatabase.xml"
 
     addEmulator 0 "$md_id" "nes" "$md_inst/nestopia_libretro.so"
     addEmulator 1 "$md_id" "fds" "$md_inst/nestopia_libretro.so"


### PR DESCRIPTION
I just found out that the `lr-nestopia` scriptmodule installs the Nestopia database file without changing the ownership back to the running user:

    pi@retropie:~$ ls -la ~/RetroPie/BIOS/NstDatabase.xml
    -rw-r--r-- 1 root root 1009534 Oct 19 17:53 /home/pi/RetroPie/BIOS/NstDatabase.xml

I adopted the approach of running `chown` from other scriptmodules in this PR, and now the file is installed properly:

    pi@retropie:~$ ls -la ~/RetroPie/BIOS/NstDatabase.xml
    -rw-r--r-- 1 pi pi 1009534 Oct 19 19:07 /home/pi/RetroPie/BIOS/NstDatabase.xml
