### PR TITLE
splitwolf - fix building by pulling the correct Git repo branch

### DIFF
--- a/scriptmodules/ports/splitwolf.sh
+++ b/scriptmodules/ports/splitwolf.sh
@@ -20,7 +20,7 @@ function depends_splitwolf() {
 }
 
 function sources_splitwolf() {
-    gitPullOrClone "$md_build" https://bitbucket.org/linuxwolf6/splitwolf.git
+    gitPullOrClone "$md_build" https://bitbucket.org/linuxwolf6/splitwolf.git scrubbed
 }
 
 function _get_opts_splitwolf() {


### PR DESCRIPTION
The upstream repository doesn't have the `master` branch available, the default one is `scrubbed` (see https://bitbucket.org/linuxwolf6/splitwolf/). Fixes building from source (https://github.com/RetroPie/RetroPie-Setup/issues/2826) on Raspbian Stretch.
