### PR TITLE
lr-snes9x - update and simplify scriptmodule

### DIFF
--- a/scriptmodules/libretrocores/lr-snes9x.sh
+++ b/scriptmodules/libretrocores/lr-snes9x.sh
@@ -20,16 +20,12 @@ function sources_lr-snes9x() {
 }
 
 function build_lr-snes9x() {
+    local params=()
+    isPlatform "arm" && params+=(platform="armv")
+
     cd libretro
-    make clean
-    local platform=""
-    isPlatform "arm" && platform+="armv"
-    isPlatform "neon" && platform+="neon"
-    if [[ -n "$platform" ]]; then
-        CXXFLAGS+=" -DARM" make platform="$platform"
-    else
-        make
-    fi
+    make "${params[@]}" clean
+    make "${params[@]}"
     md_ret_require="$md_build/libretro/snes9x_libretro.so"
 }
 


### PR DESCRIPTION
* using `platform=armv` is now sufficient for the build to use `-DARM`
  - fixed since a while here: https://github.com/libretro/snes9x/pull/62
* adding `neon` to `platform` has no effect on the built binary of this core
  - there is no NEON-specific code in the core
* also pass `platform` parameter for the clean target as well (I know you plan to remove cleaning during build, but for now at least let's keep it consistent)

Currently, `-DARM` is repeated twice because of the workaround in the scriptmodule:

    g++ -I../libretro -I.. -I../apu/ -I../apu/bapu   -O2 -march=armv8-a+crc -mtune=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard -ftree-vectorize -funsafe-math-optimizations -DARM -DGIT_VERSION=\"" dad0ae5"\" -flto -DARM -O3 -DNDEBUG -fomit-frame-pointer -Wall -W -Wno-unused-parameter -fPIC -DRIGHTSHIFT_IS_SAR -D__LIBRETRO__ -DALLOW_CPU_OVERCLOCK -DHAVE_STDINT_H -DHAVE_STRINGS_H -fno-rtti -pedantic  -fno-exceptions -c -o../apu/bapu/smp/smp.o ../apu/bapu/smp/smp.cpp

Without the workaround, `-DARM` is still added properly with current upstream:

    g++ -I../libretro -I.. -I../apu/ -I../apu/bapu   -O2 -march=armv8-a+crc -mtune=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard -ftree-vectorize -funsafe-math-optimizations -DGIT_VERSION=\"" dad0ae5"\" -flto -DARM -O3 -DNDEBUG -fomit-frame-pointer -Wall -W -Wno-unused-parameter -fPIC -DRIGHTSHIFT_IS_SAR -D__LIBRETRO__ -DALLOW_CPU_OVERCLOCK -DHAVE_STDINT_H -DHAVE_STRINGS_H -fno-rtti -pedantic  -fno-exceptions -c -o../apu/bapu/smp/smp.o ../apu/bapu/smp/smp.cpp

Build and games tested on Raspberry Pi 3 using `__platform=rpi1`, `__platform=rpi2`, `__platform=rpi3`.

Edit: to confirm the same binary, I compared the checksums of the core built before and after this PR:

    53d27f3a1ab9b62000e33dd20c24e773  snes9x_libretro.so.before
    53d27f3a1ab9b62000e33dd20c24e773  snes9x_libretro.so.after
