### PR TITLE
lr-reicast - enable for RPI

### DIFF
--- a/scriptmodules/libretrocores/lr-reicast.sh
+++ b/scriptmodules/libretrocores/lr-reicast.sh
@@ -14,7 +14,7 @@ rp_module_desc="Dreamcast emu - Reicast port for libretro"
 rp_module_help="ROM Extensions: .cdi .gdi\n\nCopy your Dreamcast roms to $romdir/dreamcast\n\nCopy the required BIOS files dc_boot.bin and dc_flash.bin to $biosdir/dc"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/reicast-emulator/master/LICENSE"
 rp_module_section="exp"
-rp_module_flags="!arm"
+rp_module_flags="!mali"
 
 function sources_lr-reicast() {
     gitPullOrClone "$md_build" https://github.com/libretro/reicast-emulator.git
@@ -22,7 +22,11 @@ function sources_lr-reicast() {
 
 function build_lr-reicast() {
     make clean
-    make
+    if isPlatform "rpi"; then
+        make platform="$__platform"
+    else
+        make
+    fi
     md_ret_require="$md_build/reicast_libretro.so"
 }
 
@@ -42,6 +46,7 @@ function configure_lr-reicast() {
     iniConfig " = " "" "$configdir/dreamcast/retroarch.cfg"
     iniSet "video_shared_context" "true"
 
-    addEmulator 0 "$md_id" "dreamcast" "$md_inst/reicast_libretro.so"
+    # segfaults on the rpi without redirecting stdin from </dev/null
+    addEmulator 0 "$md_id" "dreamcast" "$md_inst/reicast_libretro.so </dev/null"
     addSystem "dreamcast"
 }


### PR DESCRIPTION
 * redirect stdin from </dev/null to avoid segfault on RPI
 * keep disabled for kms / mali targets for now
 * ref: https://retropie.org.uk/forum/topic/20042/reicast-vs-lr-reicast-perfomance