### PR TITLE
lr-mame2016 - fix building on neon platforms by disabling bgfx

### DIFF
--- a/scriptmodules/libretrocores/lr-mame2016.sh
+++ b/scriptmodules/libretrocores/lr-mame2016.sh
@@ -17,6 +17,9 @@ rp_module_section="exp"
 
 function sources_lr-mame2016() {
     gitPullOrClone "$md_build" https://github.com/libretro/mame2016-libretro.git
+    # disable bgfx (fails on neon with recent GCC due to outdated SIMD instrinsics)
+    # see https://github.com/libretro/mame2016-libretro/pull/25
+    applyPatch "$md_data/01_disable_bgfx.diff"
 }
 
 function build_lr-mame2016() {

--- a/scriptmodules/libretrocores/lr-mame2016/01_disable_bgfx.diff
+++ b/scriptmodules/libretrocores/lr-mame2016/01_disable_bgfx.diff
@@ -1,0 +1,82 @@
+diff --git a/Makefile.libretro b/Makefile.libretro
+index 31c414be..8de62064 100644
+--- a/Makefile.libretro
++++ b/Makefile.libretro
+@@ -55,6 +55,8 @@ VERBOSE ?= 1
+ # scripts/toolchain.lua)
+ # PTR64 = 1
+ 
++USE_BGFX ?= 0
++
+ ###########################################################################
+ #
+ #   LIBRETRO PLATFORM GUESSING
+diff --git a/scripts/genie.lua b/scripts/genie.lua
+index 4655b3f4..495308a8 100644
+--- a/scripts/genie.lua
++++ b/scripts/genie.lua
+@@ -387,8 +387,22 @@ newoption {
+ 	description = "Arguments for running debug build.",
+ }
+ 
++newoption {
++	trigger = "USE_BGFX",
++	description = "Use bgfx.",
++	allowed = {
++		{ "0",   "Disabled"     },
++		{ "1",   "Enabled"      },
++	}
++}
++
+ dofile ("extlib.lua")
+ 
++if not _OPTIONS["USE_BGFX"] then
++	_OPTIONS["USE_BGFX"] = "0"
++end
++
++
+ if _OPTIONS["SHLIB"]=="1" then
+ 	LIBTYPE = "SharedLib"
+ else
+diff --git a/scripts/src/3rdparty.lua b/scripts/src/3rdparty.lua
+index 664898d1..d720578d 100644
+--- a/scripts/src/3rdparty.lua
++++ b/scripts/src/3rdparty.lua
+@@ -716,7 +716,7 @@ end
+ --------------------------------------------------
+ -- BGFX library objects
+ --------------------------------------------------
+-
++if not _OPTIONS["use_bgfx"]=="0" then
+ project "bgfx"
+ 	uuid "d3e7e119-35cf-4f4f-aba0-d3bdcd1b879a"
+ 	kind "StaticLib"
+@@ -872,7 +872,7 @@ end
+ 			MAME_DIR .. "3rdparty/bgfx/src/renderer_mtl.mm",
+ 		}
+ 	end
+-
++end
+ --------------------------------------------------
+ -- PortAudio library objects
+ --------------------------------------------------
+diff --git a/scripts/src/main.lua b/scripts/src/main.lua
+index 0b47e662..b19eb646 100644
+--- a/scripts/src/main.lua
++++ b/scripts/src/main.lua
+@@ -294,8 +294,14 @@ end
+ 			ext_lib("portmidi"),
+ 		}
+ 	end
++
++	if _OPTIONS["USE_BGFX"]~="0" then
++		links {
++			"bgfx",
++		}
++	end
+ 	links {
+-		"bgfx",
++	--	"bgfx",
+ 		"ocore_" .. _OPTIONS["osd"],
+ 	}
+ 


### PR DESCRIPTION
 * disable bgfx (fails on neon with recent GCC due to outdated SIMD instrinsics)
 * see https://github.com/libretro/mame2016-libretro/pull/25