### PR TITLE
ThreadedVideo = True for GLiden64

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -242,6 +242,8 @@ function configure_mupen64plus() {
         iniSet "ShowFPS " "True"
         iniSet "fontSize" "14"
         iniSet "fontColor" "1F1F1F"
+        # Enable Threaded GL calls
+        iniSet "ThreadedVideo" "True"
 
         # Disable gles2n64 autores feature and use dispmanx upscaling
         iniConfig " = " "" "$md_conf_root/n64/gles2n64.conf"


### PR DESCRIPTION
Better performance. You can benchmark by changing the launch string in `/opt/retropie/emulators/mupen64plus/bin/mupen64plus.sh` to:
` SDL_VIDEO_RPI_SCALE_MODE=1 "$rootdir/emulators/mupen64plus/bin/mupen64plus" --noosd --nospeedlimit --windowed $RES --rsp ${RSP_PLUGIN}.so --gfx ${VIDEO_PLUGIN}.so --audio dummy --configdir "$configdir/n64" --datadir "$configdir/n64" "$ROM"`
but note that it won't be able to go faster than vsync (ie, you won't see an improvement) unless you have https://github.com/gonetz/GLideN64/pull/2070

True:
mario64 title screen: 95-105 VI/S

False:
mario64 title screen: 72-85 VI/S

See https://github.com/gonetz/GLideN64/pull/2014 for details on the change.