### PR TITLE
lr-pcsx-rearmed - set make parameters manually according to platform

### DIFF
--- a/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
+++ b/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
@@ -26,15 +26,19 @@ function sources_lr-pcsx-rearmed() {
 }
 
 function build_lr-pcsx-rearmed() {
-    local platform
-    if isPlatform "rpi2" || isPlatform "rpi3"; then
-        platform="$__platform"
-    else
-        isPlatform "arm" && platform+="armv"
-        isPlatform "neon" && platform+="neon"
+    local params=()
+
+    if isPlatform "arm"; then
+        params+=(ARCH=arm USE_DYNAREC=1)
+        if isPlatform "neon"; then
+            params+=(HAVE_NEON=1 BUILTIN_GPU=neon)
+        else
+            params+=(HAVE_NEON=0 BUILTIN_GPU=peops)
+        fi
     fi
-    make -f Makefile.libretro platform="$platform" clean
-    make -f Makefile.libretro platform="$platform"
+
+    make -f Makefile.libretro "${params[@]}" clean
+    make -f Makefile.libretro "${params[@]}"
     md_ret_require="$md_build/pcsx_rearmed_libretro.so"
 }
 


### PR DESCRIPTION
The libretro Makefile does not select appropriate cpu/gpu flags.
Therefore, set ARCH, HAVE_NEON, BUILTIN_GPU and USE_DYNAREC manually.

Was:
> The libretro Makefile does not override an empty platform parameter, therefore we must at least start with "unix" for non-RPI2/3 devices that are not ARM nor NEON-enabled, i.e. "generic-x11" machines.
Turns out the previous check was actually necessary for passing "unix" as default when platform is left empty. The libretro makefile does not override an empty platform parameter as we thought (mpff).
> 
> Sorry I didn't catch this in the previous PR. The "generic-x11" platform is the only affected one and not many people use it there in favour of beetle psx.