### PR TITLE
sdlpop - fix quicksave and in-game settings saving

### DIFF
--- a/scriptmodules/ports/sdlpop.sh
+++ b/scriptmodules/ports/sdlpop.sh
@@ -45,6 +45,8 @@ function configure_sdlpop() {
     moveConfigFile "$md_inst/SDLPoP.ini" "$md_conf_root/$md_id/SDLPoP.ini"
 
     moveConfigFile "$md_inst/PRINCE.SAV" "$md_conf_root/$md_id/PRINCE.SAV"
+    moveConfigFile "$md_inst/QUICKSAVE.SAV" "$md_conf_root/$md_id/QUICKSAVE.SAV"
+    moveConfigFile "$md_inst/SDLPoP.cfg" "$md_conf_root/$md_id/SDLPoP.cfg"
 
     chown -R $user:$user "$md_conf_root/$md_id"
 }


### PR DESCRIPTION
The game attempts to write some files to its working directory but they aren't
writable and so they're being redirected to the /opt/retropie/conf directory