### PR TITLE
retroarch: update to v1.8.4

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -39,7 +39,7 @@ function depends_retroarch() {
 }
 
 function sources_retroarch() {
-    gitPullOrClone "$md_build" https://github.com/libretro/RetroArch.git v1.7.9.2
+    gitPullOrClone "$md_build" https://github.com/libretro/RetroArch.git v1.8.4
     applyPatch "$md_data/01_hotkey_hack.diff"
     applyPatch "$md_data/02_disable_search.diff"
     applyPatch "$md_data/03_shader_path_config_enable.diff"

--- a/scriptmodules/emulators/retroarch/01_hotkey_hack.diff
+++ b/scriptmodules/emulators/retroarch/01_hotkey_hack.diff
@@ -1,8 +1,8 @@
 diff --git a/retroarch.c b/retroarch.c
-index 0158f5c..a79bc98 100644
+index b89de3520f..d6ae484ca2 100644
 --- a/retroarch.c
 +++ b/retroarch.c
-@@ -988,6 +988,10 @@ static bool menu_widgets_fast_forward        = false;
+@@ -2556,6 +2556,10 @@ static bool menu_widgets_fast_forward        = false;
  static bool menu_widgets_rewinding           = false;
  #endif
  
@@ -13,7 +13,7 @@ index 0158f5c..a79bc98 100644
  bool menu_widgets_ready(void)
  {
  #ifdef HAVE_MENU_WIDGETS
-@@ -13835,9 +13839,16 @@ static void input_keys_pressed(input_bits_t *p_new_state)
+@@ -16042,9 +16046,16 @@ static void input_keys_pressed(input_bits_t *p_new_state)
                    current_input_data, joypad_info,
                    &binds, port,
                    RETRO_DEVICE_JOYPAD, 0, RARCH_ENABLE_HOTKEY))

--- a/scriptmodules/emulators/retroarch/02_disable_search.diff
+++ b/scriptmodules/emulators/retroarch/02_disable_search.diff
@@ -1,13 +1,14 @@
-diff --git a/menu/menu_driver.c b/menu/menu_driver.c
-index cf3a8c3..aae5231 100644
---- a/menu/menu_driver.c
-+++ b/menu/menu_driver.c
-@@ -785,7 +785,7 @@ int menu_entry_action(menu_entry_t *entry,
-                   entry->label, entry->type, i);
+diff --git a/menu/drivers/menu_generic.c b/menu/drivers/menu_generic.c
+index 20976955ed..23f688619b 100644
+--- a/menu/drivers/menu_generic.c
++++ b/menu/drivers/menu_generic.c
+@@ -396,7 +396,8 @@ int generic_menu_entry_action(
+                   entry->label, entry->type, i, entry->entry_idx);
           break;
        case MENU_ACTION_SEARCH:
 -         menu_input_dialog_start_search();
++         // Disable search action
 +         // menu_input_dialog_start_search();
           break;
- 
        case MENU_ACTION_SCAN:
+          if (cbs && cbs->action_scan)

--- a/scriptmodules/emulators/retroarch/03_shader_path_config_enable.diff
+++ b/scriptmodules/emulators/retroarch/03_shader_path_config_enable.diff
@@ -1,8 +1,8 @@
 diff --git a/configuration.c b/configuration.c
-index 0c8076d..ff0a0d2 100644
+index c339e9eb63..b2a49a17ff 100644
 --- a/configuration.c
 +++ b/configuration.c
