### PR TITLE
reicast: change input mapping scripts and simplify launch script

### DIFF
--- a/scriptmodules/emulators/reicast.sh
+++ b/scriptmodules/emulators/reicast.sh
@@ -150,7 +150,7 @@ function input_reicast() {
     ./reicast-joyconfig -f "$temp_file" >/dev/tty
     iniConfig " = " "" "$temp_file"
     iniGet "mapping_name"
-    local mapping_file="$configdir/dreamcast/mappings/controller_${ini_value// /}.cfg"
+    local mapping_file="$configdir/dreamcast/mappings/evdev_${ini_value//[:><?\"]/-}.cfg"
     mv "$temp_file" "$mapping_file"
     chown $user:$user "$mapping_file"
 }

--- a/scriptmodules/emulators/reicast/reicast.sh
+++ b/scriptmodules/emulators/reicast/reicast.sh
@@ -19,62 +19,6 @@ biosdir="$HOME/RetroPie/BIOS/dc"
 
 source "$rootdir/lib/inifuncs.sh"
 
-function mapInput() {
-    local js_device
-    local js_device_num
-    local ev_device
-    local ev_devices
-    local ev_device_num
-    local device_counter
-    local conf="$configdir/dreamcast/emu.cfg"
-    local params=""
-
-    # get a list of all present js device numbers and device names
-    # and device count
-    for js_device in /dev/input/js*; do
-        js_device_num=${js_device/\/dev\/input\/js/}
-        for ev_device in /dev/input/event*; do
-            ev_device_num=${ev_device/\/dev\/input\/event/}
-            if [[ -d "/sys/class/input/event${ev_device_num}/device/js${js_device_num}" ]]; then
-                file[$ev_device_num]=$(grep --exclude=*.bak -rl -m 1 "$configdir/dreamcast/mappings/" -e "= $(</sys/class/input/event${ev_device_num}/device/name)" | tail -n 1)
-                if [[ -f "${file[$ev_device_num]}" ]]; then
-                    #file[$ev_device_num]="${file[$ev_device_num]##*/}"
-                    ev_devices[$ev_device_num]=$(</sys/class/input/event${ev_device_num}/device/name)
-                    device_counter=$(($device_counter+1))
-                fi
-            fi
-        done
-    done
-
-    # emu.cfg: store up to four event devices and mapping files
-    if [[ "$device_counter" -gt "0" ]]; then
-        # reicast supports max 4 event devices
-        if [[ "$device_counter" -gt "4" ]]; then
-            device_counter="4"
-        fi
-        local counter=0
-        for ev_device_num in "${!ev_devices[@]}"; do
-            if [[ "$counter" -lt "$device_counter" ]]; then
-                counter=$(($counter+1))
-                params+="-config input:evdev_device_id_$counter=$ev_device_num "
-                params+="-config input:evdev_mapping_$counter=${file[$ev_device_num]} "
-            fi
-        done
-        while [[ "$counter" -lt "4" ]]; do
-            counter=$(($counter+1))
-            params+="-config input:evdev_device_id_$counter=-1 "
-            params+="-config input:evdev_mapping_$counter=-1 "
-        done
-    else
-        # fallback to keyboard setup
-        params+="-config input:evdev_device_id_1=0 "
-        device_counter=1
-    fi
-    params+="-config input:joystick_device_id=-1 "
-    params+="-config players:nb=$device_counter "
-    echo "$params"
-}
-
 if [[ ! -f "$biosdir/dc_boot.bin" ]]; then
     dialog --no-cancel --pause "You need to copy the Dreamcast BIOS files (dc_boot.bin and dc_flash.bin) to the folder $biosdir to boot the Dreamcast emulator." 22 76 15
     exit 1
@@ -82,7 +26,6 @@ fi
 
 params=(-config config:homedir=$HOME -config x11:fullscreen=1)
 [[ -n "$XRES" ]] && params+=(-config x11:width=$XRES -config x11:height=$YRES)
-getAutoConf reicast_input && params+=($(mapInput))
 [[ -n "$AUDIO" ]] && params+=(-config audio:backend=$AUDIO -config audio:disable=0)
 [[ -n "$ROM" ]] && params+=(-config config:image="$ROM")
 if [[ "$AUDIO" == "oss" ]]; then

--- a/scriptmodules/supplementary/emulationstation/configscripts/reicast.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/reicast.sh
@@ -20,7 +20,7 @@ function onstart_reicast_joystick() {
             file="$configdir/dreamcast/mappings/controller_xboxdrv.cfg"
             ;;
         *)
-            file="$configdir/dreamcast/mappings/controller_${DEVICE_NAME// /}.cfg"
+            file="$configdir/dreamcast/mappings/evdev_${DEVICE_NAME//[:><?\"]/-}.cfg"
             ;;
     esac
 
@@ -221,7 +221,7 @@ function onend_reicast_joystick() {
             file="$configdir/dreamcast/mappings/controller_xboxdrv.cfg"
             ;;
         *)
-            file="$configdir/dreamcast/mappings/controller_${DEVICE_NAME// /}.cfg"
+            file="$configdir/dreamcast/mappings/evdev_${DEVICE_NAME//[:><?\"]/-}.cfg"
             ;;
     esac
 


### PR DESCRIPTION
Reicast input handling has been problematic for quite some time. It looks like it's the result of 2 commits:
 - https://github.com/reicast/reicast-emulator/commit/8e4e2c67f2f2d00da7567d779fc734c68e676562,  which removed the input configuration performed from the CLI 
- https://github.com/reicast/reicast-emulator/commit/8b5c2a3fac54bb74e8e79ff17fe0890af9044273, which added SDL input support, but also changed the way the input `.cfg` files are named.

Instead of relying on the `input:evdev_...` CLI parameters, the configuration is loaded from the `api`_`<controller_filtered_name>` files, where `<controller_filtered_name>` is produced by [`make_mapping_filename`](https://github.com/reicast/reicast-emulator/blob/11a02e571b37144d205eebb1c2974404c4b338f6/libswirl/input/gamepad_device.cpp#L203). 

The current configuration scripts (both from EmulationStation and Reicast) create the configuration files as `controller_<gamepad_name_without_spaces>`, which are not loaded by the _Reicast_'s current version.

This PR changes the names of the `.cfg` file produced by the Reicast (auto)configuration and removes the input mapping from the emulator's starting script (not needed anymore).

Credit goes to user *rejesterd*, which analyzed this in https://retropie.org.uk/forum/topic/24544.

EDIT: the auto-configuration script called from EmulationStation doesn't reliably create a correct auto-configuration file for `reicast`, however SDL doesn't export any API to get the `evdev` event codes so we can't resolve this at the moment without modifying EmulationStation and SDL.