### PR TITLE
ioquake3: fix license link

### DIFF
--- a/scriptmodules/ports/ioquake3.sh
+++ b/scriptmodules/ports/ioquake3.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="ioquake3"
 rp_module_desc="Quake 3 source port"
-rp_module_licence="GPL2 https://raw.githubusercontent.com/atari800/atari800/master/COPYING"
+rp_module_licence="GPL2 https://github.com/ioquake/ioq3/blob/master/COPYING.txt"
 rp_module_section="exp"
 rp_module_flags="!mali !videocore"
 


### PR DESCRIPTION
Fix the wrong licence link added in https://github.com/RetroPie/RetroPie-Setup/commit/16c9075eed90054aeec608d2e5af919563bd4935.