### PR TITLE
advmame: disable multithreading temporary to resolve a crash

### DIFF
--- a/scriptmodules/emulators/advmame.sh
+++ b/scriptmodules/emulators/advmame.sh
@@ -121,6 +121,8 @@ function configure_advmame() {
             iniSet "device_keyboard" "sdl"
             # default for best performance
             iniSet "display_magnify" "1"
+            # disable threading to get rid of the crash-on-exit when using SDL, preventing config save
+            initSet "misc_smp" "no"
         else
             iniSet "device_video_output" "overlay"
             iniSet "display_aspectx" 16


### PR DESCRIPTION
This happens on the PI4, where `sdl` is the only usable video/input driver.
The race seems to be happening when waiting for the video thread to stop [here](https://github.com/amadvance/advancemame/blob/d951cdd530c30d9b3129b0d215e0163e6b71ce27/advance/osd/video.c#L1006), but for some reason the video thread is not closing (?) and the `pthread_join` call yields a SIGSEGV signal.