### PR TITLE
vice: don't depend on 'checkinstall'

### DIFF
--- a/scriptmodules/emulators/vice.sh
+++ b/scriptmodules/emulators/vice.sh
@@ -17,7 +17,7 @@ rp_module_section="opt"
 rp_module_flags=""
 
 function depends_vice() {
-    local depends=(libsdl2-dev libmpg123-dev libpng-dev zlib1g-dev libasound2-dev libvorbis-dev libflac-dev libpcap-dev automake checkinstall bison flex subversion libjpeg-dev portaudio19-dev texinfo xa65)
+    local depends=(libsdl2-dev libmpg123-dev libpng-dev zlib1g-dev libasound2-dev libvorbis-dev libflac-dev libpcap-dev automake bison flex subversion libjpeg-dev portaudio19-dev texinfo xa65)
     isPlatform "x11" && depends+=(libpulse-dev)
     getDepends "${depends[@]}"
 }


### PR DESCRIPTION
`checkinstall` is not available on Buster and it's not used by the scriptmodule, so it can be removed.