### PR TITLE
skyscraper: add priorities.xml sample when installing

### DIFF
--- a/scriptmodules/supplementary/skyscraper.sh
+++ b/scriptmodules/supplementary/skyscraper.sh
@@ -46,6 +46,7 @@ function install_skyscraper() {
         'hints.txt'
         'import'
         'resources'
+        'cache/priorities.xml.example'
     )
 }
 
@@ -231,6 +232,10 @@ function _init_config_skyscraper() {
         mkUserDir "$md_conf_dir/import/$folder"
     done
     cp -rf "$md_inst/import" "$md_conf_dir"
+
+    # Create the cache folder and add the sample 'priorities.xml' file to it
+    mkdir -p "$md_conf_dir/cache"
+    cp -f "$md_inst/priorities.xml.example" "$md_conf_dir/cache"
 }
 
 # Scrape one system, passed as parameter


### PR DESCRIPTION
Skyscraper can prioritise between different scraping sources when generating the frontend-end metadata and this is set through the `priorities.xml` file present in the `cache` folder.

Add the upstream sample for the `priorities.xml` during installation, it will be automatically used by Skyscraper instead of using a timestamp based prioritisation (i.e. last scraped resources wins). Users can then edit the file to change the order/priority when using multiple scraping sources.

See: https://retropie.org.uk/forum/topic/11826/versatile-c-game-scraper-skyscraper/1261.