### PR TITLE
FPS hack is no longer needed

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -271,11 +271,6 @@ function configure_mupen64plus() {
         iniSet "BufferSwapMode" "2"
 
         if isPlatform "videocore"; then
-            # Enable FPS Counter. Fixes zelda depth issue
-            iniSet "ShowFPS " "True"
-            iniSet "fontSize" "14"
-            iniSet "fontColor" "1F1F1F"
-
             # Disable gles2n64 autores feature and use dispmanx upscaling
             iniConfig "=" "" "$md_conf_root/n64/gles2n64.conf"
             iniSet "auto resolution" "0"


### PR DESCRIPTION
As per https://github.com/RetroPie/RetroPie-Setup/commit/96e1d73217678cc0f38bae57c312ce9396d444e8#diff-fe35047c4f73377c42592c2271157752

Small miss from the rebase. You might want to do it as a rebase rather than as a new commit, just highlighting it here :)