### PR TITLE
srb2: fix building on Stretch, disable libOpenMPT

### DIFF
--- a/scriptmodules/ports/srb2.sh
+++ b/scriptmodules/ports/srb2.sh
@@ -15,7 +15,9 @@ rp_module_licence="GPL2 https://raw.githubusercontent.com/STJr/SRB2/master/LICEN
 rp_module_section="exp"
 
 function depends_srb2() {
-    getDepends cmake libsdl2-dev libsdl2-mixer-dev libgme-dev libopenmpt-dev
+    local depends=(cmake libsdl2-dev libsdl2-mixer-dev libgme-dev)
+    compareVersions "$__os_debian_ver" gt 9 && depends+=(libopenmpt-dev)
+    getDepends "${depends[@]}"
 }
 
 function sources_srb2() {
@@ -26,7 +28,11 @@ function sources_srb2() {
 function build_srb2() {
     mkdir build
     cd build
-    cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$md_inst"
+
+    # Disable OpenMPT on Debian Stretch and old, its version is too old
+    local extra
+    compareVersions "$__os_debian_ver" lt 10 && extra="-DSRB2_CONFIG_HAVE_OPENMPT=Off"
+    cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$md_inst" $extra
     make
     md_ret_require="$md_build/build/bin/lsdlsrb2"
 }


### PR DESCRIPTION
Since `libOpenMPT` is optional, disable it on Debian/Raspbian Stretch to prevent a build failure.
Ubuntu 18.04 includes a newer version and it builds fine with it.