### PR TITLE
Fix 2x build errors, 1x gitPullOrClone bug 

### DIFF
--- a/scriptmodules/emulators/reicast.sh
+++ b/scriptmodules/emulators/reicast.sh
@@ -20,6 +20,7 @@ function depends_reicast() {
     local depends=(libsdl2-dev python-dev python-pip alsa-oss python-setuptools libevdev-dev libasound2-dev libudev-dev)
     isPlatform "vero4k" && depends+=(vero3-userland-dev-osmc)
     getDepends "${depends[@]}"
+    isPlatform "vero4k" && pip install wheel
     pip install evdev
 }
 

--- a/scriptmodules/emulators/reicast.sh
+++ b/scriptmodules/emulators/reicast.sh
@@ -24,7 +24,7 @@ function depends_reicast() {
 }
 
 function sources_reicast() {
-    gitPullOrClone "$md_build" https://github.com/reicast/reicast-emulator.git
+    gitPullOrClone "$md_build" https://github.com/reicast/reicast-emulator.git master
 }
 
 function build_reicast() {

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -367,7 +367,7 @@ function gitPullOrClone() {
         if [[ "$__persistent_repos" -ne 1 && "$repo" == *github* && -z "$commit" ]]; then
             git+=" --depth 1"
         fi
-        [[ "$branch" != "master" ]] && git+=" --branch $branch"
+        git+=" --branch $branch"
         printMsgs "console" "$git \"$repo\" \"$dir\""
         runCmd $git "$repo" "$dir"
     fi


### PR DESCRIPTION
**1st commit:**
Reicast have restructured their branches.
Presently we pull the default branch which was `master`.  It is now `alpha` (and for a short time was `develop`) and breaks the build with new paths and renaming.
Recommendation [here](https://github.com/reicast/reicast-emulator/issues/1669) is to adopt the `beta` branch until further notice.

---
**2nd commit**
Builds fail on Vero4K/OSMC/Debian at the installation of the python `evdev` dependancy:

> Collecting evdev
>   Downloading https://files.pythonhosted.org/packages/fe/6e/3fa84a43571dec4d00dc26befccc9867b6b3263651531cbc1345f718860f/evdev-1.2.0.tar.gz
> Building wheels for collected packages: evdev
>   Running setup.py bdist_wheel for evdev ... error
>   Complete output from command /usr/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-EavkPG/evdev/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpfnOGqwpip-wheel- --python-tag cp27:
>   usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
>      or: -c --help [cmd1 cmd2 ...]
>      or: -c --help-commands
>      or: -c cmd --help
>   
>   error: invalid command 'bdist_wheel'
>   
>   ----------------------------------------
>   Failed building wheel for evdev
>   Running setup.py clean for evdev
> Failed to build evdev

Fixed by installing `wheel` first.
This may be a local package/user configuration issue so I've made the fix platform specific right now.  I doubt it would hurt to apply this generically so I could change that if you think appropriate.

Many Thanks,