### PR TITLE
lr-parallel-n64 - revert 11c1ae33 to fix segfault on exit on arm

### DIFF
--- a/scriptmodules/libretrocores/lr-parallel-n64.sh
+++ b/scriptmodules/libretrocores/lr-parallel-n64.sh
@@ -25,6 +25,9 @@ function depends_lr-parallel-n64() {
 
 function sources_lr-parallel-n64() {
     gitPullOrClone "$md_build" https://github.com/libretro/parallel-n64.git
+    # revert upstream commit 11c1ae33 to fix segfault on exit
+    # modified revert due to code changes and excludes Makefile differences (as they are not relevant for us)
+    applyPatch "$md_data/01_revert_11c1ae33.diff"
     # avoid conflicting typedefs for GLfloat on rpi4/kms
     isPlatform "kms" && isPlatform "gles" && sed -i "/^typedef GLfloat GLdouble/d" "$md_build/libretro-common/include/glsm/glsm.h"
 }

--- a/scriptmodules/libretrocores/lr-parallel-n64/01_revert_11c1ae33.diff
+++ b/scriptmodules/libretrocores/lr-parallel-n64/01_revert_11c1ae33.diff
@@ -1,0 +1,392 @@
+diff --git a/libretro/libretro.c b/libretro/libretro.c
+index 785a202f..0d4ff413 100644
+--- a/libretro/libretro.c
++++ b/libretro/libretro.c
+@@ -3,7 +3,7 @@
+ #include <string.h>
+ 
+ #include <libretro.h>
+-#ifndef NO_LIBCO
++#ifndef EMSCRIPTEN
+ #include <libco.h>
+ #endif
+ 
+@@ -42,10 +42,6 @@
+ #define PRESCALE_HEIGHT 625
+ #endif
+ 
+-#if defined(NO_LIBCO) && defined(DYNAREC)
+-#error cannot currently use dynarecs without libco
+-#endif
+-
+ /* forward declarations */
+ int InitGfx(void);
+ #if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)
+@@ -90,9 +86,7 @@ static const struct retro_subsystem_info subsystems[] = {
+ 
+ save_memory_data saved_memory;
+ 
+-#ifdef NO_LIBCO
+-static bool stop_stepping;
+-#else
++#ifndef EMSCRIPTEN
+ cothread_t main_thread;
+ static cothread_t game_thread;
+ #endif
+@@ -650,7 +644,7 @@ void reinit_gfx_plugin(void)
+     if(first_context_reset)
+     {
+         first_context_reset = false;
+-#ifndef NO_LIBCO
++#ifndef EMSCRIPTEN
+         co_switch(game_thread);
+ #endif
+     }
+@@ -703,22 +697,6 @@ void deinit_gfx_plugin(void)
+     }
+ }
+ 
+-#ifdef NO_LIBCO
+-static void EmuThreadInit(void)
+-{
+-    emu_step_initialize();
+-
+-    initializing = false;
+-
+-    main_pre_run();
+-}
+-
+-static void EmuThreadStep(void)
+-{
+-    stop_stepping = false;
+-    main_run();
+-}
+-#else
+ static void EmuThreadFunction(void)
+ {
+     if (!emu_step_load_data())
+@@ -727,22 +705,27 @@ static void EmuThreadFunction(void)
+     /* ROM is loaded, switch back to main thread
+      * so retro_load_game can return (returning failure if needed).
+      * We'll continue here once the context is reset. */
++#ifndef EMSCRIPTEN
+     co_switch(main_thread);
++#endif
+ 
+     emu_step_initialize();
+ 
+     /*Context is reset too, everything is safe to use.
+      * Now back to main thread so we don't start pushing
+      * frames outside retro_run. */
++#ifndef EMSCRIPTEN
+     co_switch(main_thread);
++#endif
+ 
+     initializing = false;
+-    main_pre_run();
+     main_run();
+     if (log_cb)
+        log_cb(RETRO_LOG_INFO, "EmuThread: co_switch main_thread.\n");
+ 
++#ifndef EMSCRIPTEN
+     co_switch(main_thread);
++#endif
+ 
+ load_fail:
+     /*NEVER RETURN! That's how libco rolls */
+@@ -750,10 +733,11 @@ load_fail:
+     {
+        if (log_cb)
+           log_cb(RETRO_LOG_ERROR, "Running Dead N64 Emulator\n");
++#ifndef EMSCRIPTEN
+        co_switch(main_thread);
++#endif
+     }
+ }
+-#endif
+ 
+ const char* retro_get_system_directory(void)
+ {
+@@ -961,7 +945,7 @@ void retro_init(void)
+    polygonOffsetUnits = -3.0f;
+    polygonOffsetFactor =  -3.0f;
+ 
+-#ifndef NO_LIBCO
++#ifndef EMSCRIPTEN
+    main_thread = co_active();
+    game_thread = co_create(65536 * sizeof(void*) * 16, EmuThreadFunction);
+ #endif
+@@ -973,7 +957,7 @@ void retro_deinit(void)
+    mupen_main_stop();
+    mupen_main_exit();
+ 
+-#ifndef NO_LIBCO
++#ifndef EMSCRIPTEN
+    co_delete(game_thread);
+ #endif
+ 
+@@ -1316,7 +1300,7 @@ void update_variables(bool startup)
+          retro_filtering = 3;
+ 
+       if (retro_filtering != old_filtering)
+-	gfx_set_filtering();
++	gfx_set_filtering(); 
+ 
+       old_filtering      = retro_filtering;
+    }
+@@ -1605,12 +1589,9 @@ bool retro_load_game(const struct retro_game_info *game)
+    stop      = false;
+    /* Finish ROM load before doing anything funny,
+     * so we can return failure if needed. */
+-#ifdef NO_LIBCO
+-    emu_step_load_data();
+-#else
++#ifndef EMSCRIPTEN
+    co_switch(game_thread);
+ #endif
+-
+    if (stop)
+       return false;
+ 
+@@ -1641,9 +1622,7 @@ void retro_unload_game(void)
+     stop = 1;
+     first_time = 1;
+ 
+-#ifdef NO_LIBCO
+-    EmuThreadStep();
+-#else
++#ifndef EMSCRIPTEN
+     co_switch(game_thread);
+ #endif
+ 
+@@ -1802,14 +1781,9 @@ void retro_run (void)
+          /* Additional check for vioverlay not set at start */
+          update_variables(false);
+          gfx_set_filtering();
+-#ifdef NO_LIBCO
+-         EmuThreadInit();
+-#endif
+       }
+ 
+-#ifdef NO_LIBCO
+-      EmuThreadStep();
+-#else
++#ifndef EMSCRIPTEN
+       co_switch(game_thread);
+ #endif
+ 
+@@ -1992,16 +1966,7 @@ void retro_cheat_set(unsigned index, bool enabled, const char* codeLine)
+ 
+ void vbo_disable(void);
+ 
+-int retro_stop_stepping(void)
+-{
+-#ifdef NO_LIBCO
+-    return stop_stepping;
+-#else
+-    return false;
+-#endif
+-}
+-
+-int retro_return(bool just_flipping)
++int retro_return(int just_flipping)
+ {
+    if (stop)
+       return 0;
+@@ -2010,21 +1975,9 @@ int retro_return(bool just_flipping)
+    vbo_disable();
+ #endif
+ 
+-#ifdef NO_LIBCO
+-   if (just_flipping)
+-   {
+-      /* HACK: in case the VI comes before the render? is that possible?
+-       * remove this when we totally remove libco */
+-      flip_only = 1;
+-      emu_step_render();
+-      flip_only = 0;
+-   }
+-   else
+-      flip_only = just_flipping;
+-
+-   stop_stepping = true;
+-#else
+    flip_only = just_flipping;
++
++#ifndef EMSCRIPTEN
+    co_switch(main_thread);
+ #endif
+ 
+diff --git a/mupen64plus-core/src/main/main.c b/mupen64plus-core/src/main/main.c
+index 6dbde3da..140f4276 100644
+--- a/mupen64plus-core/src/main/main.c
++++ b/mupen64plus-core/src/main/main.c
+@@ -388,13 +388,6 @@ m64p_error main_init(void)
+    return M64ERR_SUCCESS;
+ }
+ 
+-m64p_error main_pre_run(void)
+-{
+-   r4300_init();
+-
+-   return M64ERR_SUCCESS;
+-}
+-
+ m64p_error main_run(void)
+ {
+    r4300_execute();
+diff --git a/mupen64plus-core/src/main/main.h b/mupen64plus-core/src/main/main.h
+index 40b069a4..13db0e8c 100644
+--- a/mupen64plus-core/src/main/main.h
++++ b/mupen64plus-core/src/main/main.h
+@@ -53,7 +53,6 @@ int  main_set_core_defaults(void);
+ void main_message(m64p_msg_level level, unsigned int osd_corner, const char *format, ...);
+ 
+ m64p_error main_init(void);
+-m64p_error main_pre_run(void);
+ m64p_error main_run(void);
+ void mupen_main_exit(void);
+ void mupen_main_stop(void);
+diff --git a/mupen64plus-core/src/r4300/pure_interp.c b/mupen64plus-core/src/r4300/pure_interp.c
+index a88c99d6..101def4d 100644
+--- a/mupen64plus-core/src/r4300/pure_interp.c
++++ b/mupen64plus-core/src/r4300/pure_interp.c
+@@ -727,18 +727,13 @@ void InterpretOpcode(void)
+ 	} /* switch ((op >> 26) & 0x3F) */
+ }
+ 
+-int retro_stop_stepping(void);
+-
+-void pure_interpreter_init(void)
++void pure_interpreter(void)
+ {
+    stop = 0;
+    PC = &interp_PC;
+    PC->addr = last_addr = 0xa4000040;
+-}
+ 
+-void pure_interpreter(void)
+-{
+-   while (!stop && !retro_stop_stepping())
++   while (!stop)
+    {
+ #ifdef DBG
+      if (g_DebuggerActive) update_debugger(PC->addr);
+diff --git a/mupen64plus-core/src/r4300/pure_interp.h b/mupen64plus-core/src/r4300/pure_interp.h
+index 81af7a80..2cd1193b 100644
+--- a/mupen64plus-core/src/r4300/pure_interp.h
++++ b/mupen64plus-core/src/r4300/pure_interp.h
+@@ -22,7 +22,6 @@
+ #ifndef M64P_R4300_PURE_INTERP_H
+ #define M64P_R4300_PURE_INTERP_H
+ 
+-void pure_interpreter_init(void);
+ void pure_interpreter(void);
+ 
+ #endif /* M64P_R4300_PURE_INTERP_H */
+diff --git a/mupen64plus-core/src/r4300/r4300.c b/mupen64plus-core/src/r4300/r4300.c
+index 73cb1f27..cd662fea 100644
+--- a/mupen64plus-core/src/r4300/r4300.c
++++ b/mupen64plus-core/src/r4300/r4300.c
+@@ -92,7 +92,7 @@ static void dynarec_setup_code(void)
+ }
+ #endif
+ 
+-void r4300_init(void)
++void r4300_execute(void)
+ {
+     current_instruction_table = cached_interpreter_table;
+ 
+@@ -102,7 +102,7 @@ void r4300_init(void)
+     {
+         DebugMessage(M64MSG_INFO, "Starting R4300 emulator: Pure Interpreter");
+         r4300emu = CORE_PURE_INTERPRETER;
+-        pure_interpreter_init();
++        pure_interpreter();
+     }
+ #if defined(DYNAREC)
+     else if (r4300emu >= 2)
+@@ -113,9 +113,13 @@ void r4300_init(void)
+ 
+ #if NEW_DYNAREC
+         new_dynarec_init();
++        new_dyna_start();
++        new_dynarec_cleanup();
+ #else
+         dyna_start(dynarec_setup_code);
++        PC++;
+ #endif
++        free_blocks();
+     }
+ #endif
+     else /* if (r4300emu == CORE_INTERPRETER) */
+@@ -130,49 +134,17 @@ void r4300_init(void)
+             return;
+ 
+         last_addr = PC->addr;
+-    }
+-}
+ 
+-void r4300_execute(void)
+-{
+-    if (r4300emu == CORE_PURE_INTERPRETER)
+-    {
+-        pure_interpreter();
+-    }
+-#if defined(DYNAREC)
+-    else if (r4300emu >= 2)
+-    {
+-#if NEW_DYNAREC
+-        new_dyna_start();
+-        if (stop)
+-            new_dynarec_cleanup();
+-#else
+-        dyna_start(dynarec_setup_code);
+-        if (stop)
+-            PC++;
+-#endif
+-        if (stop)
+-            free_blocks();
+-    }
+-#endif
+-    else /* if (r4300emu == CORE_INTERPRETER) */
+-    {
+         r4300_step();
+ 
+-        if (stop)
+-            free_blocks();
++        free_blocks();
+     }
+ 
+-    if (stop)
+-        DebugMessage(M64MSG_INFO, "R4300 emulator finished.");
++    DebugMessage(M64MSG_INFO, "R4300 emulator finished.");
+ }
+ 
+-int retro_stop_stepping(void);
+-
+ void r4300_step(void)
+ {
+-   while (!stop && !retro_stop_stepping())
+-   {
++   while (!stop)
+       PC->ops();
+-   }
+ }
+diff --git a/mupen64plus-core/src/r4300/r4300.h b/mupen64plus-core/src/r4300/r4300.h
+index fa30885c..6659b646 100644
+--- a/mupen64plus-core/src/r4300/r4300.h
++++ b/mupen64plus-core/src/r4300/r4300.h
+@@ -42,7 +42,6 @@ extern uint32_t last_addr;
+ extern unsigned int count_per_op;
+ extern cpu_instruction_table current_instruction_table;
+ 
+-void r4300_init(void);
+ void r4300_execute(void);
+ void r4300_step(void);
+ 
+@@ -52,3 +51,4 @@ void r4300_step(void);
+ #define CORE_DYNAREC          2
+ 
+ #endif /* M64P_R4300_R4300_H */
++


### PR DESCRIPTION
* fixes saving of core options as segfault prevented them from saving
 * note: probably unrelated but still crashes on launch in some cases and seems to be intermittent (may work on a second launch)