### PR TITLE
emulationstation: fix installation on Raspbian Jessie

### DIFF
--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -168,9 +168,13 @@ function install_emulationstation() {
         'emulationstation.sh'
         'GAMELISTS.md'
         'README.md'
-        'resources'
         'THEMES.md'
     )
+
+    # This folder is present only from 2.8.x, don't include it for older releases
+    if compareVersions "$__os_debian_ver" gt 8; then
+        md_ret_files+=('resources')
+    fi
 }
 
 function init_input_emulationstation() {


### PR DESCRIPTION
EmulationStation version `2.7.6`, installed on older Debian platforms, doesn't have the `resources` folder. Selectively add it just for newer releases of EmulationStation and Debian (Stretch or newer).

(reported in the forums in https://retropie.org.uk/forum/topic/24483/v/17)