### PR TITLE
Unneeded vero4k/mali reference

### DIFF
--- a/scriptmodules/supplementary/sdl2.sh
+++ b/scriptmodules/supplementary/sdl2.sh
@@ -23,7 +23,6 @@ function get_pkg_ver_sdl2() {
     local ver="$(get_ver_sdl2)+5"
     isPlatform "rpi" && ver+="rpi"
     isPlatform "mali" && ver+="mali"
-    isPlatform "vero4k" && ver+="mali"
     echo "$ver"
 }
 


### PR DESCRIPTION
Sorry, you'd closed the previous PR before I'd finished.  Found this straggler that yields a "malimali", which obviously breaks the binary download path (we host our own now)...

The only other optimisations I can see are to move a few `isPlatform "vero4k" && depends+=(vero3-userland-dev-osmc)` lines - that don't involve any other module specific packages - to helpers.sh. 

Those are in ScummVM, Reicast and PPSSPP.  I know there are similar lines for the RPi, but it's an option anyway.  Thoughts?