### PR TITLE
ppsspp - fix building for rpi1 target on rpi2/3 or chroot

### DIFF
--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -123,7 +123,7 @@ function build_ppsspp() {
     local params=()
     if isPlatform "videocore"; then
         if isPlatform "armv6"; then
-            params+=(-DCMAKE_TOOLCHAIN_FILE=cmake/Toolchains/raspberry.armv6.cmake)
+            params+=(-DCMAKE_TOOLCHAIN_FILE=cmake/Toolchains/raspberry.armv6.cmake -DFORCED_CPU=armv6)
         else
             params+=(-DCMAKE_TOOLCHAIN_FILE=cmake/Toolchains/raspberry.armv7.cmake)
         fi


### PR DESCRIPTION
CMakeLists.txt uses CMAKE_SYSTEM_PROCESSOR and adjusts flags based on this
however if building on rpi2/3 or in a chroot with __platform=rpi1 this will
still return armv7l as it uses "uname". This causes armv7/neon code to be included
which causes building to fail. We can override this by setting -DFORCED_CPU=armv6
which fixes building for the rpi1