### PR TITLE
helpers - fix printMsgs() return value

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -28,6 +28,7 @@ function printMsgs() {
         [[ "$type" == "console" ]] && echo -e "$msg"
         [[ "$type" == "heading" ]] && echo -e "\n= = = = = = = = = = = = = = = = = = = = =\n$msg\n= = = = = = = = = = = = = = = = = = = = =\n"
     done
+    return 0
 }
 
 ## @fn printHeading()


### PR DESCRIPTION
Without an explicit `return` command, functions in bash default to returning the exit value of the last command executed.

The current implementation of `printMsgs()` uses `[[..]]` tests for deciding on the output type (dialog, heading, console), however if the last test (for heading) is false, then this will be the final exit value to be returned from `printMsgs()`. In other words, for all cases except "heading", it always will return `1` (false).

This can be solved by using if-elif-else blocks or, more elegantly, a switch-case block as in this patch. A correct return value is obtained by returning after dialog/echo on error.

---

Example/Tests:
```
# current implementation, "OK" is not printed, except if using "heading"
$ source scriptmodules/helpers.sh
$ printMsgs "console" "Hello World" && echo OK
Hello World

# using implementation in this PR, "OK" is printed properly except on errors
$ source scriptmodules/helpers.sh
$ printMsgs "console" "Hello World" && echo OK
Hello World
OK
$ printMsgs "console" "Hello World" >&- && echo OK  # force echo to fail
-bash: echo: write error: Bad file descriptor
```

I discovered this bug when testing `gitPullOrClone` that was always returning "false" no matter if the git operations fail or not, because of the last `printMsgs` in the function.