### PR TITLE
gles2n64.conf does not not like spaces around the '='

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -244,7 +244,7 @@ function configure_mupen64plus() {
         iniSet "fontColor" "1F1F1F"
 
         # Disable gles2n64 autores feature and use dispmanx upscaling
-        iniConfig " = " "" "$md_conf_root/n64/gles2n64.conf"
+        iniConfig "=" "" "$md_conf_root/n64/gles2n64.conf"
         iniSet "auto resolution" "0"
 
         addAutoConf mupen64plus_audio 1


### PR DESCRIPTION
iniSet permits this if you put it all in the first parameter. this, in conjunction with https://github.com/ricrpi/mupen64plus-video-gles2n64/pull/28 (now accepted) will allow gles2n64 to run at low resolution scaled to screen, as was the intention (rather than full resolution of display, as it currently is)