### PR TITLE
add mupen64plus "next" for libretro to experimental

### DIFF
--- a/scriptmodules/libretrocores/lr-mupen64plus-next.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus-next.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-mupen64plus-next"
+rp_module_desc="N64 emulator - Mupen64Plus + GLideN64 for libretro (next version)"
+rp_module_help="ROM Extensions: .z64 .n64 .v64\n\nCopy your N64 roms to $romdir/n64"
+rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/mupen64plus-libretro-nx/master/LICENSE"
+rp_module_section="exp"
+
+function depends_lr-mupen64plus-next() {
+    local depends=(flex bison libpng-dev)
+    isPlatform "x11" && depends+=(libglew-dev libglu1-mesa-dev)
+    isPlatform "x86" && depends+=(nasm)
+    isPlatform "rpi" && depends+=(libraspberrypi-dev)
+    getDepends "${depends[@]}"
+}
+
+function sources_lr-mupen64plus-next() {
+    gitPullOrClone "$md_build" https://github.com/libretro/mupen64plus-libretro-nx.git GLideN64
+}
+
+function build_lr-mupen64plus-next() {
+    local params=()
+    if isPlatform "rpi"; then
+        params+=(platform="$__platform")
+    elif isPlatform "mali"; then
+        params+=(platform="odroid")
+    else
+        isPlatform "arm" && params+=(WITH_DYNAREC=arm)
+        isPlatform "neon" && params+=(HAVE_NEON=1)
+        isPlatform "gles" && params+=(FORCE_GLES=1)
+        isPlatform "kms" && params+=(FORCE_GLES3=1)
+    fi
+    # use a custom core name to avoid core option name clashes with lr-mupen64plus
+    params+=(CORE_NAME=mupen64plus-next)
+    make "${params[@]}" clean
+    make "${params[@]}"
+    md_ret_require="$md_build/mupen64plus_next_libretro.so"
+}
+
+function install_lr-mupen64plus-next() {
+    md_ret_files=(
+        'mupen64plus_next_libretro.so'
+        'README.md'
+    )
+}
+
+function configure_lr-mupen64plus-next() {
+    mkRomDir "n64"
+    ensureSystemretroconfig "n64"
+
+    addEmulator 0 "$md_id" "n64" "$md_inst/mupen64plus_next_libretro.so"
+    addSystem "n64"
+}


### PR DESCRIPTION
This scriptmodule has been under testing in the forum since Feb/2019 without major problems. Features:

* This core uses up-to-date GLideN64 plugin
* Scriptmodule sets a different namespace (`mupen64plus-next-`) for the core options to avoid clashing with the older `lr-mupen64plus` core options, i.e. they both can co-exist.

Forum Topic: https://retropie.org.uk/forum/topic/21093/
Upstream: https://github.com/libretro/mupen64plus-libretro-nx
