### PR TITLE
openmsx - fix building with new versions requiring SDL2

### DIFF
--- a/scriptmodules/emulators/openmsx.sh
+++ b/scriptmodules/emulators/openmsx.sh
@@ -14,10 +14,13 @@ rp_module_desc="MSX emulator OpenMSX"
 rp_module_help="ROM Extensions: .rom .mx1 .mx2 .col .dsk .zip\n\nCopy your MSX/MSX2 games to $romdir/msx"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/openMSX/openMSX/master/doc/GPL.txt"
 rp_module_section="opt"
-rp_module_flags="!mali !kms"
+rp_module_flags="!mali"
 
 function depends_openmsx() {
-    getDepends libsdl1.2-dev libsdl-ttf2.0-dev libglew-dev libao-dev libogg-dev libtheora-dev libxml2-dev libvorbis-dev tcl-dev
+    local depends=(libsdl2-dev libsdl2-ttf-dev libao-dev libogg-dev libtheora-dev libxml2-dev libvorbis-dev tcl-dev)
+    isPlatform "x11" && depends+=(libglew-dev)
+
+    getDepends "${depends[@]}"
 }
 
 function sources_openmsx() {
@@ -27,7 +30,7 @@ function sources_openmsx() {
 }
 
 function build_openmsx() {
-    rpSwap on 512
+    rpSwap on 1024
     ./configure
     make clean
     make


### PR DESCRIPTION
Newer OpenMSX versions use SDL2 and SDL2-TTF, pull the correct dependencies. The memory used during build increased for a couple of files so bump the required amount of memory (tested on Raspbian Stretch, Pi 3B+).

The new versions also have SDLGL support, so it might be a good candidate for removing the `!kms` flag for Raspbian Buster. However, I couldn't get it to compile under Buster due to memory constraints (seems it requires more than 1Gb and it locked on my 3B+ test system during compilation so I couldn't get a working version).  I can re-try on Buster to test under `(f)kms`, but it might take a bit.