### PR TITLE
Add runcommand hook just after retroarch config generation

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -1057,6 +1057,7 @@ function runcommand() {
     [[ -n "$GOVERNOR" ]] && set_governor "$GOVERNOR"
 
     retroarch_append_config
+    user_script "runcommand_retroarch_append_config.sh"
 
     # workaround for launching xserver on correct/user owned tty
     # see https://github.com/RetroPie/RetroPie-Setup/issues/1805

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -1057,7 +1057,7 @@ function runcommand() {
     [[ -n "$GOVERNOR" ]] && set_governor "$GOVERNOR"
 
     retroarch_append_config
-    user_script "runcommand_retroarch_append_config.sh"
+    user_script "runcommand-retroarch_append_config.sh"
 
     # workaround for launching xserver on correct/user owned tty
     # see https://github.com/RetroPie/RetroPie-Setup/issues/1805


### PR DESCRIPTION
This hook allows some auto-generated config to be inserted on the fly in /dev/shm/retroarch.cfg.
This allows the resolution switch system at https://github.com/ChloeTigre/es-rgbpi to embed a proper display configuration dynamically.