### PR TITLE
Add "Jump 'n Bump" port to experimental

### DIFF
--- a/scriptmodules/ports/jumpnbump.sh
+++ b/scriptmodules/ports/jumpnbump.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="jumpnbump"
+rp_module_desc="Jump 'n Bump, play cute bunnies jumping on each other's heads - Modernization fork"
+rp_module_help="Copy custom game levels (.dat) to $romdir/ports/jumpnbump"
+rp_module_licence="GPL2 https://gitlab.com/LibreGames/jumpnbump/raw/master/COPYING"
+rp_module_section="exp"
+rp_module_flags=""
+
+function depends_jumpnbump() {
+    getDepends libsdl2-dev libsdl2-net-dev libsdl2-mixer-dev libbz2-dev zlib1g-dev
+}
+
+function sources_jumpnbump() {
+    gitPullOrClone "$md_build" https://gitlab.com/LibreGames/jumpnbump.git
+}
+
+function build_jumpnbump() {
+    make clean
+    CFLAGS="$CFLAGS -fsigned-char" make PREFIX="$md_inst"
+}
+
+function install_jumpnbump() {
+    make PREFIX="$md_inst" install
+    strip "$md_inst"/bin/{gobpack,jnbpack,jnbunpack,jumpnbump}
+}
+
+function game_data_jumpnbump() {
+    local tmpdir="$(mktemp -d)"
+    local compressed
+    local uncompressed
+
+    # install extra levels from Debian's jumpnbump-levels package
+    downloadAndExtract "https://salsa.debian.org/games-team/jumpnbump-levels/-/archive/master/jumpnbump-levels-master.tar.bz2" "$tmpdir" --strip-components 1 --wildcards "*.bz2"
+    for compressed in "$tmpdir"/*.bz2; do
+        uncompressed="${compressed##*/}"
+        uncompressed="${uncompressed%.bz2}"
+        if [[ ! -f "$romdir/ports/jumpnbump/$uncompressed" ]]; then
+            bzcat "$compressed" > "$romdir/ports/jumpnbump/$uncompressed"
+            chown -R $user:$user "$romdir/ports/jumpnbump/$uncompressed"
+        fi
+    done
+    rm -rf "$tmpdir"
+}
+
+function configure_jumpnbump() {
+    addPort "$md_id" "jumpnbump" "Jump 'n Bump" "$md_inst/jumpnbump.sh"
+    mkRomDir "ports/jumpnbump"
+    [[ "$md_mode" == "remove" ]] && return
+
+    # install game data
+    game_data_jumpnbump
+
+    # install launch script
+    cp "$md_data/jumpnbump.sh" "$md_inst"
+    iniConfig "=" '"' "$md_inst/jumpnbump.sh"
+    iniSet "ROOTDIR" "$rootdir"
+    iniSet "MD_CONF_ROOT" "$md_conf_root"
+    iniSet "ROMDIR" "$romdir"
+    iniSet "MD_INST" "$md_inst"
+
+    # set default game options on first install
+    if [[ ! -f "$md_conf_root/jumpnbump/options.cfg" ]];  then
+        iniConfig " = " "" "$md_conf_root/jumpnbump/options.cfg"
+        iniSet "nogore" "1"
+    fi
+}

