### PR TITLE
splashscreen: RPI4/fkms support

### DIFF
--- a/scriptmodules/supplementary/splashscreen.sh
+++ b/scriptmodules/supplementary/splashscreen.sh
@@ -12,7 +12,7 @@
 rp_module_id="splashscreen"
 rp_module_desc="Configure Splashscreen"
 rp_module_section="main"
-rp_module_flags="noinstclean !x86 !osmc !xbian !mali !kms"
+rp_module_flags="noinstclean !x86 !osmc !xbian !mali"
 
 function _update_hook_splashscreen() {
     # make sure splashscreen is always up to date if updating just RetroPie-Setup
@@ -39,8 +39,8 @@ function install_bin_splashscreen() {
 [Unit]
 Description=Show custom splashscreen
 DefaultDependencies=no
-Before=local-fs-pre.target
-Wants=local-fs-pre.target
+After=console-setup.service
+Wants=console-setup.service
 ConditionPathExists=$md_inst/asplashscreen.sh
 
 [Service]
@@ -237,7 +237,7 @@ function preview_splashscreen() {
                 3)
                     file=$(choose_splashscreen "$path" "video")
                     [[ -z "$file" ]] && break
-                    omxplayer -b --layer 10000 "$file"
+                    omxplayer --no-osd -b --layer 10000 "$file"
                     ;;
             esac
         done

--- a/scriptmodules/supplementary/splashscreen/asplashscreen.sh
+++ b/scriptmodules/supplementary/splashscreen/asplashscreen.sh
@@ -10,6 +10,7 @@ do_start () {
     local config="/etc/splashscreen.list"
     local line
     local re="$REGEX_VIDEO\|$REGEX_IMAGE"
+
     case "$RANDOMIZE" in
         disabled)
             line="$(head -1 "$config")"
@@ -32,7 +33,7 @@ do_start () {
         while ! pgrep "dbus" >/dev/null; do
             sleep 1
         done
-        omxplayer -o both -b --layer 10000 "$line"
+        omxplayer --no-osd -o both -b --layer 10000 "$line"
     elif $(echo "$line" | grep -q "$REGEX_IMAGE"); then
         if [ "$RANDOMIZE" = "disabled" ]; then
             local count=$(wc -l <"$config")


### PR DESCRIPTION
* Avoid VT2 switch in KMS mode, otherwise EmulationStation will run on the
  llvmpipe software rendering path.
* Explicitly invoke --no-osd for omxplayer (set by default on RPI4, but needs
  to be set for earlier board revisions in KMS mode).