### PR TITLE
helpers / gitPullOrClone - ensure git branch command runs in $dir and print HEAD status

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -368,9 +368,13 @@ function gitPullOrClone() {
 
     if [[ -n "$commit" ]]; then
         printMsgs "console" "Winding back $repo->$branch to commit: #$commit"
-        git branch -D "$commit" &>/dev/null
+        git -C "$dir" branch -D "$commit" &>/dev/null
         runCmd git -C "$dir" checkout -f "$commit" -b "$commit"
     fi
+
+    branch=$(runCmd git -C "$dir" rev-parse --abbrev-ref HEAD)
+    commit=$(runCmd git -C "$dir" rev-parse HEAD)
+    printMsgs "console" "HEAD is now in branch '$branch' at commit '$commit'"
 }
 
 # @fn setupDirectories()


### PR DESCRIPTION
* Minor Bug: the `git branch -D $commit` command should run in `$dir`, otherwise it fails if `$dir` is different than `$PWD`, for example:

      function sources_module() {
        # here $PWD is 'tmp/build/module'
        gitPullOrClone "/other" https://github.com/user/repo branch commit
      }

* Enhancement: print the status (branch/commit) of HEAD after any operation. It is useful to know exactly at which branch/commit the pull/clone operation left the requested repository, specially on calls without branch/commit arguments where this information is not directly visible.

Tested checking-out the sources of a number of scriptmodules and all is working fine on my side.