### PR TITLE
Packaging / setup tweaks

### DIFF
--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -319,7 +319,7 @@ function section_gui_setup() {
 
         if [[ "$num_pkgs" -gt 0 ]]; then
             options+=(
-                U "Update all ${__sections[$section]} packages" "This will update any installed ${__sections[$section]} packages. The packages will be updated by the method used previously."
+                U "Update all installed ${__sections[$section]} packages" "This will update any installed ${__sections[$section]} packages. The packages will be updated by the method used previously."
             )
         fi
 

--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -300,7 +300,8 @@ function section_gui_setup() {
         local num_pkgs=0
         for idx in $(rp_getSectionIds $section); do
             if rp_isInstalled "$idx"; then
-                installed="(Installed)"
+                eval $(rp_getPackageInfo "$idx")
+                installed="\Zb(Installed - via $pkg_origin)\Zn"
                 ((num_pkgs++))
             else
                 installed=""
@@ -324,7 +325,7 @@ function section_gui_setup() {
 
         options+=("${pkgs[@]}")
 
-        local cmd=(dialog --backtitle "$__backtitle" --cancel-label "Back" --item-help --help-button --default-item "$default" --menu "Choose an option" 22 76 16)
+        local cmd=(dialog --colors --backtitle "$__backtitle" --cancel-label "Back" --item-help --help-button --default-item "$default" --menu "Choose an option" 22 76 16)
 
         local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
         [[ -z "$choice" ]] && break

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -17,6 +17,7 @@ __sections[opt]="optional"
 __sections[exp]="experimental"
 __sections[driver]="driver"
 __sections[config]="configuration"
+__sections[depends]="dependency"
 
 function rp_listFunctions() {
     local idx

--- a/scriptmodules/supplementary/golang.sh
+++ b/scriptmodules/supplementary/golang.sh
@@ -6,10 +6,11 @@
 # See the LICENSE.md file at the top-level directory of this distribution and
 # at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
 #
+
 rp_module_id="golang"
 rp_module_desc="Golang binary install"
 rp_module_license="BSD https://golang.org/LICENSE"
-rp_module_section=""
+rp_module_section="depends"
 rp_module_flags="noinstclean"
 
 function _get_goroot_golang() {

--- a/scriptmodules/supplementary/mesa-drm.sh
+++ b/scriptmodules/supplementary/mesa-drm.sh
@@ -12,7 +12,7 @@
 rp_module_id="mesa-drm"
 rp_module_desc="libdrm - userspace library for drm"
 rp_module_licence="MIT https://www.mesa3d.org/license.html"
-rp_module_section=""
+rp_module_section="depends"
 rp_module_flags=""
 
 function depends_mesa-drm() {

--- a/scriptmodules/supplementary/omxiv.sh
+++ b/scriptmodules/supplementary/omxiv.sh
@@ -12,6 +12,7 @@
 rp_module_id="omxiv"
 rp_module_desc="OpenMAX image viewer for the Raspberry Pi"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/cmitu/omxiv/master/LICENSE"
+rp_module_section="depends"
 rp_module_flags="!all rpi"
 
 function depends_omxiv() {

--- a/scriptmodules/supplementary/sdl1.sh
+++ b/scriptmodules/supplementary/sdl1.sh
@@ -12,7 +12,7 @@
 rp_module_id="sdl1"
 rp_module_desc="SDL 1.2.15 with rpi fixes and dispmanx"
 rp_module_licence="GPL2 https://hg.libsdl.org/SDL/raw-file/7676476631ce/COPYING"
-rp_module_section=""
+rp_module_section="depends"
 rp_module_flags="!all rpi"
 
 function get_pkg_ver_sdl1() {

--- a/scriptmodules/supplementary/sdl2.sh
+++ b/scriptmodules/supplementary/sdl2.sh
@@ -12,7 +12,7 @@
 rp_module_id="sdl2"
 rp_module_desc="SDL (Simple DirectMedia Layer) v2.x"
 rp_module_licence="ZLIB https://hg.libsdl.org/SDL/raw-file/f426dbef4aa0/COPYING.txt"
-rp_module_section=""
+rp_module_section="depends"
 rp_module_flags=""
 
 function get_ver_sdl2() {


### PR DESCRIPTION
setup - show install origin in manage package sections for overview
 * useful to get an overview - used bold markup but shows as grey from framebuffer - but is easier to read when differently styled imho

Wanted to get an opinion on this before I commit.

Also added a dependency section to setup also as now packages remember how they were installed it is useful to be able to switch between binary / source.

