### PR TITLE
Exclude modules harmful to Vero4k and build for armv7

### DIFF
--- a/scriptmodules/emulators/mame4all.sh
+++ b/scriptmodules/emulators/mame4all.sh
@@ -14,7 +14,7 @@ rp_module_desc="MAME emulator MAME4All-Pi"
 rp_module_help="ROM Extension: .zip\n\nCopy your MAME4all-Pi roms to either $romdir/mame-mame4all or\n$romdir/arcade"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/RetroPie/mame4all-pi/master/readme.txt"
 rp_module_section="main"
-rp_module_flags="!x11 !mali !kms"
+rp_module_flags="!x11 !mali !kms !vero4k"
 
 function depends_mame4all() {
     getDepends libasound2-dev libsdl1.2-dev libraspberrypi-dev

--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -27,11 +27,9 @@ function depends_mupen64plus() {
 
 function sources_mupen64plus() {
     local commit
-    #addresses segfault from "Add support for 64 Disk Drive. #446" in mupen64plus-core master
-    isPlatform "vero4k" && commit=("master b75fdfb")
 
     local repos=(
-        "mupen64plus core ${commit[0]}"
+        'mupen64plus core'
         'mupen64plus ui-console'
         'mupen64plus audio-sdl'
         'mupen64plus input-sdl'
@@ -85,7 +83,7 @@ function build_mupen64plus() {
             isPlatform "neon" && params+=("NEON=1")
             isPlatform "x11" && params+=("OSD=1" "PIE=1")
             isPlatform "x86" && params+=("SSE=SSE2")
-            isPlatform "vero4k" && params+=("HOST_CPU=armv8" "USE_GLES=1")
+            isPlatform "vero4k" && params+=("HOST_CPU=armv7" "USE_GLES=1")
 
             [[ "$dir" == "mupen64plus-ui-console" ]] && params+=("COREDIR=$md_inst/lib/" "PLUGINDIR=$md_inst/lib/mupen64plus/")
             make -C "$dir/projects/unix" "${params[@]}" clean
@@ -102,7 +100,7 @@ function build_mupen64plus() {
     if isPlatform "rpi3"; then
         params+=("-DCRC_ARMV8=On")
     elif isPlatform "vero4k"; then
-        params+=("-DVERO4K=On" "-DCRC_ARMV8=On" "-DEGL=On")
+        params+=("-DVERO4K=On" "-DCRC_OPT=On" "-DEGL=On")
     else
         params+=("-DCRC_OPT=On")
     fi
@@ -153,7 +151,7 @@ function install_mupen64plus() {
             isPlatform "rpi" && params+=("VC=1")
             isPlatform "neon" && params+=("NEON=1")
             isPlatform "x86" && params+=("SSE=SSE2")
-            isPlatform "vero4k" && params+=("HOST_CPU=armv8" "USE_GLES=1")
+            isPlatform "vero4k" && params+=("HOST_CPU=armv7" "USE_GLES=1")
             make -C "$source/projects/unix" PREFIX="$md_inst" OPTFLAGS="$CFLAGS -O3 -flto" "${params[@]}" install
         fi
     done

--- a/scriptmodules/emulators/pifba.sh
+++ b/scriptmodules/emulators/pifba.sh
@@ -14,7 +14,7 @@ rp_module_desc="FBA emulator PiFBA"
 rp_module_help="ROM Extension: .zip\n\nCopy your FBA roms to\n$romdir/fba or\n$romdir/neogeo or\n$romdir/arcade\n\nFor NeoGeo games the neogeo.zip BIOS is required and must be placed in the same directory as your FBA roms."
 rp_module_licence="GPL2 https://raw.githubusercontent.com/RetroPie/pifba/master/FBAcapex_src/COPYING"
 rp_module_section="main"
-rp_module_flags="!x11 !mali !kms"
+rp_module_flags="!x11 !mali !kms !vero4k"
 
 function depends_pifba() {
     getDepends libasound2-dev libsdl1.2-dev libraspberrypi-dev

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -377,9 +377,9 @@ function platform_imx6() {
 }
 
 function platform_vero4k() {
-    __default_cflags="-I/opt/vero3/include -L/opt/vero3/lib -O2 -march=armv8-a+crc -mtune=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard -ftree-vectorize -funsafe-math-optimizations"
+    __default_cflags="-I/opt/vero3/include -L/opt/vero3/lib -O2 -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard -ftree-vectorize -funsafe-math-optimizations"
     __default_asflags=""
     __default_makeflags="-j4"
-    __platform_flags="arm armv8 neon vero4k gles"
+    __platform_flags="arm armv7 neon vero4k gles"
 }
 


### PR DESCRIPTION
Changes:

1. Build armv7 binaries from now on.  This is harmless enough and may iron out a few quirks in Reicast.  It definitely resolves the mystery dynarec bug in Mupen64plus triggered by the addition of 64 Disk Drive support .  I have a [PR out there to optionally disable 64 Disk Drive support](https://github.com/mupen64plus/mupen64plus-core/pull/649) in builds that are affected, but it hasn't had any attention.  That is beyond our control, but this is not.
2. There are only 2 modules in "main" that are totally toxic to the Vero4k. Excluding these means users can safely perform a the bulk "basic install" without breaking their systems #2738 .

Many thanks,