### PR TITLE
kodi: unblock installation for fkms (buster)

### DIFF
--- a/scriptmodules/ports/kodi.sh
+++ b/scriptmodules/ports/kodi.sh
@@ -13,7 +13,7 @@ rp_module_id="kodi"
 rp_module_desc="Kodi - Open source home theatre software"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/xbmc/xbmc/master/LICENSE.GPL"
 rp_module_section="opt"
-rp_module_flags="!mali !osmc !xbian !kms"
+rp_module_flags="!mali !osmc !xbian"
 
 function _update_hook_kodi() {
     # to show as installed in retropie-setup 4.x


### PR DESCRIPTION
As of version 2:18.4-4~buster, pipplware's Kodi package ships with
kodi-rbpi_v8 built to target Mesa/KMS for RPI4, but also works on
RPI3 in fkms mode.

The v7 binary is still present, so the packages will work for older
board revisions with the legacy graphics drivers.

Thanks to Rascas for providing the packages & updating the launcher
script to support RPI3 in fkms mode, and popcornmix (built from his
leia_pi4 Kodi branch).