### PR TITLE
Use a common data file on the stat pages

### DIFF
--- a/scriptmodules/admin/stats.sh
+++ b/scriptmodules/admin/stats.sh
@@ -13,12 +13,6 @@ rp_module_id="stats"
 rp_module_desc="Generates statistics about packages"
 rp_module_section=""
 
-function _dest_stats() {
-    local dest="$__tmpdir/stats"
-    mkUserDir "$dest"
-    echo "$dest"
-}
-
 function _get_commit_data_stats() {
     local hash=$(git -C "$scriptdir" log -1 --format=%h)
     local date=$(git -C "$scriptdir" log -1 --format=%cd --date=iso-strict)
@@ -26,39 +20,24 @@ function _get_commit_data_stats() {
     echo "$hash;$date;$branch;"
 }
 
-function licences_stats() {
+function _get_package_data_stats() {
     local data=()
-
-    local dest="$(_dest_stats)/licences"
-    mkUserDir "$dest"
-
     local idx
     for idx in ${__mod_idx[@]}; do
-        data+=("${__mod_section[$idx]};${__mod_id[$idx]};${__mod_desc[$idx]};${__mod_licence[$idx]};")
+        data+=("${__mod_section[$idx]};${__mod_id[$idx]};${__mod_desc[$idx]};${__mod_licence[$idx]};${__mod_flags[$idx]};")
     done
-    printf "%s\n" "${data[@]}" >"$dest/packages.csv"
-
-    echo "$(_get_commit_data_stats)" > "$dest/commit.csv"
-
-    cp -v "$md_data/licences/"* "$dest/"
-    chown -R $user:$user "$dest"
+    printf "%s\n" "${data[@]}"
 }
 
-function packages_stats() {
-    local data=()
-
-    local dest="$(_dest_stats)/pkgflags"
+function build_stats() {
+    local dest="$__tmpdir/stats"
     mkUserDir "$dest"
 
-    local idx
-    for idx in ${__mod_idx[@]}; do
-        data+=("${__mod_section[$idx]};${__mod_id[$idx]};${__mod_desc[$idx]};${__mod_flags[$idx]};")
-    done
-    printf "%s\n" "${data[@]}" >"$dest/packages.csv"
-
+    echo "$(_get_package_data_stats)" > "$dest/packages.csv"
     echo "$(_get_commit_data_stats)" > "$dest/commit.csv"
 
-    cp -v "$md_data/pkgflags/"* "$dest/"
+    cp -rv "$md_data/licences" "$dest/"
+    cp -rv "$md_data/pkgflags" "$dest/"
     chown -R $user:$user "$dest"
 }
 

--- a/scriptmodules/admin/stats/licences/app.js
+++ b/scriptmodules/admin/stats/licences/app.js
@@ -1,5 +1,5 @@
 async function fetch_packages() {
-	const resp = await fetch('packages.csv');
+	const resp = await fetch('../packages.csv');
 	const data = await resp.text();
 
 	return data
@@ -15,7 +15,7 @@ async function fetch_packages() {
 }
 
 async function fetch_commit_info() {
-	const resp = await fetch('commit.csv');
+	const resp = await fetch('../commit.csv');
 	const data = await resp.text();
 	const fields = data.split(';');
 	return {

--- a/scriptmodules/admin/stats/pkgflags/app.js
+++ b/scriptmodules/admin/stats/pkgflags/app.js
@@ -1,21 +1,22 @@
 async function fetch_packages() {
-	const resp = await fetch('packages.csv');
+	const resp = await fetch('../packages.csv');
 	const data = await resp.text();
 
 	return data
 		.split('\n')
 		.map(line => line.split(';'))
-		.filter(fields => fields.length >= 4)
+		.filter(fields => fields.length >= 5)
 		.map(fields => ({
 			section: fields[0],
 			id: fields[1],
 			desc: fields[2],
-			flags: fields[3].split(' '),
+			// fields[3] is the licence
+			flags: fields[4].split(' '),
 		}));
 }
 
 async function fetch_commit_info() {
-	const resp = await fetch('commit.csv');
+	const resp = await fetch('../commit.csv');
 	const data = await resp.text();
 	const fields = data.split(';');
 	return {


### PR DESCRIPTION
Continuing from #2921, this merges the licence and pkgflag CSVs into one, which are deployed under `stats/`.