### PR TITLE
Add detection for Vero4k+

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -268,7 +268,7 @@ function get_platform() {
             "Rockchip (Device Tree)")
                 __platform="tinker"
                 ;;
-            Vero4K)
+            Vero4K|Vero4KPlus)
                 __platform="vero4k"
                 ;;
             "Allwinner sun8i Family")


### PR DESCRIPTION
Add detection for the Vero4k+. This is a minor hardware revision of the Vero4k which upgrades Ethernet to Gigabit and improves onboard flash performance. In other regards it is the same and should be treated as a minor revision of the same platform for the purposes of RetroPie and emulators.

This patch prevents it being reported as an unknown platform when trying to use retropie_setup.sh.