### PR TITLE
joy2key: move delay into joy2key script

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -1046,7 +1046,6 @@ function joy2keyStart() {
     # if joy2key.py is installed run it with cursor keys for axis/dpad, and enter + space for buttons 0 and 1
     if "$scriptdir/scriptmodules/supplementary/runcommand/joy2key.py" "$__joy2key_dev" "${params[@]}" & 2>/dev/null; then
         __joy2key_pid=$!
-        sleep 1
         return 0
     fi
 

--- a/scriptmodules/supplementary/runcommand/joy2key.py
+++ b/scriptmodules/supplementary/runcommand/joy2key.py
@@ -235,6 +235,7 @@ event_format = 'IhBB'
 event_size = struct.calcsize(event_format)
 
 try:
+    time.sleep(1)
     tty_fd = open('/dev/tty', 'w')
 except:
     print 'Unable to open /dev/tty'


### PR DESCRIPTION
Reference: https://retropie.org.uk/forum/topic/21139/error-and-gui-terminates-back-to-es-when-launching-retropie-setup-direct-on-machine-libudev-but-ssh-is-ok/33

The previous workaround did not account for runcommand; by placing the
delay inside the script, we can avoid having to slow down script
execution at the expense of potentially missing inputs for one second
(but even on a Core i7 system, joy2key with this delay is ready for
intercepting inputs immediately by the time the main menu appears)