### PR TITLE
Fix bad Bluetooth input lag when all registered Bluetooth devices are…

### DIFF
--- a/scriptmodules/supplementary/bluetooth.sh
+++ b/scriptmodules/supplementary/bluetooth.sh
@@ -327,8 +327,7 @@ function boot_bluetooth() {
             while read mac_address; read device_name; do
                 macs+=($mac_address)
             done < <(list_registered_bluetooth)
-            local script="while true; do for mac in ${macs[@]}; do hcitool con | grep -q \"\$mac\" || { echo \"connect \$mac\nquit\"; sleep 1; } | bluetoothctl >/dev/null 2>&1; sleep 10; done; done"
-            nohup nice -n19 /bin/sh -c "$script" >/dev/null &
+            nohup nice -n19 /usr/bin/env bash "$md_data/bluetooth_background.sh" "${macs[@]}" >/dev/null &
             ;;
     esac
 }

--- a/scriptmodules/supplementary/bluetooth/bluetooth_background.sh
+++ b/scriptmodules/supplementary/bluetooth/bluetooth_background.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+registered_macs=("$@")
+
+function contains() {
+    local argc=$#
+    local value=${!argc}
+    for (( argi=1; argi < $argc; argi++ )); do
+        if [ "${!argi}" == "$value" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+while true; do
+    connected_macs=( $( hcitool con | grep -o -e '..:..:..:..:..:..' ) )
+    disconnected_macs=()
+    for mac in "${registered_macs[@]}"; do
+        if contains ${connected_macs[@]} "$mac"; then 
+            echo "$mac - connected"
+        else
+            disconnected_macs+=( "$mac" )
+	fi
+    done
+    for mac in "${disconnected_macs[@]}"; do
+        echo "$mac - disconnected"
+        echo "connect $mac\nquit" | bluetoothctl >/dev/null 2>&1
+    done
+    sleep_seconds=5
+    echo "Sleeping $sleep_seconds seconds..."
+    sleep $sleep_seconds
+done
+


### PR DESCRIPTION
… already attached and the Bluetooth connection mode is set to "background".  Under those conditions, the original background script would repeatedly run "hcitool con" without any sleep time in between consecutive calls.  Debugging the script was difficult, and locating where the script came from when viewing processes with "htop" etc was also difficult, due to the script not being implemented by a file on disk -- so I've moved it out to its own file, added some helpful output (so that when it is run manually for debugging purposes, you can easily see what it's doing), and updated its logic to be as efficient as possible.  Due to the efficiency improvements, it's also now safe to decrease the retry interval from 10 seconds to 5 seconds.  Original repro was found with two 8bitdo SN30 Pro Bluetooth controllers both registered/paired and simultaneously connected.  The fix was validated using the same configuration, with all possible combinations of connection state (0/1/2 controllers connected at any given time out of a total of 2 registered controllers).