-@@ -1209,6 +1209,8 @@ static struct config_path_setting *populate_settings_path(settings_t *settings,
+@@ -1214,6 +1214,8 @@ static struct config_path_setting *populate_settings_path(settings_t *settings,
           settings->paths.path_core_options, false, NULL, true);
     SETTING_PATH("libretro_info_path",
           settings->paths.path_libretro_info, false, NULL, true);
@@ -11,7 +11,7 @@ index 0c8076d..ff0a0d2 100644
     SETTING_PATH("content_database_path",
           settings->paths.path_content_database, false, NULL, true);
     SETTING_PATH("cheat_database_path",
-@@ -2225,6 +2227,7 @@ void config_set_defaults(void)
+@@ -2238,6 +2240,7 @@ void config_set_defaults(void *data)
     *settings->paths.path_content_image_history   = '\0';
     *settings->paths.path_content_video_history   = '\0';
     *settings->paths.path_cheat_settings    = '\0';
@@ -19,7 +19,7 @@ index 0c8076d..ff0a0d2 100644
  #ifndef IOS
     *settings->arrays.bundle_assets_src = '\0';
     *settings->arrays.bundle_assets_dst = '\0';
-@@ -4102,6 +4105,10 @@ bool config_save_overrides(int override_type)
+@@ -4117,6 +4120,10 @@ bool config_save_overrides(int override_type)
  
        for (i = 0; i < (unsigned)path_settings_size; i++)
        {
@@ -31,10 +31,10 @@ index 0c8076d..ff0a0d2 100644
              config_set_path(conf, path_overrides[i].ident,
                    path_overrides[i].ptr);
 diff --git a/configuration.h b/configuration.h
-index 5be7863..112bf2f 100644
+index 12aa7d446e..804b2e7820 100644
 --- a/configuration.h
 +++ b/configuration.h
-@@ -667,6 +667,7 @@ typedef struct settings
+@@ -686,6 +686,7 @@ typedef struct settings
        char path_libretro_info[PATH_MAX_LENGTH];
        char path_cheat_settings[PATH_MAX_LENGTH];
        char path_font[PATH_MAX_LENGTH];
@@ -43,10 +43,10 @@ index 5be7863..112bf2f 100644
  
        char directory_audio_filter[PATH_MAX_LENGTH];
 diff --git a/retroarch.c b/retroarch.c
-index a79bc98..c86f2cd 100644
+index d6ae484ca2..308c6e97ad 100644
 --- a/retroarch.c
 +++ b/retroarch.c
-@@ -24057,6 +24057,7 @@ static bool retroarch_load_shader_preset_internal(
+@@ -26359,6 +26359,7 @@ static bool retroarch_load_shader_preset_internal(
  {
     unsigned i;
     char *shader_path = (char*)malloc(PATH_MAX_LENGTH);
@@ -54,7 +54,7 @@ index a79bc98..c86f2cd 100644
  
     static enum rarch_shader_type types[] =
     {
-@@ -24084,11 +24085,13 @@ static bool retroarch_load_shader_preset_internal(
+@@ -26386,11 +26387,13 @@ static bool retroarch_load_shader_preset_internal(
           if (string_is_empty(special_name))
              break;
  
@@ -73,7 +73,7 @@ index a79bc98..c86f2cd 100644
  
        if (!path_is_valid(shader_path))
           continue;
-@@ -24112,6 +24115,7 @@ static bool retroarch_load_shader_preset_internal(
+@@ -26414,6 +26417,7 @@ static bool retroarch_load_shader_preset_internal(
   * Tries to load a supported core-, game-, folder-specific or global
   * shader preset from its respective location:
   *
@@ -81,7 +81,7 @@ index a79bc98..c86f2cd 100644
   * global:          $SHADER_DIR/presets/global.$PRESET_EXT
   * core-specific:   $SHADER_DIR/presets/$CORE_NAME/$CORE_NAME.$PRESET_EXT
   * folder-specific: $SHADER_DIR/presets/$CORE_NAME/$FOLDER_NAME.$PRESET_EXT
-@@ -24185,6 +24189,13 @@ static bool retroarch_load_shader_preset(void)
+@@ -26487,6 +26491,13 @@ static bool retroarch_load_shader_preset(void)
        goto success;
     }
  


### PR DESCRIPTION
Only change is the rebased patches, it should fix the crashes reported in the `lr-atari800` core.