### PR TITLE
N64: GLideN64: set Texture Cache to 128MB for Pi 2+, 64MB for Pi 1/0 (RPI)

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -231,7 +231,13 @@ function configure_mupen64plus() {
         # Bilinear filtering mode (0=N64 3point, 1=standard)
         iniSet "bilinearMode" "1"
         # Size of texture cache in megabytes. Good value is VRAM*3/4
-        iniSet "CacheSize" "50"
+        local gpu_mem
+        if isPlatform "armv6"; then
+            gpu_mem=64
+        else
+            gpu_mem=128
+        fi
+        iniSet "CacheSize" "$gpu_mem"
         iniSet "EnableFBEmulation" "True"
         # Use native res
         iniSet "UseNativeResolutionFactor" "1"

--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -232,7 +232,6 @@ function configure_mupen64plus() {
         iniSet "bilinearMode" "1"
         # Size of texture cache in megabytes. Good value is VRAM*3/4
         iniSet "CacheSize" "50"
-        # Disable FB emulation until visual issues are sorted out
         iniSet "EnableFBEmulation" "True"
         # Use native res
         iniSet "UseNativeResolutionFactor" "1"

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -253,8 +253,6 @@ function testCompatibility() {
                 config_version=$(<"$configdir/n64/GLideN64_config_version.ini")
             fi
             iniSet "configVersion" "$config_version"
-            # Size of texture cache in megabytes. Good value is VRAM*3/4
-            iniSet "CacheSize" "50"
             # Set native resolution factor of 1
             iniSet "UseNativeResolutionFactor" "1"
             for game in "${GLideN64NativeResolution_blacklist[@]}"; do

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -255,8 +255,6 @@ function testCompatibility() {
             iniSet "configVersion" "$config_version"
             # Size of texture cache in megabytes. Good value is VRAM*3/4
             iniSet "CacheSize" "50"
-            # Enable FBEmulation if necessary
-            iniSet "EnableFBEmulation" "True"
             # Set native resolution factor of 1
             iniSet "UseNativeResolutionFactor" "1"
             for game in "${GLideN64NativeResolution_blacklist[@]}"; do


### PR DESCRIPTION
The recommended value is 3/4 VRAM, so let's calculate it 👍 I don't see any performance change, but it was fun to do anyway!

Also done a little cleanup with the FBEmulation setting. I think unless we're using that setting in a blacklist, there's no need to force it to enabled at launch. Users should have the ability to play with these settings after install if they so wish.