### PR TITLE
lr-pcsx-rearmed - use correct make invocation for cleaning

### DIFF
--- a/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
+++ b/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
@@ -33,8 +33,7 @@ function build_lr-pcsx-rearmed() {
         isPlatform "arm" && platform+="armv"
         isPlatform "neon" && platform+="neon"
     fi
-    [[ -z "$platform" ]] && platform="unix"
-    make -f Makefile.libretro clean
+    make -f Makefile.libretro platform="$platform" clean
     make -f Makefile.libretro platform="$platform"
     md_ret_require="$md_build/pcsx_rearmed_libretro.so"
 }


### PR DESCRIPTION
* Pass `platform` parameter also for the clean target, otherwise there are files left uncleaned because of the configuration set by the platform parameter itself.
* Removed unnecessary default setting for platform as well (as noted before)

This is a very small and inoffensive fix. Most of the time the core is built from a freshly cloned directory, therefore the built core is exactly the same as before. The cleaning operation now works properly for cases such as debugging and building multiple times from the same directory.