### PR TITLE
fuse - update to v1.5.7

### DIFF
--- a/scriptmodules/emulators/fuse.sh
+++ b/scriptmodules/emulators/fuse.sh
@@ -21,12 +21,13 @@ function depends_fuse() {
 }
 
 function sources_fuse() {
-    downloadAndExtract "$__archive_url/fuse-1.4.1.tar.gz" "$md_build" --strip-components 1
+    downloadAndExtract "$__archive_url/fuse-1.5.7.tar.gz" "$md_build" --strip-components 1
     mkdir libspectrum
-    downloadAndExtract "$__archive_url/libspectrum-1.4.1.tar.gz" "$md_build/libspectrum" --strip-components 1
+    downloadAndExtract "$__archive_url/libspectrum-1.4.4.tar.gz" "$md_build/libspectrum" --strip-components 1
     if ! isPlatform "x11"; then
         applyPatch "$md_data/01_disable_cursor.diff"
     fi
+    applyPatch "$md_data/02_sdl_fix.diff"
 }
 
 function build_fuse() {

--- a/scriptmodules/emulators/fuse/02_sdl_fix.diff
+++ b/scriptmodules/emulators/fuse/02_sdl_fix.diff
@@ -1,0 +1,23 @@
+diff --git a/ui/sdl/sdldisplay.c b/ui/sdl/sdldisplay.c
+index e4d640b..fafe0ac 100644
+--- a/ui/sdl/sdldisplay.c
++++ b/ui/sdl/sdldisplay.c
+@@ -249,11 +249,13 @@ uidisplay_init( int width, int height )
+     return 0;
+   }
+ 
+-  for( i=0; modes[i]; ++i ); /* count modes */
+-  if( settings_current.sdl_fullscreen_mode ) {
+-    if( sscanf( settings_current.sdl_fullscreen_mode, " %dx%d", &mw, &mh ) != 2 ) {
+-      if( sscanf( settings_current.sdl_fullscreen_mode, " %d", &mn ) == 1 && mn <= i ) {
+-        mw = modes[mn - 1]->w; mh = modes[mn - 1]->h;
++  if ( ! no_modes ) {
++    for( i=0; modes[i]; ++i ); /* count modes */
++    if( settings_current.sdl_fullscreen_mode ) {
++      if( sscanf( settings_current.sdl_fullscreen_mode, " %dx%d", &mw, &mh ) != 2 ) {
++        if( sscanf( settings_current.sdl_fullscreen_mode, " %d", &mn ) == 1 && mn <= i ) {
++          mw = modes[mn - 1]->w; mh = modes[mn - 1]->h;
++        }
+       }
+     }
+   }


### PR DESCRIPTION
 * include patch to avoid segfault when using dispmanx sdl driver
 * ref: https://sourceforge.net/p/fuse-emulator/bugs/449/