### PR TITLE
dosbox: ensure freepats soundfonts are configured

### DIFF
--- a/scriptmodules/emulators/dosbox.sh
+++ b/scriptmodules/emulators/dosbox.sh
@@ -87,12 +87,16 @@ function midi_synth() {
     case "\$1" in
         "start")
             timidity -Os -iAD &
-            until [[ -n "\$(aconnect -o | grep TiMidity)" ]]; do
+            sleep 1
+            pgrep timidity || timidity -Os -iAD -c /etc/timidity/freepats.cfg &
+            local timeout=5
+            until [[ -n "\$(aconnect -o | grep TiMidity)" || \$timeout -le 0 ]]; do
                 sleep 1
+                timeout=\$((timeout-1))
             done
             ;;
         "stop")
-            killall timidity
+            killall timidity 2>/dev/null
             ;;
         *)
             ;;


### PR DESCRIPTION
In Buster, the default soundfont configured in Timidity is `fluidr3_gm`. Without it, `timidity` logs an error during the `runcommand` startup for `dosbox` and the emulator is not started:
```
   /etc/timidity/fluidr3_gm.cfg: No such file or directory
   timidity: Error reading configuration file.
   Please check /etc/timidity/timidity.cfg
```

We could use the `fluid-soundfont-gm` as default (and remove `freepats`), that would require to modifying `/etc/timidity/timidity.cfg` . On the other hand, the `fluid-soundfont-gm` is considerably larger than `freepats` (149MB vs 34MB).