### PR TITLE
scummvm - pull using stable tag and disable experimental engines

### DIFF
--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -17,7 +17,11 @@ rp_module_section="opt"
 rp_module_flags=""
 
 function depends_scummvm() {
-    local depends=(libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev libjpeg-dev libasound2-dev libcurl4-openssl-dev)
+    local depends=(
+        libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng-dev
+        libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev
+        libjpeg-dev libasound2-dev libcurl4-openssl-dev
+    )
     if isPlatform "vero4k"; then
         depends+=(vero3-userland-dev-osmc)
     fi
@@ -30,17 +34,21 @@ function depends_scummvm() {
 }
 
 function sources_scummvm() {
-    gitPullOrClone "$md_build" https://github.com/scummvm/scummvm.git "branch-2-1"
+    gitPullOrClone "$md_build" https://github.com/scummvm/scummvm.git v2.1.0
     if isPlatform "rpi"; then
         applyPatch "$md_data/01_rpi_enable_scalers.diff"
     fi
 }
 
 function build_scummvm() {
-    local params=(--enable-all-engines --enable-vkeybd --enable-release --disable-debug --enable-keymapper --disable-eventrecorder --prefix="$md_inst")
+    local params=(
+        --enable-release --enable-vkeybd --enable-keymapper
+        --disable-debug --disable-eventrecorder --prefix="$md_inst"
+    )
     isPlatform "rpi" && params+=(--host=raspberrypi)
     isPlatform "vero4k" && params+=(--opengl-mode=gles2)
-    # stop scummvm using arm-linux-gnueabihf-g++ which is v4.6 on wheezy and doesn't like rpi2 cpu flags
+    # stop scummvm using arm-linux-gnueabihf-g++ which is v4.6 on
+    # wheezy and doesn't like rpi2 cpu flags
     if isPlatform "rpi"; then
         CC="gcc" CXX="g++" ./configure "${params[@]}"
     else

--- a/scriptmodules/emulators/scummvm/01_rpi_enable_scalers.diff
+++ b/scriptmodules/emulators/scummvm/01_rpi_enable_scalers.diff
@@ -1,6 +1,6 @@
 --- a/configure
 +++ b/configure
-@@ -3144,10 +3144,6 @@
+@@ -3139,10 +3139,6 @@
  			append_var LDFLAGS "-L$RPI_ROOT/opt/vc/lib"
  			# This is so optional OpenGL ES includes are found.
  			append_var CXXFLAGS "-I$RPI_ROOT/opt/vc/include"


### PR DESCRIPTION
* Use official tags as requested by upstream developers
* Do not enable experimental engines as requested by upstream developers
* Re-organised long lines
* Rebased patches

Tested on Raspberry Pi 3B+ with latest stable RetroPie.
Tested building with `__platform=rpi1` as well.

EDIT: I started the PR as draft for allowing testing from the originating forum member. Once confirmed working as expected I'll undraft the PR.