### PR TITLE
joy2key: daemonize to prevent early-init related errors

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -1044,8 +1044,8 @@ function joy2keyStart() {
     [[ -z "$__joy2key_dev" ]] || pgrep -f joy2key.py >/dev/null && return 1
 
     # if joy2key.py is installed run it with cursor keys for axis/dpad, and enter + space for buttons 0 and 1
-    if __joy2key_ppid=$$ "$scriptdir/scriptmodules/supplementary/runcommand/joy2key.py" "$__joy2key_dev" "${params[@]}" & 2>/dev/null; then
-        __joy2key_pid=$!
+    if "$scriptdir/scriptmodules/supplementary/runcommand/joy2key.py" "$__joy2key_dev" "${params[@]}" 2>/dev/null; then
+        __joy2key_pid=$(pgrep -f joy2key.py)
         return 0
     fi
 
@@ -1057,6 +1057,8 @@ function joy2keyStart() {
 function joy2keyStop() {
     if [[ -n $__joy2key_pid ]]; then
         kill $__joy2key_pid 2>/dev/null
+        __joy2key_pid=""
+        sleep 1
     fi
 }
 

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -117,6 +117,9 @@ function start_joy2key() {
         # see: http://pubs.opengroup.org/onlinepubs/7908799/xcurses/terminfo.html
         "$ROOTDIR/supplementary/runcommand/joy2key.py" "$JOY2KEY_DEV" kcub1 kcuf1 kcuu1 kcud1 0x0a 0x09
         JOY2KEY_PID=$(pgrep -f joy2key.py)
+
+    # ensure coherency between on-screen prompts and actual button mapping functionality
+    sleep 0.3
     fi
 }
 
@@ -960,7 +963,6 @@ function show_launch() {
 
 function check_menu() {
     local dont_launch=0
-    start_joy2key
     # check for key pressed to enter configuration
     IFS= read -s -t 2 -N 1 key </dev/tty
     if [[ -n "$key" ]]; then
@@ -974,7 +976,6 @@ function check_menu() {
         tput civis
         clear
     fi
-    stop_joy2key
     return $dont_launch
 }
 
@@ -1035,15 +1036,18 @@ function runcommand() {
 
     load_mode_defaults
 
+    start_joy2key
     show_launch
 
     if [[ "$DISABLE_MENU" -ne 1 ]]; then
         if ! check_menu; then
+            stop_joy2key
             user_script "runcommand-onend.sh"
             clear
             restore_cursor_and_exit 0
         fi
     fi
+    stop_joy2key
 
     mode_switch "$MODE_REQ_ID"
 

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -115,14 +115,16 @@ function start_joy2key() {
 
         # call joy2key.py: arguments are curses capability names or hex values starting with '0x'
         # see: http://pubs.opengroup.org/onlinepubs/7908799/xcurses/terminfo.html
-        __joy2key_ppid=$$ "$ROOTDIR/supplementary/runcommand/joy2key.py" "$JOY2KEY_DEV" kcub1 kcuf1 kcuu1 kcud1 0x0a 0x09 &
-        JOY2KEY_PID=$!
+        "$ROOTDIR/supplementary/runcommand/joy2key.py" "$JOY2KEY_DEV" kcub1 kcuf1 kcuu1 kcud1 0x0a 0x09
+        JOY2KEY_PID=$(pgrep -f joy2key.py)
     fi
 }
 
 function stop_joy2key() {
     if [[ -n "$JOY2KEY_PID" ]]; then
         kill "$JOY2KEY_PID"
+        JOY2KEY_PID=""
+        sleep 1
     fi
 }
 


### PR DESCRIPTION
joy2key:
* Protect signal_handler from concurrent calls via multiple kill requests
* Daemonize to background as soon as signal handlers are registered;
  guarantees that joy2keyStart/start_joy2key returns only when the script
  is in a functional state (and thus the stop calls can't run too early).
* Ensure tty_fd is also closed on exit.

helper/runcommand:
* Don't run script in background
* Remove parent pid check (no longer needed)
* Remove joy2key PID upon kill to avoid unbalanced stop calls (although
  the script now protects from this via signal_handler)