### PR TITLE
lr-mupen64plus-next - update for new repo branching model upstream

### DIFF
--- a/scriptmodules/libretrocores/lr-mupen64plus-next.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus-next.sh
@@ -26,7 +26,7 @@ function depends_lr-mupen64plus-next() {
 }
 
 function sources_lr-mupen64plus-next() {
-    gitPullOrClone "$md_build" https://github.com/libretro/mupen64plus-libretro-nx.git GLideN64
+    gitPullOrClone "$md_build" https://github.com/libretro/mupen64plus-libretro-nx.git develop
 
     # HACK: force EGL detection on FKMS
     isPlatform "mesa" && applyPatch "$md_data/0001-force-egl.patch"


### PR DESCRIPTION
New git repository branching model entered in effect upstream.

Ref: https://github.com/libretro/mupen64plus-libretro-nx/issues/76

Commit in `libretro-super`: https://github.com/libretro/libretro-super/commit/476d2e4e662eea4337013af0a43c4a14a540b963