### PR TITLE
Sixaxis fixes for bare installation

### DIFF
--- a/scriptmodules/supplementary/customhidsony.sh
+++ b/scriptmodules/supplementary/customhidsony.sh
@@ -10,7 +10,7 @@
 #
 
 rp_module_id="customhidsony"
-rp_module_desc="Custom hid-sony driver backported from kernel 4.15"
+rp_module_desc="Custom hid-sony (Sony DualShock) driver with enhanced third-party controller support"
 rp_module_help="Improves support for third-party (Shanwan & Gasia) DualShock 3 controllers.\n\nNote: BlueZ 5.50+ may also be installed via the 'custombluez' module to enable pairing on third-party controllers."
 rp_module_section="driver"
 rp_module_flags="noinstclean"

--- a/scriptmodules/supplementary/customhidsony/0001-hidsony-gasiafix.diff
+++ b/scriptmodules/supplementary/customhidsony/0001-hidsony-gasiafix.diff
@@ -1,6 +1,6 @@
 --- a/drivers/hid/hid-sony.c	2018-11-15 05:39:31.762572258 +0000
 +++ b/drivers/hid/hid-sony.c	2018-11-15 05:38:55.762745843 +0000
-@@ -2063,6 +2063,7 @@
+@@ -2067,6 +2067,7 @@
  	struct sixaxis_output_report *report =
  		(struct sixaxis_output_report *)sc->output_report_dmabuf;
  	int n;
@@ -8,7 +8,7 @@
  
  	/* Initialize the report with default values */
  	memcpy(report, &default_report, sizeof(struct sixaxis_output_report));
-@@ -2097,9 +2097,18 @@
+@@ -2101,9 +2101,18 @@
  		}
  	}
  

--- a/scriptmodules/supplementary/sixaxis.sh
+++ b/scriptmodules/supplementary/sixaxis.sh
@@ -17,6 +17,12 @@ rp_module_section="driver"
 function depends_sixaxis() {
     getDepends checkinstall libevdev-tools
 
+    # add special check for presence of sixaxis plugin, and restart bluetooth stack if necessary
+    if ! hasPackage "libbluetooth3"; then
+        getDepends libbluetooth3
+        service bluetooth restart
+    fi
+
     rp_callModule ps3controller remove
 }
 


### PR DESCRIPTION
Mark "libbluetooth3" for installation in sixaxis module (with service stack reload if necessary).

Just a thought, but perhaps we could consider adding "sixaxis" to the default package list for image builds? The package shouldn't really cause any issues for users that will never use a DualShock, and the messy third-party driver is split off (and not installed by default until the user selects via the gui option of the driver).

I would also like to rip out the "custombluez" module completely, but perhaps we can leave that until stretch support is fully dropped.