### PR TITLE
eduke32: fix build on gcc 6.3.x

### DIFF
--- a/scriptmodules/ports/eduke32.sh
+++ b/scriptmodules/ports/eduke32.sh
@@ -38,6 +38,8 @@ function sources_eduke32() {
     # r6776 breaks VC4 & GLES 2.0 devices that lack GL_RED internal
     # format support for glTexImage2D/glTexSubImage2D
     isPlatform "gles" && applyPatch "$md_data/0003-replace-gl_red.patch"
+    # gcc 6.3.x compiler fix
+    applyPatch "$md_data/0004-recast-function.patch"
 }
 
 function build_eduke32() {

--- a/scriptmodules/ports/eduke32.sh
+++ b/scriptmodules/ports/eduke32.sh
@@ -29,21 +29,15 @@ function depends_eduke32() {
 function sources_eduke32() {
     local revision="-r8090"
 
-    # stretch has an older gcc that doesn't work with the newer code
-    compareVersions $__gcc_version lt 7.0.0 && revision="-r7077"
-
     svn checkout "$revision" http://svn.eduke32.com/eduke32 "$md_build"
 
-    if [[ "$revision" == "-r7077" ]]; then
-        # r6918 causes a 20+ second delay on startup on ARM devices
-        isPlatform "arm" && applyPatch "$md_data/0001-revert-r6918.patch"
-    else
-        # r7424 gives a black skybox when r_useindexedcolortextures is 0
-        applyPatch "$md_data/0002-fix-skybox.patch"
-        # r6776 breaks VC4 & GLES 2.0 devices that lack GL_RED internal
-        # format support for glTexImage2D/glTexSubImage2D
-        isPlatform "gles" && applyPatch "$md_data/0003-replace-gl_red.patch"
-    fi
+    # r6918 causes a 20+ second delay on startup on ARM devices
+    isPlatform "arm" && applyPatch "$md_data/0001-revert-r6918.patch"
+    # r7424 gives a black skybox when r_useindexedcolortextures is 0
+    applyPatch "$md_data/0002-fix-skybox.patch"
+    # r6776 breaks VC4 & GLES 2.0 devices that lack GL_RED internal
+    # format support for glTexImage2D/glTexSubImage2D
+    isPlatform "gles" && applyPatch "$md_data/0003-replace-gl_red.patch"
 }
 
 function build_eduke32() {

--- a/scriptmodules/ports/eduke32/0004-recast-function.patch
+++ b/scriptmodules/ports/eduke32/0004-recast-function.patch
@@ -1,0 +1,26 @@
+Index: source/duke3d/src/astub.cpp
+===================================================================
+--- a/source/duke3d/src/astub.cpp	(revision 8090)
++++ b/source/duke3d/src/astub.cpp	(working copy)
+@@ -4291,7 +4291,7 @@
+     i = (i&0x4)+((i>>4)&3);
+     i = eitherSHIFT ? prev3[i] : next3[i];
+     message("Sector %d %s flip %d deg%s", sectnum, typestr[search],
+-            klabs(orient[i])%360, orient[i] < 0 ? " mirrored":"");
++            (int)klabs(orient[i])%360, orient[i] < 0 ? " mirrored":"");
+     i = (i&0x4)+((i&3)<<4);
+     *stat &= ~0x34;
+     *stat |= i;
+Index: source/duke3d/src/player.cpp
+===================================================================
+--- a/source/duke3d/src/player.cpp	(revision 8090)
++++ b/source/duke3d/src/player.cpp	(working copy)
+@@ -1666,7 +1666,7 @@
+ 
+     for (bssize_t i=0; i < pPlayer->numloogs; i++)
+     {
+-        int const rotAng = klabs(sintable[((loogCounter + i) << 5) & 2047]) >> 5;
++        int const rotAng = (int)klabs(sintable[((loogCounter + i) << 5) & 2047]) >> 5;
+         int const rotZoom  = 4096 + ((loogCounter + i) << 9);
+         int const rotX     = (-fix16_to_int(g_player[screenpeek].input->q16avel) >> 1) + (sintable[((loogCounter + i) << 6) & 2047] >> 10);
+ 


### PR DESCRIPTION
Recast klabs function to integer to prevent compiler error on older gcc versions.

--

Only verified that it fixes compilation via chroot. If you can, please verify the build works on stretch before merging. Thanks.