### PR TITLE
N64: Disabled hybrid upscaling filter (causes slowdown on RPI4)

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -274,6 +274,8 @@ function configure_mupen64plus() {
         iniSet "ThreadedVideo" "True"
         # Swap frame buffers On buffer update (most performant)
         iniSet "BufferSwapMode" "2"
+        # Disable hybrid upscaling filter (needs better GPU)
+        iniSet "EnableHybridFilter" "False"
 
         if isPlatform "videocore"; then
             # Disable gles2n64 autores feature and use dispmanx upscaling


### PR DESCRIPTION
Currently we're getting slowdowns on mupen64plus-GLideN64 with default settings. See https://retropie.org.uk/forum/topic/25112/getting-the-best-n64-experience-on-a-pi-4/44