### PR TITLE
fkms: enable residualvm and xroar

### DIFF
--- a/scriptmodules/emulators/residualvm.sh
+++ b/scriptmodules/emulators/residualvm.sh
@@ -14,7 +14,7 @@ rp_module_desc="ResidualVM - A 3D Game Interpreter"
 rp_module_help="Copy your ResidualVM games to $romdir/residualvm"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/residualvm/residualvm/master/COPYING"
 rp_module_section="exp"
-rp_module_flags="dispmanx !mali !kms"
+rp_module_flags="dispmanx !mali"
 
 function depends_residualvm() {
     local depends=(
@@ -23,7 +23,7 @@ function depends_residualvm() {
         zlib1g-dev libjpeg-dev
     )
     isPlatform "x11" && depends+=(libglew-dev)
-    isPlatform "rpi" && depends+=(libraspberrypi-dev)
+    isPlatform "videocore" && depends+=(libraspberrypi-dev)
     getDepends "${depends[@]}"
 }
 
@@ -41,7 +41,7 @@ function build_residualvm() {
         --prefix="$md_inst"
     )
     ! isPlatform "x11" && params+=(--force-opengles2)
-    if isPlatform "rpi"; then
+    if isPlatform "videocore"; then
         CXXFLAGS+=" -I/opt/vc/include" LDFLAGS+=" -L/opt/vc/lib" ./configure "${params[@]}"
     else
         ./configure "${params[@]}"

--- a/scriptmodules/emulators/xroar.sh
+++ b/scriptmodules/emulators/xroar.sh
@@ -14,7 +14,7 @@ rp_module_desc="Dragon / CoCo emulator XRoar"
 rp_module_help="ROM Extensions: .cas .wav .bas .asc .dmk .jvc .os9 .dsk .vdk .rom .ccc .sna\n\nCopy your Dragon roms to $romdir/dragon32\n\nCopy your CoCo games to $romdir/coco\n\nCopy the required BIOS files d32.rom (Dragon 32) and bas13.rom (CoCo) to $biosdir"
 rp_module_licence="GPL2 http://www.6809.org.uk/xroar/"
 rp_module_section="opt"
-rp_module_flags="!mali !kms"
+rp_module_flags="!mali"
 
 function depends_xroar() {
     getDepends libsdl2-dev automake


### PR DESCRIPTION
* Xroar already uses SDL2 and works fine under `fkms`
* ResidualVM also uss SDL2, it just needs to be linked to the Mesa GLESv2 library under the `fkms` platform.