### PR TITLE
splashscreen: added KMS/RPI4 support (2)

### DIFF
--- a/scriptmodules/supplementary/omxiv.sh
+++ b/scriptmodules/supplementary/omxiv.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="omxiv"
+rp_module_desc="OpenMAX image viewer for the Raspberry Pi"
+rp_module_licence="GPL2 https://raw.githubusercontent.com/cmitu/omxiv/master/LICENSE"
+rp_module_flags="!x86 !osmc !xbian !mali"
+
+function depends_omxiv() {
+    getDepends libraspberrypi-dev libpng-dev libjpeg-dev
+}
+
+function sources_omxiv() {
+    gitPullOrClone "$md_build" https://github.com/retropie/omxiv.git
+}
+
+function build_omxiv() {
+    make clean
+    make ilclient
+    make
+    md_ret_require="omxiv.bin"
+}
+
+function install_omxiv() {
+    make install INSTALL="$md_inst"
+}

--- a/scriptmodules/supplementary/splashscreen/asplashscreen.sh
+++ b/scriptmodules/supplementary/splashscreen/asplashscreen.sh
@@ -6,10 +6,19 @@ RANDOMIZE="disabled"
 REGEX_VIDEO=""
 REGEX_IMAGE=""
 
+is_fkms() {
+    if grep -q okay /proc/device-tree/soc/v3d@7ec00000/status 2> /dev/null || grep -q okay /proc/device-tree/soc/firmwarekms@7e600000/status 2> /dev/null ; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 do_start () {
     local config="/etc/splashscreen.list"
     local line
     local re="$REGEX_VIDEO\|$REGEX_IMAGE"
+    local omxiv="/opt/retropie/supplementary/omxiv/omxiv"
     case "$RANDOMIZE" in
         disabled)
             line="$(head -1 "$config")"
@@ -32,7 +41,7 @@ do_start () {
         while ! pgrep "dbus" >/dev/null; do
             sleep 1
         done
-        omxplayer -o both -b --layer 10000 "$line"
+        omxplayer --no-osd -o both -b --layer 10000 "$line"
     elif $(echo "$line" | grep -q "$REGEX_IMAGE"); then
         if [ "$RANDOMIZE" = "disabled" ]; then
             local count=$(wc -l <"$config")
@@ -40,12 +49,12 @@ do_start () {
             local count=1
         fi
         [ $count -eq 0 ] && count=1
-        [ $count -gt 20 ] && count=20
-        local delay=$((20/count))
+        [ $count -gt 12 ] && count=12
+        local delay=$((12/count))
         if [ "$RANDOMIZE" = "disabled" ]; then
-            fbi -T 2 -once -t $delay -noverbose -a -l "$config" >/dev/null 2>&1
+            "$omxiv" --once -t $delay -b --layer 1000 -f "$config" >/dev/null 2>&1
         else
-            fbi -T 2 -once -t $delay -noverbose -a "$line" >/dev/null 2>&1
+            "$omxiv" --once -t $delay -b --layer 1000 -r "$line" >/dev/null 2>&1
         fi
     fi
     exit 0
@@ -70,5 +79,3 @@ case "$1" in
         exit 3
         ;;
 esac
-
-:


### PR DESCRIPTION
This commit changes the `splashscreen` from using `fbi` to [omxiv](https://github.com/HaarigerHarald/omxiv), an OpenMax image viewer for Raspberry PI that bypasses the KMS/DRM layer (similar to `omxplayer`). I added a separte module for it, using a modified version which adds a few `fbi`-compatible features (randomisation or images, exiting after a slideshow, reading the image list from a text file).

It's backwards compatible with non-KMS setups (I tested on a RPI3 using the _master_ RetroPie branch).

Notes:
 - on `kms` enabled systems, there is a video mode initialisation done after boot, when the DRM module gets loaded, so I added an extra dependency for the `systemd` service on module loading. Otherwise, the splashscreen gets cut off after the DRM initialisation. This doesn't happen for `omxplayer` since it's started later, after the `dbus` service.
- `omxiv` needs a version of the `libraspberrypi-dev` package released after Sept. 2018 (because it needs [this commit](https://github.com/raspberrypi/userland/commit/58f4b168d3368928e80d72f846a99ba926191f02) for `OMX_DISPLAY_ALPHA_FLAGS_MIX`. If we intend to support older versions, I'll see if we can modify `omxiv` to not depend on this flag (it's only used for alpha blending).

This is an alternative approach to implement https://github.com/RetroPie/RetroPie-Setup/pull/2849. It might be worth finding a generic KMS alternative in the future, it could benefit more systems than the Raspberry Pi.