### PR TITLE
lr-nestopia - fix build after upstream repository changes

### DIFF
--- a/scriptmodules/libretrocores/lr-nestopia.sh
+++ b/scriptmodules/libretrocores/lr-nestopia.sh
@@ -32,11 +32,7 @@ function install_lr-nestopia() {
     md_ret_files=(
         'libretro/nestopia_libretro.so'
         'NstDatabase.xml'
-        'README.md'
-        'ChangeLog'
-        'readme.html'
         'COPYING'
-        'AUTHORS'
     )
 }
 


### PR DESCRIPTION
Seems like the upstream repository was re-created as a standalone repository (instead of a fork) and some re-organization has taken place. The files no longer in the repository have been removed from `md_ret_files` to allow installation from source of the core.