### PR TITLE
esthemes: add MiniJawn theme

### DIFF
--- a/scriptmodules/supplementary/esthemes.sh
+++ b/scriptmodules/supplementary/esthemes.sh
@@ -119,6 +119,7 @@ function gui_esthemes() {
         'coinjunkie synthwave'
         'nickearl retrowave'
         'nickearl retrowave_4_3'
+        'pacdude minijawn'
         'RetroHursty69 magazinemadness'
         'RetroHursty69 stirling'
         'RetroHursty69 boxalloyred'


### PR DESCRIPTION
Added with author's permission - https://retropie.org.uk/forum/topic/22621.
The theme is designed for small screens (like the one present in the RetroFlag's GPICase)

![Screenshot](https://camo.githubusercontent.com/ab54a86c88657f1758b207f2fb5648adff09d79f/68747470733a2f2f692e696d6775722e636f6d2f687066786e4b722e6a7067)