### PR TITLE
NO NOT MERGE: gl4es scriptmodule

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -246,6 +246,15 @@ function getDepends() {
                 packages+=("$required")
                 continue
             fi
+
+            # gl4es translation library installation for gles targets
+            if [[ "$required" == "libgl1-mesa-dev" ]] \
+              && isPlatform "gles" \
+              && hasFlag "${__mod_flags[$md_idx]}" "gl4es" \
+              && ! rp_isInstalled "$(rp_getIdxFromId "gl4es")"; then
+                packages+=("gl4es")
+                continue
+            fi
         fi
 
         if [[ "$md_mode" == "remove" ]]; then
@@ -276,6 +285,12 @@ function getDepends() {
                     rp_callModule sdl2 install_bin
                 else
                     rp_callModule sdl2
+                fi
+            elif [[ "$required" == "gl4es" ]]; then
+                if [[ "$__has_binaries" -eq 1 ]]; then
+                    rp_callModule gl4es install_bin
+                else
+                    rp_callModule gl4es
                 fi
             else
                 temp+=("$required")
@@ -1259,6 +1274,11 @@ function addEmulator() {
     # automatically add parameters for libretro modules
     if [[ "$id" == lr-* && "$cmd" =~ ^"$md_inst"[^[:space:]]*\.so ]]; then
         cmd="$emudir/retroarch/bin/retroarch -L $cmd --config $md_conf_root/$system/retroarch.cfg %ROM%"
+    fi
+
+    # prepend gl4es environment variables if indicated as needed by scriptmodule
+    if hasFlag "${__mod_flags[$md_idx]}" "gl4es" && isPlatform "gles" && ! isPlatform "mesa"; then
+        cmd="SDL_VIDEO_GL_DRIVER=libGL.so.1 LD_LIBRARY_PATH=$rootdir/supplementary/gl4es $cmd"
     fi
 
     # create a config folder for the system / port

--- a/scriptmodules/ports/neverball.sh
+++ b/scriptmodules/ports/neverball.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="neverball"
+rp_module_desc="3D floor-tilting & miniature golf games"
+rp_module_licence="GPL2 https://github.com/Neverball/neverball/blob/master/LICENSE.md"
+rp_module_section="exp"
+rp_module_flags="!mali gl4es"
+
+function depends_neverball() {
+    local depends=("libgl1-mesa-dev")
+
+    getDepends "${depends[@]}"
+}
+
+function _update_hook_neverball() {
+    # to show as installed in retropie-setup 4.x
+    hasPackage neverball && hasPackage neverputt && mkdir -p "$md_inst"
+}
+
+function install_bin_neverball() {
+    aptInstall neverball neverputt
+}
+
+function remove_neverball() {
+    aptRemove neverball neverball-common neverball-data neverputt neverputt-data
+}
+
+function configure_neverball() {
+    moveConfigDir "$home/.neverball" "$md_conf_root/neverball"
+
+    addPort "$md_id" "neverball" "Neverball" "neverball"
+    addPort "$md_id" "neverputt" "Neverputt" "neverputt"
+}

--- a/scriptmodules/supplementary/gl4es.sh
+++ b/scriptmodules/supplementary/gl4es.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="gl4es"
+rp_module_desc="GL4ES - OpenGL 2.1/1.5 to GL ES 2.0/1.1 translation library"
+rp_module_licence="OTHER https://github.com/ptitSeb/gl4es/blob/master/LICENSE"
+rp_module_section=""
+rp_module_flags=""
+
+function depends_gl4es() {
+    local depends=(libgl1-mesa-dev libgles2-mesa-dev)
+    isPlatform "videocore" && depends+=(libraspberrypi-dev)
+
+    getDepends "${depends[@]}"
+}
+
+function sources_gl4es() {
+    gitPullOrClone "$md_build" https://github.com/ptitSeb/gl4es
+}
+
+function build_gl4es() {
+    local params=()
+    isPlatform "videocore" && params=("-DBCMHOST=1")
+
+    rm -rf build
+    mkdir build
+    cd build
+    cmake .. "${params[@]}"
+    make
+
+    md_ret_require="$md_build/build/lib/libGL.so.1"
+}
+
+function install_gl4es() {
+    md_ret_files=(
+        'build/lib/libGL.so.1'
+        'README.md'
+        'LICENSE'
+    )
+}


### PR DESCRIPTION
Would appreciate any feedback, but keep in mind it's not ready to be merged due to deliberate `rp_callModule gl4es install_bin || rp_callModule gl4es` bypass that's needed to ensure that the module builds (as binaries aren't available, obviously).

I've included a scriptmodule that installs neverball and neverputt to demonstrate the library being used.

When a scriptmodule includes the `gl4es` tag, it will enable the translation library on generic `gles` targets (such as RPI with the legacy driver), but not RPI using `mesa` due to the GL 2.1 hardware support being present.

Note: SDL2 needs to be compiled with OpenGL support even on `videocore` to work with `gl4es`; my [other](https://github.com/RetroPie/RetroPie-Setup/pull/2770) PR will account for this.