### PR TITLE
zesarux: use SDL2 for KMS targets

### DIFF
--- a/scriptmodules/emulators/zesarux.sh
+++ b/scriptmodules/emulators/zesarux.sh
@@ -12,13 +12,20 @@
 rp_module_id="zesarux"
 rp_module_desc="ZX Spectrum emulator ZEsarUX"
 rp_module_help="ROM Extensions: .sna .szx .z80 .tap .tzx .gz .udi .mgt .img .trd .scl .dsk .zip\n\nCopy your ZX Spectrum games to $romdir/zxspectrum"
-rp_module_licence="GPL3 https://sourceforge.net/p/zesarux/code/ci/master/tree/LICENSE"
+rp_module_licence="GPL3 https://raw.githubusercontent.com/chernandezba/zesarux/master/src/LICENSE"
 rp_module_section="opt"
 rp_module_flags="dispmanx !mali"
 
 function depends_zesarux() {
-    local depends=(libssl-dev libpthread-stubs0-dev libsdl1.2-dev libasound2-dev)
+    local depends=(libssl-dev libpthread-stubs0-dev libasound2-dev)
     isPlatform "x11" && depends+=(libpulse-dev)
+
+    if isPlatform "kms"; then
+        depends+=(libsdl2-dev)
+    else
+        depends+=(libsdl1.2-dev)
+    fi
+
     getDepends "${depends[@]}"
 }
 
@@ -30,8 +37,10 @@ function build_zesarux() {
     local params=()
     isPlatform "videocore" && params+=(--enable-raspberry)
     ! isPlatform "x11" && params+=(--disable-pulse)
+    isPlatform "kms" && params+=(--enable-sdl2)
+
     cd src
-    ./configure --prefix "$md_inst" "${params[@]}"
+    ./configure --prefix "$md_inst" "${params[@]}" --enable-ssl
     make clean
     make
     md_ret_require="$md_build/src/zesarux"


### PR DESCRIPTION
Adds support for using SDL2 on KMS targets. Other changes
* explicitely `--enable-ssl` for build configuration, otherwise it seems SSL support is not [enabled by default](https://github.com/chernandezba/zesarux/blob/89b077721f30157e825cd2d76a00bd81a97f8493/src/Changelog#L434). 
~~* for PI0/1, run with the `--spectrum-reduced-core` parameter for performance. This disables the following: _Debug t-states, Char detection, +3 Disk, Save to tape, Divide, Divmmc, RZX, Raster interrupts, Audio DAC, Video out to file_~~