### PR TITLE
fixing edge case where multiplayer is broken for dreamcast

### DIFF
--- a/scriptmodules/emulators/reicast/reicast.sh
+++ b/scriptmodules/emulators/reicast/reicast.sh
@@ -33,7 +33,7 @@ function mapInput() {
         for ev_device in /dev/input/event*; do
             ev_device_num=${ev_device/\/dev\/input\/event/}
             if [[ -d "/sys/class/input/event${ev_device_num}/device/js${js_device_num}" ]]; then
-                file[$ev_device_num]=$(grep --exclude=*.bak -rl "$configdir/dreamcast/mappings/" -e "= $(</sys/class/input/event${ev_device_num}/device/name)")
+                file[$ev_device_num]=$(grep --exclude=*.bak -rl -m 1 "$configdir/dreamcast/mappings/" -e "= $(</sys/class/input/event${ev_device_num}/device/name)" | tail -n 1)
                 if [[ -f "${file[$ev_device_num]}" ]]; then
                     #file[$ev_device_num]="${file[$ev_device_num]##*/}"
                     ev_devices[$ev_device_num]=$(</sys/class/input/event${ev_device_num}/device/name)


### PR DESCRIPTION
Changed grep pipe so that it parses the last match for the controller mapping file. In the case where xbox userspace controllers were found, there was a userspace #2 which was matching for the first and second controller. This led to only the second controller being recognized.