### PR TITLE
builder - variable / parameter changes

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -48,6 +48,12 @@ function setup_env() {
     [[ -z "${ASFLAGS}" ]] && export ASFLAGS="${__default_asflags}"
     [[ -z "${MAKEFLAGS}" ]] && export MAKEFLAGS="${__default_makeflags}"
 
+    # if using distcc, add /usr/lib/distcc to PATH/MAKEFLAGS
+    if [[ -n "$DISTCC_HOSTS" ]]; then
+        PATH="/usr/lib/distcc:$PATH"
+        MAKEFLAGS+=" PATH=/usr/lib/distcc:$PATH"
+    fi
+
     # test if we are in a chroot
     if [[ "$(stat -c %d:%i /)" != "$(stat -c %d:%i /proc/1/root/.)" ]]; then
         [[ -z "$QEMU_CPU" && -n "$__qemu_cpu" ]] && export QEMU_CPU=$__qemu_cpu
@@ -196,6 +202,8 @@ function get_os_version() {
 
 function get_retropie_depends() {
     local depends=(git dialog wget gcc g++ build-essential unzip xmlstarlet python-pyudev ca-certificates)
+
+    [[ -n "$DISTCC_HOSTS" ]] && depends+=(distcc)
 
     if ! getDepends "${depends[@]}"; then
         fatalError "Unable to install packages required by $0 - ${md_ret_errors[@]}"


### PR DESCRIPTION
* use $__builder_dists instead of $__dists for distribution
 * switch platform var name from $sys to $platform
 * allow target platform configuration via __builder_platform env var
 * simplify distcc configuration to use DISTCC_HOSTS rather than editing config
 * allow manual setting of DISTCC_HOSTS for chroot building via __builder_distcc_hosts
 * install distcc as a dependency is DISTCC_HOSTS is set
 * allow setting of MAKEFLAGS for chroot building via __builder_makeflags
 * add /usr/lib/distcc to PATH/MAKEFLAGS if set