### PR TITLE
mkarcadejoystick: update the scriptmodule for kernels 4.15+ 

### DIFF
--- a/scriptmodules/supplementary/mkarcadejoystick.sh
+++ b/scriptmodules/supplementary/mkarcadejoystick.sh
@@ -17,7 +17,7 @@ rp_module_section="driver"
 rp_module_flags="noinstclean !x86 !mali"
 
 function _version_mkarcadejoystick() {
-    echo "0.1.5"
+    echo "0.1.6"
 }
 
 function depends_mkarcadejoystick() {
@@ -26,7 +26,10 @@ function depends_mkarcadejoystick() {
 
 function sources_mkarcadejoystick() {
     gitPullOrClone "$md_inst" https://github.com/recalbox/mk_arcade_joystick_rpi
+    pushd "$md_inst"
+    applyPatch "$md_data/01_kernel_timers_api.diff"
     sed -i "s/\$MKVERSION/$(_version_mkarcadejoystick)/" "$md_inst/dkms.conf"
+    popd
 }
 
 function build_mkarcadejoystick() {

--- a/scriptmodules/supplementary/mkarcadejoystick/01_kernel_timers_api.diff
+++ b/scriptmodules/supplementary/mkarcadejoystick/01_kernel_timers_api.diff
@@ -1,0 +1,50 @@
+diff --git a/mk_arcade_joystick_rpi.c b/mk_arcade_joystick_rpi.c
+index 5a50d8f..13f88e2 100755
+--- a/mk_arcade_joystick_rpi.c
++++ b/mk_arcade_joystick_rpi.c
+@@ -35,6 +35,7 @@
+ #include <linux/slab.h>
+ 
+ #include <linux/ioport.h>
++#include <linux/version.h>
+ #include <asm/io.h>
+ 
+ 
+@@ -108,6 +109,10 @@ MODULE_LICENSE("GPL");
+ 
+ #define CLEAR_STATUS	BSC_S_CLKT|BSC_S_ERR|BSC_S_DONE
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
++#define HAVE_TIMER_SETUP
++#endif
++
+ static volatile unsigned *gpio;
+ static volatile unsigned *bsc1;
+ 
+@@ -365,9 +370,13 @@ static void mk_process_packet(struct mk *mk) {
+ /*
+  * mk_timer() initiates reads of console pads data.
+  */
+-
++#ifdef HAVE_TIMER_SETUP
++static void mk_timer(struct timer_list *t) {
++    struct mk *mk = from_timer(mk, t, timer);
++#else
+ static void mk_timer(unsigned long private) {
+     struct mk *mk = (void *) private;
++#endif
+     mk_process_packet(mk);
+     mod_timer(&mk->timer, jiffies + MK_REFRESH_TIME);
+ }
+@@ -545,7 +554,11 @@ static struct mk __init *mk_probe(int *pads, int n_pads) {
+     }
+ 
+     mutex_init(&mk->mutex);
++    #ifdef HAVE_TIMER_SETUP
++    timer_setup(&mk->timer, mk_timer, 0);
++    #else
+     setup_timer(&mk->timer, mk_timer, (long) mk);
++    #endif
+ 
+     for (i = 0; i < n_pads && i < MK_MAX_DEVICES; i++) {
+         if (!pads[i])


### PR DESCRIPTION
Similar to https://github.com/RetroPie/RetroPie-Setup/pull/2725, the driver fails buiding on 4.15+ Linux kernels.

I've submitted the patch to the - closest - upstream I could find, in the [Recalbox](https://gitlab.com/recalbox/mk_arcade_joystick_rpi/merge_requests/71) repository for the driver, but there's no response so far.

Reported in https://retropie.org.uk/forum/topic/22859, tested by the reporting user.
