### PR TITLE
correct mame2003-plus artwork path & copy artwork sources

### DIFF
--- a/scriptmodules/libretrocores/lr-mame2003.sh
+++ b/scriptmodules/libretrocores/lr-mame2003.sh
@@ -59,17 +59,21 @@ function configure_lr-mame2003() {
         for mame_sub_dir in cfg ctrlr diff hi memcard nvram; do
             mkRomDir "$mame_dir/$dir_name/$mame_sub_dir"
         done
-
-        # lr-mame2003-plus also has an artwork folder
-        [[ "$md_id" == "lr-mame2003-plus" ]] && mkRomDir "$mame_dir/$dir_name/artwork"
     done
 
     mkUserDir "$biosdir/$dir_name"
     mkUserDir "$biosdir/$dir_name/samples"
 
-    # copy hiscore.dat
+    # copy hiscore.dat and cheat.dat
     cp "$md_inst/metadata/"{hiscore.dat,cheat.dat} "$biosdir/$dir_name/"
     chown $user:$user "$biosdir/$dir_name/"{hiscore.dat,cheat.dat}
+    
+    # lr-mame2003-plus also has an artwork folder
+    if [[ "$md_id" == "lr-mame2003-plus" ]]; then
+        mkRomDir "$biosdir/$dir_name/artwork"
+        cp "$md_inst"/metadata/artwork/* "$biosdir/$dir_name"/artwork/
+        chown -R $user:$user "$biosdir/$dir_name/artwork"
+    fi
 
     # Set core options
     setRetroArchCoreOption "${dir_name}-skip_disclaimer" "enabled"


### PR DESCRIPTION
This PR pertains to a feature of mame2003-plus which had bugs and had thought I would give up on: backdrop artwork. However, the bugs with artwork unexpectedly were solved by an unrelated fix, and now backdrops can be displayed.

@joolswills would you please review this PR? I do not have a RetroPie setup to test it on.

My intentions are to:
  1. Correctly locate the artwork folder within the mame2003-plus SYSTEM folder instead of the SAVE folder
  2. Using the `hiscore.dat` and `cheat.dat` as a model, copy and chown the backdrop artwork files to the right place

In case you are wondering: at the moment there is just one artwork file in the repository folder, but there may be as many as a dozen or two files eventually. Not all that many games have backdrop art to begin with.