### PR TITLE
Fix for getting OS version on Armbian

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -67,7 +67,7 @@ function get_os_version() {
 
     # get os distributor id, description, release number and codename
     local os
-    mapfile -t os < <(lsb_release -sidrc)
+    mapfile -t os < <(lsb_release -s -i -d -r -c)
     __os_id="${os[0]}"
     __os_desc="${os[1]}"
     __os_release="${os[2]}"


### PR DESCRIPTION
Without this fix on Armbian OS ```lsb_release -sidrc``` returns an empty value.