### PR TITLE
helpers: add dkmsManager helper function

### DIFF
--- a/scriptmodules/supplementary/mkarcadejoystick.sh
+++ b/scriptmodules/supplementary/mkarcadejoystick.sh
@@ -16,8 +16,12 @@ rp_module_licence="GPL2 https://raw.githubusercontent.com/recalbox/mk_arcade_joy
 rp_module_section="driver"
 rp_module_flags="noinstclean !x86 !mali"
 
-function _dkms_remove_mkarcadejoystick() {
-    dkms remove -m mk_arcade_joystick_rpi -v 0.1.5 --all
+function _version_mkarcadejoystick() {
+    echo "0.1.5"
+}
+
+function _update_hook_mkarcadejoystick() {
+    dkmsManager update_hook mk_arcade_joystick_rpi "$(_version_mkarcadejoystick)"
 }
 
 function depends_mkarcadejoystick() {
@@ -26,31 +30,15 @@ function depends_mkarcadejoystick() {
 
 function sources_mkarcadejoystick() {
     gitPullOrClone "$md_inst" https://github.com/recalbox/mk_arcade_joystick_rpi
-    sed -i "s/MKVERSION/0.1.5/" "$md_inst/dkms.conf"
+    sed -i "s/\$MKVERSION/$(_version_mkarcadejoystick)/" "$md_inst/dkms.conf"
 }
 
 function build_mkarcadejoystick() {
-    ln -sf "$md_inst" "/usr/src/mk_arcade_joystick_rpi-0.1.5"
-    if dkms status | grep -q "^mk_arcade_joystick"; then
-        _dkms_remove_mkarcadejoystick
-    fi
-    local kernel
-    if [[ "$__chroot" -eq 1 ]]; then
-        kernel="$(ls -1 /lib/modules | tail -n -1)"
-    else
-        kernel="$(uname -r)"
-    fi
-    dkms install --force -m mk_arcade_joystick_rpi -v 0.1.5 -k "$kernel"
-    if dkms status | grep -q "^mk_arcade_joystick"; then
-        md_ret_error+=("Failed to install $md_id")
-        return 1
-    fi
+    dkmsManager install mk_arcade_joystick_rpi "$(_version_mkarcadejoystick)"
 }
 
 function remove_mkarcadejoystick() {
-    [[ -n "$(lsmod | grep mk_arcade_joystick_rpi)" ]] && rmmod mk_arcade_joystick_rpi
-    _dkms_remove_mkarcadejoystick
-    rm -rf /usr/src/mk_arcade_joystick_rpi-0.1.5
+    dkmsManager remove mk_arcade_joystick_rpi "$(_version_mkarcadejoystick)"
     rm -f /etc/modprobe.d/mk_arcade_joystick_rpi.conf
     sed -i "/mk_arcade_joystick_rpi/d" /etc/modules
 }
@@ -66,6 +54,5 @@ function configure_mkarcadejoystick() {
         echo "options mk_arcade_joystick_rpi map=1" >/etc/modprobe.d/mk_arcade_joystick_rpi.conf
     fi
 
-    [[ -n "$(lsmod | grep mk_arcade_joystick_rpi)" ]] && rmmod mk_arcade_joystick_rpi
-    modprobe mk_arcade_joystick_rpi
-} 
+    dkmsManager reload mk_arcade_joystick_rpi
+}

--- a/scriptmodules/supplementary/xpad.sh
+++ b/scriptmodules/supplementary/xpad.sh
@@ -16,6 +16,14 @@ rp_module_licence="GPL2 https://www.kernel.org/pub/linux/kernel/COPYING"
 rp_module_section="driver"
 rp_module_flags="noinstclean !mali"
 
+function _version_xpad() {
+    echo "0.4"
+}
+
+function _update_hook_xpad() {
+    dkmsManager update_hook xpad "$(_version_xpad)"
+}
+
 function depends_xpad() {
     local depends=(dkms)
     isPlatform "rpi" && depends+=(raspberrypi-kernel-headers)
@@ -32,27 +40,19 @@ function sources_xpad() {
 }
 
 function build_xpad() {
-    ln -sf "$md_inst" "/usr/src/xpad-0.4"
-    if dkms status | grep -q "^xpad"; then
-        dkms remove -m xpad -v 0.4 --all
-    fi
-    local kernel
-    if [[ "$__chroot" -eq 1 ]]; then
-        kernel="$(ls -1 /lib/modules | tail -n -1)"
-    else
-        kernel="$(uname -r)"
-    fi
-    dkms install --force -m xpad -v 0.4 -k "$kernel"
+    dkmsManager install xpad "$(_version_xpad)"
 }
 
 function remove_xpad() {
-    dkms remove -m xpad -v 0.4 --all
-    rm -rf /usr/src/xpad-0.4
+    dkmsManager remove xpad "$(_version_xpad)"
     rm -f /etc/modprobe.d/xpad.conf
 }
 
 function configure_xpad() {
+    [[ "$md_mode" == "remove" ]] && return
+
     if [[ ! -f /etc/modprobe.d/xpad.conf ]]; then
         echo "options xpad triggers_to_buttons=1" >/etc/modprobe.d/xpad.conf
     fi
+    dkmsManager reload xpad "$(_version_xpad)"
 }


### PR DESCRIPTION
Introduce new DKMS helper function to consolidate DKMS management in
the relevant scriptmodules (customhidsony, mkarcadejoystick and xpad).

The helper will properly remove old versions of DKMS modules to prevent
"dkms.conf not found" errors occurring when removing a related scriptmodule
but an older DKMS module version was present.

Also fix the update hooks and ensure proper module reload when needed.