### PR TITLE
pcsx2: fix emulator path with PPA install

### DIFF
--- a/scriptmodules/emulators/pcsx2.sh
+++ b/scriptmodules/emulators/pcsx2.sh
@@ -55,8 +55,8 @@ function remove_pcsx2() {
 function configure_pcsx2() {
     mkRomDir "ps2"
     # Windowed option
-    addEmulator 0 "$md_id" "ps2" "$md_inst/bin/PCSX2 %ROM% --windowed"
+    addEmulator 0 "$md_id" "ps2" "/usr/games/PCSX2 %ROM% --windowed"
     # Fullscreen option with no gui (default, because we can close with `Esc` key, easy to map for gamepads)
-    addEmulator 1 "$md_id-nogui" "ps2" "$md_inst/bin/PCSX2 %ROM% --fullscreen --nogui"
+    addEmulator 1 "$md_id-nogui" "ps2" "/usr/games/PCSX2 %ROM% --fullscreen --nogui"
     addSystem "ps2"
 }


### PR DESCRIPTION
Previous PR (#2894) didn't modify the emulator path; fix the path so the correct configuration is produced.