### PR TITLE
Add .cue support to Commodore Amiga

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -4,7 +4,7 @@
 ags_exts=".exe"
 ags_fullname="Adventure Game Studio"
 
-amiga_exts=".adf .adz .dms .ipf .lha .sh .uae .zip"
+amiga_exts=".adf .adz .cue .dms .ipf .lha .sh .uae .zip"
 amiga_fullname="Commodore Amiga"
 
 amstradcpc_exts=".cdt .cpc .dsk .zip"


### PR DESCRIPTION
Assists with launching CD32 images from ES.