### PR TITLE
Fix pm2 installation in virtualgampead.sh

### DIFF
--- a/scriptmodules/supplementary/virtualgamepad.sh
+++ b/scriptmodules/supplementary/virtualgamepad.sh
@@ -50,7 +50,9 @@ function sources_virtualgamepad() {
 }
 
 function install_virtualgamepad() {
-    npm install pm2 -g --unsafe-perm
+    if ! [[ -x "$(command -v pm2)" ]]; then
+        wget -qO- https://getpm2.com/install.sh | bash
+    fi
     cd "$md_inst"
     sudo -u $user npm install
     sudo -u $user npm install ref


### PR DESCRIPTION
I had problems installing virtual gamepad because pm2 installation was throwing errors (Method Not Allowed). Installing it using the official installation script instead of npm worked for me