### PR TITLE
extended iniSet to support section headers. Fixes some n64 install/launch issues

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -237,28 +237,21 @@ function configure_mupen64plus() {
         iniConfig " = " "" "$config"
         # VSync is mandatory for good performance on KMS
         if isPlatform "kms"; then
-            if ! grep -q "\[Video-General\]" "$config"; then
-                echo "[Video-General]" >> "$config"
-            fi
-            iniSet "VerticalSync" "True"
+            iniSet "VerticalSync" "True" "" "[Video-General]"
         fi
-        # Create GlideN64 section in .cfg
-        if ! grep -q "\[Video-GLideN64\]" "$config"; then
-            echo "[Video-GLideN64]" >> "$config"
-        fi
-        # Settings version. Don't touch it.
-        iniSet "configVersion" "17"
+        # GLideN64 config version number - will be updated on launch
+        iniSet "configVersion" "17" "" "[Video-GlideN64]"
         # Bilinear filtering mode (0=N64 3point, 1=standard)
-        iniSet "bilinearMode" "1"
-        iniSet "EnableFBEmulation" "True"
+        iniSet "bilinearMode" "1" "" "[Video-GLideN64]"
+        iniSet "EnableFBEmulation" "True" "" "[Video-GLideN64]"
         # Use native res
-        iniSet "UseNativeResolutionFactor" "1"
+        iniSet "UseNativeResolutionFactor" "1" "" "[Video-GLideN64]"
         # Enable legacy blending
-        iniSet "EnableLegacyBlending" "True"
+        iniSet "EnableLegacyBlending" "True" "" "[Video-GLideN64]"
         # Enable Threaded GL calls
-        iniSet "ThreadedVideo" "True"
+        iniSet "ThreadedVideo" "True" "" "[Video-GLideN64]"
         # Swap frame buffers On buffer update (most performant)
-        iniSet "BufferSwapMode" "2"
+        iniSet "BufferSwapMode" "2" "" "[Video-GLideN64]"
 
         if isPlatform "videocore"; then
             # Disable gles2n64 autores feature and use dispmanx upscaling

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -105,10 +105,7 @@ function remap() {
     local j
 
     iniConfig " = " "" "$config"
-    if ! grep -q "\[CoreEvents\]" "$config"; then
-        echo "[CoreEvents]" >> "$config"
-        echo "Version = 1" >> "$config"
-    fi
+    iniSet "Version" "1" "" "[CoreEvents]"
 
     local atebitdo_hack
     for i in {0..2}; do
@@ -127,7 +124,7 @@ function remap() {
         done
         # write hotkey to mupen64plus.cfg
         iniConfig " = " "\"" "$config"
-        iniSet "${hotkeys_m64p[$i]}" "$bind"
+        iniSet "${hotkeys_m64p[$i]}" "$bind" "" "[CoreEvents]"
     done
 }
 
@@ -139,11 +136,7 @@ function setAudio() {
             # use audio omx if we use rpi internal audio device
             AUDIO_PLUGIN="mupen64plus-audio-omx"
             iniConfig " = " "\"" "$config"
-            # create section if necessary
-            if ! grep -q "\[Audio-OMX\]" "$config"; then
-                echo "[Audio-OMX]" >> "$config"
-                echo "Version = 1" >> "$config"
-            fi
+            iniSet "Version" "1" "" "[Audio-OMX]"
             # read output configuration
             local audio_port=$(amixer cget numid=3)
             # set output port
@@ -152,16 +145,16 @@ function setAudio() {
                 # try to find the best solution
                 local video_device=$(tvservice -s)
                 if [[ "$video_device" == *HDMI* ]]; then
-                    iniSet "OUTPUT_PORT" "1"
+                    iniSet "OUTPUT_PORT" "1" "" "[Audio-OMX]"
                 else
-                    iniSet "OUTPUT_PORT" "0"
+                    iniSet "OUTPUT_PORT" "0" "" "[Audio-OMX]"
                 fi
             elif [[ "$audio_port" == *": values=1"* ]]; then
                 # echo "audio jack"
-                iniSet "OUTPUT_PORT" "0"
+                iniSet "OUTPUT_PORT" "0" "" "[Audio-OMX]"
             else
                 # echo "hdmi"
-                iniSet "OUTPUT_PORT" "1"
+                iniSet "OUTPUT_PORT" "1" "" "[Audio-OMX]"
             fi
         fi
     fi
@@ -171,7 +164,7 @@ function testCompatibility() {
     # fallback for glesn64 and rice plugin
     # some roms lead to a black screen of death
     local game
-    
+
     # these games need RSP-LLE
     local blacklist=(
         naboo
@@ -244,29 +237,26 @@ function testCompatibility() {
 
     case "$VIDEO_PLUGIN" in
         "mupen64plus-video-GLideN64")
-            if ! grep -q "\[Video-GLideN64\]" "$config"; then
-                echo "[Video-GLideN64]" >> "$config"
-            fi
             iniConfig " = " "" "$config"
             # Settings version. Don't touch it.
             local config_version="20"
             if [[ -f "$configdir/n64/GLideN64_config_version.ini" ]]; then
                 config_version=$(<"$configdir/n64/GLideN64_config_version.ini")
             fi
-            iniSet "configVersion" "$config_version"
+            iniSet "configVersion" "$config_version" "" "[Video-GLideN64]"
             # Set native resolution factor of 1
-            iniSet "UseNativeResolutionFactor" "1"
+            iniSet "UseNativeResolutionFactor" "1" "" "[Video-GLideN64]"
             for game in "${GLideN64NativeResolution_blacklist[@]}"; do
                 if [[ "${ROM,,}" == *"$game"* ]]; then
-                    iniSet "UseNativeResolutionFactor" "0"
+                    iniSet "UseNativeResolutionFactor" "0" "" "[Video-GLideN64]"
                     break
                 fi
             done
             # Disable LegacyBlending if necessary
-            iniSet "EnableLegacyBlending" "True"
+            iniSet "EnableLegacyBlending" "True" "" "[Video-GLideN64]"
             for game in "${GLideN64LegacyBlending_blacklist[@]}"; do
                 if [[ "${ROM,,}" == *"$game"* ]]; then
-                    iniSet "EnableLegacyBlending" "False"
+                    iniSet "EnableLegacyBlending" "False" "" "[Video-GLideN64]"
                     break
                 fi
             done
@@ -292,33 +282,23 @@ function testCompatibility() {
 
     # fix Audio-SDL crackle
     iniConfig " = " "\"" "$config"
-    # create section if necessary
-    if ! grep -q "\[Audio-SDL\]" "$config"; then
-        echo "[Audio-SDL]" >> "$config"
-        echo "Version = 1" >> "$config"
-    fi
-    iniSet "RESAMPLE" "src-sinc-fastest"
+    iniSet "Version" "1" "" "[Audio-SDL]"
+    iniSet "RESAMPLE" "src-sinc-fastest" "" "[Audio-SDL]"
 }
 
 function useTexturePacks() {
     # video-GLideN64
-    if ! grep -q "\[Video-GLideN64\]" "$config"; then
-        echo "[Video-GLideN64]" >> "$config"
-    fi
     iniConfig " = " "" "$config"
     # Settings version. Don't touch it.
     local config_version="17"
     if [[ -f "$configdir/n64/GLideN64_config_version.ini" ]]; then
         config_version=$(<"$configdir/n64/GLideN64_config_version.ini")
     fi
-    iniSet "configVersion" "$config_version"
-    iniSet "txHiresEnable" "True"
+    iniSet "configVersion" "$config_version" "" "[Video-GLideN64]"
+    iniSet "txHiresEnable" "True" "" "[Video-GLideN64]"
 
     # video-rice
-    if ! grep -q "\[Video-Rice\]" "$config"; then
-        echo "[Video-Rice]" >> "$config"
-    fi
-    iniSet "LoadHiResTextures" "True"
+    iniSet "LoadHiResTextures" "True" "" "[Video-Rice]"
 }
 
 function autoset() {
@@ -378,16 +358,13 @@ function autoset() {
     done
 }
 
-if ! grep -q "\[Core\]" "$config"; then
-    echo "[Core]" >> "$config"
-    echo "Version = 1.010000" >> "$config"
-fi
 iniConfig " = " "\"" "$config"
+iniSet "Version" "1.010000" "" "[Core]"
 
 function setPath() {
-    iniSet "ScreenshotPath" "$romdir/n64"
-    iniSet "SaveStatePath" "$romdir/n64"
-    iniSet "SaveSRAMPath" "$romdir/n64"
+    iniSet "ScreenshotPath" "$romdir/n64" "" "[Core]"
+    iniSet "SaveStatePath" "$romdir/n64" "" "[Core]"
+    iniSet "SaveSRAMPath" "$romdir/n64" "" "[Core]"
 }
 
 

--- a/scriptmodules/inifuncs.sh
+++ b/scriptmodules/inifuncs.sh
@@ -41,6 +41,7 @@ function iniConfig() {
 # @param key ini key to operate on
 # @param value to set
 # @param file optional file to use another file than the one configured with iniConfig
+# @param section optional section header within the file under which the line will be added
 # @brief The main function for setting and deleting from ini files - usually
 # not called directly but via iniSet iniUnset and iniDel
 function iniProcess() {
@@ -48,6 +49,7 @@ function iniProcess() {
     local key="$2"
     local value="$3"
     local file="$4"
+    local section="$5"
     [[ -z "$file" ]] && file="$__ini_cfg_file"
     local delim="$__ini_cfg_delim"
     local quote="$__ini_cfg_quote"
@@ -62,8 +64,16 @@ function iniProcess() {
     local match_re="^[[:space:]#]*$key[[:space:]]*$delim_strip.*$"
 
     local match
+    local file_temp
     if [[ -f "$file" ]]; then
-        match=$(egrep -i "$match_re" "$file" | tail -1)
+        if [[ ! -z "$section" ]]; then
+            # if section header exists, use the first match following it
+            file_temp=$(sed -n --follow-symlinks "/$(sedQuote "$section")/,\$p" "$file")
+            match=$(echo "$file_temp" | egrep -i "$match_re" | head -n 1)
+        else
+            # otherwise, use the last match in the file
+            match=$(egrep -i "$match_re" "$file" | tail -1)
+        fi
     else
         touch "$file"
     fi
@@ -77,9 +87,19 @@ function iniProcess() {
 
     local replace="$key$delim$quote$value$quote"
     if [[ -z "$match" ]]; then
-        # make sure there is a newline then add the key-value pair
-        sed -i --follow-symlinks '$a\' "$file"
-        echo "$replace" >> "$file"
+        # if section passed, add header if not already present
+        if [[ ! -z "$section" ]]; then
+            if ! grep -q -F "$section" "$file"; then
+                sed -i --follow-symlinks '$a\' "$file"
+                echo "$section" >> "$file"
+            fi
+            # add the key-value pair under the section header
+            sed -i --follow-symlinks "/$(sedQuote "$section")/a$replace" "$file"
+        else
+            # make sure there is a newline then add the key-value pair
+            sed -i --follow-symlinks '$a\' "$file"
+            echo "$replace" >> "$file"
+        fi
     else
         # replace existing key-value pair
         sed -i --follow-symlinks "s|$(sedQuote "$match")|$(sedQuote "$replace")|g" "$file"
@@ -108,11 +128,12 @@ function iniUnset() {
 ## @param key ini key to operate on
 ## @param value to set
 ## @param file optional file to use another file than the one configured with iniConfig
+## @param section optional section header within the file under which the line will be added
 ## @brief Set a key / value pair in an ini file.
 ## @details If the key already exists the existing line will be changed. If not
 ## a new line will be created.
 function iniSet() {
-    iniProcess "set" "$1" "$2" "$3"
+    iniProcess "set" "$1" "$2" "$3" "$4"
 }
 
 ## @fn iniDel()
@@ -224,10 +245,11 @@ function getAutoConf(){
     return 1
 }
 
-# escape backslashes and pipes for sed
+# escape backslashes, pipes and left square brackets for sed
 function sedQuote() {
     local string="$1"
     string="${string//\\/\\\\}"
     string="${string//|/\\|}"
+    string="${string//[/\\[}"
     echo "$string"
 }


### PR DESCRIPTION
I found some issues with the mupen64plus scripts where it was duplicating options (`txHiresEnable` was appearing twice), and also that the hotkeys didn't work on first launch with pi4. I tried to solve these in the install scripts, but found fundamental problems caused by mupen64plus use of section headers (`[Video-GLideN64]', etc) and duplicated option keys (`Version = ` is used several times). The previous iniSet would always append to the end of the file, which could be the wrong section, and it would always match on the first match, which could be in the wrong section.

The previous method of manually adding the section headers as install progresses works to a point, but quickly falls over if you do things out of sequence. Rather than add further complexity to that file, I think having a seperate 'section' argument and supporting logic makes it a little more robust and maintainable.

The feature also removes a bunch of duplicated code in the mupen64plus.sh scripts :)

There's a remaining issue where some stuff in `testCompatibility' needs to run for pi4 (currently it's skipped) as it has some relevant blacklists and audio tweaks. will save that for another PR.