### PR TITLE
solarus - fix missing "false" case in wrapper script

### DIFF
--- a/scriptmodules/ports/solarus.sh
+++ b/scriptmodules/ports/solarus.sh
@@ -83,7 +83,7 @@ ARGS=("-fullscreen=yes" "-cursor-visible=no" "-lua-console=no")
 [[ -f "$(_options_cfg_file_solarus)" ]] && source "$(_options_cfg_file_solarus)"
 [[ -n "\$JOYPAD_DEADZONE" ]] && ARGS+=("-joypad-deadzone=\$JOYPAD_DEADZONE")
 [[ -n "\$QUIT_COMBO" ]] && ARGS+=("-quit-combo=\$QUIT_COMBO")
-if $(isPlatform "videocore" && echo true); then
+if $(isPlatform "videocore" && echo true || echo false); then
   if [[ -f /opt/vc/lib/libbrcmGLESv2.so ]]; then
     export LD_PRELOAD="/opt/vc/lib/libbrcmGLESv2.so"
   fi


### PR DESCRIPTION
* when not in videocore, the script fails due to missing "false" case

Shameful bug from my previous PR :disappointed:

Tested by a user running RetroPie on RPI4.