### PR TITLE
helpers - add getIPAddress() function

### DIFF
--- a/scriptmodules/admin/builder.sh
+++ b/scriptmodules/admin/builder.sh
@@ -73,7 +73,7 @@ function chroot_build_builder() {
     mkdir -p "$md_build"
 
     # get current host ip for the distcc in the emulated chroot to connect to
-    local ip="$(ip route get 8.8.8.8 2>/dev/null | awk '{print $NF; exit}')"
+    local ip="$(getIPAddress)"
 
     local dist
     local sys

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -1371,3 +1371,25 @@ function dkmsManager() {
             ;;
     esac
 }
+
+## @fn getIPAddress()
+## @param dev optional specific network device to use for address lookup
+## @brief Obtains the current externally routable source IP address of the machine
+## @details This function first tries to obtain an external IPv4 route and
+## otherwise tries an IPv6 route if the IPv4 route can not be determined.
+## If no external route can be determined, nothing will be returned.
+## This function uses Google's DNS servers as the external lookup address.
+function getIPAddress() {
+    local dev="$1"
+    local ip_route
+
+    # first try to obtain an external IPv4 route
+    ip_route=$(ip -4 route get 8.8.8.8 ${dev:+dev $dev} 2>/dev/null)
+    if [[ -z "$ip_route" ]]; then
+        # if there is no IPv4 route, try to obtain an IPv6 route instead
+        ip_route=$(ip -6 route get 2001:4860:4860::8888 ${dev:+dev $dev} 2>/dev/null)
+    fi
+
+    # if an external route was found, report its source address
+    [[ -n "$ip_route" ]] && grep -oP "src \K[^\s]+" <<< "$ip_route"
+}

--- a/scriptmodules/supplementary/retropiemenu.sh
+++ b/scriptmodules/supplementary/retropiemenu.sh
@@ -151,8 +151,8 @@ function launch_retropiemenu() {
             mc
             ;;
         showip.rp)
-            local ip="$(ip route get 8.8.8.8 2>/dev/null | awk '{print $NF; exit}')"
-            printMsgs "dialog" "Your IP is: $ip\n\nOutput of 'ip addr show':\n\n$(ip addr show)"
+            local ip="$(getIPAddress)"
+            printMsgs "dialog" "Your IP is: ${ip:-(unknown)}\n\nOutput of 'ip addr show':\n\n$(ip addr show)"
             ;;
         *.rp)
             rp_callModule $no_ext depends

--- a/scriptmodules/supplementary/wifi.sh
+++ b/scriptmodules/supplementary/wifi.sh
@@ -184,9 +184,9 @@ function gui_wifi() {
 
     local default
     while true; do
-        local ip_current=$(ip route get 8.8.8.8 2>/dev/null | awk '{print $NF; exit}')
-        local ip_wlan=$(ip route ls dev wlan0 2>/dev/null | awk 'END {print $7}')
-        local cmd=(dialog --backtitle "$__backtitle" --cancel-label "Exit" --item-help --help-button --default-item "$default" --menu "Configure WiFi\nCurrent IP: $ip_current\nWireless IP: $ip_wlan\nWireless ESSID: $(iwgetid -r)" 22 76 16)
+        local ip_current="$(getIPAddress)"
+        local ip_wlan="$(getIPAddress wlan0)"
+        local cmd=(dialog --backtitle "$__backtitle" --cancel-label "Exit" --item-help --help-button --default-item "$default" --menu "Configure WiFi\nCurrent IP: ${ip_current:-(unknown)}\nWireless IP: ${ip_wlan:-(unknown)}\nWireless ESSID: $(iwgetid -r)" 22 76 16)
         local options=(
             1 "Connect to WiFi network"
             "1 Connect to your WiFi network"


### PR DESCRIPTION
I created a cleaner version of the snippet proposed before.

* the function obtains an externally routable source IP address for the machine
* an IPv4 route is tried first and, if not found, then an IPv6 route is tried
* the function also handles queries for specific devices (used in `wifi.sh`)
* replace all instances of `ip route (...)` with new `getIPAddress` function

I also found one more usage of `ip route (...)` in the `bashwelcometweak.sh` scriptmodule, however it is used from within the installed `.bashrc` snippet, therefore it does not have access to the helpers library.
(( btw, that `.bashrc` snippet does not seem to use any scriptmodule variable, perhaps it is better to move it outside the scriptmodule into `$md_data` for a cleaner code? ))

I tested the function in different machines I have around and seems to be working okay in different scenarios, however I do not have any publicly routable IPv6 machine so I couldn't test that part of the function easily. Nevertheless the logic is simple enough and should still work. Once merged I will pay attention to the forum in case someone reports something odd with that.

Closes #2650 