### PR TITLE
pcsx2: use upstream PPA for the latest version

### DIFF
--- a/scriptmodules/emulators/pcsx2.sh
+++ b/scriptmodules/emulators/pcsx2.sh
@@ -17,41 +17,39 @@ rp_module_section="exp"
 rp_module_flags="!arm"
 
 function depends_pcsx2() {
-    # Build dependencies (from the Debian/Ubuntu package: https://github.com/PCSX2/pcsx2/blob/master/debian-packager/control)
-    local depends=(cmake libaio-dev:i386 libasound2-dev:i386 libbz2-dev:i386 libgl1-mesa-dev:i386 libglu1-mesa-dev:i386 libgtk2.0-dev:i386 liblzma-dev:i386 libpng-dev:i386 libpulse-dev:i386 libpcap0.8-dev:i386 libsdl2-dev:i386 libsoundtouch-dev:i386 libwxbase3.0-dev:i386 libwxgtk3.0-dev:i386 libx11-dev:i386 libxml2-dev:i386 portaudio19-dev:i386 zlib1g-dev:i386 libasound2-plugins:i386 libusb-0.1-4:i386)
     if isPlatform "64bit"; then
-        # We need to add the target architecture (no side effects if it's already added)
-        dpkg --add-architecture i386
-        # Installing compiler dependencies for crossbuild
-        depends+=(gcc-multilib g++-multilib)
+        iniConfig " = " '"' "$configdir/all/retropie.cfg"
+        iniGet "own_sdl2"
+        if [[ "$ini_value" != "0" ]]; then
+            if dialog --yesno "PCSX2 cannot be installed on a 64bit system with the RetroPie custom version of SDL2 installed due to version conflicts with the multiarch i386 version of SDL2.\n\nDo you want to downgrade to your OS version of SDL2 and continue to install PCSX2?" 22 76 2>&1 >/dev/tty; then
+                chown $user:$user "$configdir/all/retropie.cfg"
+                if rp_callModule sdl2 revert; then
+                    iniSet "own_sdl2" "0"
+                else
+                    md_ret_errors+=("Failed to install $md_desc")
+                fi
+            else
+                md_ret_errors+=("$md_desc install aborted.")
+            fi
+        fi
     fi
-    getDepends "${depends[@]}"
+
+    if [[ "$md_mode" == "install" ]]; then
+        add-apt-repository -y ppa:pcsx2-team/pcsx2-daily
+        dpkg --add-architecture i386
+    else
+        rm -f /etc/apt/sources.list.d/pcsx2-team-ubuntu-pcsx2-daily-*.list
+        apt-key del "D7B4 49CF E17E 659E 5A12  EE8E DD6E EEA2 BD74 7717" >/dev/null  
+    fi
 }
 
-function sources_pcsx2() {
-    gitPullOrClone "$md_build" https://github.com/PCSX2/pcsx2.git master
+function install_bin_pcsx2() {
+    aptInstall pcsx2-unstable
 }
 
-function build_pcsx2() {
-    mkdir build
-    cd build
-    # Flags are the same as the Debian/Ubuntu package: https://github.com/PCSX2/pcsx2/blob/master/debian-packager/rules.
-    # More info at https://github.com/PCSX2/pcsx2/wiki/Installing-on-Linux.
-    # -DCMAKE_BUILD_TYPE=Release  -> Best in speed, but provides little or no debug/crash info 
-    # -DXDG_STD=TRUE              -> Use the Debian/Ubuntu configuration dir path, at ~/.config/PCSX2 
-    # -DPACKAGE_MODE=TRUE         -> Required to make it installable in different folders
-    # -DCMAKE_BUILD_STRIP=FALSE   -> Keep symbols. Better for debug. (recommended since it should not have any impact on speed)
-    # -DDISABLE_ADVANCE_SIMD=TRUE -> Disable AVX
-    # -DGSDX_LEGACY=TRUE          -> Build a GSdx legacy plugin compatible with GL3.3
-    cmake .. -DCMAKE_BUILD_TYPE=Release -DXDG_STD=TRUE -DPACKAGE_MODE=TRUE -DCMAKE_BUILD_STRIP=FALSE -DDISABLE_ADVANCE_SIMD=TRUE -DGSDX_LEGACY=TRUE -DCMAKE_TOOLCHAIN_FILE=cmake/linux-compiler-i386-multilib.cmake -DCMAKE_INSTALL_PREFIX="$md_inst"
-    make clean
-    make
-    md_ret_require="$md_build/build/pcsx2/PCSX2"
-}
-
-function install_pcsx2() {
-    cd build
-    make install
+function remove_pcsx2() {
+    aptRemove pcsx2-unstable
+    rp_callModule pcsx2 depends remove
 }
 
 function configure_pcsx2() {


### PR DESCRIPTION
After #2872, installing `pcsx2` on 64 bit is no longer possible on Ubuntu, due to `libsdl2-dev:i386` installation conflicts (see https://bugs.launchpad.net/ubuntu/+source/mir/+bug/1808060). 

So will use the PPA maintained by the upstream team (from https://launchpad.net/~pcsx2-team/+archive/ubuntu/pcsx2-daily) and add back the SDL2 downgrade option.

Tested on 18.04, should work on newer versions since the PPA builds up-to-date packages for 19.04 and 19.10 also. Should fix https://retropie.org.uk/forum/topic/23992.