### PR TITLE
lr-atari800 - rename config file used by core

### DIFF
--- a/scriptmodules/libretrocores/lr-atari800.sh
+++ b/scriptmodules/libretrocores/lr-atari800.sh
@@ -21,7 +21,7 @@ function sources_lr-atari800() {
 
 function build_lr-atari800() {
     make clean
-    make
+    CFLAGS+=" -DDEFAULT_CFG_NAME=\\\"$md_conf_root/atari800/lr-atari800.cfg\\\"" make
     md_ret_require="$md_build/atari800_libretro.so"
 }
 
@@ -40,7 +40,6 @@ function configure_lr-atari800() {
     ensureSystemretroconfig "atari5200"
 
     mkUserDir "$md_conf_root/atari800"
-    moveConfigFile "$home/.atari800.cfg" "$md_conf_root/atari800/atari800.cfg"
 
     addEmulator 1 "lr-atari800" "atari800" "$md_inst/atari800_libretro.so"
     addEmulator 1 "lr-atari800" "atari5200" "$md_inst/atari800_libretro.so"


### PR DESCRIPTION
 * use $config_root/atari800/lr-atari800.cfg to avoid conflict with standalone atari800 emulator