### PR TITLE
DOSbox FKMS support & FKMS-related fixes

### DIFF
--- a/scriptmodules/emulators/dosbox-sdl2.sh
+++ b/scriptmodules/emulators/dosbox-sdl2.sh
@@ -14,10 +14,11 @@ rp_module_desc="DOS emulator (enhanced DOSBox fork)"
 rp_module_help="ROM Extensions: .bat .com .exe .sh .conf\n\nCopy your DOS games to $romdir/pc"
 rp_module_licence="GPL2 https://sourceforge.net/p/dosbox/code-0/HEAD/tree/dosbox/trunk/COPYING"
 rp_module_section="exp"
-rp_module_flags="!mali !kms"
+rp_module_flags="!mali"
 
 function depends_dosbox-sdl2() {
-    depends_dosbox libsdl2-dev libsdl2-net-dev libfluidsynth-dev fluid-soundfont-gm
+    local depends=(libsdl2-dev libsdl2-net-dev libfluidsynth-dev fluid-soundfont-gm)
+    depends_dosbox "${depends[@]}"
 }
 
 function sources_dosbox-sdl2() {
@@ -40,7 +41,7 @@ function configure_dosbox-sdl2() {
     if [[ "$md_mode" == "install" ]]; then
         local config_path=$(su "$user" -c "\"$md_inst/bin/dosbox\" -printconf")
         if [[ -f "$config_path" ]]; then
-            iniConfig "=" "" "$config_path"
+            iniConfig " = " "" "$config_path"
             iniSet "fluid.driver" "alsa"
             iniSet "fluid.soundfont" "/usr/share/sounds/sf2/FluidR3_GM.sf2"
             iniSet "fullresolution" "desktop"

--- a/scriptmodules/emulators/dosbox.sh
+++ b/scriptmodules/emulators/dosbox.sh
@@ -14,7 +14,7 @@ rp_module_desc="DOS emulator"
 rp_module_help="ROM Extensions: .bat .com .exe .sh .conf\n\nCopy your DOS games to $romdir/pc"
 rp_module_licence="GPL2 https://sourceforge.net/p/dosbox/code-0/HEAD/tree/dosbox/trunk/COPYING"
 rp_module_section="opt"
-rp_module_flags="dispmanx !mali !kms"
+rp_module_flags="dispmanx !mali"
 
 function depends_dosbox() {
     local depends=(libsdl1.2-dev libsdl-net1.2-dev libsdl-sound1.2-dev libasound2-dev libpng-dev automake autoconf zlib1g-dev subversion "$@")
@@ -24,7 +24,7 @@ function depends_dosbox() {
 
 function sources_dosbox() {
     local revision="$1"
-    [[ -z "$revision" ]] && revision="4194"
+    [[ -z "$revision" ]] && revision="4252"
 
     svn checkout https://svn.code.sf.net/p/dosbox/code-0/dosbox/trunk "$md_build" -r "$revision"
     applyPatch "$md_data/01-fully-bindable-joystick.diff"
@@ -122,7 +122,7 @@ _EOF_
 
         local config_path=$(su "$user" -c "\"$md_inst/bin/dosbox\" -printconf")
         if [[ -f "$config_path" ]]; then
-            iniConfig "=" "" "$config_path"
+            iniConfig " = " "" "$config_path"
             iniSet "usescancodes" "false"
             iniSet "core" "dynamic"
             iniSet "cycles" "max"
@@ -130,6 +130,11 @@ _EOF_
             if isPlatform "rpi" || [[ -n "$(aconnect -o | grep -e TiMidity -e FluidSynth)" ]]; then
                 iniSet "mididevice" "alsa"
                 iniSet "midiconfig" "128:0"
+            fi
+            if isPlatform "mesa"; then
+                iniSet "fullscreen" "true"
+                iniSet "fullresolution" "desktop"
+                iniSet "output" "overlay"
             fi
         fi
     fi

--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -17,6 +17,7 @@ rp_module_section="core"
 function depends_retroarch() {
     local depends=(libudev-dev libxkbcommon-dev libsdl2-dev libasound2-dev libusb-1.0-0-dev)
     isPlatform "rpi" && depends+=(libraspberrypi-dev)
+    isPlatform "gles" && depends+=(libgles2-mesa-dev)
     isPlatform "mali" && depends+=(mali-fbdev)
     isPlatform "x11" && depends+=(libx11-xcb-dev libpulse-dev libvulkan-dev)
     isPlatform "vero4k" && depends+=(vero3-userland-dev-osmc zlib1g-dev libfreetype6-dev)

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -265,7 +265,7 @@ function getDepends() {
         # workaround to force installation of our fixed libsdl1.2 and custom compiled libsdl2
         local temp=()
         for required in ${packages[@]}; do
-            if isPlatform "rpi" && [[ "$required" == "libsdl1.2-dev" ]]; then
+            if isPlatform "videocore" && [[ "$required" == "libsdl1.2-dev" ]]; then
                 if [[ "$__has_binaries" -eq 1 ]]; then
                     rp_callModule sdl1 install_bin
                 else
@@ -596,7 +596,7 @@ function addUdevInputRules() {
 ## @details Set a dispmanx flag for a module as to whether it should use the
 ## sdl1 dispmanx backend by default or not (0 for framebuffer, 1 for dispmanx).
 function setDispmanx() {
-    isPlatform "rpi" || return
+    isPlatform "dispmanx" || return
     local mod_id="$1"
     local status="$2"
     iniConfig "=" "\"" "$configdir/all/dispmanx.cfg"


### PR DESCRIPTION
* DOSBox:  update to r4252 & add fkms support
* DOSBox-sdl2: unblock & confirm fkms support.
* retroarch: add missing GLESv2 mesa headers.
* helpers: don't install custom SDL1 build for fkms targets