### PR TITLE
lr-neocd - added libretro neocd core to experimental packages

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -135,7 +135,7 @@ n64_fullname="Nintendo 64"
 nds_exts=".nds .zip"
 nds_fullname="Nintendo DS"
 
-neogeo_exts=".7z .cue .fba .iso .zip"
+neogeo_exts=".7z .chd .cue .fba .iso .zip"
 neogeo_fullname="Neo Geo"
 
 nes_exts=".7z .nes .zip"

--- a/scriptmodules/libretrocores/lr-neocd.sh
+++ b/scriptmodules/libretrocores/lr-neocd.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-neocd"
+rp_module_desc="Neo Geo CD Emulator - rewrite of NeoCD for libretro"
+rp_module_help="ROM Extension: .chd .cue\n\nCopy your roms to\n$romdir/neogeo\n\nYou will need a minimum of two BIOS files (eg. ng-lo.rom, uni-bioscd.rom) which should be copied to $biosdir/neocd"
+rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/neocd_libretro/master/LICENSE.md"
+rp_module_section="exp"
+
+function sources_lr-neocd() {
+    gitPullOrClone "$md_build" https://github.com/libretro/neocd_libretro.git
+}
+
+function build_lr-neocd() {
+    make clean
+    make
+    md_ret_require="$md_build/neocd_libretro.so"
+}
+
+function install_lr-neocd() {
+    md_ret_files=(
+        'LICENSE.md'
+        'neocd_libretro.so'
+        'README.md'
+    )
+}
+
+function configure_lr-neocd() {
+    mkRomDir "neogeo"
+    ensureSystemretroconfig "neogeo"
+
+    addEmulator 0 "$md_id" "neogeo" "$md_inst/neocd_libretro.so"
+    addSystem "neogeo"
+}


### PR DESCRIPTION
This was requested a while back. Tested working on RPI. Should be fine.

I used the neogeo system as we don't have support for a neogeocd system with default theme etc.