### PR TITLE
Mali-DRM support

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -390,3 +390,9 @@ function platform_vero4k() {
     __platform_flags="arm armv7 neon vero4k gles"
 }
 
+function platform_armv8-mali-drm-gles2() {
+    __default_cflags="-O2 -march=armv8-a+crypto+crc -mtune=cortex-a53 -ftree-vectorize -funsafe-math-optimizations"
+    __default_asflags=""
+    __default_makeflags="-j`nproc`"
+    __platform_flags="armv8 kms gles"
+}


### PR DESCRIPTION
This pull request adds initial platform support for KMS/DRM systems using ARM's Mali Utgard 4xx generation binary blobs for acceleration. It does not use the legacy FBDEV and exhibits tear free video output. SDL 2.0.8 was swapped out for SDL 2.0.9 because 2.0.9 fixes a resource locking bug when emulationstation exits and retroarch starts. We upstream that fix for that a few months ago but did not get around to submitting this pull into RetroPie.

I would suggest making targets more generic so that we don't riddle the code base with board specific targets when they really should be architecture specific. These changes should support armhf and arm64 systems.

One area of uncertainty is include and library file paths. We elected to use /usr/local/ since these blobs are usually not native to distributions. We currently have a few mali-drm-gles3 platforms based on newer Mali Midgard and Mali Bitfrost as well and we will make mali-drm-gles3 targets for those as well.

With regards to Lima and Panfrost projects, both are targeting GLES2. When they are complete, we can just add another target drm-gles2 instead of mali-drm-gles2.

Please review and let us know if any changes are necessary. We have some other unfinished patches in the mali-drm-gles2-next branch that we will clean up and send pull requests for in March base on the feedback and edits needed for this.