### PR TITLE
Add FUNDING Github metadata

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+patreon: retropie
+custom: https://retropie.org.uk/donate/


### PR DESCRIPTION
* Adds a "sponsors" button in Github

You might need to check if funding links are enabled on the repository settings.