### PR TITLE
Add Allwinner H3 and H5 devices

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -262,6 +262,9 @@ function get_platform() {
             Vero4K)
                 __platform="vero4k"
                 ;;
+            "Allwinner sun8i Family")
+                __platform="armv7-mali"
+                ;;
             *)
                 case $architecture in
                     i686|x86_64|amd64)


### PR DESCRIPTION
My images are based on Armbian next.
Linux kernel is 4.14
Mali drivers r8p1 fbdev
If approved i will share image for supported devices with official RetroPie Setup script