### PR TITLE
Install libnss3 with Kodi to support Widevine DRM

### DIFF
--- a/scriptmodules/ports/kodi.sh
+++ b/scriptmodules/ports/kodi.sh
@@ -44,7 +44,7 @@ function depends_kodi() {
 function install_bin_kodi() {
     # force aptInstall to get a fresh list before installing
     __apt_update=0
-    aptInstall kodi kodi-peripheral-joystick kodi-inputstream-adaptive kodi-inputstream-rtmp kodi-vfs-libarchive kodi-vfs-sftp kodi-vfs-nfs
+    aptInstall kodi kodi-peripheral-joystick kodi-inputstream-adaptive kodi-inputstream-rtmp kodi-vfs-libarchive kodi-vfs-sftp kodi-vfs-nfs libnss3
 }
 
 function remove_kodi() {


### PR DESCRIPTION
The package libnss3 is needed to play Widevine DRM content in Kodi.

This fixes the following problem:
https://github.com/asciidisco/plugin.video.netflix/issues/489