### PR TITLE
reicast: update for rpi4 & generic kms

### DIFF
--- a/scriptmodules/emulators/reicast/0001-enable-rpi4-sdl2-target.patch
+++ b/scriptmodules/emulators/reicast/0001-enable-rpi4-sdl2-target.patch
@@ -1,0 +1,20 @@
+diff --git a/shell/linux/Makefile b/shell/linux/Makefile
+index 96c2e58..a975698 100644
+--- a/shell/linux/Makefile
++++ b/shell/linux/Makefile
+@@ -185,9 +185,13 @@ else ifneq (,$(findstring lincpp,$(platform)))
+ else ifneq (,$(findstring rpi4,$(platform)))
+ 
+     CFLAGS += -D TARGET_BEAGLE -D TARGET_LINUX_ARMELv7 -DARM_HARDFP -fsingle-precision-constant
+-    CFLAGS += -DGLES3
++    ifneq (,$(findstring sdl,$(platform)))
++        USE_SDL := 1
++    else
++        CFLAGS += -DGLES3
++        USE_X11 := 1
++    endif
+ 
+-    USE_X11 := 1
+     USE_GLES := 1
+ 
+     MFLAGS += -march=armv8-a+crc -mtune=cortex-a72 -mfpu=neon-fp-armv8 -mfloat-abi=hard

--- a/scriptmodules/emulators/reicast/0002-enable-vsync.patch
+++ b/scriptmodules/emulators/reicast/0002-enable-vsync.patch
@@ -1,0 +1,13 @@
+diff --git a/core/sdl/sdl.cpp b/core/sdl/sdl.cpp
+index 6dc0eea..c161fa1 100644
+--- a/core/sdl/sdl.cpp
++++ b/core/sdl/sdl.cpp
+@@ -272,6 +272,8 @@ void sdl_window_create()
+ bool gl_init(void* wind, void* disp)
+ {
+ 	SDL_GL_MakeCurrent(window, glcontext);
++	SDL_GL_SetSwapInterval(1);
++
+ 	#ifdef GLES
+ 		return true;
+ 	#else

--- a/scriptmodules/emulators/reicast/0003-fix-sdl2-sighandler-conflict.patch
+++ b/scriptmodules/emulators/reicast/0003-fix-sdl2-sighandler-conflict.patch
@@ -1,0 +1,48 @@
+diff --git a/core/linux-dist/main.cpp b/core/linux-dist/main.cpp
+index aa29515..f53c871 100644
+--- a/core/linux-dist/main.cpp
++++ b/core/linux-dist/main.cpp
+@@ -374,6 +374,9 @@ int main(int argc, wchar* argv[])
+ 	printf("Data dir is:   %s\n", get_writable_data_path("/").c_str());
+ 
+ 	#if defined(USE_SDL)
++		// bypass SDL internal signal handlers due to conflict with reicast handlers
++		SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");
++
+ 		if (SDL_Init(0) != 0)
+ 		{
+ 			die("SDL: Initialization failed!");
+@@ -410,6 +413,10 @@ int main(int argc, wchar* argv[])
+ 		x11_window_destroy();
+ 	#endif
+ 
++	#if defined(USE_SDL)
++		SDL_Quit();
++	#endif
++
+ 	return 0;
+ }
+ #endif
+diff --git a/core/linux/common.cpp b/core/linux/common.cpp
+index 26449cb..fd73602 100644
+--- a/core/linux/common.cpp
++++ b/core/linux/common.cpp
+@@ -1,6 +1,8 @@
+ #include "types.h"
+ #include "cfg/cfg.h"
+ 
++extern void dc_exit();
++
+ #if HOST_OS==OS_LINUX || HOST_OS == OS_DARWIN
+ #if HOST_OS == OS_DARWIN
+ 	#define _XOPEN_SOURCE 1
+@@ -195,7 +197,8 @@ void common_linux_setup()
+ 
+ 	enable_runfast();
+ 	install_fault_handler();
+-	signal(SIGINT, exit);
++	signal(SIGINT, dc_exit);
++	signal(SIGTERM, dc_exit);
+ 	
+ 	settings.profile.run_counts=0;
+ 	

--- a/scriptmodules/emulators/reicast/reicast.sh
+++ b/scriptmodules/emulators/reicast/reicast.sh
@@ -11,6 +11,8 @@
 
 AUDIO="$1"
 ROM="$2"
+XRES="$3"
+YRES="$4"
 rootdir="/opt/retropie"
 configdir="$rootdir/configs"
 biosdir="$HOME/RetroPie/BIOS/dc"
@@ -79,11 +81,12 @@ if [[ ! -f "$biosdir/dc_boot.bin" ]]; then
 fi
 
 params=(-config config:homedir=$HOME -config x11:fullscreen=1)
+[[ -n "$XRES" ]] && params+=(-config x11:width=$XRES -config x11:height=$YRES)
 getAutoConf reicast_input && params+=($(mapInput))
 [[ -n "$AUDIO" ]] && params+=(-config audio:backend=$AUDIO -config audio:disable=0)
 [[ -n "$ROM" ]] && params+=(-config config:image="$ROM")
 if [[ "$AUDIO" == "oss" ]]; then
-    aoss "$rootdir/emulators/reicast/bin/reicast" "${params[@]}" >/dev/null
+    aoss "$rootdir/emulators/reicast/bin/reicast" "${params[@]}"
 else
-    "$rootdir/emulators/reicast/bin/reicast" "${params[@]}" >/dev/null
+    "$rootdir/emulators/reicast/bin/reicast" "${params[@]}"
 fi


### PR DESCRIPTION
reicast: update for rpi4 & generic kms

* Add support for RPI4 and generic KMS targets
* Allow configuration of rpi3 platform in favour of rpi2 platform
* Move build configuration into separate function to avoid duplication between
  build and install functions.
* avoid duplication of addEmulator definitions due to audio backend options
* Set alsa as default audio backend for mesa (omx doesn't work, and oss backend via
  aoss causes emulator stuttering).

Patch details (may be removed after upstream is fixed):
* Add SDL/gles2 sub-platform for rpi4 to allow kmsdrm compatibility
* Ensure vsync is enforced for SDL, otherwise KMSDRM will run at unlocked framerate.
* Fix signal handler conflict by disabling SDL2's exit signal handler, and ensuring that
  reicast gracefully cleans up by stopping emulation and invoking SDL_Quit() during exit.