### PR TITLE
helpers - don't use our custom sdl2 by default on x11 target

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -199,9 +199,13 @@ function getDepends() {
     # check whether to use our own sdl2 - can be disabled to resolve issues with
     # mixing custom 64bit sdl2 and os distributed i386 version on multiarch
     local own_sdl2=1
+    # default to off for x11 targets due to issues with dependencies with recent
+    # Ubuntu (19.04). eg libavdevice58 requiring exactly 2.0.9 sdl2.
+    isPlatform "x11" && own_sdl2=0
     iniConfig " = " '"' "$configdir/all/retropie.cfg"
     iniGet "own_sdl2"
-    [[ "$ini_value" == "0" ]] && own_sdl2=0
+    [[ "$ini_value" == 1 ]] && own_sdl2=1
+    [[ "$ini_value" == 0 ]] && own_sdl2=0
 
     for required in $@; do
 

--- a/scriptmodules/supplementary/sdl2.sh
+++ b/scriptmodules/supplementary/sdl2.sh
@@ -16,7 +16,11 @@ rp_module_section=""
 rp_module_flags=""
 
 function get_ver_sdl2() {
-    echo "2.0.8"
+    if isPlatform "x11"; then
+        echo "2.0.9"
+    else
+        echo "2.0.8"
+    fi
 }
 
 function get_pkg_ver_sdl2() {


### PR DESCRIPTION
 * resolves issues with recent Ubuntu packages having dependencies on a specific sdl2 version - eg libavdevice58