### PR TITLE
cgenius.sh: Update to allow joystick game saving

### DIFF
--- a/scriptmodules/ports/cgenius.sh
+++ b/scriptmodules/ports/cgenius.sh
@@ -28,7 +28,7 @@ function sources_cgenius() {
 }
 
 function build_cgenius() {
-    cmake -DUSE_SDL2=yes -DCMAKE_INSTALL_PREFIX="$md_inst"
+    cmake -DUSE_SDL2=yes -DCMAKE_INSTALL_PREFIX="$md_inst" -DNOTYPESAVE=on
     make
     md_ret_require="$md_build/src/CGeniusExe"
 }


### PR DESCRIPTION
As per cgenius recommendation at https://github.com/gerstrong/Commander-Genius/issues/309#issuecomment-358072833

Update the cgenius `cmake` command to include `-DNOTYPESAVE=on` by default.