### PR TITLE
runcommand: Add onbeforelaunch user script

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -1064,6 +1064,8 @@ function runcommand() {
         COMMAND+=" -- vt$TTY -keeptty"
     fi
 
+    user_script "runcommand-onbeforelaunch.sh"
+
     local ret
     launch_command
     ret=$?


### PR DESCRIPTION
I'm trying to use xboxdrv as a more powerful joy2key for actual emulators that are launched by runcommand. (the Retroflag GPi case has a built-in xbox 360 controller and no USB)

The original solution that someone else did was to launch it in `runcommand-onstart.sh` and kill it in `runcommand-onend.sh`. However, that runs into a problem with all of the stuff that happens between start and launch. Specifically the art and the launch configuration screens. They're not accessible because the keymapper for the emulator is active.

So I needed a hook to act as a wrapper for the emulator itself.

There's currently no need for a `runcommand-onafterlaunch.sh` because not much happens between the launch the `runcommand-onend.sh`