### PR TITLE
xroar: disable any X11 dependency for non-X11 platforms

### DIFF
--- a/scriptmodules/emulators/xroar.sh
+++ b/scriptmodules/emulators/xroar.sh
@@ -17,7 +17,7 @@ rp_module_section="opt"
 rp_module_flags="!mali !kms"
 
 function depends_xroar() {
-    getDepends libsdl1.2-dev automake
+    getDepends libsdl2-dev automake
 }
 
 function sources_xroar() {
@@ -27,7 +27,7 @@ function sources_xroar() {
 function build_xroar() {
     local params=(--without-gtk2 --without-gtkgl)
     if ! isPlatform "x11"; then
-        params+=(--without-pulse)
+        params+=(--without-pulse --disable-kbd-translate --without-x)
     fi
     ./autogen.sh
     ./configure --prefix="$md_inst" "${params[@]}"
@@ -48,7 +48,7 @@ function configure_xroar() {
     ln -snf "$biosdir" "$md_inst/share/xroar/roms"
 
     local params=(-fs)
-    ! isPlatform "x11" && params+=(-vo sdl --ccr simple)
+    ! isPlatform "x11" && params+=(-vo sdl -ccr simple)
     addEmulator 1 "$md_id-dragon32" "dragon32" "$md_inst/bin/xroar ${params[*]} -machine dragon32 -run %ROM%"
     addEmulator 1 "$md_id-cocous" "coco" "$md_inst/bin/xroar ${params[*]} -machine cocous -run %ROM%"
     addEmulator 0 "$md_id-coco" "coco" "$md_inst/bin/xroar ${params[*]} -machine coco -run %ROM%"


### PR DESCRIPTION
The latest version will add an unwanted dependency on X11 if compiled without `--disable-kbd-translation` and fails to run on a Pi system. Reported in:
* https://retropie.org.uk/forum/topic/22623/gpi-case-xroar-emulator-crashes-solved/11
* (possibly also affects) https://retropie.org.uk/forum/topic/23084/

Other changes:
* SDL2 support is added and picked up if present by `configure`, so add the explicit dependency for `libsdl2-dev`.
* correct the typo in the start command line (`-ccr` vs `--ccr`).

I've also tested on a `(f)kms` enabled system and it looks fine, but we can remove the `!kms` flag later. In the 1st topic, the poster said the SDL2 version was slower, a `-sdl1` version can also be added if desired.