### PR TITLE
runcommand: fix rare default kms mode detection problem

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -241,7 +241,7 @@ function get_all_tvs_modes() {
 
 function get_all_kms_modes() {
     declare -Ag MODE
-    local default_mode="$(echo "$KMS_BUFFER" | grep "crtc" | grep -m1 "Mode:")"
+    local default_mode="$(echo "$KMS_BUFFER" | grep -m1 "^Mode:.*preferred.*crtc")"
     local crtc="$(echo "$default_mode" | awk '{ print $(NF-1) }')"
     local crtc_encoder="$(echo "$KMS_BUFFER" | grep "Encoder map:" | awk -v crtc="$crtc" '$5 == crtc { print $3 }')"
 


### PR DESCRIPTION
Certain KMS systems may enumerate multiple CRTCs, some of which have
empty/invalid modes defined. If the first grepped entry happens to be such a
mode, modesetting will break. Fix by using a more accurate grep expression
to find an active CRTC with a valid mode that is marked with the "preferred"
flag.

Issue can be reproduced on Pi 3B with the vc4-kms-v3d overlay.