### PR TITLE
Add .zip ROM extension support for Dreamcast

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -63,7 +63,7 @@ daphne_fullname="Daphne"
 dragon32_exts=".cas .wav .bas .asc .dmk .jvc .os9 .dsk .vdk .rom .ccc .sna"
 dragon32_fullname="Dragon 32"
 
-dreamcast_exts=".cdi .chd .gdi .sh"
+dreamcast_exts=".cdi .chd .gdi .sh .zip"
 dreamcast_fullname="Dreamcast"
 
 fba_exts=".7z .cue .fba .iso .zip"

--- a/scriptmodules/libretrocores/lr-flycast.sh
+++ b/scriptmodules/libretrocores/lr-flycast.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="lr-flycast"
 rp_module_desc="Dreamcast emulator - Reicast port for libretro"
-rp_module_help="Previously named lr-reicast then lr-beetle-dc\n\nROM Extensions: .cdi .gdi\n\nCopy your Dreamcast roms to $romdir/dreamcast\n\nCopy the required BIOS files dc_boot.bin and dc_flash.bin to $biosdir/dc"
+rp_module_help="Previously named lr-reicast then lr-beetle-dc\n\nDreamcast ROM Extensions: .cdi .gdi .chd, Naomi/Atomiswave ROM Extension: .zip\n\nCopy your Dreamcast/Naomi roms to $romdir/dreamcast\n\nCopy the required Dreamcast BIOS files dc_boot.bin and dc_flash.bin to $biosdir/dc\n\nCopy the required Naomi/Atomiswave BIOS files naomi.zip and awbios.zip to $biosdir/dc"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/flycast/master/LICENSE"
 rp_module_section="exp"
 rp_module_flags="!mali !armv6"


### PR DESCRIPTION
Add `.zip` as valid Dreamcast system extension, for Naomi/Atomiswave ROM support.
Naomi/Atomiswave ROM can be run with `lr-flycast`.