### PR TITLE
image: don't set custom gpu_mem allocation for mesa targets

### DIFF
--- a/scriptmodules/admin/image.sh
+++ b/scriptmodules/admin/image.sh
@@ -100,11 +100,13 @@ function install_rp_image() {
         sed -i "s/quiet/quiet loglevel=3 consoleblank=0 plymouth.enable=0 quiet/" "$chroot/boot/cmdline.txt"
     fi
 
-    # set default GPU mem, and overscan_scale so ES scales to overscan settings.
+    # set default GPU mem (videocore only) and overscan_scale so ES scales to overscan settings.
     iniConfig "=" "" "$chroot/boot/config.txt"
-    iniSet "gpu_mem_256" 128
-    iniSet "gpu_mem_512" 256
-    iniSet "gpu_mem_1024" 256
+    if ! [[ "$platform" =~ rpi.*kms|rpi4 ]]; then
+        iniSet "gpu_mem_256" 128
+        iniSet "gpu_mem_512" 256
+        iniSet "gpu_mem_1024" 256
+    fi
     iniSet "overscan_scale" 1
 
     cat > "$chroot/home/pi/install.sh" <<_EOF_


### PR DESCRIPTION
The RPI VC4/VC6 drivers use the kernel CMA heap allocation for GPU memory
(which defaults to 256MB on 1GB+ targets) instead of the gpu_mem allocation.

Although the gpu_mem allocation is still used, it's needed only for camera and
hardware decoders, but the default allocation (~64-76MB) is sufficient.

Without this change, we are losing ~192MB of user-addressible kernel memory
for no reason.