### PR TITLE
lr-mame2003-plus: fix installation of artwork in $biosrom instead of $romdir

### DIFF
--- a/scriptmodules/libretrocores/lr-mame2003.sh
+++ b/scriptmodules/libretrocores/lr-mame2003.sh
@@ -67,11 +67,11 @@ function configure_lr-mame2003() {
     # copy hiscore.dat and cheat.dat
     cp "$md_inst/metadata/"{hiscore.dat,cheat.dat} "$biosdir/$dir_name/"
     chown $user:$user "$biosdir/$dir_name/"{hiscore.dat,cheat.dat}
-    
+
     # lr-mame2003-plus also has an artwork folder
     if [[ "$md_id" == "lr-mame2003-plus" ]]; then
-        mkRomDir "$biosdir/$dir_name/artwork"
-        cp "$md_inst"/metadata/artwork/* "$biosdir/$dir_name"/artwork/
+        mkUserDir "$biosdir/$dir_name/artwork"
+        cp "$md_inst/metadata/artwork/"* "$biosdir/$dir_name/artwork/"
         chown -R $user:$user "$biosdir/$dir_name/artwork"
     fi
 


### PR DESCRIPTION
The correct function to use is `mkUserDir()` instead of `mkRomDir()`.
Also did some minor code cosmetic clean-up.

As reported in the forum posts:
* https://retropie.org.uk/forum/post/171213
* https://retropie.org.uk/forum/post/171515