### PR TITLE
kms bins

### DIFF
--- a/scriptmodules/admin/builder.sh
+++ b/scriptmodules/admin/builder.sh
@@ -105,7 +105,7 @@ _EOF_
             git -C "$md_build/$dist/home/pi/RetroPie-Setup" pull
         fi
 
-        for sys in rpi1 rpi2; do
+        for sys in rpi1 rpi2 rpi4; do
             rp_callModule image chroot "$md_build/$dist" \
                 sudo \
                 PATH="/usr/lib/distcc:$PATH" \

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -345,7 +345,7 @@ function rp_createBin() {
     fi
 
     local archive="$md_id.tar.gz"
-    local dest="$__tmpdir/archives/$__os_codename/$__platform/$md_type"
+    local dest="$__tmpdir/archives/$__binary_path/$md_type"
     rm -f "$dest/$archive"
     mkdir -p "$dest"
     tar cvzf "$dest/$archive" -C "$rootdir/$md_type" "$md_id"

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -36,7 +36,9 @@ function setup_env() {
 
     # set location of binary downloads
     __binary_host="files.retropie.org.uk"
-    [[ "$__has_binaries" -eq 1 ]] && __binary_url="https://$__binary_host/binaries/$__os_codename/$__platform"
+    __binary_path="$__os_codename/$__platform"
+    isPlatform "kms" && __binary_path+="/kms"
+    __binary_url="https://$__binary_host/binaries/$__binary_path"
 
     __archive_url="https://files.retropie.org.uk/archives"
 

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -20,6 +20,14 @@ function setup_env() {
     __memory_phys=$(free -m | awk '/^Mem:/{print $2}')
     __memory_total=$(free -m -t | awk '/^Total:/{print $2}')
 
+    # test if we are in a chroot
+    if [[ "$(stat -c %d:%i /)" != "$(stat -c %d:%i /proc/1/root/.)" ]]; then
+        [[ -z "$QEMU_CPU" && -n "$__qemu_cpu" ]] && export QEMU_CPU=$__qemu_cpu
+        __chroot=1
+    else
+        __chroot=0
+    fi
+
     __has_binaries=0
 
     get_platform
@@ -49,14 +57,6 @@ function setup_env() {
     [[ -z "${CXXFLAGS}" ]] && export CXXFLAGS="${__default_cxxflags}"
     [[ -z "${ASFLAGS}" ]] && export ASFLAGS="${__default_asflags}"
     [[ -z "${MAKEFLAGS}" ]] && export MAKEFLAGS="${__default_makeflags}"
-
-    # test if we are in a chroot
-    if [[ "$(stat -c %d:%i /)" != "$(stat -c %d:%i /proc/1/root/.)" ]]; then
-        [[ -z "$QEMU_CPU" && -n "$__qemu_cpu" ]] && export QEMU_CPU=$__qemu_cpu
-        __chroot=1
-    else
-        __chroot=0
-    fi
 
     if [[ -z "$__nodialog" ]]; then
         __nodialog=0


### PR DESCRIPTION
use separate binary path for kms binaries

Fix some logic up regarding adding kms platform flag in chroot (__chroot var was used before it was set)