### PR TITLE
reicast: remove 'Start' link when emulator is removed

### DIFF
--- a/scriptmodules/emulators/reicast.sh
+++ b/scriptmodules/emulators/reicast.sh
@@ -116,15 +116,16 @@ function configure_reicast() {
 
     chown -R $user:$user "$md_conf_root/dreamcast"
 
-    cat > "$romdir/dreamcast/+Start Reicast.sh" << _EOF_
+    if [[ "$md_mode" == "install" ]]; then
+        cat > "$romdir/dreamcast/+Start Reicast.sh" << _EOF_
 #!/bin/bash
 $md_inst/bin/reicast.sh
 _EOF_
-    chmod a+x "$romdir/dreamcast/+Start Reicast.sh"
-    chown $user:$user "$romdir/dreamcast/+Start Reicast.sh"
-
-    # remove old systemManager.cdi symlink
-    rm -f "$romdir/dreamcast/systemManager.cdi"
+        chmod a+x "$romdir/dreamcast/+Start Reicast.sh"
+        chown $user:$user "$romdir/dreamcast/+Start Reicast.sh"
+    else
+        rm "$romdir/dreamcast/+Start Reicast.sh"
+    fi
 
     if [[ "$md_mode" == "install" ]]; then
         # possible audio backends: alsa, oss, omx


### PR DESCRIPTION
Should fix https://github.com/RetroPie/RetroPie-Setup/issues/2998.