--- a/scriptmodules/ports/jumpnbump/jumpnbump.sh
+++ b/scriptmodules/ports/jumpnbump/jumpnbump.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+ROOTDIR=""
+MD_CONF_ROOT=""
+ROMDIR=""
+MD_INST=""
+DIALOG=(dialog --backtitle "RetroPie Jump n' Bump Launcher")
+
+# source ini functions from RetroPie
+source "$ROOTDIR/lib/inifuncs.sh"
+
+# init program args
+function init_args() {
+    args=(-fullscreen)
+    iniConfig " = " "" "$MD_CONF_ROOT/jumpnbump/options.cfg"
+    iniGet "nogore" && [[ "$ini_value" -eq 1 ]] && args+=(-nogore)
+    iniGet "noflies" && [[ "$ini_value" -eq 1 ]] && args+=(-noflies)
+    iniGet "scaleup" && [[ "$ini_value" -eq 1 ]] && args+=(-scaleup)
+    iniGet "musicnosound" && [[ "$ini_value" -eq 1 ]] && args+=(-musicnosound)
+    return 0
+}
+
+# main menu
+function main_menu() {
+    local cmd
+    local options
+    local choice
+    while true; do
+        cmd=("${DIALOG[@]}" --menu "Main Menu" 0 0 0)
+        options=(
+            L "Local Game Mode"
+            S "Net: Start Server"
+            C "Net: Connect to Server"
+            H "Net: Help"
+        )
+        choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty) || return
+        case "$choice" in
+            L) init_args && select_level_menu && return ;;
+            S) init_args && start_server_menu && select_level_menu && return ;;
+            C) init_args && connect_server_menu && select_level_menu && return ;;
+            H) netplay_help ;;
+        esac
+    done
+}
+
+# select level menu
+function select_level_menu() {
+    local cmd=("${DIALOG[@]}" --ok-label "Start" --extra-button --extra-label "Start Mirror" --menu "Select Level" 16 0 16)
+    local levels=(D "(default level)")
+    local idx=1
+    local choice
+    local ret
+    for file in "$ROMDIR"/ports/jumpnbump/*.dat; do
+        levels+=("$idx" "${file##*/}")
+        ((idx++))
+    done
+    choice=$("${cmd[@]}" "${levels[@]}" 2>&1 >/dev/tty)
+    ret=$?
+    [[ "$ret" -eq 1 ]] && return 1
+    [[ "$ret" -eq 3 ]] && args+=(-mirror)
+    [[ "$choice" == "D" ]] && return
+    args+=(-dat "$ROMDIR/ports/jumpnbump/${levels[$((choice * 2 + 1))]}")
+}
+
+# start server menu
+function start_server_menu() {
+    local cmd=("${DIALOG[@]}" --menu "Number of players" 0 0 0)
+    local options=(
+        1 "One Remote + One Local"
+        2 "Two Remotes + One Local"
+        3 "Three Remotes + One Local"
+    )
+    choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty) || return
+    args+=(-server "$choice")
+}
+
+# connect to server menu
+function connect_server_menu() {
+    local cmd=("${DIALOG[@]}" --inputbox "Please enter the address of the remote server" 10 35)
+    choice=$("${cmd[@]}" 2>&1 >/dev/tty) || return
+    args+=(-connect "$choice")
+}
+
+# netplay help
+function netplay_help() {
+    local help
+    read -r -d "" help <<"_EOF_"
+1. On the server device, select "Start Server" and choose the number of additional players (1-3) to wait for.
+
+2. On each remote player device, select "Connect to Server" and enter the IP address of the server.
+
+3. All players (server and clients) must select the same level and mirror settings.
+_EOF_
+    "${DIALOG[@]}" --title "Net Help" --msgbox "$help" 16 50 2>&1 >/dev/tty
+}
+
+# start main menu
+main_menu || exit
+"$MD_INST"/bin/jumpnbump "${args[@]}" "$@"


### PR DESCRIPTION
I found this little game recently and decided to make a scriptmodule for RetroPie.
It's a very simple but fun multiplayer game, ideal for kids -- and not so kids too :)

About the Game:
https://en.wikipedia.org/wiki/Jump_%27n_Bump

Also found it was previously requested in the RetroPie Forum:
https://retropie.org.uk/forum/topic/12370/jump-n-bump-as-a-port

Scriptmodule Features:

* Installs extra levels from https://wiki.debian.org/Games/Jumpnbump
* Creates a launcher for selecting levels and starting net play
* Configurable options such as "nogore" (no blood for kids)
* Installs tools for creating own levels (gobpack, jnbpack, jnbunpack)

Considerations:

* When waiting for network players or connecting to a server, the game can't be killed (CTRL+C). This is not a runcommand nor RetroPie limitation, but the game is ignoring signals while waiting. Must be addressed upstream.
* While the game supports joysticks for gameplay, it can't currently be used without a keyboard because you still need it for exiting via ESC or F12, i.e. no joystick support for this action.

Configurable Options (`$md_conf_dir/jumpnbump/options.cfg`):

    nogore=0|1           play without blood (set as default on first install)
    noflies=0|1          disable flies
    scaleup=0|1          play with doubled resolution (800x512)
    musicnosound=0|1     play with music but without sound

Let me know if you want to make adjustments.