### PR TITLE
system.sh: arithmetic expansion smallfix

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -46,7 +46,7 @@ function test_chroot() {
 
 function conf_memory_vars() {
     __memory_total_kb=$(awk '/^MemTotal:/{print $2}' /proc/meminfo)
-    __memory_total=$(( "$__memory_total_kb" / 1024 ))
+    __memory_total=$(( __memory_total_kb / 1024 ))
     if grep -q "^MemAvailable:" /proc/meminfo; then
         __memory_avail_kb=$(awk '/^MemAvailable:/{print $2}' /proc/meminfo)
     else
@@ -55,7 +55,7 @@ function conf_memory_vars() {
         local mem_buffers=$(awk '/^Buffers:/{print $2}' /proc/meminfo)
         __memory_avail_kb=$((mem_free + mem_cached + mem_buffers))
     fi
-    __memory_avail=$(( "$__memory_avail_kb" / 1024 ))
+    __memory_avail=$(( __memory_avail_kb / 1024 ))
 }
 
 function conf_binary_vars() {


### PR DESCRIPTION
Noticed some messages right after calling retropie_setup.sh and before the dialog:
```
/home/meleu/RetroPie-Setup/scriptmodules/system.sh: linha 49: "8078788" / 1024 : erro de sintaxe: operando esperado (token com erro é ""8078788" / 1024 ")
```
It happens because the bash version on the computer I'm running it is 4.3, and it doesn't accept quotes inside the arithmetic expansion `$((...))` (it was [fixed in bash-4.4](http://git.savannah.gnu.org/cgit/bash.git/tree/CHANGES?h=bash-4.4-testing#n3433))

For consistency, I also removed the `$` prefix for variables inside the arithmetic expansion (same style used on line 56).