### PR TITLE
stats: modify the pkgflags stats logic after the flags reorganization

### DIFF
--- a/scriptmodules/admin/stats/pkgflags/app.js
+++ b/scriptmodules/admin/stats/pkgflags/app.js
@@ -92,6 +92,32 @@ function create_commit_info(commit) {
 	document.getElementById('commit').innerHTML = text;
 }
 
+function package_enabled_for(pkg, flag) {
+	const video_flag_synonyms = {
+		'videocore' : [ 'arm', 'rpi', 'rpi1', 'rpi2', 'rpi3', 'dispmanx', 'gles' ],
+		'mali'     : [ 'arm' , 'gles' ],
+		'kms'      : [ 'arm' , 'rpi', 'rpi4', 'dispmanx', 'mesa' , 'gles3' ],
+		'x11'      : [ 'x86' , '64bit', 'mesa' ]
+	};
+
+	var equivs = (video_flag_synonyms[flag] ? [flag].concat(video_flag_synonyms[flag]) : [flag]);
+
+	if ( pkg.flags.includes('!all') ) {
+		return _flags_include(pkg.flags, equivs) && !_flags_exclude(pkg.flags, equivs);
+	} else {
+		return !_flags_exclude(pkg.flags, equivs);
+	}
+
+}
+
+function _flags_include(pkg_flags, flags) {
+	return flags.reduce( (acc, flag) => acc || pkg_flags.includes(flag), false);
+}
+
+function _flags_exclude(pkg_flags, flags) {
+	return flags.reduce( (acc, flag) => acc || pkg_flags.includes('!' + flag), false);
+}
+
 function append_pkg_text_cell(parent, klass, text) {
 	const cell = document.createElement('td');
 	cell.innerText = text;
@@ -129,12 +155,13 @@ function create_section_thead() {
 
 function create_section_row(pkg) {
 	const row = document.createElement('tr');
+	row.title='Script flags: ' + pkg.flags.join(' ');
 	append_pkg_text_cell(row, 'id', pkg.id);
 	append_pkg_text_cell(row, 'desc', pkg.desc);
-	append_pkg_flag_cell(row, 'video', !pkg.flags.includes('!videocore'));
-	append_pkg_flag_cell(row, 'video', !pkg.flags.includes('!mali'));
-	append_pkg_flag_cell(row, 'video', !pkg.flags.includes('!kms'));
-	append_pkg_flag_cell(row, 'video', !pkg.flags.includes('!x11'));
+	append_pkg_flag_cell(row, 'video', package_enabled_for(pkg, 'videocore'));
+	append_pkg_flag_cell(row, 'video', package_enabled_for(pkg, 'mali'));
+	append_pkg_flag_cell(row, 'video', package_enabled_for(pkg, 'kms'));
+	append_pkg_flag_cell(row, 'video', package_enabled_for(pkg, 'x11'));
 	append_pkg_flag_cell(row, 'cpu', !pkg.flags.includes('!arm') && !pkg.flags.includes('!armv6'));
 	append_pkg_flag_cell(row, 'cpu', !pkg.flags.includes('!arm') && !pkg.flags.includes('!armv7'));
 	append_pkg_flag_cell(row, 'cpu', !pkg.flags.includes('!arm') && !pkg.flags.includes('!armv8'));


### PR DESCRIPTION
After https://github.com/RetroPie/RetroPie-Setup/pull/3000, the logic for calculating the Video category for a package has changed with the introduction of the `!all` flag. The modification updates the `pkgflags` page to better match a package to the corresponding video section (Mali/DRM&KMD/VideoCore/X11).

I also added a title (which should be visible as a tool tip on a desktop browser) on each package row entry to show the script flags, just to make it easier to spot errors.