### PR TITLE
pegasus-fe: Fix gradient banding

### DIFF
--- a/scriptmodules/supplementary/pegasus-fe.sh
+++ b/scriptmodules/supplementary/pegasus-fe.sh
@@ -74,6 +74,9 @@ fi
 tty=\$(tty)
 export TTY="\${tty:8:1}"
 
+# improve gradients
+export QT_QPA_EGLFS_FORCE888=1
+
 clear
 "$md_inst/pegasus-fe" "\$@"
 _EOF_


### PR DESCRIPTION
Qt applications on the Pi, like Pegasus, tend to have less detailed color gradients due to some framebuffer format related reasons. A kind user pointed out these banding issues can be fixed by defining an env var before launching Pegasus (mmatyas/pegasus-frontend#467).