### PR TITLE
image - install newer kernel from buster repos onto stretch to fix sony bt issues

### DIFF
--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -421,7 +421,7 @@ function update_packages_gui_setup() {
     rps_logInit
     {
         rps_logStart
-        [[ "$update_os" -eq 1 ]] && apt_upgrade_raspbiantools
+        [[ "$update_os" -eq 1 ]] && rp_callModule raspbiantools apt_upgrade
         update_packages_setup
         rps_logEnd
     } &> >(_setup_gzip_log "$logfilename")


### PR DESCRIPTION
proposed solution to get a newer kernel onto Stretch with the Sony BT fix.

if a new kernel/firmware is released for Stretch soon this won't be needed.