### PR TITLE
Prevent welcome message when using scp or rsync

### DIFF
--- a/scriptmodules/supplementary/bashwelcometweak.sh
+++ b/scriptmodules/supplementary/bashwelcometweak.sh
@@ -124,8 +124,9 @@ function retropie_welcome() {
     done
     echo -e "\n$out"
 }
-
-retropie_welcome
+if shopt -q login_shell; then¬
+    retropie_welcome
+fi
 # RETROPIE PROFILE END
 _EOF_
 


### PR DESCRIPTION
When running this command with `rsync`:
`rsync -a pi@retropie:/opt/retropie/configs/all/retroarch/screenshots/ ~/`

I got the following error:
```
tput: No value for $TERM and no -T specified
protocol version mismatch -- is your shell clean?
```

This is because the bash welcome script runs and outputs data that rsync is not expecting, I found the change made prevents this.