### PR TITLE
lr-atari800 - fix for intermittent segfault on load

### DIFF
--- a/scriptmodules/libretrocores/lr-atari800.sh
+++ b/scriptmodules/libretrocores/lr-atari800.sh
@@ -17,6 +17,7 @@ rp_module_section="main"
 
 function sources_lr-atari800() {
     gitPullOrClone "$md_build" https://github.com/libretro/libretro-atari800.git
+    applyPatch "$md_data/01_threading_fix.diff"
 }
 
 function build_lr-atari800() {

--- a/scriptmodules/libretrocores/lr-atari800/01_threading_fix.diff
+++ b/scriptmodules/libretrocores/lr-atari800/01_threading_fix.diff
@@ -1,0 +1,12 @@
+diff --git a/libretro/libretro-core.c b/libretro/libretro-core.c
+index 2992e78..950ae4e 100644
+--- a/libretro/libretro-core.c
++++ b/libretro/libretro-core.c
+@@ -711,7 +711,6 @@ bool retro_load_game(const struct retro_game_info *info)
+ #endif
+ 	memset(SNDBUF,0,1024*2*2);
+ 
+-	co_switch(emuThread);
+ 
+    return true;
+ }


### PR DESCRIPTION
seems to be a lot of code that's called more than once - there's an odd timing issue that can cause a segfault in retroarch. When lauching, the emulator seems to trigger video initialisation twice, but removing this co_switch seems to resolve the crash but this core looks like it needs work

@cmitu 