### PR TITLE
lr-mupen64plus: buster & fkms support

### DIFF
--- a/scriptmodules/libretrocores/lr-mupen64plus.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus.sh
@@ -33,19 +33,27 @@ function depends_lr-mupen64plus() {
     local depends=(flex bison libpng-dev)
     isPlatform "x11" && depends+=(libglew-dev libglu1-mesa-dev)
     isPlatform "x86" && depends+=(nasm)
-    isPlatform "rpi" && depends+=(libraspberrypi-dev)
+    isPlatform "mesa" && depends+=(libgles2-mesa-dev)
+    isPlatform "videocore" && depends+=(libraspberrypi-dev)
     getDepends "${depends[@]}"
 }
 
 function sources_lr-mupen64plus() {
     gitPullOrClone "$md_build" https://github.com/libretro/mupen64plus-libretro.git
+
+    # mesa workaround; see: https://github.com/libretro/libretro-common/issues/98
+    if hasPackage libgles2-mesa-dev 18.2 ge; then
+        applyPatch "$md_data/0001-eliminate-conflicting-typedefs.patch"
+    fi
 }
 
 function build_lr-mupen64plus() {
     rpSwap on 750
     local params=()
-    if isPlatform "rpi"; then
+    if isPlatform "videocore"; then
         params+=(platform="$__platform")
+    elif isPlatform "mesa"; then
+        params+=(platform="$__platform-mesa")
     elif isPlatform "mali"; then
         params+=(platform="odroid")
     else

--- a/scriptmodules/libretrocores/lr-mupen64plus/0001-eliminate-conflicting-typedefs.patch
+++ b/scriptmodules/libretrocores/lr-mupen64plus/0001-eliminate-conflicting-typedefs.patch
@@ -1,0 +1,15 @@
+diff --git a/libretro-common/include/glsm/glsm.h b/libretro-common/include/glsm/glsm.h
+index d422267..ecafdb2 100644
+--- a/libretro-common/include/glsm/glsm.h
++++ b/libretro-common/include/glsm/glsm.h
+@@ -32,8 +32,8 @@
+ RETRO_BEGIN_DECLS
+ 
+ #ifdef HAVE_OPENGLES2
+-typedef GLfloat GLdouble;
+-typedef GLclampf GLclampd;
++//typedef GLfloat GLdouble;
++//typedef GLclampf GLclampd;
+ #endif
+ 
+ #if defined(HAVE_OPENGLES2)


### PR DESCRIPTION
Tested on RPI against fkms and legacy driver.

Legacy driver seems same as stretch, and the fkms version seems to run at similar speed - but there seems to be some tearing, as though vsync is not working correctly.

The mesa workaround may not be suitable for upstream submission due to it having potential to break on older distributions, so it's patched only for newer versions that have the different typedef definition.