### PR TITLE
scummvm - bump version to latest stable (2.1)

### DIFF
--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -30,7 +30,7 @@ function depends_scummvm() {
 }
 
 function sources_scummvm() {
-    gitPullOrClone "$md_build" https://github.com/scummvm/scummvm.git "branch-2-0"
+    gitPullOrClone "$md_build" https://github.com/scummvm/scummvm.git "branch-2-1"
     if isPlatform "rpi"; then
         applyPatch "$md_data/01_rpi_enable_scalers.diff"
     fi

--- a/scriptmodules/emulators/scummvm/01_rpi_enable_scalers.diff
+++ b/scriptmodules/emulators/scummvm/01_rpi_enable_scalers.diff
@@ -1,6 +1,6 @@
 --- a/configure
 +++ b/configure
-@@ -2914,10 +2914,6 @@ if test -n "$_host"; then
+@@ -3144,10 +3144,6 @@
  			append_var LDFLAGS "-L$RPI_ROOT/opt/vc/lib"
  			# This is so optional OpenGL ES includes are found.
  			append_var CXXFLAGS "-I$RPI_ROOT/opt/vc/include"


### PR DESCRIPTION
User in the forum tested new version with different games and all seems to be working fine.
Ref: https://retropie.org.uk/forum/topic/23778/scummvm-2-1-0

@joolswills once this is merged I would suggest to rebuild the binary with the updated version as well, considering how long it takes to build from source. Thanks!