### PR TITLE
Don't remove analogues on EmulationStation post config

### DIFF
--- a/scriptmodules/supplementary/emulationstation/configscripts/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/emulationstation.sh
@@ -54,7 +54,7 @@ function map_emulationstation_joystick() {
         rightbottom|rightshoulder)
             key="pagedown"
             ;;
-        up|right|down|left|start|select|x|y)
+        up|right|down|left|start|select|x|y|leftanalogup|leftanalogright|leftanalogdown|leftanalogleft|rightanalogup|rightanalogright|rightanalogdown|rightanalogleft)
             key="$input_name"
             ;;
         a)


### PR DESCRIPTION
I've in a different on PR https://github.com/RetroPie/EmulationStation/pull/499 to make EmulationStation work with both digital and analogue directionals, but the `/opt/retropie/supplementary/emulationstation/configscripts/emulationstation.sh` script actually remove analogues from final configuration.

So this PR is about to keep analogues directionals.