### PR TITLE
image: boot partition should be 256Mb for Buster

### DIFF
--- a/scriptmodules/admin/image.sh
+++ b/scriptmodules/admin/image.sh
@@ -208,7 +208,7 @@ function create_image() {
 
     # make image size 300mb larger than contents of chroot
     local mb_size=$(du -s --block-size 1048576 $chroot 2>/dev/null | cut -f1)
-    ((mb_size+=300))
+    ((mb_size+=492))
 
     # create image
     printMsgs "console" "Creating image $image ..."
@@ -218,9 +218,9 @@ function create_image() {
     printMsgs "console" "partitioning $image ..."
     parted -s "$image" -- \
         mklabel msdos \
-        mkpart primary fat16 4 64 \
+        mkpart primary fat16 4 256 \
         set 1 boot on \
-        mkpart primary 64 -1
+        mkpart primary 256 -1
 
     # format
     printMsgs "console" "Formatting $image ..."


### PR DESCRIPTION
The recommendation for Buster (Pi4 related probably) is for a larger boot partition:
* https://www.raspberrypi.org/blog/buster-the-new-version-of-raspbian/#comment-1510398

Upstream `pi-gen` has been updated also with the new size:
* https://github.com/RPi-Distro/pi-gen/commit/0308e92705bc9a22b7574ab5acaa7623e9050b8f