### PR TITLE
solarus - update and modernise scriptmodule

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -206,6 +206,9 @@ sg-1000_fullname="Sega SG-1000"
 snes_exts=".7z .bin .bs .smc .sfc .fig .swc .mgd .zip"
 snes_fullname="Super Nintendo"
 
+solarus_exts=".solarus .zip"
+solarus_fullname="Solarus Engine"
+
 ti99_exts=".ctg"
 ti99_fullname="TI99"
 


### PR DESCRIPTION
General changes:

* Use the official repositories that are now in GitLab
* Use latest HEAD for OpenGL ES support and other required features
* Build with RPATH-replacement for proper dynamic library linking
* Moved Solarus from `ports` to `emulators` to be used as a system
* Added official theme assets to Carbon and Simple ES themes
* Configuration is symlinked to `$md_conf_root/solarus`
* Added a shell script launcher to assist with runtime options

Added scriptmodule GUI:

* Option to configure joypad axis deadzone
* Option to configure joypad buttons combo for quitting

Solarus quests (games) changes:

* Quests (games) no longer need to be "built"
* Do not ship games/quests anymore as the contain copyrighted material
* Users just have to download and place `.solarus` files in `$romdir/solarus`

Users should update their Carbon and Simple themes to get the new assets.

Closes #2686 and Closes #2453
