### PR TITLE
usbromservice - small fix in update hook and improve remove function

### DIFF
--- a/scriptmodules/supplementary/usbromservice.sh
+++ b/scriptmodules/supplementary/usbromservice.sh
@@ -18,6 +18,7 @@ function _get_ver_usbromservice() {
 }
 
 function _update_hook_usbromservice() {
+    [[ ! -f "$md_inst/installed" ]] && return
     [[ ! -f "$md_inst/disabled" ]] && install_scripts_usbromservice
 }
 
@@ -67,6 +68,7 @@ function disable_usbromservice() {
 
 function remove_usbromservice() {
     disable_usbromservice
+    rm -f "$md_inst/installed"
     apt-get remove -y usbmount
 }
 


### PR DESCRIPTION
**PR summary:** do not run update hook if not installed and clean installed flag file on remove

I observed the following error during updates when you don't have the `usbromservice` installed:
```
= = = = = = = = = = = = = = = = = = = = =
Running post update hooks
= = = = = = = = = = = = = = = = = = = = =

/home/hughro/RetroPie-Setup/scriptmodules/supplementary/usbromservice.sh: line 49: /etc/usbmount/mount.d/01_retropie_copyroms: No such file or directory
chmod: cannot access '/etc/usbmount/mount.d/01_retropie_copyroms': No such file or directory
/home/hughro/RetroPie-Setup/scriptmodules/supplementary/usbromservice.sh: line 49: /etc/usbmount/mount.d/10_retropie_mount: No such file or directory
chmod: cannot access '/etc/usbmount/mount.d/10_retropie_mount': No such file or directory

Log ended at: Sun Oct 28 12:39:48 GMT 2018
Total running time: 0 hours, 0 mins, 1 secs
```
It appears very quickly between the *fetched latest* and *notice disclaimer* dialogs when you update the RetroPie script and you **don't have** the `usbromservice` module installed. It is easier to see using an ssh session where you can simply scroll-up your terminal.

The fix is simple: use the installed flag file feature introduced in commit e95bca3 to condition the execution of the update hook function. Btw, I also noticed that this flag file is not cleaned when removing the module, henceforth I quickly fixed that too.