### PR TITLE
retropiemenu: fix printing of own IP address

### DIFF
--- a/scriptmodules/supplementary/retropiemenu.sh
+++ b/scriptmodules/supplementary/retropiemenu.sh
@@ -151,7 +151,7 @@ function launch_retropiemenu() {
             mc
             ;;
         showip.rp)
-            local ip="$(ip route get 8.8.8.8 2>/dev/null | awk '{print $NF; exit}')"
+            local ip="$(ip route get 8.8.8.8 2>/dev/null | sed -n '1{s/.*src //; s/\s.*//;p}')"
             printMsgs "dialog" "Your IP is: $ip\n\nOutput of 'ip addr show':\n\n$(ip addr show)"
             ;;
         *.rp)


### PR DESCRIPTION
Fixes the IP addresss detection when the `ip` adds extra info to the route output (ex. _uid_). On Ubuntu 18.04:

    ip route get 8.8.8.8

outputs (2 lines):
```
8.8.8.8 via 10.0.1.1 dev ens160 src 10.0.1.88 uid 1000 
    cache 
```
In this case, the IP shown in the **Show IP** menu entry is `0` .

The change gets only the next value after the `src` field in the `ip` output.