### PR TITLE
Mesa unneeded for Vero4K GLES and appears to be harmful.

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -17,7 +17,7 @@ rp_module_section="core"
 function depends_retroarch() {
     local depends=(libudev-dev libxkbcommon-dev libsdl2-dev libasound2-dev libusb-1.0-0-dev)
     isPlatform "rpi" && depends+=(libraspberrypi-dev)
-    isPlatform "gles" && depends+=(libgles2-mesa-dev)
+    isPlatform "gles" && ! isPlatform "vero4k" && depends+=(libgles2-mesa-dev)
     isPlatform "mesa" && depends+=(libx11-xcb-dev)
     isPlatform "mali" && depends+=(mali-fbdev)
     isPlatform "x11" && depends+=(libx11-xcb-dev libpulse-dev libvulkan-dev)


### PR DESCRIPTION
`libgles2-mesa-dev` is unneeded on this platform and pulls in an awful lot of extra packages.  Some of these appear to break the GPU drivers.

Many Thanks.