### PR TITLE
Added squiglies around CPU Temperature variables

### DIFF
--- a/scriptmodules/supplementary/bashwelcometweak.sh
+++ b/scriptmodules/supplementary/bashwelcometweak.sh
@@ -123,7 +123,7 @@ function retropie_welcome() {
                 out+="${fgred}IP Address.........: $(getIPAddress)"
                 ;;
             9)
-                out+="Temperature........: CPU: $cpuTempC°C/$cpuTempF°F GPU: $gpuTempC°C/$gpuTempF°F"
+                out+="Temperature........: CPU: ${cpuTempC}°C/${cpuTempF}°F GPU: ${gpuTempC}°C/${gpuTempF}°F"
                 ;;
             10)
                 out+="${fgwht}The RetroPie Project, https://retropie.org.uk"


### PR DESCRIPTION
I added squigly brackets around the CPU Temp variables in the output string.  This is what made the display work correctly for me on my latest version of Raspian on a Raspberry Pi 4.  I suspect that BASH was trying to use the temperature symbol as part of the variable name.