### PR TITLE
lr-mupen64plus{-next} - install LICENSE files from upstream

### DIFF
--- a/scriptmodules/libretrocores/lr-mupen64plus-next.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus-next.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-mupen64plus-next"
 rp_module_desc="N64 emulator - Mupen64Plus + GLideN64 for libretro (next version)"
 rp_module_help="ROM Extensions: .z64 .n64 .v64\n\nCopy your N64 roms to $romdir/n64"
-rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/mupen64plus-libretro-nx/master/LICENSE"
+rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mupen64plus-libretro-nx/GLideN64/LICENSE"
 rp_module_section="exp"
 rp_module_flags="!armv6"
 
@@ -50,6 +50,7 @@ function build_lr-mupen64plus-next() {
 function install_lr-mupen64plus-next() {
     md_ret_files=(
         'mupen64plus_next_libretro.so'
+        'LICENSE'
         'README.md'
     )
 }

--- a/scriptmodules/libretrocores/lr-mupen64plus.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-mupen64plus"
 rp_module_desc="N64 emu - Mupen64Plus + GLideN64 for libretro"
 rp_module_help="ROM Extensions: .z64 .n64 .v64\n\nCopy your N64 roms to $romdir/n64"
-rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/mupen64plus-libretro/master/LICENSE"
+rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mupen64plus-libretro/master/LICENSE"
 rp_module_section="main"
 rp_module_flags="!aarch64"
 
@@ -63,6 +63,7 @@ function build_lr-mupen64plus() {
 function install_lr-mupen64plus() {
     md_ret_files=(
         'mupen64plus_libretro.so'
+        'LICENSE'
         'README.md'
         'BUILDING.md'
     )


### PR DESCRIPTION
m4xw kindly asked me to make sure we include the LICENSE files in the installed mupen cores

EDIT: also use the correct license (GPL3 -> GPL2)