### PR TITLE
N64: GLideN64: FPS Counter hack no-longer works, and redundant since zelda* is in the GLideN64 blacklist

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -238,10 +238,6 @@ function configure_mupen64plus() {
         iniSet "UseNativeResolutionFactor" "1"
         # Enable legacy blending
         iniSet "EnableLegacyBlending" "True"
-        # Enable FPS Counter. Fixes zelda depth issue
-        iniSet "ShowFPS " "True"
-        iniSet "fontSize" "14"
-        iniSet "fontColor" "1F1F1F"
         # Enable Threaded GL calls
         iniSet "ThreadedVideo" "True"
         # Swap frame buffers On buffer update (most performant)

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -255,10 +255,6 @@ function testCompatibility() {
             iniSet "configVersion" "$config_version"
             # Size of texture cache in megabytes. Good value is VRAM*3/4
             iniSet "CacheSize" "50"
-            # Enable FPS Counter. Fixes zelda depth issue
-            iniSet "ShowFPS " "True"
-            iniSet "fontSize" "14"
-            iniSet "fontColor" "1F1F1F"
             # Enable FBEmulation if necessary
             iniSet "EnableFBEmulation" "True"
             # Set native resolution factor of 1


### PR DESCRIPTION
See https://github.com/gonetz/GLideN64/issues/1688#issuecomment-545045823

If this eventually gets fixed (I doubt there is much appetite to fix GLES2/videocore bugs, though), the FPS hack may become relevant again, but there are apparently even more issues with Zelda*, hence it is in the GLideN64 blacklist.

I suggest we retire this FPS Counter hack (which affects all games ran in GLideN64) for now, as it does nothing.