### PR TITLE
dosbox - allows for larger C drive

### DIFF
--- a/scriptmodules/emulators/dosbox.sh
+++ b/scriptmodules/emulators/dosbox.sh
@@ -104,7 +104,7 @@ function midi_synth() {
 
 params=("\$@")
 if [[ -z "\${params[0]}" ]]; then
-    params=(-c "@MOUNT C $romdir/pc" -c "@C:")
+    params=(-c "@MOUNT C $romdir/pc -freesize 1024" -c "@C:")
 elif [[ "\${params[0]}" == *.sh ]]; then
     midi_synth start
     bash "\${params[@]}"

--- a/scriptmodules/emulators/dosbox.sh
+++ b/scriptmodules/emulators/dosbox.sh
@@ -111,7 +111,7 @@ elif [[ "\${params[0]}" == *.sh ]]; then
     midi_synth stop
     exit
 elif [[ "\${params[0]}" == *.conf ]]; then
-    params=(-conf "\${params[@]}")
+    params=(-userconf -conf "\${params[@]}")
 else
     params+=(-exit)
 fi

--- a/scriptmodules/emulators/dosbox.sh
+++ b/scriptmodules/emulators/dosbox.sh
@@ -111,7 +111,7 @@ elif [[ "\${params[0]}" == *.sh ]]; then
     midi_synth stop
     exit
 elif [[ "\${params[0]}" == *.conf ]]; then
-    params=(-userconf -conf "\${params[@]}")
+    params=(-conf "\${params[@]}")
 else
     params+=(-exit)
 fi


### PR DESCRIPTION
2 very small changes to improve a bit the Dosbox experience.

* larger C drive is required to install games like Fallout, M.A.X, KKND, etc. I went with 1GB to be absolutely sure but 768GB should be fine too.

* relying on the elegant method described [in the doc](http://dosonthepi.blogspot.com/2015/02/dosbox-configuration-for-individual.html) - which has you populate the **[autoexec]** section at the bottom of the .conf file (one .conf file = one game) - works great with Retropie. This allows for a single extension type (.conf) to be registered. Yet Dosbox default config file is also called anytime and along the user's own config file for the game. This comes with side effects like Mount points declared twice, sound card parameters mess and even preventing games to run. I've fixed that behavior by removing the **[-userconf](https://www.dosbox.com/DOSBoxManual.html#Parameters)** flag from the launch script (+Start....sh).

Note: it is my very first attempt at issuing a PR for Retropie (more to come for Dosbox as detailed in the [forum](https://retropie.org.uk/forum/topic/25041/dosbox-a-thread)). Therefore let me know what's wrong and I'll follow your guidance. Thanks for your time.

