### PR TITLE
cgenius - fixed building with Raspbian Strech "cmake"

### DIFF
--- a/scriptmodules/ports/cgenius.sh
+++ b/scriptmodules/ports/cgenius.sh
@@ -19,7 +19,7 @@ function depends_cgenius() {
 }
 
 function sources_cgenius() {
-    gitPullOrClone "$md_build" https://gitlab.com/Dringgstein/Commander-Genius.git stable
+    gitPullOrClone "$md_build" https://gitlab.com/Dringgstein/Commander-Genius.git v2.3.1
 
     # use -O2 on older GCC due to segmentation fault when compiling with -O3
     if compareVersions $__gcc_version lt 6.0.0; then


### PR DESCRIPTION
The `stable` upstream branch has made some changes that require a newer (3.12) CMake - but the Stretch version is still at 3.7. 
Upstream has fixed the issue, but it's not in the `stable` branch yet, but we can use the latest tagged branch and then switch to `stable` again when the fix is added there.

Reported in https://retropie.org.uk/forum/topic/21149/.
Fixed (upstream) in https://gitlab.com/Dringgstein/Commander-Genius/issues/355.