### PR TITLE
image - move default gpu_mem and overscan_scale settings out of the E…

### DIFF
--- a/scriptmodules/admin/image.sh
+++ b/scriptmodules/admin/image.sh
@@ -95,6 +95,13 @@ function install_rp_image() {
         sed -i "s/quiet/quiet loglevel=3 consoleblank=0 plymouth.enable=0 quiet/" "$chroot/boot/cmdline.txt"
     fi
 
+    # set default GPU mem, and overscan_scale so ES scales to overscan settings.
+    iniConfig "=" "" "$chroot/boot/config.txt"
+    iniSet "gpu_mem_256" 128
+    iniSet "gpu_mem_512" 256
+    iniSet "gpu_mem_1024" 256
+    iniSet "overscan_scale" 1
+
     cat > "$chroot/home/pi/install.sh" <<_EOF_
 #!/bin/bash
 cd

--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -279,15 +279,6 @@ function configure_emulationstation() {
 
     install_launch_emulationstation
 
-    if isPlatform "rpi"; then
-        # make sure that ES has enough GPU memory
-        iniConfig "=" "" /boot/config.txt
-        iniSet "gpu_mem_256" 128
-        iniSet "gpu_mem_512" 256
-        iniSet "gpu_mem_1024" 256
-        iniSet "overscan_scale" 1
-    fi
-
     mkdir -p "/etc/emulationstation"
 
     # ensure we have a default theme


### PR DESCRIPTION
 * users may want to change these and not have them reset to defaults when updating ES.

Currently testing this.