### PR TITLE
sdl2 - mali targets require opengl driver disabled

### DIFF
--- a/scriptmodules/supplementary/sdl2.sh
+++ b/scriptmodules/supplementary/sdl2.sh
@@ -79,7 +79,7 @@ function build_sdl2() {
         conf_flags+=("--disable-video-x11")
     fi
     ! isPlatform "x11" && conf_flags+=("--disable-video-vulkan")
-    isPlatform "mali" && conf_flags+=("--enable-video-mali")
+    isPlatform "mali" && conf_flags+=("--enable-video-mali" "--disable-video-opengl")
     isPlatform "rpi" && conf_flags+=("--enable-video-rpi")
     isPlatform "kms" || isPlatform "rpi" && conf_flags+=("--enable-video-kmsdrm")
 


### PR DESCRIPTION
without --disable-video-opengl SDL2 when building with mali driver SDL2 will try and
use opengl driver first and fail due to driver ordering in SDL_video.c

@psyke83 - rpi doesn't need this for kms target - I assume other kms targets will be ok or ?