### PR TITLE
Fix colour sticking at white if you're logged in as root

### DIFF
--- a/scriptmodules/supplementary/bashwelcometweak.sh
+++ b/scriptmodules/supplementary/bashwelcometweak.sh
@@ -129,7 +129,7 @@ function retropie_welcome() {
                 out+="${fgwht}The RetroPie Project, https://retropie.org.uk"
                 ;;
         esac
-        out+="\n"
+        out+="${rst}\n"
     done
     echo -e "\n$out"
 }


### PR DESCRIPTION
I often log in as root to my retropie box (via ssh with a pubkey). Since the account doesn't have colours in its PS1, the last one used stays on the prompt, which is white and not very readable on my light terminal background. This is a quick fix for that problem.