### PR TITLE
Add Libretro Dolphin build changes

### DIFF
--- a/scriptmodules/libretrocores/lr-dolphin.sh
+++ b/scriptmodules/libretrocores/lr-dolphin.sh
@@ -27,7 +27,7 @@ function sources_lr-dolphin() {
 function build_lr-dolphin() {
     mkdir build
     cd build
-    cmake .. -DLIBRETRO=ON
+    cmake .. -DLIBRETRO=ON -DLIBRETRO_STATIC=1
     make clean
     make
     md_ret_require="$md_build/build/dolphin_libretro.so"


### PR DESCRIPTION
Upstream changed the build commands, so adding `-DLIBRETRO_STATIC=1` is the preferred way to build with GCC. 
References:
* https://github.com/libretro/libretro-super/pull/946/files (changes to the build used by the Libretro buildbot)
* https://github.com/libretro/dolphin/commit/ce4833fc5b15773bfa64b9b1702f3d6d3f557cae - upstream commit.

Started by https://retropie.org.uk/forum/topic/21080/