### PR TITLE
retroarch - backport menu widget corruption fix to our v1.8.4

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -43,6 +43,7 @@ function sources_retroarch() {
     applyPatch "$md_data/01_hotkey_hack.diff"
     applyPatch "$md_data/02_disable_search.diff"
     applyPatch "$md_data/03_shader_path_config_enable.diff"
+    applyPatch "$md_data/04_fix_corrupted_widgets.diff"
 }
 
 function build_retroarch() {

--- a/scriptmodules/emulators/retroarch/04_fix_corrupted_widgets.diff
+++ b/scriptmodules/emulators/retroarch/04_fix_corrupted_widgets.diff
@@ -1,0 +1,13 @@
+diff --git a/retroarch.c b/retroarch.c
+index b89de3520f..02a3912e49 100644
+--- a/retroarch.c
++++ b/retroarch.c
+@@ -23402,7 +23402,7 @@ void driver_set_nonblock_state(void)
+  **/
+ static void drivers_init(int flags)
+ {
+-   bool video_is_threaded = false;
++   bool video_is_threaded = video_driver_is_threaded_internal();
+    settings_t *settings   = configuration_settings;
+ 
+ #ifdef HAVE_MENU


### PR DESCRIPTION
 * backport https://github.com/libretro/RetroArch/pull/10246