### PR TITLE
frotz: remove module flags

### DIFF
--- a/scriptmodules/emulators/frotz.sh
+++ b/scriptmodules/emulators/frotz.sh
@@ -14,7 +14,7 @@ rp_module_desc="Z-Machine Interpreter for Infocom games"
 rp_module_help="ROM Extensions: .dat .zip .z1 .z2 .z3 .z4 .z5 .z6 .z7 .z8\n\nCopy your Infocom games to $romdir/zmachine"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/DavidGriffith/frotz/master/COPYING"
 rp_module_section="opt"
-rp_module_flags="!mali !kms"
+rp_module_flags=""
 
 function _update_hook_frotz() {
     # to show as installed in retropie-setup 4.x


### PR DESCRIPTION
Since `frotz` has only a text interface (`ncurses` based), enable it for all platforms.
I don't have an Odroid to check if it's available in the repositories, but if they're using also upstream repositories, then it should be installable.