### PR TITLE
lr-caprice32: Set combokey default to Y-Button

### DIFF
--- a/scriptmodules/libretrocores/lr-caprice32.sh
+++ b/scriptmodules/libretrocores/lr-caprice32.sh
@@ -38,6 +38,7 @@ function configure_lr-caprice32() {
     setRetroArchCoreOption "cap32_autorun" "enabled"
     setRetroArchCoreOption "cap32_Model" "6128"
     setRetroArchCoreOption "cap32_Ram" "128"
+    setRetroArchCoreOption "cap32_combokey" "y"
 
     addEmulator 1 "$md_id" "amstradcpc" "$md_inst/cap32_libretro.so"
     addSystem "amstradcpc"


### PR DESCRIPTION
the default combokey is SELECT
this key collides with RETROARCH and the combination START+SELECT to activate the virtual keyboard will terminate the emulator.
Therefore setup to Y and now START+Y activates virtual keyboard

The retroarch shortcuts like START+SELECT, SELECT+B .... are not affected