### PR TITLE
ppsspp: buster & fkms support

### DIFF
--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -17,8 +17,9 @@ rp_module_section="opt"
 rp_module_flags=""
 
 function depends_ppsspp() {
-    local depends=(cmake libsdl2-dev libzip-dev)
-    isPlatform "rpi" && depends+=(libraspberrypi-dev)
+    local depends=(cmake libsdl2-dev libsnappy-dev libzip-dev zlib1g-dev)
+    isPlatform "videocore" && depends+=(libraspberrypi-dev)
+    isPlatform "mesa" && depends+=(libgles2-mesa-dev)
     isPlatform "vero4k" && depends+=(vero3-userland-dev-osmc)
     getDepends "${depends[@]}"
 }
@@ -120,12 +121,14 @@ function build_ppsspp() {
     cd "$md_build/$md_id"
     rm -rf CMakeCache.txt CMakeFiles
     local params=()
-    if isPlatform "rpi"; then
+    if isPlatform "videocore"; then
         if isPlatform "armv6"; then
             params+=(-DCMAKE_TOOLCHAIN_FILE=cmake/Toolchains/raspberry.armv6.cmake)
         else
             params+=(-DCMAKE_TOOLCHAIN_FILE=cmake/Toolchains/raspberry.armv7.cmake)
         fi
+    elif isPlatform "mesa"; then
+        params+=(-DUSING_GLES2=ON -DUSING_EGL=OFF)
     elif isPlatform "mali"; then
         params+=(-DUSING_GLES2=ON -DUSING_FBDEV=ON)
     elif isPlatform "tinker"; then


### PR DESCRIPTION
* Implement fkms support (treated as a generic GLES2 target)
* Update build dependencies to enable additional emulator features

Observations on rpi3 via fkms:
* performance seems roughly on par with the legacy driver
* the core and standalone version have tearing; this may be an issue unique to rpi3's fkms overlay and not rpi4, but I can't be sure until someone tests. Same issue observed with `lr-pcsx-rearmed` and `lr-mupen64plus`.
* load & save of save states now appears to be stable in `lr-ppsspp`; building against the most recent tag, `v1.8.0`, causes the instability to return.
~~* sound is currently not working in `lr-ppsspp`, but it's a known issue and unrelated to this PR: https://github.com/libretro/ppsspp/issues/36~~
