### PR TITLE
runcommand & retroarch X11-related fixes

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -18,6 +18,7 @@ function depends_retroarch() {
     local depends=(libudev-dev libxkbcommon-dev libsdl2-dev libasound2-dev libusb-1.0-0-dev)
     isPlatform "rpi" && depends+=(libraspberrypi-dev)
     isPlatform "gles" && depends+=(libgles2-mesa-dev)
+    isPlatform "mesa" && depends+=(libx11-xcb-dev)
     isPlatform "mali" && depends+=(mali-fbdev)
     isPlatform "x11" && depends+=(libx11-xcb-dev libpulse-dev libvulkan-dev)
     isPlatform "vero4k" && depends+=(vero3-userland-dev-osmc zlib1g-dev libfreetype6-dev)
@@ -47,7 +48,10 @@ function sources_retroarch() {
 
 function build_retroarch() {
     local params=(--disable-sdl --enable-sdl2 --disable-oss --disable-al --disable-jack --disable-qt)
-    ! isPlatform "x11" && params+=(--disable-x11 --disable-pulse)
+    if ! isPlatform "x11"; then
+        params+=(--disable-pulse)
+        ! isPlatform "mesa" && params+=(--disable-x11)
+    fi
     if compareVersions "$__os_debian_ver" lt 9; then
         params+=(--disable-ffmpeg)
     fi
@@ -160,6 +164,7 @@ function configure_retroarch() {
     iniSet "video_font_size" "12"
     iniSet "core_options_path" "$configdir/all/retroarch-core-options.cfg"
     isPlatform "x11" && iniSet "video_fullscreen" "true"
+    isPlatform "mesa" && iniSet "video_fullscreen" "true"
 
     # set default render resolution to 640x480 for rpi1
     if isPlatform "rpi1"; then

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -900,12 +900,6 @@ function get_sys_command() {
         COMMAND="${COMMAND:4}"
         CONSOLE_OUT=1
     fi
-
-    # workaround for launching xserver on correct/user owned tty
-    # see https://github.com/RetroPie/RetroPie-Setup/issues/1805
-    if [[ -n "$TTY" && "$COMMAND" =~ ^(startx|xinit) ]]; then
-        COMMAND+=" -- vt$TTY -keeptty"
-    fi
 }
 
 function show_launch() {
@@ -1059,6 +1053,12 @@ function runcommand() {
     [[ -n "$GOVERNOR" ]] && set_governor "$GOVERNOR"
 
     retroarch_append_config
+
+    # workaround for launching xserver on correct/user owned tty
+    # see https://github.com/RetroPie/RetroPie-Setup/issues/1805
+    if [[ -n "$TTY" && "$COMMAND" =~ ^(startx|xinit) ]]; then
+        COMMAND+=" -- vt$TTY -keeptty"
+    fi
 
     local ret
     launch_command


### PR DESCRIPTION
runcommand: fix server argument appending when parsing retroarch emulator entries
retroarch: build with X11 support on fkms targets to extend desktop coexistence and potentially work around vsync issues with certain cores using kmsdrm driver.