### PR TITLE
lr-flycast - only set video_shared_context for gl targets

### DIFF
--- a/scriptmodules/libretrocores/lr-flycast.sh
+++ b/scriptmodules/libretrocores/lr-flycast.sh
@@ -59,8 +59,10 @@ function configure_lr-flycast() {
     mkUserDir "$biosdir/dc"
 
     # system-specific
-    iniConfig " = " "" "$configdir/dreamcast/retroarch.cfg"
-    iniSet "video_shared_context" "true"
+    if isPlatform "gl"; then
+        iniConfig " = " "" "$configdir/dreamcast/retroarch.cfg"
+        iniSet "video_shared_context" "true"
+    fi
 
     # segfaults on the rpi without redirecting stdin from </dev/null
     addEmulator 0 "$md_id" "dreamcast" "$md_inst/flycast_libretro.so </dev/null"


### PR DESCRIPTION
this option was originally added before the core was enabled on arm. it may not even be needed on x11/x86 anymore

@gizmo98 do you remember why this was added. I think you added this code originally

If it's not needed on x11/GL we can remove completely

