### PR TITLE
sdl1 / sdl2 - add __binary_url functions and rework packaging logic

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -301,12 +301,7 @@ function getDepends() {
 
     # install any custom packages
     for pkg in ${own_pkgs[@]}; do
-       # we need to check if we have binaries else install_bin for sdl1/sdl2 could fail
-       if [[ "$__has_binaries" -eq 1 ]]; then
-           rp_callModule "$pkg" _auto_
-       else
-           rp_callModule "$pkg"
-       fi
+       rp_callModule "$pkg" _auto_
     done
 
     aptInstall --no-install-recommends "${apt_pkgs[@]}"

--- a/scriptmodules/supplementary/sdl1.sh
+++ b/scriptmodules/supplementary/sdl1.sh
@@ -75,11 +75,12 @@ function install_sdl1() {
     echo "libsdl1.2-dev hold" | dpkg --set-selections
 }
 
+
+function __binary_url_sdl1() {
+    rp_hasBinaries && echo "$__binary_url/libsdl1.2debian_$(get_pkg_ver_sdl1)_armhf.deb"
+}
+
 function install_bin_sdl1() {
-    if ! isPlatform "rpi"; then
-        md_ret_errors+=("$md_id is only available as a binary package for platform rpi")
-        return 1
-    fi
     wget "$__binary_url/libsdl1.2debian_$(get_pkg_ver_sdl1)_armhf.deb"
     wget "$__binary_url/libsdl1.2-dev_$(get_pkg_ver_sdl1)_armhf.deb"
     install_sdl1

--- a/scriptmodules/supplementary/sdl2.sh
+++ b/scriptmodules/supplementary/sdl2.sh
@@ -126,11 +126,11 @@ function install_sdl2() {
     echo "libsdl2-dev hold" | dpkg --set-selections
 }
 
+function __binary_url_sdl2() {
+    rp_hasBinaries && echo "$__binary_url/libsdl2-dev_$(get_pkg_ver_sdl2)_armhf.deb"
+}
+
 function install_bin_sdl2() {
-    if ! isPlatform "rpi"; then
-        md_ret_errors+=("$md_id is only available as a binary package for platform rpi")
-        return 1
-    fi
     wget -c "$__binary_url/libsdl2-dev_$(get_pkg_ver_sdl2)_armhf.deb"
     wget -c "$__binary_url/libsdl2-2.0-0_$(get_pkg_ver_sdl2)_armhf.deb"
     install_sdl2


### PR DESCRIPTION
 * create a rp_getBinaryUrl function to get the binary url of a package
 * if a module has a __binary_url and it returns an empty string, treat this as no binary available - this allows removing hardcoded logic for sdl1/sdl2 from getDepends
 * if a module doesn't have this function but it has its own install_bin don't test for a binary and assume it's ok