### PR TITLE
Initial support Nvidia jetson nano dev kit

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -270,15 +270,22 @@ function get_platform() {
             "Allwinner sun8i Family")
                 __platform="armv7-mali"
                 ;;
-            *)
+            *)  #For now nvidia jetson nano no have Hardware name string by /proc/cpuinfo you can info by base/model 
+                if grep -q "NVIDIA Jetson Nano Developer Kit" /sys/firmware/devicetree/base/model 2>/dev/null; then
+                    __platform="jetson-nano" 
+                
+                else
+
                 case $architecture in
                     i686|x86_64|amd64)
                         __platform="x86"
                         ;;
-                esac
-                ;;
+                   esac
+                fi
+              ;;
         esac
     fi
+
 
     if ! fnExists "platform_${__platform}"; then
         fatalError "Unknown platform - please manually set the __platform variable to one of the following: $(compgen -A function platform_ | cut -b10- | paste -s -d' ')"
@@ -332,6 +339,14 @@ function platform_odroid-c2() {
         __default_cflags="-O2 -march=native"
         __platform_flags="aarch64 mali gles"
     fi
+    __default_cflags+=" -ftree-vectorize -funsafe-math-optimizations"
+    __default_asflags=""
+    __default_makeflags="-j2"
+}
+
+function platform_jetson-nano() {
+    __default_cflags="-O2 -march=armv8-a+crc -mcpu=cortex-a57 -mtune=cortex-a57"
+    __platform_flags="aarch64 x11 gl"
     __default_cflags+=" -ftree-vectorize -funsafe-math-optimizations"
     __default_asflags=""
     __default_makeflags="-j2"


### PR DESCRIPTION
Hello I'm Add Initial support for nvidia jetson nano dev kit
Currently the kernel has no support identification through from /proc/cpuinfo so I instean use looking for the model where there is identifiable information of the system from firmware base/model name.
By default I recommended  are compiled for opengl desktop in this device due conflict with retroarch binary if it is compiled giving both opengl desktop support and opengl es enabled, with some cores it needs that retroarch be a linker in exclusive Opengl Desktop only or opengl es only, not detected correctly what context lib are use if retroarch not linker in the same mode.
and some cores working better on Opengl Desktop .

It is the only way to operate mupen64plus or yabause sanshiro libretro to working.
Some screenshots added :) 

![Screenshot from 2019-08-25 14-18-27](https://user-images.githubusercontent.com/1274014/63649864-525be080-c743-11e9-8c4f-a1478e2d5fab.png)
![Screenshot from 2019-08-25 11-37-02](https://user-images.githubusercontent.com/1274014/63649871-6b649180-c743-11e9-85f3-2ac1399c1e61.png)


