### PR TITLE
Added CPU min and max clockspeed to bashwelcometweak

### DIFF
--- a/scriptmodules/supplementary/bashwelcometweak.sh
+++ b/scriptmodules/supplementary/bashwelcometweak.sh
@@ -27,6 +27,10 @@ function getIPAddress() {
     [[ -n "$ip_route" ]] && grep -oP "src \K[^\s]+" <<< "$ip_route"
 }
 
+function getClockSpeed() {
+    expr $(echo $(vcgencmd measure_clock $1|awk -F= '{print $2}') / 1000000 )
+}
+
 function retropie_welcome() {
     local upSeconds="$(/usr/bin/cut -d. -f1 /proc/uptime)"
     local secs=$((upSeconds%60))
@@ -126,6 +130,9 @@ function retropie_welcome() {
                 out+="Temperature........: CPU: $cpuTempC°C/$cpuTempF°F GPU: $gpuTempC°C/$gpuTempF°F"
                 ;;
             10)
+                out+="Clock Speed........: CPU: $(getClockSpeed arm)MHz Core: $(getClockSpeed core)MHz V3D: $(getClockSpeed v3d)MHz"
+                ;;
+            11)
                 out+="${fgwht}The RetroPie Project, https://retropie.org.uk"
                 ;;
         esac

--- a/scriptmodules/supplementary/bashwelcometweak.sh
+++ b/scriptmodules/supplementary/bashwelcometweak.sh
@@ -27,6 +27,10 @@ function getIPAddress() {
     [[ -n "$ip_route" ]] && grep -oP "src \K[^\s]+" <<< "$ip_route"
 }
 
+function getClockSpeed() {
+    expr $(echo $(vcgencmd measure_clock $1|awk -F= '{print $2}') / 1000000 )
+}
+
 function retropie_welcome() {
     local upSeconds="$(/usr/bin/cut -d. -f1 /proc/uptime)"
     local secs=$((upSeconds%60))
@@ -34,12 +38,6 @@ function retropie_welcome() {
     local hours=$((upSeconds/3600%24))
     local days=$((upSeconds/86400))
     local UPTIME=$(printf "%d days, %02dh%02dm%02ds" "$days" "$hours" "$mins" "$secs")
-
-    # calculate CPU minimum and maximum clockspeed:
-    local cpuClockMax
-    local cpuClockMin
-    cpuClockMax=$(lscpu|grep "max MHz"|awk '{print $NF}'| awk '{print int($1+0.5)}')
-    cpuClockMin=$(lscpu|grep "min MHz"|awk '{print $NF}'| awk '{print int($1+0.5)}')
 
     # calculate rough CPU and GPU temperatures:
     local cpuTempC
@@ -97,6 +95,7 @@ function retropie_welcome() {
         "${fgred}\`*${bfgred}****${bfgylw}@@${bfgred}*${fgred}*'"
         "${fgred} \`*******'${fgrst} "
         "${fgred}   \`\"\"\"'${fgrst}   "
+        "           "
         )
 
     local out
@@ -132,7 +131,7 @@ function retropie_welcome() {
                 out+="Temperature........: CPU: $cpuTempC°C/$cpuTempF°F GPU: $gpuTempC°C/$gpuTempF°F"
                 ;;
             10)
-                out+="CPU Clock Speed....: Max: ${cpuClockMax}MHz Min: ${cpuClockMin}MHz" 
+                [[ -f /usr/bin/vcgencmd ]] && out+="Clock Speed........: CPU: $(getClockSpeed arm)MHz Core: $(getClockSpeed core)MHz V3D: $(getClockSpeed v3d)MHz\n"
                 ;;
             11)
                 out+="${fgwht}The RetroPie Project, https://retropie.org.uk"

--- a/scriptmodules/supplementary/bashwelcometweak.sh
+++ b/scriptmodules/supplementary/bashwelcometweak.sh
@@ -27,13 +27,6 @@ function getIPAddress() {
     [[ -n "$ip_route" ]] && grep -oP "src \K[^\s]+" <<< "$ip_route"
 }
 
-function getClockSpeed() {
-    local cpuClock
-    local gpuClock
-    
-    expr $(echo $(vcgencmd measure_clock $1|awk -F= '{print $2}') / 1000000 )
-}
-
 function retropie_welcome() {
     local upSeconds="$(/usr/bin/cut -d. -f1 /proc/uptime)"
     local secs=$((upSeconds%60))

--- a/scriptmodules/supplementary/bashwelcometweak.sh
+++ b/scriptmodules/supplementary/bashwelcometweak.sh
@@ -28,6 +28,9 @@ function getIPAddress() {
 }
 
 function getClockSpeed() {
+    local cpuClock
+    local gpuClock
+    
     expr $(echo $(vcgencmd measure_clock $1|awk -F= '{print $2}') / 1000000 )
 }
 
@@ -38,6 +41,12 @@ function retropie_welcome() {
     local hours=$((upSeconds/3600%24))
     local days=$((upSeconds/86400))
     local UPTIME=$(printf "%d days, %02dh%02dm%02ds" "$days" "$hours" "$mins" "$secs")
+
+    # calculate CPU minimum and maximum clockspeed:
+    local cpuClockMax
+    local cpuClockMin
+    cpuClockMax=$(lscpu|grep "max MHz"|awk '{print $NF}'| awk '{print int($1+0.5)}')
+    cpuClockMin=$(lscpu|grep "min MHz"|awk '{print $NF}'| awk '{print int($1+0.5)}')
 
     # calculate rough CPU and GPU temperatures:
     local cpuTempC
@@ -130,7 +139,7 @@ function retropie_welcome() {
                 out+="Temperature........: CPU: $cpuTempC°C/$cpuTempF°F GPU: $gpuTempC°C/$gpuTempF°F"
                 ;;
             10)
-                out+="Clock Speed........: CPU: $(getClockSpeed arm)MHz Core: $(getClockSpeed core)MHz V3D: $(getClockSpeed v3d)MHz"
+                out+="CPU Clock Speed....: Max: ${cpuClockMax}MHz Min: ${cpuClockMin}MHz" 
                 ;;
             11)
                 out+="${fgwht}The RetroPie Project, https://retropie.org.uk"


### PR DESCRIPTION
For the new Pi4 I've added tweaks to the bashwelcometweaks.sh to add clockspeed for CPU, Core, and V3D.  Doesn't extend the length of retropiewelcome display.