### PR TITLE
BufferSwapMode=2 (On buffer update) is most performant.

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -244,6 +244,8 @@ function configure_mupen64plus() {
         iniSet "fontColor" "1F1F1F"
         # Enable Threaded GL calls
         iniSet "ThreadedVideo" "True"
+        # Swap frame buffers On buffer update (most performant)
+        iniSet "BufferSwapMode" "2"
 
         # Disable gles2n64 autores feature and use dispmanx upscaling
         iniConfig "=" "" "$md_conf_root/n64/gles2n64.conf"


### PR DESCRIPTION
Small performance boost:

mario64 title screen (with --nospeedlimit)

**bufferswapmode=0**
78-98 VI/sec (mainly around low 80s) 

**bufferswapmode=1**
85-97 (mainly around low-high 80s)

**bufferswapmode=2**
86-96 (mainly around mid-high 80s) 

This is the value that mupen64plus-fz (android port of mupen64plus that targets similar hardware) uses: https://github.com/fzurita/mupen64plus-ae/blob/master/app/src/main/java/paulscode/android/mupen64plusae/persistent/GLideN64Prefs.java#L194