### PR TITLE
gitPullOrClone: always specify branch to pull explicitly

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -367,7 +367,7 @@ function gitPullOrClone() {
         if [[ "$__persistent_repos" -ne 1 && "$repo" == *github* && -z "$commit" ]]; then
             git+=" --depth 1"
         fi
-        [[ "$branch" != "master" ]] && git+=" --branch $branch"
+        git+=" --branch $branch"
         printMsgs "console" "$git \"$repo\" \"$dir\""
         runCmd $git "$repo" "$dir"
     fi


### PR DESCRIPTION
Hello gentlemen! :)

Currently when calling `gitPullOrClone` and specifying target branch `master` (or not specifying a branch at all) actually the `git clone` command will omit the `branch` parameter and retrieve the project's default branch. It seems to assume that `master` always is the default branch which is not always true.

This PR will change the behavior to always explicitly specify the branch for `git clone` so when targeting `master` or not specifying then it will explicitly clone `master`.

This issue came to my attention cause Reicast did not compile for me. The .sh-script clones the Reicast repo without specifying a branch and assumes that `master` will be cloned (it expects the directory `shell/linux` to be present in the project which is only the case for `master`). But actually the default branch of Reicast is `alpha`.

So with this PR, not specifying a branch means to use `master`.