### PR TITLE
bashwelcometweak - add getIPAddress() function

### DIFF
--- a/scriptmodules/supplementary/bashwelcometweak.sh
+++ b/scriptmodules/supplementary/bashwelcometweak.sh
@@ -18,6 +18,15 @@ function install_bashwelcometweak() {
     cat >> "$home/.bashrc" <<\_EOF_
 # RETROPIE PROFILE START
 
+function getIPAddress() {
+    local ip_route
+    ip_route=$(ip -4 route get 8.8.8.8 2>/dev/null)
+    if [[ -z "$ip_route" ]]; then
+        ip_route=$(ip -6 route get 2001:4860:4860::8888 2>/dev/null)
+    fi
+    [[ -n "$ip_route" ]] && grep -oP "src \K[^\s]+" <<< "$ip_route"
+}
+
 function retropie_welcome() {
     local upSeconds="$(/usr/bin/cut -d. -f1 /proc/uptime)"
     local secs=$((upSeconds%60))
@@ -111,7 +120,7 @@ function retropie_welcome() {
                 out+="${fgred}Running Processes..: $(ps ax | wc -l | tr -d " ")"
                 ;;
             8)
-                out+="${fgred}IP Address.........: $(ip route get 8.8.8.8 2>/dev/null | awk '{print $NF; exit}')"
+                out+="${fgred}IP Address.........: $(getIPAddress)"
                 ;;
             9)
                 out+="Temperature........: CPU: $cpuTempC°C/$cpuTempF°F GPU: $gpuTempC°C/$gpuTempF°F"


### PR DESCRIPTION
In Buster, IPv6 seems to be enabled by default, therefore the `bashwelcometweak` displays the IPv6 localhost instead of preferring IPv4 as done in the more recent function implemented in `helpers.sh` in 1e849710 .

For now, just copy the newer function from `helpers.sh` in the `bashwelcometweak`. However, in the future, code duplication can be avoided by deploying a public library with RetroPie utilities.