### PR TITLE
Fix pcsx2 chain dependency

### DIFF
--- a/scriptmodules/emulators/pcsx2.sh
+++ b/scriptmodules/emulators/pcsx2.sh
@@ -38,6 +38,9 @@ function depends_pcsx2() {
         # On Ubuntu, add the PCSX2 PPA to get the latest version
         [[ -n "${__os_ubuntu_ver}" ]] && add-apt-repository -y ppa:pcsx2-team/pcsx2-daily
         dpkg --add-architecture i386
+        # For some reason, this dependency is not explicity, and can lead to broken system state
+        local depends=(libjack-jackd2-0:i386)
+        getDepends "${depends[@]}"
     else
         rm -f /etc/apt/sources.list.d/pcsx2-team-ubuntu-pcsx2-daily-*.list
         apt-key del "D7B4 49CF E17E 659E 5A12  EE8E DD6E EEA2 BD74 7717" >/dev/null  


### PR DESCRIPTION
After install [`Dolphin`](https://github.com/RetroPie/RetroPie-Setup/blob/master/scriptmodules/emulators/dolphin.sh), PCSX2 will be removed, due packages dependencies.

User should be able to just reinstall PCSX2, but after request the reinstall, system will be lead to a broken dependencies state in `apt`.

The reason: Dolphin **build** requires `portaudio19-dev` and the PCSX2 package is missing a dependency on `libjack-jackd2-0:i386` (and both packages are not compatible).

This PR is just changing the PCSX2 script to explicitly require `libjack-jackd2-0:i386`, so when we request to install/reinstall, `apt` will be able to solve the dependencies.

This is valid for Ubuntu and Debian.
