### PR TITLE
runcommand - use binary install for mesa-drm if available

### DIFF
--- a/scriptmodules/supplementary/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand.sh
@@ -49,7 +49,7 @@ function install_bin_runcommand() {
 
     # needed for KMS modesetting (debian buster or later only)
     if compareVersions "$__os_debian_ver" ge 10; then
-        rp_callModule mesa-drm
+        rp_installModule "$(rp_getIdxFromId mesa-drm)"
     fi
 
     md_ret_require="$md_inst/runcommand.sh"


### PR DESCRIPTION
 * use rp_installModule so we will install from binary rather than source if a binary is available

@psyke83 @cmitu 

Binaries are built and should be ok but I've not tested.