### PR TITLE
Added RapidJSON as dependency for Emulationstation

### DIFF
--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -126,8 +126,9 @@ function depends_emulationstation() {
         libboost-system-dev libboost-filesystem-dev
         libboost-date-time-dev libfreeimage-dev libfreetype6-dev
         libcurl4-openssl-dev libasound2-dev cmake libsdl2-dev libsm-dev
-        libvlc-dev libvlccore-dev vlc
+        libvlc-dev libvlccore-dev rapidjson-dev
     )
+
 
     isPlatform "x11" && depends+=(gnome-terminal)
     getDepends "${depends[@]}"


### PR DESCRIPTION
Accompanying https://github.com/RetroPie/EmulationStation/commit/9ce4419a5a1af248032ceffb78432c5dbb3ca226, it won't build without it.

Since the `dev` will switch to `-stable`, I havent' added checks to see if we're on `-dev` or `-stable`.
Also removed the `vlc`, it's not needed on runtime or build, and it pulls un-needed dependencies.