### PR TITLE
N64: Mesa: support high resolutions modes

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -176,20 +176,27 @@ function configure_mupen64plus() {
     isPlatform "kms" && resolutions=("%XRES%x%YRES%")
 
     if isPlatform "rpi"; then
-        isPlatform "videocore" && addEmulator 1 "${md_id}-auto" "n64" "$md_inst/bin/mupen64plus.sh AUTO %ROM%"
-        for res in "${resolutions[@]}"; do
-            local name=""
-            local nativeResFactor=""
-            if [[ "$res" == "640x480" ]]; then
-                name="-highres"
-                nativeResFactor=2
-            else
-                nativeResFactor=1
-            fi
-            addEmulator 1 "${md_id}-GLideN64$name" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM% $res 0 --set Video-GLideN64[UseNativeResolutionFactor]\=$nativeResFactor"
+        # mesa needs to run at full screen as it doesn't benefit from our SDL scaling hint
+        if isPlatform "mesa"; then
+            res="${resolutions[0]}"
+            addEmulator 1 "${md_id}-GLideN64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM% $res 0 --set Video-GLideN64[UseNativeResolutionFactor]\=1"
+            addEmulator 0 "${md_id}-GLideN64-highres" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM% $res 0 --set Video-GLideN64[UseNativeResolutionFactor]\=2"
             addEmulator 0 "${md_id}-gles2rice$name" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-rice %ROM% $res"
-        done
-        addEmulator 0 "${md_id}-gles2n64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-n64 %ROM%"
+            addEmulator 0 "${md_id}-gles2n64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-n64 %ROM%"
+        else
+            for res in "${resolutions[@]}"; do
+                local name=""
+                local nativeResFactor=1
+                if [[ "$res" == "640x480" ]]; then
+                    name="-highres"
+                    nativeResFactor=2
+                fi
+                addEmulator 0 "${md_id}-GLideN64$name" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM% $res 0 --set Video-GLideN64[UseNativeResolutionFactor]\=$nativeResFactor"
+                addEmulator 0 "${md_id}-gles2rice$name" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-rice %ROM% $res"
+            done
+            addEmulator 1 "${md_id}-auto" "n64" "$md_inst/bin/mupen64plus.sh AUTO %ROM%"
+            addEmulator 0 "${md_id}-gles2n64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-n64 %ROM%"
+        fi
     elif isPlatform "vero4k"; then
         addEmulator 1 "${md_id}-gles2n64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-n64 %ROM%"
         addEmulator 0 "${md_id}-GLideN64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM%"

--- a/scriptmodules/emulators/mupen64plus/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus/mupen64plus.sh
@@ -12,7 +12,7 @@
 AUDIO_PLUGIN="mupen64plus-audio-sdl"
 VIDEO_PLUGIN="$1"
 ROM="$2"
-[[ "$3" -ne 0 ]] && RES="$3"
+[[ "$3" != 0 ]] && RES="$3"
 [[ "$4" -ne 0 ]] && RSP_PLUGIN="$4"
 PARAMS="${@:5}"
 [[ -n "$RES" ]] && RES="--resolution $RES"


### PR DESCRIPTION
Because we only had one resolution for Mesa, we weren't able to traverse the resolutions loop properly to add the high resolution modes, so I did it another way.

~Also took the opportunity to retire every video plugin bar GLideN64 for pi4, since I doubt they offer any advantage now we have a GLES3 device with decent drivers. Kept them around for mesa on pi3 as its GLES2 pathway probably has some limitations.~

**Note**: only tested on pi4 (mesa). will test on pi3 for mesa and non-mesa once my new SD card arrives! non-mesa should be functionally identical to prev version, though.