### PR TITLE
added theodore: libretro core for Thomson MO/TO emulation

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -129,6 +129,9 @@ megadrive_platform="megadrive"
 msx_exts=".rom .mx1 .mx2 .col .dsk .zip .m3u"
 msx_fullname="MSX"
 
+moto_exts=".fd .k7 .m5 .m7 .rom .sap"
+moto_fullname="Thomson MO/TO"
+
 n64_exts=".z64 .n64 .v64 .zip"
 n64_fullname="Nintendo 64"
 

--- a/scriptmodules/libretrocores/lr-theodore.sh
+++ b/scriptmodules/libretrocores/lr-theodore.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-theodore"
+rp_module_desc="Thomson MO/TO system emulator"
+rp_module_help="ROM Extensions: *.fd, *.sap, *.k7, *.m5, *.m7, *.rom\n\nAdd your game files in $romdir/moto"
+rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/theodore/master/LICENSE"
+rp_module_section="exp"
+rp_module_flags=""
+
+function sources_lr-theodore() {
+    gitPullOrClone "$md_build" https://github.com/libretro/theodore
+}
+
+function build_lr-theodore() {
+    make clean
+    make
+    md_ret_require="theodore_libretro.so"
+}
+
+function install_lr-theodore() {
+    md_ret_files=(
+        'theodore_libretro.so'
+        'README.md'
+        'README-FR.md'
+        'LICENSE'
+    )
+}
+
+function configure_lr-theodore() {
+    mkRomDir "moto"
+    ensureSystemretroconfig "moto"
+
+    addEmulator 1 "$md_id" "moto" "$md_inst/theodore_libretro.so"
+    addSystem "moto"
+}


### PR DESCRIPTION
Adds support for Thomson MO/TO, a line of 8bit computers produced during 1982 and 1989 (TO7, TO7/70, TO8, TO8D, TO9, TO9+, MO5, MO6) and used mainly in France.

The Libretro [core](https://docs.libretro.com/library/theodore/) is based on the [DCMOTO](http://dcmoto.free.fr/) emulator. 
The system has a medium library of games and application/educational software - 515 entries on [ScreenScraper](https://screenscraper.fr/gamesinfos.php?plateforme=141&alpha=0&numpage=0), more in the associated Libretro DB.