### PR TITLE
nestopia: remove the board database file from the package installation

### DIFF
--- a/scriptmodules/libretrocores/lr-nestopia.sh
+++ b/scriptmodules/libretrocores/lr-nestopia.sh
@@ -31,7 +31,6 @@ function build_lr-nestopia() {
 function install_lr-nestopia() {
     md_ret_files=(
         'libretro/nestopia_libretro.so'
-        'NstDatabase.xml'
         'COPYING'
     )
 }


### PR DESCRIPTION
Nestopia doesn't need an external `NstDatabase.xml` file anymore, it's been added to the core source file in [this commit](https://github.com/libretro/nestopia/commit/354fa2f0f3bb9884988b05a6bc0e60dae961bec4).