### PR TITLE
samba: fixes for buster release

### DIFF
--- a/scriptmodules/supplementary/samba.sh
+++ b/scriptmodules/supplementary/samba.sh
@@ -14,7 +14,7 @@ rp_module_desc="Configure Samba ROM Shares"
 rp_module_section="config"
 
 function depends_samba() {
-    getDepends samba
+    DEBIAN_FRONTEND=noninteractive getDepends samba
 }
 
 function remove_share_samba() {
@@ -41,7 +41,7 @@ _EOF_
 }
 
 function restart_samba() {
-    service samba restart
+    service samba restart || service smbd restart
 }
 
 function install_shares_samba() {
@@ -58,6 +58,7 @@ function remove_shares_samba() {
     for name in roms bios configs splashscreens; do
         remove_share_samba "$name"
     done
+    restart_samba
 }
 
 function gui_samba() {


### PR DESCRIPTION
* force DEBIAN_FRONTEND=noninteractive for getDepends, as samba-common
  will otherwise force user interaction despite the "-y" argument
  being passed to apt-get.
* The service name is now "smbd"; try to restart if "samba" fails to
  keep compatibility with older releases.
* Ensure service restart is performed when RetroPie shares are removed.