### PR TITLE
Update lr-stella due to rebrand

### DIFF
--- a/scriptmodules/libretrocores/lr-stella.sh
+++ b/scriptmodules/libretrocores/lr-stella.sh
@@ -12,23 +12,23 @@
 rp_module_id="lr-stella"
 rp_module_desc="Atari 2600 emulator - Stella port for libretro"
 rp_module_help="ROM Extensions: .a26 .bin .rom .zip .gz\n\nCopy your Atari 2600 roms to $romdir/atari2600"
-rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/stella-libretro/master/stella/license.txt"
+rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/stella2014-libretro/master/stella/license.txt"
 rp_module_section="main"
 
 function sources_lr-stella() {
-    gitPullOrClone "$md_build" https://github.com/libretro/stella-libretro.git
+    gitPullOrClone "$md_build" https://github.com/libretro/stella2014-libretro.git
 }
 
 function build_lr-stella() {
     make clean
     make
-    md_ret_require="$md_build/stella_libretro.so"
+    md_ret_require="$md_build/stella2014_libretro.so"
 }
 
 function install_lr-stella() {
     md_ret_files=(
         'README.md'
-        'stella_libretro.so'
+        'stella2014_libretro.so'
     )
 }
 
@@ -36,6 +36,6 @@ function configure_lr-stella() {
     mkRomDir "atari2600"
     ensureSystemretroconfig "atari2600"
 
-    addEmulator 1 "$md_id" "atari2600" "$md_inst/stella_libretro.so"
+    addEmulator 1 "$md_id" "atari2600" "$md_inst/stella2014_libretro.so"
     addSystem "atari2600"
 }


### PR DESCRIPTION
stella has rebranded to become stella2014. This commit reflects that
change and now enable the build and install to complete.