### PR TITLE
vice: enable 'x64' to be built with recent Vice 3, fixes building from source.

### DIFF
--- a/scriptmodules/emulators/vice.sh
+++ b/scriptmodules/emulators/vice.sh
@@ -27,7 +27,7 @@ function sources_vice() {
 }
 
 function build_vice() {
-    local params=(--enable-sdlui2 --without-oss --enable-ethernet)
+    local params=(--enable-sdlui2 --without-oss --enable-ethernet --enable-x64)
     ! isPlatform "x11" && params+=(--disable-catweasel --without-pulse)
     ./autogen.sh
     ./configure --prefix="$md_inst" "${params[@]}"


### PR DESCRIPTION
Upstream recently dropped the **x64** target from their default build and intends to deprecate it, replacing it with **x64sc**. References:
* https://sourceforge.net/p/vice-emu/code/36182/
* https://sourceforge.net/p/vice-emu/mailman/message/36654013/

To allow building from source, this change explicitely adds `--enable-x64` (as per the last ref). The scriptmodule should probably be modified to use **x64sc** as `md_ret_require` and make **x64sc** as default emulator.