### PR TITLE
Blacklist indiana jones n64 in a way that picks a config that runs

### DIFF
--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -175,7 +175,6 @@ function testCompatibility() {
     local blacklist=(
         naboo
         body
-        infernal
     )
 
     # these games do not run with gles2n64
@@ -197,6 +196,7 @@ function testCompatibility() {
         rogue
         squadron
         gauntlet
+        infernal
     )
 
     # these games have massive glitches if legacy blending is enabled
@@ -206,6 +206,7 @@ function testCompatibility() {
         donkey
         zelda
         bomberman
+        infernal
     )
 
     local GLideN64NativeResolution_blacklist=(
@@ -225,6 +226,7 @@ function testCompatibility() {
         starcraft
         rogue
         squadron
+        infernal
     )
 
     for game in "${blacklist[@]}"; do


### PR DESCRIPTION
Fixes #2649 
