### PR TITLE
image: really set boot partition to 256MiB

### DIFF
--- a/scriptmodules/admin/image.sh
+++ b/scriptmodules/admin/image.sh
@@ -218,9 +218,10 @@ function create_image() {
     printMsgs "console" "partitioning $image ..."
     parted -s "$image" -- \
         mklabel msdos \
-        mkpart primary fat16 4 256 \
+        unit mib \
+        mkpart primary fat16 4 260 \
         set 1 boot on \
-        mkpart primary 256 -1
+        mkpart primary 260 -1s
 
     # format
     printMsgs "console" "Formatting $image ..."


### PR DESCRIPTION
The Pi4 Buster recommendation is actually 256MiB but the script was creating
a much smaller boot partition (240MiB)  because of two bugs:

- parted mkpart units defaults to MB not MiB for input (256MiB is 268MB)

- parted's parameters are `start` `end` not `start` `size`. We need to specify
  260 as an end because the start is 4

I changed the default unit to MiB because while explicitly specifying 260MiB
is possible, specifying units on mkpart disables parted's helpful range of
sloppiness.