### PR TITLE
Fkms initial support

### DIFF
--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -68,9 +68,8 @@ function depends_setup() {
         exec "$scriptdir/retropie_packages.sh" setup post_update gui_setup
     fi
 
-    if isPlatform "rpi" && isPlatform "mesa"; then
-        printMsgs "dialog" "ERROR: You have the experimental desktop GL driver enabled. This is NOT compatible with RetroPie, and Emulation Station as well as emulators will fail to launch.\n\nPlease disable the experimental desktop GL driver from the raspi-config 'Advanced Options' menu."
-        exit 1
+    if isPlatform "rpi" && isPlatform "mesa" && ! isPlatform "rpi4"; then
+        printMsgs "dialog" "WARNING: You have the experimental desktop GL driver enabled. This is NOT supported by RetroPie, and Emulation Station as well as emulators may fail to launch.\n\nPlease disable the experimental desktop GL driver from the raspi-config 'Advanced Options' menu."
     fi
 
     if [[ "$__os_debian_ver" -eq 8 ]]; then

--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -51,7 +51,9 @@ function build_retroarch() {
         params+=(--disable-ffmpeg)
     fi
     isPlatform "gles" && params+=(--enable-opengles)
-    isPlatform "rpi" && params+=(--enable-dispmanx)
+    # Temporarily block dispmanx support for fkms until upstream support is fixed
+    isPlatform "dispmanx" && ! isPlatform "kms" && params+=(--enable-dispmanx)
+    isPlatform "rpi" && isPlatform "mesa" && params+=(--disable-videocore)
     isPlatform "mali" && params+=(--enable-mali_fbdev)
     isPlatform "kms" && params+=(--enable-kms)
     isPlatform "arm" && params+=(--enable-floathard)

--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -148,8 +148,11 @@ function sources_emulationstation() {
 }
 
 function build_emulationstation() {
+    local params=(-DFREETYPE_INCLUDE_DIRS=/usr/include/freetype2/)
+    # Temporary workaround until GLESv2 support is implemented
+    isPlatform "rpi" && isPlatform "mesa" && params+=(-DGL=On)
     rpSwap on 1000
-    cmake . -DFREETYPE_INCLUDE_DIRS=/usr/include/freetype2/
+    cmake . "${params[@]}"
     make clean
     make
     rpSwap off
@@ -205,11 +208,6 @@ function install_launch_emulationstation() {
 
 if [[ \$(id -u) -eq 0 ]]; then
     echo "emulationstation should not be run as root. If you used 'sudo emulationstation' please run without sudo."
-    exit 1
-fi
-
-if [[ -d "/sys/module/vc4" ]]; then
-    echo -e "ERROR: You have the experimental desktop GL driver enabled. This is NOT compatible with RetroPie, and Emulation Station as well as emulators will fail to launch.\\n\\nPlease disable the experimental desktop GL driver from the raspi-config 'Advanced Options' menu."
     exit 1
 fi
 


### PR DESCRIPTION
* Use the GL driver for EmulationStation; can be switched to GLESv2 after support is implemented
* Disable dispmanx on retroarch for mesa targets; should be possible to be enabled after upstream changes, but disable for now to avoid build error.
* Remove hard block on f/kms detection (don't even print error for RPI4)
* Requires SDL2 built with OpenGL support.

Should allow basic bringup for with fkms driver (default for rpi4).