### PR TITLE
get_rpi_video: clean up legacy pkgconfig

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -221,6 +221,10 @@ function get_rpi_video() {
         __platform_flags+=" videocore dispmanx"
     fi
 
+    # delete legacy pkgconfig that conflicts with Mesa (may be installed via rpi-update)
+    # see: https://github.com/raspberrypi/userland/pull/585
+    rm -rf $pkgconfig/{egl.pc,glesv2.pc,vg.pc}
+
     # set pkgconfig path for vendor libraries
     export PKG_CONFIG_PATH="$pkgconfig"
 }


### PR DESCRIPTION
These files (which can be installed via rpi-update) will cause build conflicts
when targeting Mesa for Pi 4B or FKMS.