### PR TITLE
Enforce vsync for KMS targets (1)

### DIFF
--- a/scriptmodules/emulators/dosbox-sdl2.sh
+++ b/scriptmodules/emulators/dosbox-sdl2.sh
@@ -41,7 +41,7 @@ function configure_dosbox-sdl2() {
     if [[ "$md_mode" == "install" ]]; then
         local config_path=$(su "$user" -c "\"$md_inst/bin/dosbox\" -printconf")
         if [[ -f "$config_path" ]]; then
-            iniConfig " = " "" "$config_path"
+            iniConfig "=" "" "$config_path"
             iniSet "fluid.driver" "alsa"
             iniSet "fluid.soundfont" "/usr/share/sounds/sf2/FluidR3_GM.sf2"
             iniSet "fullresolution" "desktop"
@@ -49,6 +49,7 @@ function configure_dosbox-sdl2() {
             iniSet "mididevice" "fluidsynth"
             iniSet "output" "texture"
             iniDel "usescancodes"
+            isPlatform "kms" && iniSet "vsync" "true"
         fi
     fi
 }

--- a/scriptmodules/ports/darkplaces-quake.sh
+++ b/scriptmodules/ports/darkplaces-quake.sh
@@ -47,7 +47,9 @@ function install_darkplaces-quake() {
 }
 
 function add_games_darkplaces-quake() {
-    _add_games_lr-tyrquake "$md_inst/darkplaces-sdl -basedir $romdir/ports/quake -game %QUAKEDIR%"
+    local params=()
+    isPlatform "kms" && params+=("+vid_vsync 1")
+    _add_games_lr-tyrquake "$md_inst/darkplaces-sdl -basedir $romdir/ports/quake -game %QUAKEDIR% ${params[*]}"
 }
 
 function configure_darkplaces-quake() {

--- a/scriptmodules/ports/dxx-rebirth.sh
+++ b/scriptmodules/ports/dxx-rebirth.sh
@@ -114,6 +114,7 @@ function game_data_dxx-rebirth() {
 }
 
 function configure_dxx-rebirth() {
+    local config
     local ver
     local name="Descent Rebirth"
     for ver in 1 2; do
@@ -123,6 +124,12 @@ function configure_dxx-rebirth() {
 
         # copy any existing configs from ~/.d1x-rebirth and symlink the config folder to $md_conf_root/descent1/
         moveConfigDir "$home/.d${ver}x-rebirth" "$md_conf_root/descent${ver}/"
+        if isPlatform "kms"; then
+            config="$md_conf_root/descent${ver}/descent.cfg"
+            iniConfig "=" '' "$config"
+            iniSet "VSync" "1"
+            chown $user:$user "$config"
+        fi
     done
 
     [[ "$md_mode" == "install" ]] && game_data_dxx-rebirth

--- a/scriptmodules/ports/ioquake3.sh
+++ b/scriptmodules/ports/ioquake3.sh
@@ -45,7 +45,7 @@ function install_ioquake3() {
 function configure_ioquake3() {
     local launcher=("$md_inst/ioquake3.$(_arch_ioquake3)")
     isPlatform "mesa" && launcher+=("+set cl_renderer opengl1")
-    isPlatform "kms" && launcher+=("+set r_mode -1" "+set r_customwidth %XRES%" "+set r_customheight %YRES%")
+    isPlatform "kms" && launcher+=("+set r_mode -1" "+set r_customwidth %XRES%" "+set r_customheight %YRES%" "+set r_swapInterval 1")
 
     addPort "$md_id" "quake3" "Quake III Arena" "${launcher[*]}"
 

--- a/scriptmodules/ports/lzdoom/0001-kmsdrm-fix-atexit-segfault.patch
+++ b/scriptmodules/ports/lzdoom/0001-kmsdrm-fix-atexit-segfault.patch
@@ -1,0 +1,143 @@
+From ca2348e899d5d76152fb021fe948d08f281ad541 Mon Sep 17 00:00:00 2001
+From: Conn O'Griofa <connogriofa@gmail.com>
+Date: Sun, 8 Sep 2019 09:24:03 +0100
+Subject: [PATCH] Use signal handler to invoke call_terms() before exit when
+ possible
+
+It's not advisable to rely on atexit() to invoke SDL_Quit(), as it
+causes a segmentation fault on exit for the SDL2 KMSDRM driver due to
+a conflict with the Mesa drivers* which upstream Mesa may not elect to fix.
+
+The issue can be resolved by replacing the atexit() call with a signal
+handler that will interrupt the D_DoomMain() and D_DoomLoop()
+functions, then invoke call_terms() within the main thread before exiting.
+
+We can leave the atexit() hook intact to handle edge cases such as abnormal
+process exit, or exit methods which do not produce signals such as Alt+F4 or
+window close via GUI (neither of which are possible in a KMS context, so
+should not affect KMSDRM sessions).
+
+Fixes a segmentation fault/uninterruptible application hang on exit
+for all KMS targets, including Raspberry Pi 4B, 3B and Intel i965.
+
+* See: https://bugzilla.libsdl.org/show_bug.cgi?id=4530 and
+https://lists.freedesktop.org/archives/mesa-users/2019-March/001519.html
+---
+ src/d_main.cpp             | 10 ++++++----
+ src/posix/sdl/i_main.cpp   | 19 +++++++++++++++++++
+ src/posix/sdl/st_start.cpp |  1 +
+ 3 files changed, 26 insertions(+), 4 deletions(-)
+
+diff --git a/src/d_main.cpp b/src/d_main.cpp
+index 109484d7f..91a4e984c 100644
+--- a/src/d_main.cpp
++++ b/src/d_main.cpp
+@@ -260,6 +260,7 @@ cycle_t FrameCycles;
+ // [SP] Store the capabilities of the renderer in a global variable, to prevent excessive per-frame processing
+ uint32_t r_renderercaps = 0;
+ 
++volatile int game_running = 1;
+ 
+ // PRIVATE DATA DEFINITIONS ------------------------------------------------
+ 
+@@ -1050,7 +1051,7 @@ void D_DoomLoop ()
+ 
+ 	vid_cursor.Callback();
+ 
+-	for (;;)
++	do
+ 	{
+ 		try
+ 		{
+@@ -1107,7 +1108,7 @@ void D_DoomLoop ()
+ 			Printf("%s", error.stacktrace.GetChars());
+ 			D_ErrorCleanup();
+ 		}
+-	}
++	} while (game_running);
+ }
+ 
+ //==========================================================================
+@@ -2839,7 +2840,8 @@ void D_DoomMain (void)
+ 
+ 		GC::DelSoftRootHead();
+ 
+-		PClass::StaticShutdown();
++		if (game_running)
++			PClass::StaticShutdown();
+ 
+ 		GC::FullGC();					// perform one final garbage collection after shutdown
+ 
+@@ -2851,7 +2853,7 @@ void D_DoomMain (void)
+ 
+ 		gamestate = GS_STARTUP;
+ 	}
+-	while (1);
++	while (game_running);
+ }
+ 
+ //==========================================================================
+diff --git a/src/posix/sdl/i_main.cpp b/src/posix/sdl/i_main.cpp
+index 4ee534fd4..9bcfed4c1 100644
+--- a/src/posix/sdl/i_main.cpp
++++ b/src/posix/sdl/i_main.cpp
+@@ -85,6 +85,8 @@ void Linux_I_FatalError(const char* errortext);
+ 
+ // EXTERNAL DATA DECLARATIONS ----------------------------------------------
+ 
++extern volatile int game_running;
++
+ // PUBLIC DATA DEFINITIONS -------------------------------------------------
+ 
+ // The command line arguments.
+@@ -95,6 +97,9 @@ FArgs *Args;
+ 
+ // CODE --------------------------------------------------------------------
+ 
++void exit_handler(int dummy) {
++        game_running = 0;
++}
+ 
+ static void NewFailure ()
+ {
+@@ -206,6 +211,19 @@ int main (int argc, char **argv)
+ 
+ 		atexit (call_terms);
+ 		atterm (I_Quit);
++#ifdef __linux__
++		/*
++		  Register signal handlers to interrupt D_DoomMain and D_DoomLoop, allowing
++		  call_terms() to be invoked at the conclusion of the main thread/quit menu
++		  rather than at exit. The atexit() call can remain to handle edge cases
++		  where a signal cannot be intercepted, such as Alt+F4 or closing the window
++		  via the GUI.
++
++		  Fixes segmentation fault on exit when using the KMSDRM SDL video driver.
++		*/
++		signal(SIGINT, exit_handler);
++		signal(SIGTERM, exit_handler);
++#endif
+ 
+ 		// Should we even be doing anything with progdir on Unix systems?
+ 		char program[PATH_MAX];
+@@ -262,5 +280,6 @@ int main (int argc, char **argv)
+ 		call_terms ();
+ 		throw;
+     }
++    call_terms();
+     return 0;
+ }
+diff --git a/src/posix/sdl/st_start.cpp b/src/posix/sdl/st_start.cpp
+index 3bba816d4..ba2bedc77 100644
+--- a/src/posix/sdl/st_start.cpp
++++ b/src/posix/sdl/st_start.cpp
+@@ -351,5 +351,6 @@ bool FTTYStartupScreen::NetLoop(bool (*timer_callback)(void *), void *userdata)
+ void ST_Endoom()
+ {
+ 	I_ShutdownJoysticks();
++	call_terms();
+ 	exit(0);
+ }
+-- 
+2.20.1
+

--- a/scriptmodules/ports/tyrquake.sh
+++ b/scriptmodules/ports/tyrquake.sh
@@ -16,7 +16,7 @@ rp_module_section="opt"
 
 function depends_tyrquake() {
     local depends=(libsdl2-dev)
-    if isPlatform "x11" || isPlatform "mesa"; then
+    if isPlatform "gl" || isPlatform "mesa"; then
         depends+=(libgl1-mesa-dev)
     fi
 
@@ -25,6 +25,7 @@ function depends_tyrquake() {
 
 function sources_tyrquake() {
     gitPullOrClone "$md_build" https://github.com/RetroPie/tyrquake.git
+    isPlatform "kms" && applyPatch "$md_data/0001-force-vsync.patch"
 }
 
 function build_tyrquake() {
@@ -49,7 +50,7 @@ function add_games_tyrquake() {
     local binary="$md_inst/bin/tyr-quake"
 
     isPlatform "kms" && params+=("-width %XRES%" "-height %YRES%")
-    if isPlatform "x11" || isPlatform "mesa"; then
+    if isPlatform "gl" || isPlatform "mesa"; then
         binary="$md_inst/bin/tyr-glquake"
     fi
 

--- a/scriptmodules/ports/tyrquake/0001-force-vsync.patch
+++ b/scriptmodules/ports/tyrquake/0001-force-vsync.patch
@@ -1,0 +1,17 @@
+diff --git a/common/vid_sgl.c b/common/vid_sgl.c
+index 560248f..0bd5c3b 100644
+--- a/common/vid_sgl.c
++++ b/common/vid_sgl.c
+@@ -274,6 +274,12 @@ VID_SetMode(const qvidmode_t *mode, const byte *palette)
+ 	Sys_Error("%s: SDL_GL_MakeCurrent() failed: %s",
+ 		  __func__, SDL_GetError());
+ 
++    // force vsync
++    err = SDL_GL_SetSwapInterval(1);
++    if (err)
++	Sys_Error("%s: SDL_GL_SetSwapInterval() failed: %s",
++		  __func__, SDL_GetError());
++
+     VID_InitGL();
+ 
+     vid.numpages = 1;

--- a/scriptmodules/ports/yquake2.sh
+++ b/scriptmodules/ports/yquake2.sh
@@ -22,9 +22,7 @@ function depends_yquake2() {
 }
 
 function sources_yquake2() {
-    gitPullOrClone "$md_build" https://github.com/yquake2/yquake2.git
-    # workaround for hang on startup
-    sed -i "$md_build/src/backends/unix/system.c" -e '/setegid/d' -e '/setreuid/d'
+    gitPullOrClone "$md_build" https://github.com/yquake2/yquake2.git "QUAKE2_7_41"
 }
 
 function build_yquake2() {
@@ -86,16 +84,16 @@ function game_data_yquake2() {
 function configure_yquake2() {
     local params=()
 
-    if isPlatform "x11"; then
+    if isPlatform "gl3"; then
         params+=("+set vid_renderer gl3")
-    elif isPlatform "mesa"; then
+    elif isPlatform "gl" || isPlatform "mesa"; then
         params+=("+set vid_renderer gl1")
     else
         params+=("+set vid_renderer soft")
     fi
 
     if isPlatform "kms"; then
-        params+=("+set r_mode -1" "+set r_customwidth %XRES%" "+set r_customheight %YRES%")
+        params+=("+set r_mode -1" "+set r_customwidth %XRES%" "+set r_customheight %YRES%" "+set r_vsync 1")
     fi
 
     mkRomDir "ports/quake2"


### PR DESCRIPTION
The RPI legacy driver seems to default to vsync on, but the Mesa driver of RPI3, RPI4 (and Intel i965) via KMS does not. Enabling vsync per-application greatly improves video smoothness and eliminates tearing.

Additional changes:
* lzdoom: resolve segfault on exit via KMS and avoid FluidSynth (due to excessive memory/CPU usage).
