### PR TITLE
vice: add fullscreen parameter for the (f)kms

### DIFF
--- a/scriptmodules/emulators/vice.sh
+++ b/scriptmodules/emulators/vice.sh
@@ -100,7 +100,9 @@ _EOF_
         iniSet "SDLWindowHeight" "272"
         isPlatform "rpi1" && iniSet "SoundSampleRate" "22050"
         iniSet "SidEngine" "0"
-    else
+    fi
+
+    if isPlatform "x11" || isPlatform "kms"; then
         iniSet "VICIIFullscreen" "1"
     fi
 
@@ -116,5 +118,4 @@ _EOF_
         iniSet "SDLWindowWidth" "384"
         iniSet "SDLWindowHeight" "272"
     fi
-
 }


### PR DESCRIPTION
Using the RPI `(f)kms` video driver, the emulator window is not fullscreen, but setting the`VICIIFullscreen` resource will make it start in fullscreen.