### PR TITLE
lr-pcsx-rearmed - fix build by using the libretro makefile directly

### DIFF
--- a/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
+++ b/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
@@ -26,14 +26,17 @@ function sources_lr-pcsx-rearmed() {
 }
 
 function build_lr-pcsx-rearmed() {
-    if isPlatform "neon"; then
-        ./configure --platform=libretro --enable-neon
+    local platform
+    if isPlatform "rpi2" || isPlatform "rpi3"; then
+        platform="$__platform"
     else
-        ./configure --platform=libretro --disable-neon
+        isPlatform "arm" && platform+="armv"
+        isPlatform "neon" && platform+="neon"
     fi
-    make clean
-    make
-    md_ret_require="$md_build/libretro.so"
+    [[ -z "$platform" ]] && platform="unix"
+    make -f Makefile.libretro clean
+    make -f Makefile.libretro platform="$platform"
+    md_ret_require="$md_build/pcsx_rearmed_libretro.so"
 }
 
 function install_lr-pcsx-rearmed() {
@@ -41,7 +44,7 @@ function install_lr-pcsx-rearmed() {
         'AUTHORS'
         'ChangeLog.df'
         'COPYING'
-        'libretro.so'
+        'pcsx_rearmed_libretro.so'
         'NEWS'
         'README.md'
         'readme.txt'
@@ -52,6 +55,6 @@ function configure_lr-pcsx-rearmed() {
     mkRomDir "psx"
     ensureSystemretroconfig "psx"
 
-    addEmulator 1 "$md_id" "psx" "$md_inst/libretro.so"
+    addEmulator 1 "$md_id" "psx" "$md_inst/pcsx_rearmed_libretro.so"
     addSystem "psx"
 }


### PR DESCRIPTION
* After upstream commit b26afb9 the build broke because of the configure script incorrectly trying to always build `gpu_unai.so`
* Instead use the libretro makefile directly and set `platform` as done in other cores in RetroPie
* For non-RPI2/3 devices, use `arm` and `neon` flags to set platform
* For none of the above, use `unix` as fallback platform
* The built core is now correctly named: `pcsx_rearmed_libretro.so`

I tested the PR on an RPI3B+ using `__platform` set to `rpi1`, `rpi2` and `rpi3` to ensure it builds for all these variants. For other platforms it should use the correct parameters, but can't test myself. I also tested playing some games, all seems okay on my side.