### PR TITLE
Changed module according to recent changes in the PowerBlock driver (#2860)

### DIFF
--- a/scriptmodules/supplementary/powerblock.sh
+++ b/scriptmodules/supplementary/powerblock.sh
@@ -28,18 +28,17 @@ function sources_powerblock() {
 
 function build_powerblock() {
     cd "$md_inst"
-    rm -rf "build"
-    mkdir build
-    cd build
-    cmake ..
-    make
-    md_ret_require="$md_inst/build/src/powerblock/powerblock"
+    md_ret_require="$md_inst/install.sh"
 }
 
 function install_powerblock() {
-    # install from there to system folders
-    cd "$md_inst/build"
-    make install
+    cd "$md_inst"
+    sh install.sh
+}
+
+function remove_powerblock() {
+    cd "$md_inst"
+    sh uninstall.sh
 }
 
 function gui_powerblock() {
@@ -53,18 +52,13 @@ function gui_powerblock() {
     if [[ -n "$choice" ]]; then
         case "$choice" in
             1)
-                make -C "$md_inst/build" installservice
+                install_powerblock
                 printMsgs "dialog" "Enabled PowerBlock driver."
                 ;;
             2)
-                make -C "$md_inst/build" uninstallservice
+                remove_powerblock
                 printMsgs "dialog" "Disabled PowerBlock driver."
                 ;;
         esac
     fi
-}
-
-function remove_powerblock() {
-    make -C "$md_inst/build" uninstallservice
-    make -C "$md_inst/build" uninstall
 }

--- a/scriptmodules/supplementary/powerblock.sh
+++ b/scriptmodules/supplementary/powerblock.sh
@@ -26,10 +26,6 @@ function sources_powerblock() {
     gitPullOrClone "$md_inst" https://github.com/petrockblog/PowerBlock.git
 }
 
-function build_powerblock() {
-    cd "$md_inst"
-    md_ret_require="$md_inst/install.sh"
-}
 
 function install_powerblock() {
     cd "$md_inst"

--- a/scriptmodules/supplementary/powerblock.sh
+++ b/scriptmodules/supplementary/powerblock.sh
@@ -26,15 +26,14 @@ function sources_powerblock() {
     gitPullOrClone "$md_inst" https://github.com/petrockblog/PowerBlock.git
 }
 
-
 function install_powerblock() {
     cd "$md_inst"
-    sh install.sh
+    bash install.sh
 }
 
 function remove_powerblock() {
     cd "$md_inst"
-    sh uninstall.sh
+    bash uninstall.sh
 }
 
 function gui_powerblock() {


### PR DESCRIPTION
Addresses issue #2860.

This PR includes changes for the powerblock module to reflect recent changes in the PowerBLock driver: The installation and deinstallation fo the driver is now only based on the exception of two bash scripts (install.sh and uninstallation, respectively). Nothing needs to be compiled anymore.

I did not have the chance to test these changes for now on the current RetroPie installation. It should work, though.