### PR TITLE
psx: add support for CHD files

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -182,7 +182,7 @@ ps2_fullname="PlayStation 2"
 psp_exts=".iso .pbp .cso"
 psp_fullname="PlayStation Portable"
 
-psx_exts=".cue .cbn .img .iso .m3u .mdf .pbp .toc .z .znx"
+psx_exts=".cue .cbn chd .img .iso .m3u .mdf .pbp .toc .z .znx"
 psx_fullname="PlayStation"
 
 samcoupe_exts=".dsk .mgt .sbt .sad"


### PR DESCRIPTION
`lr-pcsx-rearmed` has support for CHD (https://github.com/libretro/pcsx_rearmed/pull/280) now.
This change adds the `.chd` extension to the list of `psx` supported extensions.