### PR TITLE
Add rpi platform to lr-mame2010

### DIFF
--- a/scriptmodules/libretrocores/lr-mame2010.sh
+++ b/scriptmodules/libretrocores/lr-mame2010.sh
@@ -23,7 +23,7 @@ function build_lr-mame2010() {
     rpSwap on 750
     make clean
     local params=()
-    isPlatform "arm" && params+=("VRENDER=soft" "ARM_ENABLED=1")
+    isPlatform "arm" && params+=("VRENDER=soft" "ARM_ENABLED=1" "FORCE_DRC_C_BACKEND=1")
     make "${params[@]}" ARCHOPTS="$CFLAGS" buildtools
     make "${params[@]}" ARCHOPTS="$CFLAGS"
     rpSwap off


### PR DESCRIPTION
Should address https://github.com/libretro/mame2010-libretro/issues/130
and be a (hopefully working) alternative to
https://github.com/RetroPie/RetroPie-Setup/pull/2773