### PR TITLE
emulationstation: enable the PI bits on supported platforms

### DIFF
--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -130,6 +130,7 @@ function depends_emulationstation() {
 
     compareVersions "$__os_debian_ver" gt 8 && depends+=(rapidjson-dev)
     isPlatform "x11" && depends+=(gnome-terminal)
+    isPlatform "rpi" && depends+=(omxplayer)
     getDepends "${depends[@]}"
 }
 
@@ -151,6 +152,7 @@ function build_emulationstation() {
     local params=(-DFREETYPE_INCLUDE_DIRS=/usr/include/freetype2/)
     # Temporary workaround until GLESv2 support is implemented
     isPlatform "rpi" && isPlatform "mesa" && params+=(-DGL=On)
+    isPlatform "rpi" && params+=(-DRPI=On)
     rpSwap on 1000
     cmake . "${params[@]}"
     make clean


### PR DESCRIPTION
On the PI4 system, the `omxplayer` and the additional audio devices don't get enabled automatically since it's not using the legacy GLES library. Use the parameter added in https://github.com/RetroPie/EmulationStation/pull/573 to enable them.
Added an explicit dependency on `omxplayer`, it wasn't needed before since it got installed with the `splashscreen` scriptmodule.

EDIT: forgot to mention, this needs https://github.com/RetroPie/EmulationStation/pull/573 to be cherry-picked to the ES stable branch.