### PR TITLE
mupen64plus: debian buster & initial fkms support

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -14,11 +14,12 @@ rp_module_desc="N64 emulator MUPEN64Plus"
 rp_module_help="ROM Extensions: .z64 .n64 .v64\n\nCopy your N64 roms to $romdir/n64"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/mupen64plus/mupen64plus-core/master/LICENSES"
 rp_module_section="main"
-rp_module_flags="!mali !kms"
+rp_module_flags="!mali"
 
 function depends_mupen64plus() {
     local depends=(cmake libsamplerate0-dev libspeexdsp-dev libsdl2-dev libpng-dev fonts-freefont-ttf)
     isPlatform "rpi" && depends+=(libraspberrypi-bin libraspberrypi-dev)
+    isPlatform "mesa" && depends+=(libgles2-mesa-dev)
     isPlatform "x11" && depends+=(libglew-dev libglu1-mesa-dev libboost-filesystem-dev)
     isPlatform "x86" && depends+=(nasm)
     isPlatform "vero4k" && depends+=(vero3-userland-dev-osmc libboost-all-dev)
@@ -63,8 +64,17 @@ function sources_mupen64plus() {
     done
     gitPullOrClone "$md_build/GLideN64" https://github.com/gonetz/GLideN64.git
 
-    # workaround for shader cache crash issue on Raspbian stretch. See: https://github.com/gonetz/GLideN64/issues/1665
-    applyPatch "$md_data/0001-GLideN64-use-emplace.patch"
+    if [[ -d "GLideN64" ]]; then
+        if isPlatform "videocore"; then
+            # workaround for shader cache crash issue on Raspbian stretch. See: https://github.com/gonetz/GLideN64/issues/1665
+            applyPatch "$md_data/0001-GLideN64-use-emplace.patch"
+        elif isPlatform "mesa"; then
+            # HACK: force EGL detection on FKMS targets
+            applyPatch "$md_data/0002-GLideN64-force-egl.patch"
+        fi
+    fi
+    # vsync fix; see: https://github.com/mupen64plus/mupen64plus-core/pull/670
+    applyPatch "$md_data/0003-core-vsync-670.patch"
 
     local config_version=$(grep -oP '(?<=CONFIG_VERSION_CURRENT ).+?(?=U)' GLideN64/src/Config.h)
     echo "$config_version" > "$md_build/GLideN64_config_version.ini"
@@ -79,7 +89,8 @@ function build_mupen64plus() {
         if [[ -f "$dir/projects/unix/Makefile" ]]; then
             params=()
             isPlatform "rpi1" && params+=("VFP=1" "VFP_HARD=1" "HOST_CPU=armv6")
-            isPlatform "rpi" && params+=("VC=1")
+            isPlatform "videocore" || [[ "$dir" == "mupen64plus-audio-omx" ]] && params+=("VC=1")
+            isPlatform "mesa" && params+=("USE_GLES=1")
             isPlatform "neon" && params+=("NEON=1")
             isPlatform "x11" && params+=("OSD=1" "PIE=1")
             isPlatform "x86" && params+=("SSE=SSE2")
@@ -97,7 +108,8 @@ function build_mupen64plus() {
     pushd "$md_build/GLideN64/projects/cmake"
     params=("-DMUPENPLUSAPI=On" "-DVEC4_OPT=On" "-DUSE_SYSTEM_LIBS=On")
     isPlatform "neon" && params+=("-DNEON_OPT=On")
-    if isPlatform "rpi3"; then
+    isPlatform "mesa" && params+=("-DMESA=On" "-DEGL=On")
+    if isPlatform "armv8"; then
         params+=("-DCRC_ARMV8=On")
     elif isPlatform "vero4k"; then
         params+=("-DVERO4K=On" "-DCRC_OPT=On" "-DEGL=On")
@@ -148,7 +160,8 @@ function install_mupen64plus() {
             # optflags is needed due to the fact the core seems to rebuild 2 files and relink during install stage most likely due to a buggy makefile
             local params=()
             isPlatform "armv6" && params+=("VFP=1" "HOST_CPU=armv6")
-            isPlatform "rpi" && params+=("VC=1")
+            isPlatform "videocore" || [[ "$dir" == "mupen64plus-audio-omx" ]] && params+=("VC=1")
+            isPlatform "mesa" && params+=("USE_GLES=1")
             isPlatform "neon" && params+=("NEON=1")
             isPlatform "x86" && params+=("SSE=SSE2")
             isPlatform "vero4k" && params+=("HOST_CPU=armv7" "USE_GLES=1")
@@ -163,16 +176,19 @@ function install_mupen64plus() {
 }
 
 function configure_mupen64plus() {
+    local res
+    local resolutions=("320x240" "640x480")
+    isPlatform "kms" && resolutions=("%XRES%x%YRES%")
+
     if isPlatform "rpi"; then
-        local res
-        for res in "320x240" "640x480"; do
+        isPlatform "videocore" && addEmulator 1 "${md_id}-auto" "n64" "$md_inst/bin/mupen64plus.sh AUTO %ROM%"
+        for res in "${resolutions[@]}"; do
             local name=""
             [[ "$res" == "640x480" ]] && name="-highres"
-            addEmulator 0 "${md_id}-GLideN64$name" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM% $res"
+            addEmulator 1 "${md_id}-GLideN64$name" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM% $res"
             addEmulator 0 "${md_id}-gles2rice$name" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-rice %ROM% $res"
         done
         addEmulator 0 "${md_id}-gles2n64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-n64 %ROM%"
-        addEmulator 1 "${md_id}-auto" "n64" "$md_inst/bin/mupen64plus.sh AUTO %ROM%"
     elif isPlatform "vero4k"; then
         addEmulator 1 "${md_id}-gles2n64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-n64 %ROM%"
         addEmulator 0 "${md_id}-GLideN64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM%"
@@ -180,10 +196,12 @@ function configure_mupen64plus() {
         addEmulator 0 "${md_id}-gles2rice" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-rice %ROM%"
         addEmulator 0 "${md_id}-auto" "n64" "$md_inst/bin/mupen64plus.sh AUTO %ROM%"
     else
-        addEmulator 0 "${md_id}-GLideN64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM%"
-        addEmulator 1 "${md_id}-glide64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-glide64mk2 %ROM%"
+        isPlatform "kms" && res="${resolutions[0]}"
+        addEmulator 0 "${md_id}-GLideN64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM% $res"
+        addEmulator 1 "${md_id}-glide64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-glide64mk2 %ROM% $res"
         if isPlatform "x86"; then
-            addEmulator 0 "${md_id}-GLideN64-LLE" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM% 640x480 mupen64plus-rsp-cxd4-sse2"
+            ! isPlatform "kms" && res="640x480"
+            addEmulator 0 "${md_id}-GLideN64-LLE" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM% $res mupen64plus-rsp-cxd4-sse2"
         fi
     fi
     addSystem "n64"
@@ -219,9 +237,16 @@ function configure_mupen64plus() {
         su "$user" -c "$cmd"
     fi
 
-    # RPI GLideN64 settings
+    # RPI main/GLideN64 settings
     if isPlatform "rpi"; then
         iniConfig " = " "" "$config"
+        # VSync is mandatory for good performance on KMS
+        if isPlatform "kms"; then
+            if ! grep -q "\[Video-General\]" "$config"; then
+                echo "[Video-General]" >> "$config"
+            fi
+            iniSet "VerticalSync" "True"
+        fi
         # Create GlideN64 section in .cfg
         if ! grep -q "\[Video-GLideN64\]" "$config"; then
             echo "[Video-GLideN64]" >> "$config"
@@ -238,19 +263,25 @@ function configure_mupen64plus() {
         iniSet "UseNativeResolutionFactor" "1"
         # Enable legacy blending
         iniSet "EnableLegacyBlending" "True"
-        # Enable FPS Counter. Fixes zelda depth issue
-        iniSet "ShowFPS " "True"
-        iniSet "fontSize" "14"
-        iniSet "fontColor" "1F1F1F"
         # Enable Threaded GL calls
         iniSet "ThreadedVideo" "True"
 
-        # Disable gles2n64 autores feature and use dispmanx upscaling
-        iniConfig "=" "" "$md_conf_root/n64/gles2n64.conf"
-        iniSet "auto resolution" "0"
+        if isPlatform "videocore"; then
+            # Enable FPS Counter. Fixes zelda depth issue
+            iniSet "ShowFPS " "True"
+            iniSet "fontSize" "14"
+            iniSet "fontColor" "1F1F1F"
 
-        addAutoConf mupen64plus_audio 1
-        addAutoConf mupen64plus_compatibility_check 1
+            # Disable gles2n64 autores feature and use dispmanx upscaling
+            iniConfig "=" "" "$md_conf_root/n64/gles2n64.conf"
+            iniSet "auto resolution" "0"
+
+            setAutoConf mupen64plus_audio 1
+            setAutoConf mupen64plus_compatibility_check 1
+        elif isPlatform "mesa"; then
+            setAutoConf mupen64plus_audio 0
+            setAutoConf mupen64plus_compatibility_check 0
+        fi
     else
         addAutoConf mupen64plus_audio 0
         addAutoConf mupen64plus_compatibility_check 0

--- a/scriptmodules/emulators/mupen64plus/0002-GLideN64-force-egl.patch
+++ b/scriptmodules/emulators/mupen64plus/0002-GLideN64-force-egl.patch
@@ -1,0 +1,13 @@
+diff --git a/GLideN64/src/Graphics/OpenGLContext/opengl_GLInfo.cpp b/GLideN64/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+index 9f2de97..745133f 100644
+--- a/GLideN64/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
++++ b/GLideN64/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+@@ -145,7 +145,7 @@ void GLInfo::init() {
+ 	texture_barrierNV = Utils::isExtensionSupported(*this, "GL_NV_texture_barrier");
+ 
+ 	ext_fetch = Utils::isExtensionSupported(*this, "GL_EXT_shader_framebuffer_fetch") && !isGLES2 && (!isGLESX || ext_draw_buffers_indexed) && !imageTextures;
+-	eglImage = (Utils::isEGLExtensionSupported("EGL_KHR_image_base") || Utils::isEGLExtensionSupported("EGL_KHR_image"));
++	eglImage = true; //(Utils::isEGLExtensionSupported("EGL_KHR_image_base") || Utils::isEGLExtensionSupported("EGL_KHR_image"));
+ 
+ #ifdef OS_ANDROID
+ 	eglImage = eglImage &&

--- a/scriptmodules/emulators/mupen64plus/0003-core-vsync-670.patch
+++ b/scriptmodules/emulators/mupen64plus/0003-core-vsync-670.patch
@@ -1,0 +1,151 @@
+From 7fbfbf3f90e7f214f59175fa560882739df40be6 Mon Sep 17 00:00:00 2001
+From: cbransden <chris.bransden@objectway.com>
+Date: Fri, 12 Jul 2019 14:41:32 +0100
+Subject: [PATCH 1/4] Log error when VSync set fails.
+
+---
+ src/api/vidext.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/mupen64plus-core/src/api/vidext.c b/mupen64plus-core/src/api/vidext.c
+index 6ff9bd96..c3798dce 100644
+--- a/mupen64plus-core/src/api/vidext.c
++++ b/mupen64plus-core/src/api/vidext.c
+@@ -429,7 +429,10 @@ EXPORT m64p_error CALL VidExt_GL_SetAttribute(m64p_GLattr Attr, int Value)
+     if (Attr == M64P_GL_SWAP_CONTROL)
+     {
+         if (SDL_GL_SetSwapInterval(Value) != 0)
++        {
++            DebugMessage(M64MSG_ERROR, "SDL swap interval (VSync) set failed: %s", SDL_GetError());
+             return M64ERR_SYSTEM_FAIL;
++        }
+         return M64ERR_SUCCESS;
+     }
+ #endif
+
+From 3e07fdd82d864ed22a1a665128d820948b56768e Mon Sep 17 00:00:00 2001
+From: cbransden <chris.bransden@objectway.com>
+Date: Sun, 14 Jul 2019 12:34:53 +0100
+Subject: [PATCH 2/4] Applied Swap Control/VSync after current context.
+
+---
+ src/api/vidext.c | 16 ++++++++++------
+ 1 file changed, 10 insertions(+), 6 deletions(-)
+
+diff --git a/mupen64plus-core/src/api/vidext.c b/mupen64plus-core/src/api/vidext.c
+index c3798dce..7c57adaa 100644
+--- a/mupen64plus-core/src/api/vidext.c
++++ b/mupen64plus-core/src/api/vidext.c
+@@ -47,6 +47,7 @@ static m64p_video_extension_functions l_ExternalVideoFuncTable = {12, NULL, NULL
+ static int l_VideoExtensionActive = 0;
+ static int l_VideoOutputActive = 0;
+ static int l_Fullscreen = 0;
++static int l_SwapControl = 0;
+ static SDL_Surface *l_pScreen = NULL;
+ 
+ /* global function for use by frontend.c */
+@@ -256,6 +257,13 @@ EXPORT m64p_error CALL VidExt_SetVideoMode(int Width, int Height, int BitsPerPix
+ 
+     SDL_ShowCursor(SDL_DISABLE);
+ 
++    /* set swap interval/VSync */
++    if (SDL_GL_SetSwapInterval(l_SwapControl) != 0)
++    {
++        DebugMessage(M64MSG_ERROR, "SDL swap interval (VSync) set failed: %s", SDL_GetError());
++        return M64ERR_SYSTEM_FAIL;
++    }
++
+     l_Fullscreen = (ScreenMode == M64VIDEO_FULLSCREEN);
+     l_VideoOutputActive = 1;
+     StateChanged(M64CORE_VIDEO_MODE, ScreenMode);
+@@ -428,12 +436,8 @@ EXPORT m64p_error CALL VidExt_GL_SetAttribute(m64p_GLattr Attr, int Value)
+ #if SDL_VERSION_ATLEAST(1,3,0)
+     if (Attr == M64P_GL_SWAP_CONTROL)
+     {
+-        if (SDL_GL_SetSwapInterval(Value) != 0)
+-        {
+-            DebugMessage(M64MSG_ERROR, "SDL swap interval (VSync) set failed: %s", SDL_GetError());
+-            return M64ERR_SYSTEM_FAIL;
+-        }
+-        return M64ERR_SUCCESS;
++        /* SDL swap interval/vsync needs to be set on current GL context, so save it for later */
++        l_SwapControl = Value;
+     }
+ #endif
+ 
+
+From 1cc9ed8e58f96ff6088fa73a567a1cd64ae1111e Mon Sep 17 00:00:00 2001
+From: dankcushions <chris.bransden@gmail.com>
+Date: Sat, 20 Jul 2019 14:01:21 +0100
+Subject: [PATCH 3/4] retrieve default swap interval/VSync during init
+
+---
+ src/api/vidext.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/mupen64plus-core/src/api/vidext.c b/mupen64plus-core/src/api/vidext.c
+index 7c57adaa..438d2d75 100644
+--- a/mupen64plus-core/src/api/vidext.c
++++ b/mupen64plus-core/src/api/vidext.c
+@@ -104,6 +104,8 @@ EXPORT m64p_error CALL VidExt_Init(void)
+ 
+ #if SDL_VERSION_ATLEAST(2,0,0)
+     SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
++    /* retrieve default swap interval/VSync */ 
++    l_SwapControl = SDL_GL_GetSwapInterval();
+ #endif
+ 
+     if (SDL_InitSubSystem(SDL_INIT_VIDEO) == -1)
+
+From 0363e7658cb67958bb2734a85df31adb4e446f69 Mon Sep 17 00:00:00 2001
+From: dankcushions <chris.bransden@gmail.com>
+Date: Mon, 22 Jul 2019 14:13:53 +0100
+Subject: [PATCH 4/4] SDL_GL_SetSwapInterval and _GetSwapInterval are SDL
+ 2.0.0.
+
+---
+ src/api/vidext.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/mupen64plus-core/src/api/vidext.c b/mupen64plus-core/src/api/vidext.c
+index 438d2d75..f33bfd63 100644
+--- a/mupen64plus-core/src/api/vidext.c
++++ b/mupen64plus-core/src/api/vidext.c
+@@ -259,12 +259,14 @@ EXPORT m64p_error CALL VidExt_SetVideoMode(int Width, int Height, int BitsPerPix
+ 
+     SDL_ShowCursor(SDL_DISABLE);
+ 
++#if SDL_VERSION_ATLEAST(2,0,0)
+     /* set swap interval/VSync */
+     if (SDL_GL_SetSwapInterval(l_SwapControl) != 0)
+     {
+         DebugMessage(M64MSG_ERROR, "SDL swap interval (VSync) set failed: %s", SDL_GetError());
+         return M64ERR_SYSTEM_FAIL;
+     }
++#endif
+ 
+     l_Fullscreen = (ScreenMode == M64VIDEO_FULLSCREEN);
+     l_VideoOutputActive = 1;
+@@ -435,13 +437,11 @@ EXPORT m64p_error CALL VidExt_GL_SetAttribute(m64p_GLattr Attr, int Value)
+     if (!SDL_WasInit(SDL_INIT_VIDEO))
+         return M64ERR_NOT_INIT;
+ 
+-#if SDL_VERSION_ATLEAST(1,3,0)
+     if (Attr == M64P_GL_SWAP_CONTROL)
+     {
+         /* SDL swap interval/vsync needs to be set on current GL context, so save it for later */
+         l_SwapControl = Value;
+     }
+-#endif
+ 
+     /* translate the GL context type mask if necessary */
+ #if SDL_VERSION_ATLEAST(2,0,0)
+@@ -491,7 +491,7 @@ EXPORT m64p_error CALL VidExt_GL_GetAttribute(m64p_GLattr Attr, int *pValue)
+     if (!SDL_WasInit(SDL_INIT_VIDEO))
+         return M64ERR_NOT_INIT;
+ 
+-#if SDL_VERSION_ATLEAST(1,3,0)
++#if SDL_VERSION_ATLEAST(2,0,0)
+     if (Attr == M64P_GL_SWAP_CONTROL)
+     {
+         *pValue = SDL_GL_GetSwapInterval();

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -16,6 +16,7 @@ RES="$3"
 RSP_PLUGIN="$4"
 [[ -n "$RES" ]] && RES="--resolution $RES"
 [[ -z "$RSP_PLUGIN" ]] && RSP_PLUGIN="mupen64plus-rsp-hle"
+WINDOW_MODE="--fullscreen $RES"
 
 rootdir="/opt/retropie"
 configdir="$rootdir/configs"
@@ -439,10 +440,13 @@ getAutoConf mupen64plus_compatibility_check && testCompatibility
 getAutoConf mupen64plus_texture_packs && useTexturePacks
 
 if [[ "$(sed -n '/^Hardware/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo)" == BCM* ]]; then
+    WINDOW_MODE="--windowed $RES"
+    SDL_VIDEO_RPI_SCALE_MODE=1
     # If a raspberry pi is used lower resolution to 320x240 and enable SDL dispmanx scaling mode 1
-    SDL_VIDEO_RPI_SCALE_MODE=1 "$rootdir/emulators/mupen64plus/bin/mupen64plus" --noosd --windowed $RES --rsp ${RSP_PLUGIN}.so --gfx ${VIDEO_PLUGIN}.so --audio ${AUDIO_PLUGIN}.so --configdir "$configdir/n64" --datadir "$configdir/n64" "$ROM"
 elif [[ -e /opt/vero3/lib/libMali.so  ]]; then
-    SDL_AUDIODRIVER=alsa "$rootdir/emulators/mupen64plus/bin/mupen64plus" --noosd --fullscreen --rsp ${RSP_PLUGIN}.so --gfx ${VIDEO_PLUGIN}.so --audio mupen64plus-audio-sdl.so --configdir "$configdir/n64" --datadir "$configdir/n64" "$ROM"
+    SDL_AUDIODRIVER=alsa
 else
-    SDL_AUDIODRIVER=pulse "$rootdir/emulators/mupen64plus/bin/mupen64plus" --noosd --fullscreen --rsp ${RSP_PLUGIN}.so --gfx ${VIDEO_PLUGIN}.so --audio mupen64plus-audio-sdl.so --configdir "$configdir/n64" --datadir "$configdir/n64" "$ROM"
+    SDL_AUDIODRIVER=pulse
 fi
+
+SDL_AUDIODRIVER=${SDL_AUDIODRIVER} SDL_VIDEO_RPI_SCALE_MODE=${SDL_VIDEO_RPI_SCALE_MODE} "$rootdir/emulators/mupen64plus/bin/mupen64plus" --noosd ${WINDOW_MODE} --rsp ${RSP_PLUGIN}.so --gfx ${VIDEO_PLUGIN}.so --audio ${AUDIO_PLUGIN}.so --configdir "$configdir/n64" --datadir "$configdir/n64" "$ROM"


### PR DESCRIPTION
Note: fkms targets uses the GLideN64 video plugins only, as the older
plugins are much less accurate and not as well-maintained. Additionally,
these targets will build the omx plugin, but will not be used by default
due to the better compatibility offered by the SDL audio plugin.

* apply armv8 optimization based on platform flag (rpi3/4)
* remove kms blocking flag and add initial fkms build support
* consolidate launcher script execution arguments
* skip "emplace" patch for fkms targets (no crash observed)