### PR TITLE
Add kodi virtual filesystems | Use kodi-standalone instead

### DIFF
--- a/scriptmodules/ports/kodi.sh
+++ b/scriptmodules/ports/kodi.sh
@@ -43,7 +43,7 @@ function depends_kodi() {
 function install_bin_kodi() {
     # force aptInstall to get a fresh list before installing
     __apt_update=0
-    aptInstall kodi kodi-peripheral-joystick kodi-inputstream-adaptive kodi-inputstream-rtmp
+    aptInstall kodi kodi-peripheral-joystick kodi-inputstream-adaptive kodi-inputstream-rtmp kodi-vfs-libarchive kodi-vfs-sftp kodi-vfs-nfs
 }
 
 function remove_kodi() {
@@ -57,5 +57,5 @@ function configure_kodi() {
 
     moveConfigDir "$home/.kodi" "$md_conf_root/kodi"
 
-    addPort "$md_id" "kodi" "Kodi" "kodi"
+    addPort "$md_id" "kodi" "Kodi" "kodi-standalone"
 }


### PR DESCRIPTION
In Kodi 18, some components where split from the Kodi binary, the kodi-vfs-* binary addons. For people to use, for example, the integrated nfs, sftp, etc, filesystems and open compressed archives, they need to have them installed.
"kodi-standalone" can now be used instead of "kodi", it doesn't crash on exit anymore.