### PR TITLE
joy2key - convert to python3 and use python3-pyudev dependency

### DIFF
--- a/scriptmodules/supplementary/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand.sh
@@ -31,7 +31,7 @@ function install_bin_runcommand() {
     cp "$md_data/joy2key.py" "$md_inst/"
     chmod a+x "$md_inst/runcommand.sh"
     chmod a+x "$md_inst/joy2key.py"
-    python -m compileall "$md_inst/joy2key.py"
+    python3 -m compileall "$md_inst/joy2key.py"
     if [[ ! -f "$configdir/all/runcommand.cfg" ]]; then
         mkUserDir "$configdir/all"
         iniConfig " = " '"' "$configdir/all/runcommand.cfg"

--- a/scriptmodules/supplementary/runcommand/joy2key.py
+++ b/scriptmodules/supplementary/runcommand/joy2key.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # This file is part of The RetroPie Project
 # 
@@ -136,14 +136,15 @@ def signal_handler(signum, frame):
     if (js_fds):
         close_fds(js_fds)
     if (tty_fd):
-        tty_fd.close()
+        os.close(tty_fd)
     sys.exit(0)
 
 def get_hex_chars(key_str):
     if (key_str.startswith("0x")):
-        return key_str[2:].decode('hex')
+        out = bytes.fromhex(key_str[2:])
     else:
-        return curses.tigetstr(key_str)
+        out = curses.tigetstr(key_str)
+    return out.decode('utf-8')
 
 def get_devices():
     devs = []
@@ -177,7 +178,7 @@ def read_event(fd):
     while True:
         try:
             event = os.read(fd, event_size)
-        except OSError, e:
+        except OSError as e:
             if e.errno == errno.EWOULDBLOCK:
                 return None
             return False
@@ -248,9 +249,9 @@ event_format = 'IhBB'
 event_size = struct.calcsize(event_format)
 
 try:
-    tty_fd = open('/dev/tty', 'a')
+    tty_fd = os.open('/dev/tty', os.O_WRONLY)
 except IOError:
-    print 'Unable to open /dev/tty'
+    print('Unable to open /dev/tty', file = sys.stderr)
     sys.exit(1)
 
 rescan_time = time.time()
@@ -288,7 +289,7 @@ while True:
 
     if time.time() - rescan_time > 2:
         rescan_time = time.time()
-        if cmp(js_devs, get_devices()):
+        if js_devs != get_devices():
             close_fds(js_fds)
             js_fds = []
 

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -264,7 +264,7 @@ function get_os_version() {
 }
 
 function get_retropie_depends() {
-    local depends=(git dialog wget gcc g++ build-essential unzip xmlstarlet python-pyudev ca-certificates)
+    local depends=(git dialog wget gcc g++ build-essential unzip xmlstarlet python3-pyudev ca-certificates)
 
     [[ -n "$DISTCC_HOSTS" ]] && depends+=(distcc)
 


### PR DESCRIPTION
 * Ubuntu 20.04 will no longer include python-pyudev
 * Use stderr for /dev/tty opening error msg
 * Use python3 in runcommand module for compilation
 * Open with 'append' which was added in f614804 fails with python3 on rpi4 console. Use lower level os.open and O_WRONLY to avoid possible buffer issues. Could not reproduce the ghost inputs the append was added for