### PR TITLE
pegasus-fe: fix license abbrev

### DIFF
--- a/scriptmodules/supplementary/pegasus-fe.sh
+++ b/scriptmodules/supplementary/pegasus-fe.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="pegasus-fe"
 rp_module_desc="Pegasus: A cross platform, customizable graphical frontend (latest alpha release)"
-rp_module_licence="GPL3+ https://raw.githubusercontent.com/mmatyas/pegasus-frontend/master/LICENSE.md"
+rp_module_licence="GPL3 https://raw.githubusercontent.com/mmatyas/pegasus-frontend/master/LICENSE.md"
 rp_module_section="exp"
 rp_module_flags="!mali frontend"
 


### PR DESCRIPTION
The license abbreviation of this module should be `GPL3` for consistency.

@mmatyas is this okay for you?
Btw this discrepancy was found using your recent license viewer tool :)