### PR TITLE
dosbox-sdl2: add libglew-dev to depends

### DIFF
--- a/scriptmodules/emulators/dosbox-sdl2.sh
+++ b/scriptmodules/emulators/dosbox-sdl2.sh
@@ -17,7 +17,7 @@ rp_module_section="exp"
 rp_module_flags="!mali"
 
 function depends_dosbox-sdl2() {
-    local depends=(libsdl2-dev libsdl2-net-dev libfluidsynth-dev fluid-soundfont-gm)
+    local depends=(libsdl2-dev libsdl2-net-dev libfluidsynth-dev fluid-soundfont-gm libglew-dev)
     depends_dosbox "${depends[@]}"
 }
 


### PR DESCRIPTION
Current master is failing due to libglew-dev being required
even if opengl is disabled. As a temporary measure, install
package to satisfy build (and raise the issue upstream later).