### PR TITLE
jzintv - update to 20181225 version

### DIFF
--- a/scriptmodules/emulators/jzintv.sh
+++ b/scriptmodules/emulators/jzintv.sh
@@ -21,17 +21,15 @@ function depends_jzintv() {
 }
 
 function sources_jzintv() {
-    downloadAndExtract "$__archive_url/jzintv-20141028.zip" "$md_build"
+    downloadAndExtract "$__archive_url/jzintv-20181225.zip" "$md_build"
     cd jzintv/src
-    # don't build event_diag.rom/emu_ver.rom/joy_diag.rom/jlp_test.bin due to missing example/library files from zip
-    sed -i '/^PROGS/,$d' {event,joy,jlp,util}/subMakefile
 }
 
 function build_jzintv() {
     mkdir -p jzintv/bin
     cd jzintv/src
     make clean
-    make OPT_FLAGS="$CFLAGS"
+    make CC="gcc" CXX="g++" WARNXX="" OPT_FLAGS="$CFLAGS"
     md_ret_require="$md_build/jzintv/bin/jzintv"
 }
 


### PR DESCRIPTION
 * repack source archive so it unpacks to jzintv not jzintv-20181225-src and remove dlls from bin subfolder
 * remove now unneeded subMakefile changes
 * override CC/CXX in Makefile to use just gcc rather than hardcoded version
 * clear WARNXX to avoid incompatibility with -Wc++1z-compat and older g++