### PR TITLE
drastic: update to 2.5.0.4 with RPI4 compatibility

### DIFF
--- a/scriptmodules/emulators/drastic.sh
+++ b/scriptmodules/emulators/drastic.sh
@@ -14,11 +14,14 @@ rp_module_desc="NDS emu - DraStic"
 rp_module_help="ROM Extensions: .nds .zip\n\nCopy your Nintendo DS roms to $romdir/nds"
 rp_module_licence="PROP"
 rp_module_section="exp"
-rp_module_flags="!mali !x86 !armv6 !kms"
+rp_module_flags="!mali !x86 !armv6"
+
+function depends_drastic() {
+    getDepends libasound2-dev libsdl2-dev zlib1g-dev
+}
 
 function install_bin_drastic() {
-    downloadAndExtract "http://drastic-ds.com/drastic_rpi.tar.bz2" "$md_inst" --strip-components 1
-    patchVendorGraphics "$md_inst/drastic"
+    downloadAndExtract "$__archive_url/drastic-2.5.0.4.tar.gz" "$md_inst" --strip-components 1
 }
 
 function configure_drastic() {


### PR DESCRIPTION
Permission for new release has been granted; see: https://drastic-ds.com/viewtopic.php?f=5&t=5610

Please note that while RPI4 (and RPI3/fkms) has been confirmed as working by me,
the developers have not explicitly advertised this release as supporting
RPI4; it works only because it is built as a generic arm binary that is
not dependent on the proprietary Broadcom GLES libraries.

Please keep the above in mind if reporting any bugs upstream.

Closes https://github.com/RetroPie/RetroPie-Setup/issues/2669