### PR TITLE
ppsspp - fix building on rpi2/3 in chroot

### DIFF
--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -36,6 +36,10 @@ function sources_ppsspp() {
     # set ARCH_FLAGS to our own CXXFLAGS (which includes GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 if needed)
     sed -i "s/^set(ARCH_FLAGS.*/set(ARCH_FLAGS \"$CXXFLAGS\")/" cmake/Toolchains/raspberry.armv7.cmake
 
+    # remove file(READ "/sys/firmware/devicetree/base/compatible" PPSSPP_PI_MODEL)
+    # as it fails when building in a chroot
+    sed -i "/^file(READ .*/d" cmake/Toolchains/raspberry.armv7.cmake
+
     # ensure Pi vendor libraries are available for linking of shared library
     sed -n -i "p; s/^set(CMAKE_EXE_LINKER_FLAGS/set(CMAKE_SHARED_LINKER_FLAGS/p" cmake/Toolchains/raspberry.armv?.cmake
 


### PR DESCRIPTION
upstream are now doing a check for rpi model based on sysfs file which breaks when building in a chroot or on other non rpi hardware (but targetting the rpi)

@psyke83 we don't use this file for rpi4, but maybe it's worth checking if we need to adjust anything for our rpi4 target.

Personally I think upstream should just have cmake flags and not include checks like this. Or at least skip them if flags are already set.

Hopefully this doesn't break anything but I have to merge as I need to complete my buster binaries.