### PR TITLE
dxx-rebirth: update for fkms and buster

### DIFF
--- a/scriptmodules/ports/dxx-rebirth.sh
+++ b/scriptmodules/ports/dxx-rebirth.sh
@@ -10,14 +10,21 @@
 #
 
 rp_module_id="dxx-rebirth"
-rp_module_desc="DXX-Rebirth (Descent & Descent 2) build from source"
+rp_module_desc="DXX-Rebirth (Descent & Descent 2) source port"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/dxx-rebirth/dxx-rebirth/master/COPYING.txt"
 rp_module_section="opt"
-rp_module_flags="!mali !kms"
+rp_module_flags="!mali"
 
 function depends_dxx-rebirth() {
-    local depends=(libphysfs1 libphysfs-dev libsdl1.2-dev libsdl-mixer1.2-dev scons)
-    isPlatform "rpi" && depends+=(libraspberrypi-dev)
+    local depends=(libpng-dev libphysfs-dev libsdl1.2-dev libsdl-mixer1.2-dev scons)
+    if isPlatform "videocore"; then
+        depends+=(libraspberrypi-dev)
+    elif isPlatform "gles" && ! isPlatform "mesa"; then
+        depends+=(libgles2-mesa-dev)
+    else
+        depends+=(libgl1-mesa-dev libglu1-mesa-dev libsdl2-dev libsdl2-mixer-dev)
+    fi
+
     getDepends "${depends[@]}"
 }
 
@@ -27,7 +34,18 @@ function sources_dxx-rebirth() {
 
 function build_dxx-rebirth() {
     local params=()
-    isPlatform "rpi" && params+=(raspberrypi=1)
+    isPlatform "arm" && params+=("words_need_alignment=1")
+    if isPlatform "videocore"; then
+        params+=("raspberrypi=1")
+    elif isPlatform "mesa"; then
+        # GLES is limited to ES 1 and blocks SDL2; GL works at fullspeed on Pi 3.
+        params+=("raspberrypi=mesa" "opengl=1" "opengles=0" "sdl2=1")
+    elif isPlatform "gles";  then
+        params+=("opengl=0" "opengles=1")
+    else
+        params+=("opengl=1" "opengles=0" "sdl2=1")
+    fi
+
     scons -c
     scons "${params[@]}"
     md_ret_require=(


### PR DESCRIPTION
* Update dependencies
* Enable OpenGL + SDL2 build for non-gles targets
* Enable fkms/mesa target, also using SDL2+GL (due to upstream
  source requiring changes to support GLESv2 builds)