### PR TITLE
steamlink: add overscan override

### DIFF
--- a/scriptmodules/ports/steamlink.sh
+++ b/scriptmodules/ports/steamlink.sh
@@ -14,14 +14,14 @@ rp_module_desc="Steam Link for Raspberry Pi 3"
 rp_module_licence="PROP https://steamcommunity.com/app/353380/discussions/0/1743353164093954254/"
 rp_module_section="exp"
 rp_module_flags="!mali !x86 !kms !rpi1 !rpi2"
-rp_module_help="Streaming games to your computer with Steam."
+rp_module_help="Streaming games to your computer with Steam.\n\nIf you experience a black screen during startup, you may need to disable the overscan_scale setting in your Pi's /boot/config.txt."
 
 function depends_steamlink() {
     getDepends python3-dev curl xz-utils
 }
 
 function install_bin_steamlink() {
-    local ver="1.0.4"
+    local ver="1.0.5"
     local url="http://media.steampowered.com/steamlink/rpi"
     wget -qO "$__tmpdir/steamlink_"$ver"_armhf.deb" ""$url"/steamlink_"$ver"_armhf.deb"
     dpkg -i "$__tmpdir/steamlink_"$ver"_armhf.deb"
@@ -32,5 +32,23 @@ function remove_steamlink() {
 }
 
 function configure_steamlink() {
+    local sl_dir="$home/.local/share/SteamLink"
+    local valve_dir="$home/.local/share/Valve Software"
+
+    mkUserDir "$sl_dir"
+    mkUserDir "$valve_dir"
+    mkUserDir "$valve_dir/Streaming Client"
+
+    # create optional streaming_args.txt for user modification
+    touch "$valve_dir/Streaming Client/streaming_args.txt"
+    chown $user:$user "$valve_dir/Streaming Client/streaming_args.txt"
+    moveConfigFile "$valve_dir/Streaming Client/streaming_args.txt" "$md_conf_root/$md_id/streaming_args.txt"
+
+    # RetroPie sets overscan by default, which requires an override
+    if grep '^overscan_scale=1' /boot/config.txt &>/dev/null; then
+        touch "$sl_dir/.ignore_overscan"
+        chown $user:$user "$sl_dir/.ignore_overscan"
+    fi
+
     addPort "$md_id" "steamlink" "Steam Link" "/usr/bin/steamlink"
 }


### PR DESCRIPTION
The steamlink client will refuse to launch when overscan is enabled
(which is enabled by default on our RetroPie image), but an override
is supported.

(they added this overscan detection to their scripts after I submitted the initial PR)