### PR TITLE
Vero4k needs explicit video-mali build since the merger

### DIFF
--- a/scriptmodules/supplementary/sdl2.sh
+++ b/scriptmodules/supplementary/sdl2.sh
@@ -79,7 +79,7 @@ function build_sdl2() {
         conf_flags+=("--disable-video-x11")
     fi
     ! isPlatform "x11" && conf_flags+=("--disable-video-vulkan")
-    isPlatform "mali" && conf_flags+=("--enable-video-mali" "--disable-video-opengl")
+    isPlatform "mali" || isPlatform "vero4k" && conf_flags+=("--enable-video-mali" "--disable-video-opengl")
     isPlatform "rpi" && conf_flags+=("--enable-video-rpi")
     isPlatform "kms" || isPlatform "rpi" && conf_flags+=("--enable-video-kmsdrm")
 


### PR DESCRIPTION
Now that the Mali branch has been merged into the SDL2 super branch #2809 we need to explicitly set `--enable-video-mali` as per other Mali platforms.