### PR TITLE
PSX: Use previous ari64 dynarec for ARM targets, rather than experimental lightrec one

### DIFF
--- a/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
+++ b/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
@@ -29,7 +29,7 @@ function build_lr-pcsx-rearmed() {
     local params=()
 
     if isPlatform "arm"; then
-        params+=(ARCH=arm USE_DYNAREC=1)
+        params+=(ARCH=arm DYNAREC=ari64)
         if isPlatform "neon"; then
             params+=(HAVE_NEON=1 BUILTIN_GPU=neon)
         else


### PR DESCRIPTION
Lightrec crashes or is less performant at the moment.

Fixes https://retropie.org.uk/forum/topic/24895/pi4-lr-pcsx-rearmed-from-source-freezes-with-some-games