### PR TITLE
Add Pie Galaxy to experimental

### DIFF
--- a/scriptmodules/ports/piegalaxy.sh
+++ b/scriptmodules/ports/piegalaxy.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="piegalaxy"
+rp_module_desc="Pie Galaxy - Downloand and install GOG.com games in RetroPie"
+rp_module_licence="GPL https://github.com/sigboe/pie-galaxy/blob/master/LICENSE"
+rp_module_section="exp"
+
+function depends_piegalaxy() {
+	getDepends jq html2text unar
+}
+
+function install_bin_piegalaxy() {
+	local innoversion="1.8-dev-2019-01-13"
+	gitPullOrClone "$md_inst" https://github.com/sigboe/pie-galaxy.git master
+	isPlatform "x86" && (cd "$md_inst" && curl -o wyvern -O https://demenses.net/wyvern-nightly)
+	isPlatform "arm" && (cd "$md_inst" && curl -o wyvern -O https://demenses.net/wyvern-arm-nightly)
+	isPlatform "x86" && downloadAndExtract "http://constexpr.org/innoextract/files/snapshots/innoextract-${innoversion}/innoextract-${innoversion}-linux.tar.xz" "$md_inst" --strip-components 3 innoextract-${innoversion}-linux/bin/amd64/innoextract
+	isPlatform "arm" && downloadAndExtract "http://constexpr.org/innoextract/files/snapshots/innoextract-${innoversion}/innoextract-${innoversion}-linux.tar.xz" "$md_inst" --strip-components 3 innoextract-${innoversion}-linux/bin/armv6j-hardfloat/innoextract
+	chmod +x "$md_inst"/wyvern "$md_inst"/innoextract "$md_inst"/pie-galaxy.sh
+}
+
+function configure_piegalaxy() {
+	addPort "$md_id" "piegalaxy" "Pie Galaxy" "$md_inst/pie-galaxy.sh"
+}


### PR DESCRIPTION
<img src="https://raw.githubusercontent.com/sigboe/pie-galaxy/0.4/docs/resources/logo.png" align="right" />

Pie Galaxy is a GOG client for RetroPie, **making it the easiest way to install legally purchased games**. It will download and install the platform native binary or emulated game, making them available in Emulationstation. It is not it's own launcher it installs games to ROM folders. It can even allow you to claim free games when available on GOG Connect. [Github page](https://github.com/sigboe/pie-galaxy)

![demo](https://github.com/sigboe/pie-galaxy/raw/0.4/docs/resources/demo.gif)

The program is currently **not in** beta stage.

If you have any suggestions for the script module, feel free to comment, ill update the PR and squash the commits.