### PR TITLE
packages - added the ability to set a package section based on platfo…

### DIFF
--- a/scriptmodules/emulators/mame4all.sh
+++ b/scriptmodules/emulators/mame4all.sh
@@ -13,7 +13,7 @@ rp_module_id="mame4all"
 rp_module_desc="MAME emulator MAME4All-Pi"
 rp_module_help="ROM Extension: .zip\n\nCopy your MAME4all-Pi roms to either $romdir/mame-mame4all or\n$romdir/arcade"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/RetroPie/mame4all-pi/master/readme.txt"
-rp_module_section="main"
+rp_module_section="opt armv6=main"
 rp_module_flags="!x11 !mali !kms !vero4k"
 
 function depends_mame4all() {

--- a/scriptmodules/emulators/pifba.sh
+++ b/scriptmodules/emulators/pifba.sh
@@ -13,7 +13,7 @@ rp_module_id="pifba"
 rp_module_desc="FBA emulator PiFBA"
 rp_module_help="ROM Extension: .zip\n\nCopy your FBA roms to\n$romdir/fba or\n$romdir/neogeo or\n$romdir/arcade\n\nFor NeoGeo games the neogeo.zip BIOS is required and must be placed in the same directory as your FBA roms."
 rp_module_licence="GPL2 https://raw.githubusercontent.com/RetroPie/pifba/master/FBAcapex_src/COPYING"
-rp_module_section="main"
+rp_module_section="opt armv6=main"
 rp_module_flags="!x11 !mali !kms !vero4k"
 
 function depends_pifba() {

--- a/scriptmodules/libretrocores/lr-beetle-psx.sh
+++ b/scriptmodules/libretrocores/lr-beetle-psx.sh
@@ -13,7 +13,7 @@ rp_module_id="lr-beetle-psx"
 rp_module_desc="PlayStation emulator - Mednafen PSX Port for libretro"
 rp_module_help="ROM Extensions: .bin .cue .cbn .img .iso .m3u .mdf .pbp .toc .z .znx\n\nCopy your PlayStation roms to $romdir/psx\n\nCopy the required BIOS files\n\nscph5500.bin and\nscph5501.bin and\nscph5502.bin to\n\n$biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/beetle-psx-libretro/master/COPYING"
-rp_module_section="opt"
+rp_module_section="opt x86=main"
 rp_module_flags="!arm"
 
 function depends_lr-beetle-psx() {

--- a/scriptmodules/libretrocores/lr-fbalpha2012.sh
+++ b/scriptmodules/libretrocores/lr-fbalpha2012.sh
@@ -13,7 +13,7 @@ rp_module_id="lr-fbalpha2012"
 rp_module_desc="Arcade emu - Final Burn Alpha (0.2.97.30) port for libretro"
 rp_module_help="Previously called lr-fba\n\nROM Extension: .zip\n\nCopy your FBA roms to\n$romdir/fba or\n$romdir/neogeo or\n$romdir/arcade\n\nFor NeoGeo games the neogeo.zip BIOS is required and must be placed in the same directory as your FBA roms."
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/fbalpha2012/master/docs/license.txt"
-rp_module_section="opt"
+rp_module_section="opt armv6=main"
 
 function _update_hook_lr-fbalpha2012() {
     # move from old location and update emulators.cfg

--- a/scriptmodules/libretrocores/lr-fbneo.sh
+++ b/scriptmodules/libretrocores/lr-fbneo.sh
@@ -13,7 +13,7 @@ rp_module_id="lr-fbneo"
 rp_module_desc="Arcade emu - FinalBurn Neo v0.2.97.44 (WIP) port for libretro"
 rp_module_help="Previously called lr-fba-next and fbalpha\n\ROM Extension: .zip\n\nCopy your FBA roms to\n$romdir/fba or\n$romdir/neogeo or\n$romdir/arcade\n\nFor NeoGeo games the neogeo.zip BIOS is required and must be placed in the same directory as your FBA roms."
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/FBNeo/master/src/license.txt"
-rp_module_section="main"
+rp_module_section="main armv6=opt"
 
 function _update_hook_lr-fbneo() {
     # move from old location and update emulators.cfg

--- a/scriptmodules/libretrocores/lr-gpsp.sh
+++ b/scriptmodules/libretrocores/lr-gpsp.sh
@@ -13,7 +13,7 @@ rp_module_id="lr-gpsp"
 rp_module_desc="GBA emu - gpSP port for libretro"
 rp_module_help="ROM Extensions: .gba .zip\n\nCopy your Game Boy Advance roms to $romdir/gba\n\nCopy the required BIOS file gba_bios.bin to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/gpsp/master/COPYING"
-rp_module_section="main"
+rp_module_section="opt arm=main"
 rp_module_flags="!x86"
 
 function sources_lr-gpsp() {

--- a/scriptmodules/libretrocores/lr-mame2000.sh
+++ b/scriptmodules/libretrocores/lr-mame2000.sh
@@ -13,7 +13,7 @@ rp_module_id="lr-mame2000"
 rp_module_desc="Arcade emu - MAME 0.37b5 port for libretro"
 rp_module_help="ROM Extension: .zip\n\nCopy your MAME 0.37b5 roms to either $romdir/mame-mame4all or\n$romdir/arcade"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/mame2000-libretro/master/readme.txt"
-rp_module_section="main"
+rp_module_section="opt armv6=main"
 
 function _update_hook_lr-mame2000() {
     # move from old location and update emulators.cfg

--- a/scriptmodules/libretrocores/lr-mame2003.sh
+++ b/scriptmodules/libretrocores/lr-mame2003.sh
@@ -13,7 +13,7 @@ rp_module_id="lr-mame2003"
 rp_module_desc="Arcade emu - MAME 0.78 port for libretro"
 rp_module_help="ROM Extension: .zip\n\nCopy your MAME roms to either $romdir/mame-libretro or\n$romdir/arcade"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/mame2003-libretro/master/LICENSE.md"
-rp_module_section="main"
+rp_module_section="main armv6=opt"
 
 function _get_dir_name_lr-mame2003() {
     echo "mame2003"

--- a/scriptmodules/libretrocores/lr-parallel-n64.sh
+++ b/scriptmodules/libretrocores/lr-parallel-n64.sh
@@ -13,7 +13,7 @@ rp_module_id="lr-parallel-n64"
 rp_module_desc="N64 emu - Highly modified Mupen64Plus port for libretro"
 rp_module_help="ROM Extensions: .z64 .n64 .v64\n\nCopy your N64 roms to $romdir/n64"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/parallel-n64/master/mupen64plus-core/LICENSES"
-rp_module_section="opt"
+rp_module_section="opt x86=main"
 
 function depends_lr-parallel-n64() {
     local depends=()

--- a/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
+++ b/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
@@ -13,7 +13,7 @@ rp_module_id="lr-pcsx-rearmed"
 rp_module_desc="Playstation emulator - PCSX (arm optimised) port for libretro"
 rp_module_help="ROM Extensions: .bin .cue .cbn .img .iso .m3u .mdf .pbp .toc .z .znx\n\nCopy your PSX roms to $romdir/psx\n\nCopy the required BIOS file SCPH1001.BIN to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/pcsx_rearmed/master/COPYING"
-rp_module_section="main"
+rp_module_section="opt arm=main"
 
 function depends_lr-pcsx-rearmed() {
     local depends=(libpng-dev)

--- a/scriptmodules/libretrocores/lr-snes9x.sh
+++ b/scriptmodules/libretrocores/lr-snes9x.sh
@@ -13,7 +13,7 @@ rp_module_id="lr-snes9x"
 rp_module_desc="Super Nintendo emu - Snes9x (current) port for libretro"
 rp_module_help="ROM Extensions: .bin .smc .sfc .fig .swc .mgd .zip\n\nCopy your SNES roms to $romdir/snes"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/snes9x/master/docs/snes9x-license.txt"
-rp_module_section="opt"
+rp_module_section="opt armv8=main x86=main"
 
 function sources_lr-snes9x() {
     gitPullOrClone "$md_build" https://github.com/libretro/snes9x.git

--- a/scriptmodules/libretrocores/lr-snes9x2002.sh
+++ b/scriptmodules/libretrocores/lr-snes9x2002.sh
@@ -13,7 +13,7 @@ rp_module_id="lr-snes9x2002"
 rp_module_desc="Super Nintendo emu - ARM optimised Snes9x 1.39 port for libretro"
 rp_module_help="Previously called lr-pocketsnes\n\nROM Extensions: .bin .smc .sfc .fig .swc .mgd .zip\n\nCopy your SNES roms to $romdir/snes"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/snes9x2002/master/src/copyright.h"
-rp_module_section="main"
+rp_module_section="opt armv6=main"
 rp_module_flags="!x86 !aarch64"
 
 function _update_hook_lr-snes9x2002() {

--- a/scriptmodules/libretrocores/lr-snes9x2005.sh
+++ b/scriptmodules/libretrocores/lr-snes9x2005.sh
@@ -13,7 +13,7 @@ rp_module_id="lr-snes9x2005"
 rp_module_desc="Super Nintendo emu - Snes9x 1.43 based port for libretro"
 rp_module_help="Previously called lr-catsfc\n\nROM Extensions: .bin .smc .sfc .fig .swc .mgd .zip\n\nCopy your SNES roms to $romdir/snes"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/snes9x2005/master/copyright"
-rp_module_section="main"
+rp_module_section="opt arm=main"
 
 function _update_hook_lr-snes9x2005() {
     # move from old location and update emulators.cfg

--- a/scriptmodules/libretrocores/lr-snes9x2010.sh
+++ b/scriptmodules/libretrocores/lr-snes9x2010.sh
@@ -13,7 +13,7 @@ rp_module_id="lr-snes9x2010"
 rp_module_desc="Super Nintendo emu - Snes9x 1.52 based port for libretro"
 rp_module_help="Previously called lr-snes9x-next\n\nROM Extensions: .bin .smc .sfc .fig .swc .mgd .zip\n\nCopy your SNES roms to $romdir/snes"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/snes9x2010/master/docs/snes9x-license.txt"
-rp_module_section="main"
+rp_module_section="opt arm=main"
 
 function _update_hook_lr-snes9x2010() {
     # move from old location and update emulators.cfg

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -400,6 +400,19 @@ function rp_registerModule() {
         fi
     done
 
+    local sections=($rp_module_section)
+    # get default section
+    rp_module_section="${sections[0]}"
+
+    # loop through any additional flag=section parameters
+    local flag section
+    for section in "${sections[@]:1}"; do
+        section=(${section/=/ })
+        flag="${section[0]}"
+        section="${section[1]}"
+        isPlatform "$flag" && rp_module_section="$section"
+    done
+
     if [[ "$valid" -eq 1 ]]; then
         __mod_idx+=("$module_idx")
         __mod_id["$module_idx"]="$rp_module_id"


### PR DESCRIPTION
…rm flags

The module/package variable rp_module_section used to need a single string containing
the section for the module - eg "core" "main" "opt".

With this change, you can provide additional space separated parameters to specify the
section for a specific platform flag. This is useful for example to have a module by default
in "opt", but then promote it to "main" for certain systems.

eg for mame4all (mostly useful for slower armv6 devices) you could do

rp_module_section="opt armv6=main"

which would place it in the main section only for armv6

Note that I just threw this code together and am happy for comments/feedback.
It's been something that I've wanted to sort for a while as it will allow us to have better package selections for rpi1/2 and x86.