### PR TITLE
Add .cue extension to 3DO

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -1,4 +1,4 @@
-3do_exts=".iso"
+3do_exts=".cue .iso"
 3do_fullname="3DO Interactive Multiplayer"
 
 ags_exts=".exe"


### PR DESCRIPTION
Verified that .cue file extensions work correctly.  Already listed as supported in the wiki.