### PR TITLE
advmame - enable for kms and mali systems

### DIFF
--- a/scriptmodules/emulators/advmame.sh
+++ b/scriptmodules/emulators/advmame.sh
@@ -14,7 +14,7 @@ rp_module_desc="AdvanceMAME v3.9"
 rp_module_help="ROM Extension: .zip\n\nCopy your AdvanceMAME roms to either $romdir/mame-advmame or\n$romdir/arcade"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/amadvance/advancemame/master/COPYING"
 rp_module_section="opt"
-rp_module_flags="!mali !kms"
+rp_module_flags=""
 
 function _update_hook_advmame() {
     # if the non split advmame is installed, make directories for 0.94 / 1.4 so they will be updated
@@ -26,9 +26,12 @@ function _update_hook_advmame() {
 }
 
 function depends_advmame() {
-    local depends=(libsdl1.2-dev autoconf automake)
-    isPlatform "x11" && depends+=(libsdl2-dev)
-    isPlatform "rpi" && depends+=(libraspberrypi-dev)
+    local depends=(autoconf automake)
+    if isPlatform "videocore"; then
+        depends+=(libsdl1.2-dev libraspberrypi-dev)
+    else
+        depends+=(libsdl2-dev)
+    fi
     getDepends "${depends[@]}"
 }
 
@@ -37,8 +40,14 @@ function sources_advmame() {
 }
 
 function build_advmame() {
+    local params=()
+    if isPlatform "videocore"; then
+        params+=(--enable-sdl1 --disable-sdl2 --enable-vc)
+    else
+        params+=(--enable-sdl2 --disable-sdl1 --disable-vc)
+    fi
     ./autogen.sh
-    ./configure CFLAGS="$CFLAGS -fno-stack-protector" --prefix="$md_inst"
+    ./configure CFLAGS="$CFLAGS -fno-stack-protector" --prefix="$md_inst" "${params[@]}"
     make clean
     make
     md_ret_require="$md_build/advmame"
@@ -96,7 +105,7 @@ function configure_advmame() {
         iniSet "dir_snap" "$romdir/mame-advmame/snap"
         iniSet "dir_sta" "$romdir/mame-advmame/nvram"
 
-        if isPlatform "rpi"; then
+        if isPlatform "videocore"; then
             iniSet "device_video" "fb"
             iniSet "device_video_cursor" "off"
             iniSet "device_keyboard" "raw"
@@ -105,6 +114,12 @@ function configure_advmame() {
             iniSet "sound_normalize" "no"
             iniSet "display_resizeeffect" "none"
             iniSet "display_resize" "integer"
+            iniSet "display_magnify" "1"
+        elif isPlatform "kms" || isPlatform "mali"; then
+            iniSet "device_video" "sdl"
+            # need to force keyboard device as auto will choose event driver which doesn't work with sdl
+            iniSet "device_keyboard" "sdl"
+            # default for best performance
             iniSet "display_magnify" "1"
         else
             iniSet "device_video_output" "overlay"


### PR DESCRIPTION
 * use sdl2 on non videocore systems
 * force sdl video / keyboard input on kms / mali

This is initial work to get this working on rpi4. Also enable now for mali.

Upstream has a recent commit related to rpi4 support but it looks as though it expects the old videocore driver enabled. As we use fkms, I've made it use sdl2 which lacks the programmable video stuff but works at least. The default config maybe could be improved. Primarily I had to force keyboard driver as default didn't work and set magnify to 1 to disable slow upscaling.