### PR TITLE
retroarch - setting `video_smooth` is no longer necessary

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -157,7 +157,6 @@ function configure_retroarch() {
     iniSet "system_directory" "$biosdir"
     iniSet "config_save_on_exit" "false"
     iniSet "video_aspect_ratio_auto" "true"
-    iniSet "video_smooth" "false"
     iniSet "rgui_show_start_screen" "false"
     iniSet "rgui_browser_directory" "$romdir"
 


### PR DESCRIPTION
* `video_smooth` defaults to `false` since RetroArch 1.8.5

Ref: https://github.com/libretro/RetroArch/pull/9710