### PR TITLE
runcommand: override locale settings for printf

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -405,7 +405,7 @@ function get_x11_mode_info() {
     mode_info[4]="n/a"
 
     # get refresh rate (stripping Hz, rounded to integer)
-    mode_info[5]="$(printf '%.0f\n' ${status[3]::-2})"
+    mode_info[5]="$(LC_NUMERIC=C printf '%.0f\n' ${status[3]::-2})"
 
     echo "${mode_info[@]}"
 }


### PR DESCRIPTION
Reported in https://retropie.org.uk/forum/topic/24822/, affecting the X11 video modes calculation.

When a locale where `.` is not a decimal separator, `printf` throws an error when trying to round the refresh rate:
```
pi@retropie $ _number=60.02 && LC_ALL=ru_RU.UTF-8 printf '%.0f\n' ${_number::-2}
-bash: printf: 60.: invalid number
```

Overriding the `LC_NUMERIC` locale for the `printf` call seems ok.