### PR TITLE
cgenius: Support for ROM arguments in shell files

### DIFF
--- a/scriptmodules/ports/cgenius.sh
+++ b/scriptmodules/ports/cgenius.sh
@@ -41,7 +41,7 @@ function install_cgenius() {
 }
 
 function configure_cgenius() {
-    addPort "$md_id" "cgenius" "Commander Genius" "pushd $md_inst; ./CGeniusExe; popd"
+    addPort "$md_id" "cgenius" "Commander Genius" "pushd $md_inst; ./CGeniusExe dir=%ROM%; popd"
 
     mkRomDir "ports/$md_id"
 


### PR DESCRIPTION
If no argument is parsed then the usual GUI from CGenius is launched. So this PR is a small enhancement and is usefull if you want to launch a single episode directly form PORTs menu or by a *custom collection*.

Usage:
```
#!/bin/sh
"/opt/retropie/supplementary/runcommand/runcommand.sh" 0 _PORT_ "cgenius" "games/[episode to launch]"
```

See: https://github.com/RetroPie/RetroPie-Setup/pull/2844
Thx @hhromic 