### PR TITLE
pegasus-fe: Fixed launching X11 applications

### DIFF
--- a/scriptmodules/supplementary/pegasus-fe.sh
+++ b/scriptmodules/supplementary/pegasus-fe.sh
@@ -60,6 +60,28 @@ function install_bin_pegasus-fe() {
     # download and extract the package
     printMsgs "console" "Download URL: ${asset_url}"
     downloadAndExtract "${asset_url}" "$md_inst"
+
+    # create launcher script
+    cat > /usr/bin/pegasus-fe << _EOF_
+#!/bin/bash
+
+if [[ \$(id -u) -eq 0 ]]; then
+    echo "Pegasus should not be run as root. If you used 'sudo pegasus-fe' please run without sudo."
+    exit 1
+fi
+
+# save current tty/vt number for use with X so it can be launched on the correct tty
+tty=\$(tty)
+export TTY="\${tty:8:1}"
+
+clear
+"$md_inst/pegasus-fe" "\$@"
+_EOF_
+    chmod +x /usr/bin/pegasus-fe
+}
+
+function remove_pegasus-fe() {
+    rm -f /usr/bin/pegasus-fe
 }
 
 function configure_pegasus-fe() {


### PR DESCRIPTION
[Similarly to ES](https://github.com/RetroPie/RetroPie-Setup/blob/34426d09db82e3d59941db0b7a47d67a681a2cd9/scriptmodules/supplementary/emulationstation.sh#L217), the [X11 permission workaround](https://github.com/RetroPie/RetroPie-Setup/issues/1805#issuecomment-269387535) is also necessary for Pegasus to properly launch X11 applications. Based on the ES package code, this patch creates a similar launcher script on install to set up the TTY before launch.