### PR TITLE
Add ps3 to platforms

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -179,6 +179,9 @@ ports_platform="pc"
 ps2_exts=".iso .img .bin .mdf .z .z2 .bz2 .dump .cso .ima .gz"
 ps2_fullname="PlayStation 2"
 
+ps3_exts=".ps3"
+ps3_fullname="PlayStation 3"
+
 psp_exts=".iso .pbp .cso"
 psp_fullname="PlayStation Portable"
 


### PR DESCRIPTION
This will allow future setup scripts to easily add PS3 in `es_systems.cfg`.