### PR TITLE
fbalpha - changed version number

### DIFF
--- a/scriptmodules/libretrocores/lr-fbalpha.sh
+++ b/scriptmodules/libretrocores/lr-fbalpha.sh
@@ -10,7 +10,7 @@
 #
 
 rp_module_id="lr-fbalpha"
-rp_module_desc="Arcade emu - Final Burn Alpha (v0.2.97.43) port for libretro"
+rp_module_desc="Arcade emu - Final Burn Alpha (v0.2.97.44) port for libretro"
 rp_module_help="Previously called lr-fba-next\n\ROM Extension: .zip\n\nCopy your FBA roms to\n$romdir/fba or\n$romdir/neogeo or\n$romdir/arcade\n\nFor NeoGeo games the neogeo.zip BIOS is required and must be placed in the same directory as your FBA roms."
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/fbalpha/master/src/license.txt"
 rp_module_section="main"


### PR DESCRIPTION
The current fbalpha version it's 0.2.97.44, the 0.2.97.43 version it's now known as fbalpha2018:
https://github.com/barbudreadmon/fbalpha2018