### PR TITLE
Fix version number requirements

### DIFF
--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -74,7 +74,7 @@ function depends_setup() {
     fi
 
     if [[ "$__os_debian_ver" -eq 8 ]]; then
-        printMsgs "dialog" "Raspbian/Debian Jessie and versions of Ubuntu below 18.04 are no longer supported.\n\nPlease install RetroPie 4.4 or newer from a fresh image which is based on Raspbian Stretch (or if running Ubuntu, upgrade your OS)."
+        printMsgs "dialog" "Raspbian/Debian Jessie and versions of Ubuntu below 16.04 are no longer supported.\n\nPlease install RetroPie 4.4 or newer from a fresh image which is based on Raspbian Stretch (or if running Ubuntu, upgrade your OS)."
     fi
 
     # make sure user has the correct group permissions

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -84,7 +84,7 @@ function get_os_version() {
                 __os_release=10
             fi
 
-            if compareVersions "$__os_debian_ver" lt 8; then
+            if compareVersions "$__os_debian_ver" lt 9; then
                 error="You need Raspbian/Debian Stretch or newer"
             fi
 
@@ -129,20 +129,20 @@ function get_os_version() {
                     error="You need Linux Mint 18 or newer"
                 elif compareVersions "$__os_release" lt 19; then
                     __os_ubuntu_ver="16.04"
-                    __os_debian_ver="8"
+                    __os_debian_ver="9"
                 else
                     __os_ubuntu_ver="18.04"
-                    __os_debian_ver="9"
+                    __os_debian_ver="10"
                 fi
             fi
             ;;
         Ubuntu)
             if compareVersions "$__os_release" lt 16.04; then
                 error="You need Ubuntu 16.04 or newer"
-            elif compareVersions "$__os_release" lt 16.10; then
-                __os_debian_ver="8"
-            else
+            elif compareVersions "$__os_release" lt 18.04; then
                 __os_debian_ver="9"
+            else
+                __os_debian_ver="10"
             fi
             __os_ubuntu_ver="$__os_release"
             ;;


### PR DESCRIPTION
Update dialog to state that the minimum Ubuntu is 16.04 (upon which Linux Mint 18 [is based](https://en.wikipedia.org/wiki/Linux_Mint_version_history)), and set the [Debian version](https://askubuntu.com/a/445496) to 9 for Ubuntu 16 & 17 / Mint 18 and 10 for Ubuntu 18 & 19 / Mint 19.

This fixes the issue I encountered where the installer would attempt to install ES 2.7.6 instead of stable on Mint 18.3 and Ubuntu 16.04, and fail due to missing Boost libraries.