### PR TITLE
jzintv: enable for the kms platform.

### DIFF
--- a/scriptmodules/emulators/jzintv.sh
+++ b/scriptmodules/emulators/jzintv.sh
@@ -14,7 +14,7 @@ rp_module_desc="Intellivision emulator"
 rp_module_help="ROM Extensions: .int .bin\n\nCopy your Intellivision roms to $romdir/intellivision\n\nCopy the required BIOS files exec.bin and grom.bin to $biosdir"
 rp_module_licence="GPL2 http://spatula-city.org/%7Eim14u2c/intv/"
 rp_module_section="opt"
-rp_module_flags="dispmanx !mali !kms"
+rp_module_flags="dispmanx !mali"
 
 function depends_jzintv() {
     getDepends libsdl1.2-dev
@@ -44,10 +44,16 @@ function install_jzintv() {
 function configure_jzintv() {
     mkRomDir "intellivision"
 
-    if ! isPlatform "x11"; then
+    local resolution=""
+
+    # Enable Dispmanx for non-KMS PI platforms
+    if isPlatform "dispmanx" && ! isPlatform "kms"; then
         setDispmanx "$md_id" 1
     fi
+    if isPlatform "kms"; then
+        resolution="-z%XRES%x%YRES%,32"
+    fi
 
-    addEmulator 1 "$md_id" "intellivision" "$md_inst/bin/jzintv -p $biosdir -q %ROM%"
+    addEmulator 1 "$md_id" "intellivision" "$md_inst/bin/jzintv $resolution -p $biosdir -q %ROM%"
     addSystem "intellivision"
 }


### PR DESCRIPTION
Similar to other SDL1 based emulators, pass the resolution arguments to the emulator, to be expanded by `runcommand` when started. Enable the `dispmanx` SDL1 videodriver only for the Raspberry Pi platforms that don't use the KMS driver.