### PR TITLE
N64: GLideN64: highres mode needs to be paired with a nativeResFactor=2 to work

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -179,8 +179,14 @@ function configure_mupen64plus() {
         isPlatform "videocore" && addEmulator 1 "${md_id}-auto" "n64" "$md_inst/bin/mupen64plus.sh AUTO %ROM%"
         for res in "${resolutions[@]}"; do
             local name=""
-            [[ "$res" == "640x480" ]] && name="-highres"
-            addEmulator 1 "${md_id}-GLideN64$name" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM% $res"
+            local nativeResFactor=""
+            if [[ "$res" == "640x480" ]]; then
+                name="-highres"
+                nativeResFactor=2
+            else
+                nativeResFactor=1
+            fi
+            addEmulator 1 "${md_id}-GLideN64$name" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM% $res 0 --set Video-GLideN64[UseNativeResolutionFactor]\=$nativeResFactor"
             addEmulator 0 "${md_id}-gles2rice$name" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-rice %ROM% $res"
         done
         addEmulator 0 "${md_id}-gles2n64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-n64 %ROM%"

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -12,8 +12,9 @@
 AUDIO_PLUGIN="mupen64plus-audio-sdl"
 VIDEO_PLUGIN="$1"
 ROM="$2"
-RES="$3"
-RSP_PLUGIN="$4"
+[[ "$3" -ne 0 ]] && RES="$3"
+[[ "$4" -ne 0 ]] && RSP_PLUGIN="$4"
+PARAMS="${@:5}"
 [[ -n "$RES" ]] && RES="--resolution $RES"
 [[ -z "$RSP_PLUGIN" ]] && RSP_PLUGIN="mupen64plus-rsp-hle"
 WINDOW_MODE="--fullscreen $RES"
@@ -324,6 +325,7 @@ function useTexturePacks() {
 function autoset() {
     VIDEO_PLUGIN="mupen64plus-video-GLideN64"
     RES="--resolution 320x240"
+    PARAMS="--set Video-GLideN64[UseNativeResolutionFactor]=1"
 
     local game
     # these games run fine and look better with 640x480
@@ -344,6 +346,7 @@ function autoset() {
     for game in "${highres[@]}"; do
         if [[ "${ROM,,}" == *"$game"* ]]; then
             RES="--resolution 640x480"
+            PARAMS="--set Video-GLideN64[UseNativeResolutionFactor]=2"
             break
         fi
     done
@@ -441,4 +444,4 @@ else
     SDL_AUDIODRIVER=pulse
 fi
 
-SDL_AUDIODRIVER=${SDL_AUDIODRIVER} SDL_VIDEO_RPI_SCALE_MODE=${SDL_VIDEO_RPI_SCALE_MODE} "$rootdir/emulators/mupen64plus/bin/mupen64plus" --noosd ${WINDOW_MODE} --rsp ${RSP_PLUGIN}.so --gfx ${VIDEO_PLUGIN}.so --audio ${AUDIO_PLUGIN}.so --configdir "$configdir/n64" --datadir "$configdir/n64" "$ROM"
+SDL_AUDIODRIVER=${SDL_AUDIODRIVER} SDL_VIDEO_RPI_SCALE_MODE=${SDL_VIDEO_RPI_SCALE_MODE} "$rootdir/emulators/mupen64plus/bin/mupen64plus" --noosd $PARAMS ${WINDOW_MODE} --rsp ${RSP_PLUGIN}.so --gfx ${VIDEO_PLUGIN}.so --audio ${AUDIO_PLUGIN}.so --configdir "$configdir/n64" --datadir "$configdir/n64" "$ROM"


### PR DESCRIPTION
you can pass nativeResFactor=2 via a command line argument, so I have added that (and the ability to pass additional parameters to mupen64plus).

~~I think there's an argument that we shouldn't be using windowed mode with gliden64, as it demands you specify a resolution, but n64 resolutions aren't always factors of 320x240, so it's possible to get unwanted scaling/scaling artifacts. however, the alternative is to run fullscreen (letting gliden64 upscale from the true resolution) which removes the performance gain we get from our SDL upscaler. might be something to consider with the pi4...~~
ignore - gliden64 overrides the resolution when using `nativeResFactor`>0, so it doesn't matter what we send.