### PR TITLE
customhidsony: update for 4.19 kernel

### DIFF
--- a/scriptmodules/supplementary/customhidsony.sh
+++ b/scriptmodules/supplementary/customhidsony.sh
@@ -46,7 +46,7 @@ _EOF_
 
     cat > "hidsony_source.sh" << _EOF_
 #!/bin/bash
-rpi_kernel_ver="rpi-4.15.y"
+rpi_kernel_ver="rpi-4.19.y"
 mkdir -p "drivers/hid/" "patches"
 wget https://raw.githubusercontent.com/raspberrypi/linux/"\$rpi_kernel_ver"/drivers/hid/hid-sony.c -O "drivers/hid/hid-sony.c"
 wget https://raw.githubusercontent.com/raspberrypi/linux/"\$rpi_kernel_ver"/drivers/hid/hid-ids.h -O "drivers/hid/hid-ids.h"

--- a/scriptmodules/supplementary/customhidsony/0001-hidsony-gasiafix.diff
+++ b/scriptmodules/supplementary/customhidsony/0001-hidsony-gasiafix.diff
@@ -1,6 +1,6 @@
 --- a/drivers/hid/hid-sony.c	2018-11-15 05:39:31.762572258 +0000
 +++ b/drivers/hid/hid-sony.c	2018-11-15 05:38:55.762745843 +0000
-@@ -1987,6 +1987,7 @@
+@@ -2063,6 +2063,7 @@
  	struct sixaxis_output_report *report =
  		(struct sixaxis_output_report *)sc->output_report_dmabuf;
  	int n;
@@ -8,7 +8,7 @@
  
  	/* Initialize the report with default values */
  	memcpy(report, &default_report, sizeof(struct sixaxis_output_report));
-@@ -2021,9 +2022,18 @@
+@@ -2097,9 +2097,18 @@
  		}
  	}
  


### PR DESCRIPTION
Stretch and buster are now on 4.19 kernel, so keep in sync.