### PR TITLE
Enabling a variety of sdl1 applications for rpi4

### DIFF
--- a/scriptmodules/emulators/daphne.sh
+++ b/scriptmodules/emulators/daphne.sh
@@ -14,7 +14,7 @@ rp_module_desc="Daphne - Laserdisc Emulator"
 rp_module_help="ROM Extension: .daphne\n\nCopy your Daphne roms to $romdir/daphne"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/RetroPie/daphne-emu/master/COPYING"
 rp_module_section="opt"
-rp_module_flags="!x86 !mali !kms"
+rp_module_flags="dispmanx !x86 !mali"
 
 function depends_daphne() {
     getDepends libsdl1.2-dev libvorbis-dev libglew-dev zlib1g-dev
@@ -70,6 +70,8 @@ _EOF_
 
     chown -R $user:$user "$md_inst"
     chown -R $user:$user "$md_conf_root/daphne/dapinput.ini"
+
+    setDispmanx "$md_id" 1
 
     addEmulator 1 "$md_id" "daphne" "$md_inst/daphne.sh %ROM%"
     addSystem "daphne"

--- a/scriptmodules/emulators/jzintv.sh
+++ b/scriptmodules/emulators/jzintv.sh
@@ -14,7 +14,7 @@ rp_module_desc="Intellivision emulator"
 rp_module_help="ROM Extensions: .int .bin\n\nCopy your Intellivision roms to $romdir/intellivision\n\nCopy the required BIOS files exec.bin and grom.bin to $biosdir"
 rp_module_licence="GPL2 http://spatula-city.org/%7Eim14u2c/intv/"
 rp_module_section="opt"
-rp_module_flags="dispmanx !mali !kms"
+rp_module_flags="dispmanx !mali"
 
 function depends_jzintv() {
     getDepends libsdl1.2-dev

--- a/scriptmodules/emulators/scummvm-sdl1.sh
+++ b/scriptmodules/emulators/scummvm-sdl1.sh
@@ -14,7 +14,7 @@ rp_module_desc="ScummVM - built with legacy SDL1 support."
 rp_module_help="Copy your ScummVM games to $romdir/scummvm"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/scummvm/scummvm/master/COPYING"
 rp_module_section="opt"
-rp_module_flags="dispmanx !mali !x11 !kms"
+rp_module_flags="dispmanx !mali !x11"
 
 function depends_scummvm-sdl1() {
     depends_scummvm
@@ -25,7 +25,11 @@ function sources_scummvm-sdl1() {
     # the following only modifies $md_data for the function call
     md_data="$md_data/../scummvm" sources_scummvm
     if isPlatform "rpi"; then
-        applyPatch "$md_data/01_rpi_sdl1.diff"
+        if isPlatform "kms"; then
+            applyPatch "$md_data/01_rpi_kms_sdl1.diff"
+        else
+            applyPatch "$md_data/01_rpi_sdl1.diff"
+        fi
     fi
 }
 
@@ -38,5 +42,6 @@ function install_scummvm-sdl1() {
 }
 
 function configure_scummvm-sdl1() {
+    isPlatform "kms" && setDispmanx "$md_id" 1
     configure_scummvm
 }

--- a/scriptmodules/emulators/scummvm-sdl1/01_rpi_kms_sdl1.diff
+++ b/scriptmodules/emulators/scummvm-sdl1/01_rpi_kms_sdl1.diff
@@ -1,0 +1,19 @@
+diff --git a/configure b/configure
+index b7654c4..13799c5 100755
+--- a/configure
++++ b/configure
+@@ -3146,12 +3146,12 @@ if test -n "$_host"; then
+ 			# We prefer SDL2 on the Raspberry Pi: acceleration now depends on it
+ 			# since SDL2 manages dispmanx/GLES2 very well internally.
+ 			# SDL1 is bit-rotten on this platform.
+-			_sdlconfig=sdl2-config
++			_sdlconfig=sdl-config
+ 			# OpenGL ES support is mature enough as to be the best option on
+ 			# the Raspberry Pi, so it's enabled by default.
+ 			# The Raspberry Pi always supports OpenGL ES 2.0 contexts, thus we
+ 			# take advantage of those.
+-			_opengl_mode=gles2
++			_opengl_mode=none
+ 			;;
+ 		dreamcast)
+ 			append_var DEFINES "-DDISABLE_DEFAULT_SAVEFILEMANAGER"

--- a/scriptmodules/emulators/ti99sim.sh
+++ b/scriptmodules/emulators/ti99sim.sh
@@ -14,7 +14,7 @@ rp_module_desc="TI-99/SIM - Texas Instruments Home Computer Emulator"
 rp_module_help="ROM Extension: .ctg\n\nCopy your TI-99 games to $romdir/ti99\n\nCopy the required BIOS file TI-994A.ctg (case sensitive) to $biosdir"
 rp_module_licence="GPL2 http://www.mrousseau.org/programs/ti99sim/"
 rp_module_section="exp"
-rp_module_flags="!mali !kms"
+rp_module_flags="dispmanx !mali"
 
 function depends_ti99sim() {
     getDepends libsdl1.2-dev libssl-dev
@@ -36,9 +36,23 @@ function install_ti99sim() {
 
 function configure_ti99sim() {
     mkRomDir "ti99"
+
+    addEmulator 1 "$md_id" "ti99" "$md_inst/ti99sim.sh -f %ROM%"
+    addSystem "ti99"
+
+    [[ "$md_mode" == "remove" ]] && return
+
+    setDispmanx "$md_id" 1
+
     moveConfigDir "$home/.ti99sim" "$md_conf_root/ti99/"
     ln -sf "$biosdir/TI-994A.ctg" "$md_inst/TI-994A.ctg"
 
-    addEmulator 1 "$md_id" "ti99" "pushd $md_inst; $md_inst/ti99sim-sdl -f %ROM%; popd"
-    addSystem "ti99"
+    local file="$md_inst/ti99sim.sh"
+    cat >"$file" << _EOF_
+#!/bin/bash
+pushd "$md_inst"
+./ti99sim-sdl "\$@"
+popd
+_EOF_
+    chmod +x "$file"
 }

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -243,7 +243,7 @@ function getDepends() {
 
         if [[ "$md_mode" == "install" ]]; then
             # make sure we have our sdl1 / sdl2 installed
-            if ! isPlatform "x11" && ! isPlatform "mesa" && [[ "$required" == "libsdl1.2-dev" ]] && hasPackage libsdl1.2-dev $(get_pkg_ver_sdl1) "ne"; then
+            if ! isPlatform "x11" && [[ "$required" == "libsdl1.2-dev" ]] && hasPackage libsdl1.2-dev $(get_pkg_ver_sdl1) "ne"; then
                 packages+=("$required")
                 continue
             fi

--- a/scriptmodules/ports/bombermaaan.sh
+++ b/scriptmodules/ports/bombermaaan.sh
@@ -13,7 +13,7 @@ rp_module_id="bombermaaan"
 rp_module_desc="Bombermaaan - Classic bomberman game"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/bjaraujo/Bombermaaan/master/LICENSE.txt"
 rp_module_section="exp"
-rp_module_flags="!mali !kms"
+rp_module_flags="dispmanx !mali"
 
 function depends_bombermaaan() {
     getDepends cmake libsdl1.2-dev libsdl-mixer1.2-dev build-essential
@@ -41,5 +41,17 @@ function install_bombermaaan() {
 }
 
 function configure_bombermaaan() {
-    addPort "$md_id" "bombermaaan" "Bombermaaan" "pushd $md_inst; $md_inst/bombermaaan; popd"
+    addPort "$md_id" "bombermaaan" "Bombermaaan" "$md_inst/bombermaaan"
+
+    setDispmanx "$md_id" 1
+
+    local file="$romdir/ports/Bombermaaan.sh"
+    cat >"$file" << _EOF_
+#!/bin/bash
+pushd "$md_inst"
+"$rootdir/supplementary/runcommand/runcommand.sh" 0 _PORT_ bombermaaan ""
+popd
+_EOF_
+    chown $user:$user "$file"
+    chmod +x "$file"
 }

--- a/scriptmodules/ports/cdogs-sdl.sh
+++ b/scriptmodules/ports/cdogs-sdl.sh
@@ -13,10 +13,10 @@ rp_module_id="cdogs-sdl"
 rp_module_desc="C-Dogs SDL - Classic overhead run-and-gun game"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/cxong/cdogs-sdl/master/COPYING"
 rp_module_section="exp"
-rp_module_flags="!mali !kms"
+rp_module_flags="dispmanx !mali"
 
 function depends_cdogs-sdl() {
-    getDepends cmake libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev build-essential
+    getDepends cmake libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev build-essential libgtk-3-dev
 }
 
 function sources_cdogs-sdl() {
@@ -44,6 +44,11 @@ function install_cdogs-sdl() {
 }
 
 function configure_cdogs-sdl() {
-    moveConfigDir "$home/.config/cdogs-sdl" "$md_conf_root/cdogs-sdl"
     addPort "$md_id" "cdogs-sdl" "C-Dogs SDL" "pushd $md_inst; $md_inst/cdogs-sdl; popd"
+
+    [[ "$md_mode" == "remove" ]] && return
+
+    setDispmanx "$md_id" 1
+
+    moveConfigDir "$home/.config/cdogs-sdl" "$md_conf_root/cdogs-sdl"
 }

--- a/scriptmodules/ports/lincity-ng.sh
+++ b/scriptmodules/ports/lincity-ng.sh
@@ -13,7 +13,7 @@ rp_module_id="lincity-ng"
 rp_module_desc="lincity-ng - Open Source City Building Game"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/lincity-ng/lincity-ng/master/COPYING"
 rp_module_section="opt"
-rp_module_flags="!mali !kms"
+rp_module_flags="!mali"
 
 function _update_hook_lincity-ng() {
     # to show as installed in retropie-setup 4.x

--- a/scriptmodules/ports/micropolis.sh
+++ b/scriptmodules/ports/micropolis.sh
@@ -13,7 +13,7 @@ rp_module_id="micropolis"
 rp_module_desc="Micropolis - Open Source City Building Game"
 rp_module_licence="GPL https://raw.githubusercontent.com/SimHacker/micropolis/wiki/License.md"
 rp_module_section="opt"
-rp_module_flags="!mali !kms"
+rp_module_flags="!mali"
 
 function depends_micropolis() {
     ! isPlatform "x11" getDepends xorg matchbox-window-manager

--- a/scriptmodules/ports/openttd.sh
+++ b/scriptmodules/ports/openttd.sh
@@ -13,7 +13,7 @@ rp_module_id="openttd"
 rp_module_desc="Open Source Simulator Based On Transport Tycoon Deluxe"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/OpenTTD/OpenTTD/master/COPYING.md"
 rp_module_section="opt"
-rp_module_flags="dispmanx !mali !kms"
+rp_module_flags="dispmanx !mali"
 
 function _update_hook_openttd() {
     # to show as installed in retropie-setup 4.x
@@ -29,12 +29,16 @@ function remove_openttd() {
 }
 
 function configure_openttd() {
+    addPort "$md_id" "openttd" "OpenTTD" "openttd"
+
+    [[ "$md_mode" == "remove" ]] && return
+
+    setDispmanx "$md_id" 1
+
     local dir
     for dir in .config .local/share; do
         moveConfigDir "$home/$dir/openttd" "$md_conf_root/openttd"
     done
 
     moveConfigDir "$home/.local/openttd" "$md_conf_root/openttd"
-
-    addPort "$md_id" "openttd" "OpenTTD" "openttd"
 }

--- a/scriptmodules/ports/opentyrian.sh
+++ b/scriptmodules/ports/opentyrian.sh
@@ -13,7 +13,7 @@ rp_module_id="opentyrian"
 rp_module_desc="Open Tyrian - port of the DOS shoot-em-up Tyrian"
 rp_module_licence="GPL2 https://bitbucket.org/opentyrian/opentyrian/raw/3e3d6b925342a5891d8b937989dc50b563ff83dd/COPYING"
 rp_module_section="opt"
-rp_module_flags="dispmanx !mali !kms"
+rp_module_flags="dispmanx !mali"
 
 function depends_opentyrian() {
     getDepends libsdl1.2-dev libsdl-net1.2-dev mercurial

--- a/scriptmodules/ports/smw.sh
+++ b/scriptmodules/ports/smw.sh
@@ -13,7 +13,7 @@ rp_module_id="smw"
 rp_module_desc="Super Mario War"
 rp_module_licence="GPL http://supermariowar.supersanctuary.net/"
 rp_module_section="opt"
-rp_module_flags="!mali !kms"
+rp_module_flags="!mali"
 
 function depends_smw() {
     getDepends libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev
@@ -35,6 +35,10 @@ function install_smw() {
 
 function configure_smw() {
     addPort "$md_id" "smw" "Super Mario War" "$md_inst/smw"
+
+    [[ "$md_mode" == "remove" ]] && return
+
+    setDispmanx "$md_id" 1
 
     moveConfigFile "$home/.smw.options.bin" "$md_conf_root/smw/.smw.options.bin"
 }

--- a/scriptmodules/ports/supertux.sh
+++ b/scriptmodules/ports/supertux.sh
@@ -13,7 +13,7 @@ rp_module_id="supertux"
 rp_module_desc="SuperTux 2d scrolling platform"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/SuperTux/supertux/master/LICENSE.txt"
 rp_module_section="opt"
-rp_module_flags="!mali !kms"
+rp_module_flags="!mali"
 
 function _update_hook_supertux() {
     # to show as installed in retropie-setup 4.x

--- a/scriptmodules/ports/xrick.sh
+++ b/scriptmodules/ports/xrick.sh
@@ -13,7 +13,7 @@ rp_module_id="xrick"
 rp_module_desc="xrick - Port of Rick Dangerous"
 rp_module_licence="GPL https://raw.githubusercontent.com/HerbFargus/xrick/master/README"
 rp_module_section="opt"
-rp_module_flags="!mali !kms"
+rp_module_flags="!mali"
 
 function depends_xrick() {
     getDepends libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev zlib1g
@@ -36,5 +36,19 @@ function install_xrick() {
 }
 
 function configure_xrick() {
-    addPort "$md_id" "xrick" "XRick" "pushd $md_inst; $md_inst/xrick -fullscreen; popd"
+    addPort "$md_id" "xrick" "XRick" "$md_inst/xrick -fullscreen"
+
+    [[ "$md_mode" == "remove" ]] && return
+
+    isPlatform "kms" && setDispmanx "$md_id" 1
+
+    local file="$romdir/ports/XRick.sh"
+    cat >"$file" << _EOF_
+#!/bin/bash
+pushd "$md_inst"
+"$rootdir/supplementary/runcommand/runcommand.sh" 0 _PORT_ xrick ""
+popd
+_EOF_
+    chown $user:$user "$file"
+    chmod +x "$file"
 }

--- a/scriptmodules/supplementary/dispmanx.sh
+++ b/scriptmodules/supplementary/dispmanx.sh
@@ -12,7 +12,7 @@
 rp_module_id="dispmanx"
 rp_module_desc="Configure emulators to use dispmanx SDL"
 rp_module_section="config"
-rp_module_flags="!mali !x11 !kms"
+rp_module_flags="!mali !x11"
 
 function gui_dispmanx() {
     iniConfig " = " '"' "$configdir/all/dispmanx.cfg"

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -999,6 +999,8 @@ function restore_fb() {
 }
 
 function config_dispmanx() {
+    # if we are running under X then don't try and use dispmanx
+    [[ -n "$DISPLAY" ]] && return
     local name="$1"
     # if we have a dispmanx conf file and $name is in it (as a variable) and set to 1,
     # change the library path to load dispmanx sdl first

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -1000,7 +1000,7 @@ function restore_fb() {
 
 function config_dispmanx() {
     # if we are running under X then don't try and use dispmanx
-    [[ -n "$DISPLAY" ]] && return
+    [[ -n "$DISPLAY" || "$XINIT" -eq 1 ]] && return
     local name="$1"
     # if we have a dispmanx conf file and $name is in it (as a variable) and set to 1,
     # change the library path to load dispmanx sdl first

--- a/scriptmodules/supplementary/sdl1.sh
+++ b/scriptmodules/supplementary/sdl1.sh
@@ -13,7 +13,7 @@ rp_module_id="sdl1"
 rp_module_desc="SDL 1.2.15 with rpi fixes and dispmanx"
 rp_module_licence="GPL2 https://hg.libsdl.org/SDL/raw-file/7676476631ce/COPYING"
 rp_module_section=""
-rp_module_flags="!mali !x86 !kms"
+rp_module_flags="!mali !x86"
 
 function get_pkg_ver_sdl1() {
     local basever


### PR DESCRIPTION
This isn't everything but I have tested pretty much everything here - some of the sdl1 do not work with the dispmanx driver and have been left excluded.

for the sdl1 apps that work on dispmanx this will technically enable all the packages for other kms platforms (Only tinker board currently and this needs revisiting). The plan is to rework this so we can choose a backend based on platform and allow users to switch if needed - so for tinkerboard these would probably default to using X. 

In some cases I have enabled dispmanx by default where it wasn't before - but users on rpi1/2/3 can turn off via the dispmanx config. Some of them used X also and just needed the `!kms` removing.