### PR TITLE
configedit: improve joystick detection

### DIFF
--- a/scriptmodules/supplementary/configedit.sh
+++ b/scriptmodules/supplementary/configedit.sh
@@ -113,7 +113,7 @@ function _joypad_index_configedit() {
                 # get joystick device paths
                 while read -r dev; do
                     if udevadm info --name=$dev | grep -q "ID_INPUT_JOYSTICK=1"; then
-                        paths+=("$(udevadm info --name=$dev | grep DEVPATH | cut -d= -f2)")
+                        paths+=("$(udevadm info --name=$dev --query=name)")
                     fi
                 done < <(find /dev/input -name "js*")
 
@@ -121,7 +121,7 @@ function _joypad_index_configedit() {
                     # sort by path
                     IFS=$'\n'
                     while read -r path; do
-                        devs_name+=("$(</$(dirname sys$path)/name)")
+                        devs_name+=("$(cat /sys/class/$path/device/name)")
                     done < <(sort <<<"${paths[*]}")
                     unset IFS
                 fi


### PR DESCRIPTION
Certain hid drivers that enumerate multiple nodes (such as hid-sony)
may not advertise the device name in the parent node of udev DEVPATH.

Fix this by using a more reliable method to query the device name
through the /sys/class userspace IO.

Fixes erroneous "not connected" message on DualShock 3/4 controllers
when using the hid-sony driver.