### PR TITLE
Enable a couple more SDL1 emulators on the Pi4

### DIFF
--- a/scriptmodules/emulators/np2pi.sh
+++ b/scriptmodules/emulators/np2pi.sh
@@ -13,7 +13,7 @@ rp_module_id="np2pi"
 rp_module_desc="NEC PC-9801 emulator"
 rp_module_help="ROM Extensions: .d88 .d98 .88d .98d .fdi .xdf .hdm .dup .2hd .tfd .hdi .thd .nhd .hdd\n\nCopy your pc98 games to to $romdir/pc88\n\nCopy bios files 2608_bd.wav, 2608_hh.wav, 2608_rim.wav, 2608_sd.wav, 2608_tom.wav 2608_top.wav, bios.rom, FONT.ROM and sound.rom to $biosdir/pc98"
 rp_module_section="exp"
-rp_module_flags="dispmanx !x86 !mali !kms"
+rp_module_flags="dispmanx !x86 !mali"
 
 function depends_np2pi() {
     getDepends libsdl1.2-dev libasound2-dev libsdl-ttf2.0-dev fonts-takao-gothic
@@ -38,6 +38,7 @@ function configure_np2pi() {
     mkRomDir "pc98"
 
     mkUserDir "$md_conf_root/pc98"
+    setDispmanx "$md_id" 1
 
     # we launch from $md_conf_root/pc98 as emulator wants to create files in
     # the current directory (eg font.tmp).

--- a/scriptmodules/ports/openbor.sh
+++ b/scriptmodules/ports/openbor.sh
@@ -14,7 +14,7 @@ rp_module_desc="OpenBOR - Beat 'em Up Game Engine"
 rp_module_help="OpenBOR games need to be extracted to function properly. Place your pak files in $romdir/ports/openbor and then run $rootdir/ports/openbor/extract.sh. When the script is done, your original pak files will be found in $romdir/ports/openbor/originals and can be deleted."
 rp_module_licence="BSD https://raw.githubusercontent.com/rofl0r/openbor/master/LICENSE"
 rp_module_section="exp"
-rp_module_flags="!mali !x11 !kms"
+rp_module_flags="dispmanx !mali !x11"
 
 function depends_openbor() {
     getDepends libsdl1.2-dev libsdl-gfx1.2-dev libogg-dev libvorbisidec-dev libvorbis-dev libpng-dev zlib1g-dev
@@ -46,6 +46,7 @@ function configure_openbor() {
     addPort "$md_id" "openbor" "OpenBOR - Beats of Rage Engine" "pushd $md_inst; $md_inst/OpenBOR; popd"
 
     mkRomDir "ports/$md_id"
+    setDispmanx "$md_id" 1
 
     cat >"$md_inst/extract.sh" <<_EOF_
 #!/bin/bash


### PR DESCRIPTION
* OpenBOR - without `dispmanx` it scales badly or duplicates the screen.
* NP2PI - the PC98 emulator, which - I think - uses a fixed resolution and needs the `dispmanx` scaling to get a compatible video mode.