### PR TITLE
srb2: update to 2.2.2 and add extra asset file

### DIFF
--- a/scriptmodules/ports/srb2.sh
+++ b/scriptmodules/ports/srb2.sh
@@ -21,7 +21,7 @@ function depends_srb2() {
 }
 
 function sources_srb2() {
-    gitPullOrClone "$md_build" https://github.com/STJr/SRB2.git
+    gitPullOrClone "$md_build" https://github.com/STJr/SRB2.git "SRB2_release_2.2.2"
     downloadAndExtract "$__archive_url/srb2-assets.tar.gz" "$md_build"
 }
 
@@ -45,6 +45,7 @@ function install_srb2() {
         'assets/installer/player.dta'
         'assets/installer/zones.pk3'
         'assets/installer/srb2.pk3'
+        'assets/installer/patch.pk3'
         'assets/README.txt'
         'assets/LICENSE.txt'
     )


### PR DESCRIPTION
Upstream project added an extra `.pk3` asset file in 2.2.2, we need to include it in the scriptmodule and added to the hosted assets archive.

Since the assets and releases are somehow dependent (the missing asset is a `patch.pk3`), I've locked the version to 2.2.2. We'll need to check bumping the version to include the extra/new assets.

The new asset files are in `assets/installer`, can be downloaded http://ppa.launchpad.net/stjr/srb2/ubuntu/pool/main/s/srb2-data/srb2-data_2.2.2-20200223174531.tar.xz and added to our current assets archive. It should be enough to fix the installation from binary right now and future source installs.