### PR TITLE
CacheSize is no longer a parameter in GLideN64

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -250,14 +250,6 @@ function configure_mupen64plus() {
         iniSet "configVersion" "17"
         # Bilinear filtering mode (0=N64 3point, 1=standard)
         iniSet "bilinearMode" "1"
-        # Size of texture cache in megabytes. Good value is VRAM*3/4
-        local gpu_mem
-        if isPlatform "armv6"; then
-            gpu_mem=64
-        else
-            gpu_mem=128
-        fi
-        iniSet "CacheSize" "$gpu_mem"
         iniSet "EnableFBEmulation" "True"
         # Use native res
         iniSet "UseNativeResolutionFactor" "1"


### PR DESCRIPTION
After all the fun changing it in https://github.com/RetroPie/RetroPie-Setup/pull/2878, I've found out it was removed back in 2017 https://github.com/gonetz/GLideN64/commit/4e36fa07a2fc41ad0ba2ffc6fa0c8aba4c4ce72c#diff-ef42321f7e09f10e240c1d3cfd003e03 😒🥉 

Looks like GLideN64 now allocates from VRAM more smartly.