### PR TITLE
love: updated license and download links, updated 'mari0' game

### DIFF
--- a/scriptmodules/ports/love-0.10.2.sh
+++ b/scriptmodules/ports/love-0.10.2.sh
@@ -12,7 +12,7 @@
 rp_module_id="love-0.10.2"
 rp_module_desc="Love - 2d Game Engine v0.10.2"
 rp_module_help="Copy your Love games to $romdir/love"
-rp_module_licence="GPL3 https://bitbucket.org/rude/love/raw/7b520c437317626da2102de1aafdad0e67b54bf5/license.txt"
+rp_module_licence="ZLIB https://raw.githubusercontent.com/love2d/love/0.10.2/license.txt"
 rp_module_section="opt"
 rp_module_flags="!aarch64"
 
@@ -21,7 +21,7 @@ function depends_love-0.10.2() {
 }
 
 function sources_love-0.10.2() {
-    hg clone https://bitbucket.org/rude/love/#0.10.2 "$md_build"
+    gitPullOrClone "$md_build" https://github.com/love2d/love 0.10.2
     # libluajit-5.1-dev in buster (and also on Ubuntu 18.04+) still has
     # LUA_VERSION_NUM defined as 501 but requires the newer luaL_Reg named struct.
     # adjusting the compatibility code #if to check for LUA_VERSION_NUM >= 501 fixes this.

--- a/scriptmodules/ports/love.sh
+++ b/scriptmodules/ports/love.sh
@@ -12,18 +12,18 @@
 rp_module_id="love"
 rp_module_desc="Love - 2d Game Engine"
 rp_module_help="Copy your Love games to $romdir/love"
-rp_module_licence="GPL3 https://bitbucket.org/rude/love/raw/7b520c437317626da2102de1aafdad0e67b54bf5/license.txt"
+rp_module_licence="ZLIB https://raw.githubusercontent.com/love2d/love/master/license.txt"
 rp_module_section="opt"
 rp_module_flags="!aarch64"
 
 function depends_love() {
-    local depends=(mercurial autotools-dev automake libtool pkg-config libdevil-dev libfreetype6-dev libluajit-5.1-dev libphysfs-dev libsdl2-dev libopenal-dev libogg-dev libtheora-dev libvorbis-dev libflac-dev libflac++-dev libmodplug-dev libmpg123-dev libmng-dev libjpeg-dev)
+    local depends=(autotools-dev automake libtool pkg-config libfreetype6-dev libluajit-5.1-dev libphysfs-dev libsdl2-dev libopenal-dev libogg-dev libtheora-dev libvorbis-dev libflac-dev libflac++-dev libmodplug-dev libmpg123-dev libmng-dev libjpeg-dev)
 
     getDepends "${depends[@]}"
 }
 
 function sources_love() {
-    hg clone https://bitbucket.org/rude/love "$md_build"
+    gitPullOrClone "$md_build" https://github.com/love2d/love
 }
 
 function build_love() {
@@ -47,9 +47,13 @@ function install_love() {
 }
 
 function game_data_love() {
-    # get Mari0 10.0 (freeware game data)
+    # get Mari0 1.6.2 (freeware game data)
     if [[ ! -f "$romdir/love/mari0.love" ]]; then
-        wget "https://github.com/radgeRayden/future-mari0/releases/download/v0.2/mari0.love" -O "$romdir/love/mari0.love"
+        downloadAndExtract "https://github.com/Stabyourself/mari0/archive/1.6.2.tar.gz" "$__tmpdir/mari0" --strip-components 1
+        pushd "$__tmpdir/mari0"
+        zip -qr "$romdir/love/mari0.love" .
+        popd
+        rm -fr "$__tmpdir/mari0"
         chown $user:$user "$romdir/love/mari0.love"
     fi
 }


### PR DESCRIPTION
* updated the license, since it's actually ZLIB and not GPL(3).
* the project has moved the source and development to Github (see https://love2d.org/wiki/Building_L%C3%96VE). 
* adjusted the dependencies to remove `mercurial` (since we're using `git` to download the sources) and `devil`, not used since [2014](https://github.com/love2d/love/commit/eca8c17a693e85635b043353e431dcb9d5012e75).
* updated the included Mari0 game to 1.6.2, compatible with the 11.2.

