### PR TITLE
pegasus-fe: Raspberry Pi 4 support

### DIFF
--- a/scriptmodules/supplementary/pegasus-fe.sh
+++ b/scriptmodules/supplementary/pegasus-fe.sh
@@ -22,6 +22,7 @@ function depends_pegasus-fe() {
         gstreamer1.0-libav
         gstreamer1.0-plugins-good
         jq
+        libsdl2-dev
         policykit-1
     )
 

--- a/scriptmodules/supplementary/pegasus-fe.sh
+++ b/scriptmodules/supplementary/pegasus-fe.sh
@@ -13,7 +13,7 @@ rp_module_id="pegasus-fe"
 rp_module_desc="Pegasus: A cross platform, customizable graphical frontend (latest alpha release)"
 rp_module_licence="GPL3+ https://raw.githubusercontent.com/mmatyas/pegasus-frontend/master/LICENSE.md"
 rp_module_section="exp"
-rp_module_flags="!mali !kms frontend"
+rp_module_flags="!mali frontend"
 
 function depends_pegasus-fe() {
     local depends=(
@@ -74,8 +74,8 @@ fi
 tty=\$(tty)
 export TTY="\${tty:8:1}"
 
-# improve gradients
-export QT_QPA_EGLFS_FORCE888=1
+export QT_QPA_EGLFS_FORCE888=1  # improve gradients
+export QT_QPA_EGLFS_KMS_ATOMIC=1  # use the atomic DRM API on Pi 4
 
 clear
 "$md_inst/pegasus-fe" "\$@"


### PR DESCRIPTION
Pegasus is now functional on the Pi 4, and the build should work there too. There's also a second commit that adds SDL2 as a dependency, which is used for gamepad handling on Pi 0-3 (not on Pi 4 yet, but will be there too eventually).