### PR TITLE
esthemes - do not append `(not installed)` if a theme is not installed

### DIFF
--- a/scriptmodules/supplementary/esthemes.sh
+++ b/scriptmodules/supplementary/esthemes.sh
@@ -211,7 +211,7 @@ function gui_esthemes() {
                 installed_themes+=("$theme $repo")
             else
                 status+=("n")
-                options+=("$i" "Install $repo/$theme (not installed)")
+                options+=("$i" "Install $repo/$theme")
             fi
             ((i++))
         done


### PR DESCRIPTION
I noticed that the esthemes menu displays *(not installed)* for every non-installed theme:

![esthemes-current](https://user-images.githubusercontent.com/5802993/49935629-73d4af00-fec9-11e8-99d7-5a7a645f627a.png)

Which makes the menu look a bit cluttered/convoluted. A better approach is what is currently done in the **RetroPie packages menus**, where only the installed packages are marked as *(installed)*:

![packages-menu](https://user-images.githubusercontent.com/5802993/49935679-9797f500-fec9-11e8-87f8-55c9981d4700.png)

This PR helps reduce visual clutter in the **esthemes menu** using the same approach as the package managing menus. Example:

![esthemes-cleaner](https://user-images.githubusercontent.com/5802993/49935720-bac2a480-fec9-11e8-961b-c0ba1422b5e6.png)

