### PR TITLE
Module flags

### DIFF
--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -14,7 +14,7 @@ rp_module_desc="Amiga emulator with JIT support (forked from uae4arm)"
 rp_module_help="ROM Extension: .adf .ipf .zip\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/midwan/amiberry/master/COPYING"
 rp_module_section="opt"
-rp_module_flags="!x86"
+rp_module_flags="!all arm"
 
 function _get_platform_amiberry() {
     local platform="$__platform-sdl2"

--- a/scriptmodules/emulators/capricerpi.sh
+++ b/scriptmodules/emulators/capricerpi.sh
@@ -14,7 +14,7 @@ rp_module_desc="Amstrad CPC emulator - port of Caprice32 for the RPI"
 rp_module_help="ROM Extensions: .cdt .cpc .dsk\n\nCopy your Amstrad CPC games to $romdir/amstradcpc"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/KaosOverride/CapriceRPI/master/COPYING.txt"
 rp_module_section="opt"
-rp_module_flags="dispmanx !x86 !mali !kms"
+rp_module_flags="dispmanx !all videocore"
 
 function depends_capricerpi() {
     getDepends libsdl1.2-dev libsdl-image1.2-dev libsdl-ttf2.0-dev zlib1g-dev libpng-dev

--- a/scriptmodules/emulators/coolcv.sh
+++ b/scriptmodules/emulators/coolcv.sh
@@ -14,7 +14,7 @@ rp_module_desc="CoolCV Colecovision Emulator"
 rp_module_help="ROM Extensions: .bin .col .rom .zip\n\nCopy your Colecovision roms to $romdir/coleco"
 rp_module_licence="PROP"
 rp_module_section="opt"
-rp_module_flags="!x86 !x11 !mali !kms"
+rp_module_flags="!all videocore"
 
 function depends_coolcv() {
     getDepends libsdl2-dev

--- a/scriptmodules/emulators/dolphin.sh
+++ b/scriptmodules/emulators/dolphin.sh
@@ -14,7 +14,7 @@ rp_module_desc="Gamecube/Wii emulator Dolphin"
 rp_module_help="ROM Extensions: .gcm .iso .wbfs .ciso .gcz\n\nCopy your gamecube roms to $romdir/gc and Wii roms to $romdir/wii"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/dolphin-emu/dolphin/master/license.txt"
 rp_module_section="exp"
-rp_module_flags="!arm"
+rp_module_flags="!all 64bit"
 
 function depends_dolphin() {
     local depends=(cmake pkg-config libao-dev libasound2-dev libavcodec-dev libavformat-dev libbluetooth-dev libenet-dev liblzo2-dev libminiupnpc-dev libopenal-dev libpulse-dev libreadline-dev libsfml-dev libsoil-dev libsoundtouch-dev libswscale-dev libusb-1.0-0-dev libxext-dev libxi-dev libxrandr-dev portaudio19-dev zlib1g-dev libudev-dev libevdev-dev libmbedtls-dev libcurl4-openssl-dev libegl1-mesa-dev qtbase5-private-dev)

--- a/scriptmodules/emulators/drastic.sh
+++ b/scriptmodules/emulators/drastic.sh
@@ -14,7 +14,7 @@ rp_module_desc="NDS emu - DraStic"
 rp_module_help="ROM Extensions: .nds .zip\n\nCopy your Nintendo DS roms to $romdir/nds"
 rp_module_licence="PROP"
 rp_module_section="exp"
-rp_module_flags="!mali !x86 !armv6"
+rp_module_flags="!all arm !armv6 !mali"
 
 function depends_drastic() {
     getDepends libasound2-dev libsdl2-dev zlib1g-dev

--- a/scriptmodules/emulators/fs-uae.sh
+++ b/scriptmodules/emulators/fs-uae.sh
@@ -14,7 +14,7 @@ rp_module_desc="Amiga emulator - FS-UAE integrates the most accurate Amiga emula
 rp_module_help="ROM Extension: .adf  .adz .dms .ipf .zip\n\nCopy your Amiga games to $romdir/amiga\n\nCopy a required BIOS file (e.g. kick13.rom) to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/FrodeSolheim/fs-uae/master/COPYING"
 rp_module_section="exp"
-rp_module_flags="!arm"
+rp_module_flags="!all !arm x11"
 
 function depends_fs-uae() {
     case "$__os_id" in

--- a/scriptmodules/emulators/gngeopi.sh
+++ b/scriptmodules/emulators/gngeopi.sh
@@ -14,7 +14,7 @@ rp_module_desc="NeoGeo emulator GnGeoPi"
 rp_module_help="ROM Extension: .zip\n\nCopy your GnGeoPi roms to $romdir/neogeo\n\nCopy the required BIOS file neogeo.zip BIOS to $romdir/neogeo"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/ymartel06/GnGeo-Pi/master/gngeo/COPYING"
 rp_module_section="opt"
-rp_module_flags="!x86 !mali !kms"
+rp_module_flags="!all arm !mali !kms"
 
 function depends_gngeopi() {
     getDepends libsdl1.2-dev

--- a/scriptmodules/emulators/gpsp.sh
+++ b/scriptmodules/emulators/gpsp.sh
@@ -14,7 +14,7 @@ rp_module_desc="GameBoy Advance emulator"
 rp_module_help="ROM Extensions: .gba .zip\n\nCopy your Game Boy Advance roms to $romdir/gba\n\nCopy the required BIOS file gba_bios.bin to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/gizmo98/gpsp/master/COPYING.DOC"
 rp_module_section="opt"
-rp_module_flags="noinstclean !x86 !mali !kms"
+rp_module_flags="noinstclean !all arm !mali !kms"
 
 function depends_gpsp() {
     getDepends libsdl1.2-dev libraspberrypi-dev

--- a/scriptmodules/emulators/mame4all.sh
+++ b/scriptmodules/emulators/mame4all.sh
@@ -14,7 +14,7 @@ rp_module_desc="MAME emulator MAME4All-Pi"
 rp_module_help="ROM Extension: .zip\n\nCopy your MAME4all-Pi roms to either $romdir/mame-mame4all or\n$romdir/arcade"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/RetroPie/mame4all-pi/master/readme.txt"
 rp_module_section="opt armv6=main"
-rp_module_flags="!x11 !mali !kms !vero4k"
+rp_module_flags="!all videocore"
 
 function depends_mame4all() {
     getDepends libasound2-dev libsdl1.2-dev libraspberrypi-dev

--- a/scriptmodules/emulators/pcsx-rearmed.sh
+++ b/scriptmodules/emulators/pcsx-rearmed.sh
@@ -14,7 +14,7 @@ rp_module_desc="Playstation emulator - PCSX (arm optimised)"
 rp_module_help="ROM Extensions: .bin .cue .cbn .img .iso .m3u .mdf .pbp .toc .z .znx\n\nCopy your PSX roms to $romdir/psx\n\nCopy the required BIOS file SCPH1001.BIN to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/notaz/pcsx_rearmed/master/COPYING"
 rp_module_section="opt"
-rp_module_flags="dispmanx !x86 !mali !kms"
+rp_module_flags="dispmanx !all videocore"
 
 function depends_pcsx-rearmed() {
     getDepends libsdl1.2-dev libasound2-dev libpng-dev libx11-dev

--- a/scriptmodules/emulators/pcsx2.sh
+++ b/scriptmodules/emulators/pcsx2.sh
@@ -14,7 +14,7 @@ rp_module_desc="PS2 emulator PCSX2"
 rp_module_help="ROM Extensions: .bin .iso .img .mdf .z .z2 .bz2 .cso .ima .gz\n\nCopy your PS2 roms to $romdir/ps2\n\nCopy the required BIOS file to $biosdir"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/PCSX2/pcsx2/master/COPYING.GPLv3"
 rp_module_section="exp"
-rp_module_flags="!arm"
+rp_module_flags="!all x86"
 
 function depends_pcsx2() {
     if isPlatform "64bit"; then

--- a/scriptmodules/emulators/pifba.sh
+++ b/scriptmodules/emulators/pifba.sh
@@ -14,7 +14,7 @@ rp_module_desc="FBA emulator PiFBA"
 rp_module_help="ROM Extension: .zip\n\nCopy your FBA roms to\n$romdir/fba or\n$romdir/neogeo or\n$romdir/arcade\n\nFor NeoGeo games the neogeo.zip BIOS is required and must be placed in the same directory as your FBA roms."
 rp_module_licence="GPL2 https://raw.githubusercontent.com/RetroPie/pifba/master/FBAcapex_src/COPYING"
 rp_module_section="opt armv6=main"
-rp_module_flags="!x11 !mali !kms !vero4k"
+rp_module_flags="!all videocore"
 
 function depends_pifba() {
     getDepends libasound2-dev libsdl1.2-dev libraspberrypi-dev

--- a/scriptmodules/emulators/pisnes.sh
+++ b/scriptmodules/emulators/pisnes.sh
@@ -14,7 +14,7 @@ rp_module_desc="SNES emulator PiSNES"
 rp_module_help="ROM Extensions: .bin .smc .sfc .fig .swc .mgd .zip\n\nCopy your SNES roms to $romdir/snes"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/RetroPie/pisnes/master/snes9x.h"
 rp_module_section="opt"
-rp_module_flags="!x86 !mali !kms"
+rp_module_flags="!all videocore"
 
 function depends_pisnes() {
     getDepends libasound2-dev libsdl1.2-dev libraspberrypi-dev libjpeg-dev

--- a/scriptmodules/emulators/redream.sh
+++ b/scriptmodules/emulators/redream.sh
@@ -14,7 +14,7 @@ rp_module_desc="Redream Dreamcast emulator"
 rp_module_help="ROM Extensions: .cdi .cue .chd .gdi .iso\n\nCopy your Dreamcast roms to $romdir/dreamcast"
 rp_module_licence="PROP"
 rp_module_section="exp"
-rp_module_flags="noinstclean !x86 !x11 !mali"
+rp_module_flags="noinstclean !all rpi3 rpi4 !videocore"
 
 function install_bin_redream() {
     downloadAndExtract "https://redream.io/download/redream.aarch32-raspberry-linux-latest.tar.gz" "$md_inst"

--- a/scriptmodules/emulators/rpix86.sh
+++ b/scriptmodules/emulators/rpix86.sh
@@ -14,7 +14,7 @@ rp_module_desc="DOS Emulator rpix86"
 rp_module_help="ROM Extensions: .bat .com .exe .sh\n\nCopy your DOS games to $romdir/pc"
 rp_module_licence="FREEWARE http://rpix86.patrickaalto.com/rdown.html"
 rp_module_section="opt"
-rp_module_flags="!x86 !mali !kms"
+rp_module_flags="!all rpi !kms"
 
 function install_bin_rpix86() {
     downloadAndExtract "$__archive_url/rpix86.tar.gz" "$md_inst"

--- a/scriptmodules/emulators/snes9x.sh
+++ b/scriptmodules/emulators/snes9x.sh
@@ -14,7 +14,7 @@ rp_module_desc="SNES emulator SNES9X-RPi"
 rp_module_help="ROM Extensions: .bin .smc .sfc .fig .swc .mgd .zip\n\nCopy your SNES roms to $romdir/snes"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/RetroPie/snes9x-rpi/master/snes9x.h"
 rp_module_section="opt"
-rp_module_flags="dispmanx !x86 !mali !kms"
+rp_module_flags="dispmanx !all videocore"
 
 function depends_snes9x() {
     getDepends libsdl1.2-dev libboost-thread-dev libboost-system-dev libsdl-ttf2.0-dev libasound2-dev

--- a/scriptmodules/emulators/uae4all.sh
+++ b/scriptmodules/emulators/uae4all.sh
@@ -14,7 +14,7 @@ rp_module_desc="Amiga emulator UAE4All"
 rp_module_help="ROM Extension: .adf\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/RetroPie/uae4all2/retropie/copying"
 rp_module_section="opt"
-rp_module_flags="dispmanx !x86 !mali !kms"
+rp_module_flags="dispmanx !all videocore"
 
 function depends_uae4all() {
     getDepends libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev libsdl-gfx1.2-dev libsdl-ttf2.0-dev

--- a/scriptmodules/emulators/uae4arm.sh
+++ b/scriptmodules/emulators/uae4arm.sh
@@ -14,7 +14,7 @@ rp_module_desc="Amiga emulator with JIT support"
 rp_module_help="ROM Extension: .adf\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir"
 rp_module_licence="GPL2"
 rp_module_section="opt"
-rp_module_flags="!x86 !mali !kms"
+rp_module_flags="!all videocore"
 
 function depends_uae4arm() {
     getDepends libsdl1.2-dev libsdl-gfx1.2-dev libsdl-ttf2.0-dev libguichan-dev libmpg123-dev libxml2-dev libflac-dev "${@}"

--- a/scriptmodules/libretrocores/lr-beetle-saturn.sh
+++ b/scriptmodules/libretrocores/lr-beetle-saturn.sh
@@ -14,7 +14,7 @@ rp_module_desc="Saturn emulator - Mednafen Saturn port for libretro"
 rp_module_help="ROM Extensions: .chd .cue\n\nCopy your Saturn roms to $romdir/saturn\n\nCopy the required BIOS files sega_101.bin / mpr-17933.bin to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/beetle-saturn-libretro/master/COPYING"
 rp_module_section="exp"
-rp_module_flags="!arm !aarch64 !32bit"
+rp_module_flags="!armv6"
 
 function sources_lr-beetle-saturn() {
     gitPullOrClone "$md_build" https://github.com/libretro/beetle-saturn-libretro.git

--- a/scriptmodules/libretrocores/lr-bsnes.sh
+++ b/scriptmodules/libretrocores/lr-bsnes.sh
@@ -14,7 +14,7 @@ rp_module_desc="Super Nintendo emu - bsnes port for libretro"
 rp_module_help="ROM Extensions: .bin .smc .sfc .fig .swc .mgd .zip\n\nCopy your SNES roms to $romdir/snes"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/bsnes-libretro/libretro/COPYING"
 rp_module_section="opt"
-rp_module_flags="!arm"
+rp_module_flags="!armv6"
 
 function sources_lr-bsnes() {
     gitPullOrClone "$md_build" https://github.com/libretro/bsnes-libretro.git

--- a/scriptmodules/libretrocores/lr-dolphin.sh
+++ b/scriptmodules/libretrocores/lr-dolphin.sh
@@ -14,7 +14,7 @@ rp_module_desc="Gamecube/Wii emulator - Dolphin port for libretro"
 rp_module_help="ROM Extensions: .gcm .iso .wbfs .ciso .gcz\n\nCopy your gamecube roms to $romdir/gc and Wii roms to $romdir/wii"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/dolphin/master/license.txt"
 rp_module_section="exp"
-rp_module_flags="!arm !aarch64"
+rp_module_flags="!all 64bit"
 
 function depends_lr-dolphin() {
     depends_dolphin

--- a/scriptmodules/libretrocores/lr-gpsp.sh
+++ b/scriptmodules/libretrocores/lr-gpsp.sh
@@ -14,7 +14,7 @@ rp_module_desc="GBA emu - gpSP port for libretro"
 rp_module_help="ROM Extensions: .gba .zip\n\nCopy your Game Boy Advance roms to $romdir/gba\n\nCopy the required BIOS file gba_bios.bin to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/gpsp/master/COPYING"
 rp_module_section="opt arm=main"
-rp_module_flags="!x86"
+rp_module_flags="!all arm"
 
 function sources_lr-gpsp() {
     gitPullOrClone "$md_build" https://github.com/libretro/gpsp.git

--- a/scriptmodules/libretrocores/lr-kronos.sh
+++ b/scriptmodules/libretrocores/lr-kronos.sh
@@ -14,7 +14,7 @@ rp_module_desc="Saturn & ST-V emulator - Kronos port for libretro"
 rp_module_help="ROM Extensions: .iso .cue .zip .ccd .mds\n\nCopy your Sega Saturn & ST-V roms to $romdir/saturn\n\nCopy the required BIOS file saturn_bios.bin / stvbios.zip to $biosdir/kronos"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/yabause/kronos/yabause/COPYING"
 rp_module_section="exp"
-rp_module_flags="!arm !aarch64"
+rp_module_flags="!armv6"
 
 function sources_lr-kronos() {
     gitPullOrClone "$md_build" https://github.com/libretro/yabause.git kronos

--- a/scriptmodules/libretrocores/lr-mupen64plus-next.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus-next.sh
@@ -14,7 +14,7 @@ rp_module_desc="N64 emulator - Mupen64Plus + GLideN64 for libretro (next version
 rp_module_help="ROM Extensions: .z64 .n64 .v64\n\nCopy your N64 roms to $romdir/n64"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mupen64plus-libretro-nx/master/LICENSE"
 rp_module_section="opt kms=main"
-rp_module_flags="!armv6"
+rp_module_flags=""
 
 function depends_lr-mupen64plus-next() {
     local depends=(flex bison libpng-dev)

--- a/scriptmodules/libretrocores/lr-redream.sh
+++ b/scriptmodules/libretrocores/lr-redream.sh
@@ -14,7 +14,7 @@ rp_module_desc="Dreamcast emulator - redream port for libretro"
 rp_module_help="ROM Extensions: .cdi .gdi\n\nCopy your Dreamcast roms to $romdir/dreamcast\n\nCopy the required BIOS files dc_boot.bin and dc_flash.bin to $biosdir"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/redream/master/LICENSE.txt"
 rp_module_section="exp"
-rp_module_flags="!arm !aarch64"
+rp_module_flags="!armv6"
 
 function sources_lr-redream() {
     gitPullOrClone "$md_build" https://github.com/libretro/redream.git

--- a/scriptmodules/libretrocores/lr-snes9x2002.sh
+++ b/scriptmodules/libretrocores/lr-snes9x2002.sh
@@ -14,7 +14,7 @@ rp_module_desc="Super Nintendo emu - ARM optimised Snes9x 1.39 port for libretro
 rp_module_help="Previously called lr-pocketsnes\n\nROM Extensions: .bin .smc .sfc .fig .swc .mgd .zip\n\nCopy your SNES roms to $romdir/snes"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/snes9x2002/master/src/copyright.h"
 rp_module_section="opt armv6=main"
-rp_module_flags="!x86 !aarch64"
+rp_module_flags="!all arm"
 
 function _update_hook_lr-snes9x2002() {
     # move from old location and update emulators.cfg

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -384,11 +384,24 @@ function rp_registerModule() {
     local flag
     local valid=1
 
+    # flags are parsed in the order provided in the module - so the !all flag only makes sense first
+    # by default modules are enabled for all platforms
     if [[ "$__ignore_flags" -ne 1 ]]; then
         for flag in "${flags[@]}"; do
+            # !all excludes the module from all platforms
+            if [[ "$flag" == "!all" ]]; then
+                valid=0
+                continue
+            fi
+            # flags without ! make the module valid for the platform
+            if isPlatform "$flag"; then
+                valid=1
+                continue
+            fi
+            # flags with !flag will exclude the module for the platform
             if [[ "$flag" =~ ^\!(.+) ]] && isPlatform "${BASH_REMATCH[1]}"; then
                 valid=0
-                break
+                continue
             fi
         done
     fi

--- a/scriptmodules/ports/giana.sh
+++ b/scriptmodules/ports/giana.sh
@@ -13,7 +13,7 @@ rp_module_id="giana"
 rp_module_desc="Giana's Return"
 rp_module_license="NONCOM https://www.gianas-return.de/?page_id=6"
 rp_module_section="opt"
-rp_module_flags="!x86 !mali !kms"
+rp_module_flags="!all videocore"
 
 function depends_giana() {
     getDepends libsdl1.2-dev libsdl-mixer1.2-dev libraspberrypi-dev

--- a/scriptmodules/ports/ioquake3.sh
+++ b/scriptmodules/ports/ioquake3.sh
@@ -13,7 +13,7 @@ rp_module_id="ioquake3"
 rp_module_desc="Quake 3 source port"
 rp_module_licence="GPL2 https://github.com/ioquake/ioq3/blob/master/COPYING.txt"
 rp_module_section="opt"
-rp_module_flags="!mali !videocore"
+rp_module_flags="!videocore"
 
 function depends_ioquake3() {
     getDepends libsdl2-dev libgl1-mesa-dev

--- a/scriptmodules/ports/minecraft.sh
+++ b/scriptmodules/ports/minecraft.sh
@@ -13,7 +13,7 @@ rp_module_id="minecraft"
 rp_module_desc="Minecraft - Pi Edition"
 rp_module_licence="PROP"
 rp_module_section="exp"
-rp_module_flags="!mali !x86"
+rp_module_flags="!all rpi"
 
 function depends_minecraft() {
     getDepends xorg matchbox-window-manager

--- a/scriptmodules/ports/quake3.sh
+++ b/scriptmodules/ports/quake3.sh
@@ -13,7 +13,7 @@ rp_module_id="quake3"
 rp_module_desc="Quake 3"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/raspberrypi/quake3/master/COPYING.txt"
 rp_module_section="opt"
-rp_module_flags="!x86 !mali !kms"
+rp_module_flags="!all videocore"
 
 function depends_quake3() {
     getDepends libsdl1.2-dev libraspberrypi-dev

--- a/scriptmodules/ports/steamlink.sh
+++ b/scriptmodules/ports/steamlink.sh
@@ -13,7 +13,7 @@ rp_module_id="steamlink"
 rp_module_desc="Steam Link for Raspberry Pi 3 or later"
 rp_module_licence="PROP https://steamcommunity.com/app/353380/discussions/0/1743353164093954254/"
 rp_module_section="exp"
-rp_module_flags="!mali !x86 !rpi1 !rpi2"
+rp_module_flags="!all rpi3 rpi4"
 rp_module_help="Stream games from your computer with Steam"
 
 function depends_steamlink() {

--- a/scriptmodules/supplementary/controlblock.sh
+++ b/scriptmodules/supplementary/controlblock.sh
@@ -14,7 +14,7 @@ rp_module_desc="ControlBlock Driver"
 rp_module_help="Please note that you need to manually enable or disable the ControlBlock Service in the Configuration section. IMPORTANT: If the service is enabled and the power switch functionality is enabled (which is the default setting) in the config file, you need to have a switch connected to the ControlBlock."
 rp_module_license="NONCOM https://raw.githubusercontent.com/petrockblog/ControlBlockService2/master/LICENSE.txt"
 rp_module_section="driver"
-rp_module_flags="noinstclean !x86 !mali"
+rp_module_flags="noinstclean !all rpi"
 
 function depends_controlblock() {
     local depends=(cmake doxygen)

--- a/scriptmodules/supplementary/gamecondriver.sh
+++ b/scriptmodules/supplementary/gamecondriver.sh
@@ -13,7 +13,7 @@ rp_module_id="gamecondriver"
 rp_module_desc="Gamecon & Db9 drivers GPIO drivers"
 rp_module_license="GPL2 https://raw.githubusercontent.com/marqs85/gamecon_gpio_rpi/master/gamecon_gpio_rpi-1.4/gamecon_gpio_rpi.c"
 rp_module_section="driver"
-rp_module_flags="!x86 !mali"
+rp_module_flags="!all rpi"
 
 function depends_gamecondriver() {
     # remove any old kernel headers for current kernel

--- a/scriptmodules/supplementary/mkarcadejoystick.sh
+++ b/scriptmodules/supplementary/mkarcadejoystick.sh
@@ -14,7 +14,7 @@ rp_module_desc="Raspberry Pi GPIO Joystick Driver"
 rp_module_help="Installs the GPIO driver from https://github.com/cmitu/mk_arcade_joystick_rpi"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/recalbox/mk_arcade_joystick_rpi/master/LICENSE"
 rp_module_section="driver"
-rp_module_flags="noinstclean !x86 !mali"
+rp_module_flags="noinstclean !all rpi"
 
 function _version_mkarcadejoystick() {
     echo "0.1.7"

--- a/scriptmodules/supplementary/moonlight.sh
+++ b/scriptmodules/supplementary/moonlight.sh
@@ -14,7 +14,7 @@ rp_module_desc="Moonlight Embedded - an open source gamestream client for embedd
 rp_module_help="ROM Extensions: .ml\n\nCopy your moonlight launch configurations to $romdir/steam\n\nDon't forget to first pair with your remote host before using moonlight. You can use the configuration menu for pairing/unpairing to/from a remote machine."
 rp_module_licence="GPL3 https://raw.githubusercontent.com/irtimmer/moonlight-embedded/master/LICENSE"
 rp_module_section="exp"
-rp_module_flags="!x86"
+rp_module_flags="!all arm"
 
 function _scriptmodule_cfg_file_moonlight() {
     echo "$configdir/all/moonlight/scriptmodule.cfg"

--- a/scriptmodules/supplementary/omxiv.sh
+++ b/scriptmodules/supplementary/omxiv.sh
@@ -12,7 +12,7 @@
 rp_module_id="omxiv"
 rp_module_desc="OpenMAX image viewer for the Raspberry Pi"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/cmitu/omxiv/master/LICENSE"
-rp_module_flags="!x86 !osmc !xbian !mali"
+rp_module_flags="!all rpi"
 
 function depends_omxiv() {
     getDepends libraspberrypi-dev libpng-dev libjpeg-dev

--- a/scriptmodules/supplementary/powerblock.sh
+++ b/scriptmodules/supplementary/powerblock.sh
@@ -13,7 +13,7 @@ rp_module_id="powerblock"
 rp_module_desc="PowerBlock Driver"
 rp_module_help="Please note that you need to manually enable or disable the PowerBlock Service in the Configuration section. IMPORTANT: If the service is enabled and the power switch functionality is enabled (which is the default setting) in the config file, you need to have a switch connected to the PowerBlock."
 rp_module_section="driver"
-rp_module_flags="noinstclean !x86 !mali"
+rp_module_flags="noinstclean !all rpi"
 
 function depends_powerblock() {
     local depends=(cmake doxygen)

--- a/scriptmodules/supplementary/raspbiantools.sh
+++ b/scriptmodules/supplementary/raspbiantools.sh
@@ -12,7 +12,7 @@
 rp_module_id="raspbiantools"
 rp_module_desc="Raspbian related tools"
 rp_module_section="config"
-rp_module_flags="!x11 !mali"
+rp_module_flags="!all rpi"
 
 function apt_upgrade_raspbiantools() {
     # install an older kernel/firmware for stretch to resolve newer kernel issues or unhold if updating to a newer release

--- a/scriptmodules/supplementary/sdl1.sh
+++ b/scriptmodules/supplementary/sdl1.sh
@@ -13,7 +13,7 @@ rp_module_id="sdl1"
 rp_module_desc="SDL 1.2.15 with rpi fixes and dispmanx"
 rp_module_licence="GPL2 https://hg.libsdl.org/SDL/raw-file/7676476631ce/COPYING"
 rp_module_section=""
-rp_module_flags="!mali !x86"
+rp_module_flags="!all rpi"
 
 function get_pkg_ver_sdl1() {
     local basever

--- a/scriptmodules/supplementary/splashscreen.sh
+++ b/scriptmodules/supplementary/splashscreen.sh
@@ -12,7 +12,7 @@
 rp_module_id="splashscreen"
 rp_module_desc="Configure Splashscreen"
 rp_module_section="main"
-rp_module_flags="noinstclean !x86 !osmc !xbian !mali"
+rp_module_flags="noinstclean !all rpi !osmc !xbian"
 
 function _update_hook_splashscreen() {
     # make sure splashscreen is always up to date if updating just RetroPie-Setup


### PR DESCRIPTION
packages - expand platform flags to allow excluding all platforms and including certain ones

This should be backward compatible with the previous behaviour. By default all platforms are included.
Previously if you wanted a rpi+videocore only module you had to use lots of flags to exclude other platforms - eg

!x86 !mali !kms

which isn't ideal as new platforms are added.
Now this can be changed now by using a !all flag

!all videocore

which would first exclude all platforms, then enable the module just for videocore.