### PR TITLE
Adding rpcs3 initial script

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -179,6 +179,9 @@ ports_platform="pc"
 ps2_exts=".iso .img .bin .mdf .z .z2 .bz2 .dump .cso .ima .gz"
 ps2_fullname="PlayStation 2"
 
+ps3_exts=".ps3"
+ps3_fullname="PlayStation 3"
+
 psp_exts=".iso .pbp .cso"
 psp_fullname="PlayStation Portable"
 

--- a/scriptmodules/emulators/rpcs3.sh
+++ b/scriptmodules/emulators/rpcs3.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="rpcs3"
+rp_module_desc="PS3 emulator RPCS3"
+rp_module_help="ROM Extensions: .ps3\n\nCopy your .PS3 game folders to $romdir/ps3\n\nDon't forget to run system firmware update first!"
+rp_module_licence="GPL2 https://raw.githubusercontent.com/RPCS3/rpcs3/master/LICENSE"
+rp_module_section="exp"
+rp_module_flags="!arm"
+
+function install_bin_rpcs3() {
+    mkdir -p "$md_inst/bin"
+    wget --content-disposition https://rpcs3.net/latest-appimage -O "$md_inst/bin/rpcs3.AppImage"
+    chmod +x "$md_inst/bin/rpcs3.AppImage"
+}
+
+function configure_rpcs3() {
+    mkRomDir "ps3"
+    addEmulator 0 "$md_id" "ps3" "$md_inst/bin/rpcs3.AppImage %ROM%/PS3_GAME/USRDIR/EBOOT.BIN"
+    addEmulator 1 "$md_id-nogui" "ps3" "$md_inst/bin/rpcs3.AppImage --no-gui %ROM%/PS3_GAME/USRDIR/EBOOT.BIN"
+    addSystem "ps3"
+}


### PR DESCRIPTION
It's using the appImage download path, which always download the latest build (see the section "For Linux Users" in the [Download](https://rpcs3.net/download) page).
