### PR TITLE
lr-scummvm - Makefile fixed upstream, update scriptmodule and simplify build flags

### DIFF
--- a/scriptmodules/libretrocores/lr-scummvm.sh
+++ b/scriptmodules/libretrocores/lr-scummvm.sh
@@ -30,8 +30,7 @@ function build_lr-scummvm() {
     isPlatform "neon" && platform+="neon"
     [[ -n "$platform" ]] && params+=(platform="$platform")
 
-    CXXFLAGS="$CXXFLAGS -DHAVE_POSIX_MEMALIGN=1" LDFLAGS="$LDFLAGS -shared -Wl,--no-undefined" \
-        make "${params[@]}" -C backends/platform/libretro/build
+    make "${params[@]}" -C backends/platform/libretro/build
     md_ret_require="$md_build/backends/platform/libretro/build/scummvm_libretro.so"
 }
 


### PR DESCRIPTION
Due to recent changes upstream, the current scriptmodule is failing to build the core. This PR updates the scriptmodule so it builds again with current upstream.

* In a recent commit upstream (7f39a7f) the build for armv broke but it is fixed now (7fb4d42).
* The Makefile fix now allows to simplify the build flags in the scriptmodule.
* Also do not force the HAVE_POSIX_MEMALIGN flag and instead let the Makefile handle it.

All tested and ready to go :)