### PR TITLE
lr-flycast: improve fkms detection for older revisions

### DIFF
--- a/scriptmodules/libretrocores/lr-flycast.sh
+++ b/scriptmodules/libretrocores/lr-flycast.sh
@@ -33,6 +33,8 @@ function build_lr-flycast() {
     if isPlatform "rpi"; then
         if isPlatform "rpi4"; then
             params+=("platform=rpi4")
+        elif isPlatform "mesa"; then
+            params+=("platform=rpi-mesa")
         else
             params+=("platform=rpi")
         fi


### PR DESCRIPTION
The generic "rpi" platform string requires a "mesa" override to indicate it's a generic GLES build.
Fixes building against fkms overlay for RPI3.