### PR TITLE
lr-mame2003(-plus): update core options suffix

### DIFF
--- a/scriptmodules/libretrocores/lr-mame2003.sh
+++ b/scriptmodules/libretrocores/lr-mame2003.sh
@@ -76,9 +76,9 @@ function configure_lr-mame2003() {
     fi
 
     # Set core options
-    setRetroArchCoreOption "${dir_name}-skip_disclaimer" "enabled"
-    setRetroArchCoreOption "${dir_name}-dcs-speedhack" "enabled"
-    setRetroArchCoreOption "${dir_name}-samples" "enabled"
+    setRetroArchCoreOption "${dir_name}_skip_disclaimer" "enabled"
+    setRetroArchCoreOption "${dir_name}_dcs-speedhack" "enabled"
+    setRetroArchCoreOption "${dir_name}_samples" "enabled"
 
     local so_name="$(_get_so_name_${md_id})"
     addEmulator 0 "$md_id" "arcade" "$md_inst/${so_name}_libretro.so"


### PR DESCRIPTION
The `mame2003` and `mame2003-plus` core options are now better aligned with the other cores by prefixing the options with `<core_name>_` instead of `<core_name>-`.

* mame2003-libtetro - https://github.com/libretro/mame2003-libretro/blob/2961cbd34383f6a0d4d8a3362bb79911607158f6/src/mame2003/mame2003.c#L182-L220
* mame2003-plus-libretro : https://github.com/libretro/mame2003-plus-libretro/blob/927c5578dd5daa161b880876119444e0a414bdb4/src/mame2003/mame2003.c#L185-L223

This issue came up recently in the forums (https://retropie.org.uk/forum/topic/21828) - so I updated the Wiki, the PR also updates the core options on installation.
