### PR TITLE
runcommand.sh: assign space to button B

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -132,7 +132,7 @@ function start_joy2key() {
 
         # call joy2key.py: arguments are curses capability names or hex values starting with '0x'
         # see: http://pubs.opengroup.org/onlinepubs/7908799/xcurses/terminfo.html
-        "$ROOTDIR/supplementary/runcommand/joy2key.py" "$JOY2KEY_DEV" kcub1 kcuf1 kcuu1 kcud1 0x0a 0x09
+        "$ROOTDIR/supplementary/runcommand/joy2key.py" "$JOY2KEY_DEV" kcub1 kcuf1 kcuu1 kcud1 0x0a 0x20
         JOY2KEY_PID=$(pgrep -f joy2key.py)
 
     # ensure coherency between on-screen prompts and actual button mapping functionality

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -127,7 +127,7 @@ function start_joy2key() {
     else
         JOY2KEY_DEV="/dev/input/jsX"
     fi
-    # if joy2key.py is installed run it with cursor keys for axis, and enter + tab for buttons 0 and 1
+    # if joy2key.py is installed run it with cursor keys for axis, and enter + space for buttons 0 and 1
     if [[ -f "$ROOTDIR/supplementary/runcommand/joy2key.py" && -n "$JOY2KEY_DEV" ]] && ! pgrep -f joy2key.py >/dev/null; then
 
         # call joy2key.py: arguments are curses capability names or hex values starting with '0x'


### PR DESCRIPTION
This change will make radiolists and checklists useable

```
#!/bin/bash
pizza=`dialog --checklist "Pizza with ..." 0 0 4 \
 cheese "" on\
 chicken "" off\
 ham "" off\
 tuna "" off 3>&1 1>&2 2>&3`
dialog --clear
clear
echo "Your order: Pizza with $pizza"
```