### PR TITLE
lr-mupen64plus-next: buster & fkms support

### DIFF
--- a/scriptmodules/libretrocores/lr-mupen64plus-next.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus-next.sh
@@ -20,18 +20,24 @@ function depends_lr-mupen64plus-next() {
     local depends=(flex bison libpng-dev)
     isPlatform "x11" && depends+=(libglew-dev libglu1-mesa-dev)
     isPlatform "x86" && depends+=(nasm)
-    isPlatform "rpi" && depends+=(libraspberrypi-dev)
+    isPlatform "videocore" && depends+=(libraspberrypi-dev)
+    isPlatform "mesa" && depends+=(libgles2-mesa-dev)
     getDepends "${depends[@]}"
 }
 
 function sources_lr-mupen64plus-next() {
     gitPullOrClone "$md_build" https://github.com/libretro/mupen64plus-libretro-nx.git GLideN64
+
+    # HACK: force EGL detection on FKMS
+    isPlatform "mesa" && applyPatch "$md_data/0001-force-egl.patch"
 }
 
 function build_lr-mupen64plus-next() {
     local params=()
-    if isPlatform "rpi"; then
+    if isPlatform "videocore"; then
         params+=(platform="$__platform")
+    elif isPlatform "mesa"; then
+        params+=(platform="$__platform-mesa")
     elif isPlatform "mali"; then
         params+=(platform="odroid")
     else

--- a/scriptmodules/libretrocores/lr-mupen64plus-next/0001-force-egl.patch
+++ b/scriptmodules/libretrocores/lr-mupen64plus-next/0001-force-egl.patch
@@ -1,0 +1,13 @@
+diff --git a/GLideN64/src/Graphics/OpenGLContext/opengl_GLInfo.cpp b/GLideN64/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+index 4f16a19..98facc5 100644
+--- a/GLideN64/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
++++ b/GLideN64/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+@@ -154,7 +154,7 @@ void GLInfo::init() {
+ 	texture_barrierNV = Utils::isExtensionSupported(*this, "GL_NV_texture_barrier");
+ 
+ 	ext_fetch = Utils::isExtensionSupported(*this, "GL_EXT_shader_framebuffer_fetch") && !isGLES2 && (!isGLESX || ext_draw_buffers_indexed) && !imageTextures;
+-	eglImage = (Utils::isEGLExtensionSupported("EGL_KHR_image_base") || Utils::isEGLExtensionSupported("EGL_KHR_image"));
++	eglImage = true; //(Utils::isEGLExtensionSupported("EGL_KHR_image_base") || Utils::isEGLExtensionSupported("EGL_KHR_image"));
+ 
+ #ifdef OS_ANDROID
+ 	eglImage = eglImage &&


### PR DESCRIPTION
EGL detection needs to be forced for RPI3 via FKMS, otherwise the
core will segfault.

Seems to work well, apart from graphical tearing. 