### PR TITLE
lr-bsnes: update to the current BSNES version of the libretro fork

### DIFF
--- a/scriptmodules/libretrocores/lr-bsnes.sh
+++ b/scriptmodules/libretrocores/lr-bsnes.sh
@@ -10,26 +10,36 @@
 #
 
 rp_module_id="lr-bsnes"
-rp_module_desc="Super Nintendo emu - bsnes port for libretro"
-rp_module_help="ROM Extensions: .bin .smc .sfc .fig .swc .mgd .zip\n\nCopy your SNES roms to $romdir/snes"
-rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/bsnes-libretro/libretro/COPYING"
+rp_module_desc="Super Nintendo Emulator - bsnes port for libretro (v115)"
+rp_module_help="ROM Extensions: .bml .smc .sfc .zip\n\nCopy your SNES roms to $romdir/snes"
+rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/bsnes/master/LICENSE.txt"
 rp_module_section="opt"
 rp_module_flags="!armv6"
 
+function depends_lr-bsnes() {
+    if compareVersions $__gcc_version lt 7.0.0; then
+        md_ret_errors+=("You need an OS with gcc 7.0 or newer to compile $md_id")
+        return 1
+    fi
+}
+
 function sources_lr-bsnes() {
-    gitPullOrClone "$md_build" https://github.com/libretro/bsnes-libretro.git
+    gitPullOrClone "$md_build" https://github.com/libretro/bsnes.git
 }
 
 function build_lr-bsnes() {
-    make clean
-    make
-    md_ret_require="$md_build/out/bsnes_accuracy_libretro.so"
+    make -C bsnes clean
+    make -C bsnes target="libretro" build="release"
+    md_ret_require="$md_build/bsnes/out/bsnes_libretro.so"
 }
 
 function install_lr-bsnes() {
     md_ret_files=(
-        'out/bsnes_accuracy_libretro.so'
-        'COPYING'
+        'bsnes/out/bsnes_libretro.so'
+        'LICENSE.txt'
+        'GPLv3.txt'
+        'CREDITS.md'
+        'README.md'
     )
 }
 
@@ -37,6 +47,6 @@ function configure_lr-bsnes() {
     mkRomDir "snes"
     ensureSystemretroconfig "snes"
 
-    addEmulator 1 "$md_id" "snes" "$md_inst/bsnes_accuracy_libretro.so"
+    addEmulator 1 "$md_id" "snes" "$md_inst/bsnes_libretro.so"
     addSystem "snes"
 }


### PR DESCRIPTION
Updated `lr-bsnes` to the latest BSNES version.

The libretro fork of the current/latest version has a different repo, the previous `bsnes` core fork has been renamed to `bsnes2014` [^1][^2] and hasn't been updated since last year.

The (new) [BSNES](https://github.com/bsnes-emu/bsnes) seems to work reasonably well on the Pi4. It requires a C++17 compiler, this means at least GCC 7 (no Raspbian/Debian Stretch).

[1] - BSNES2014 https://github.com/libretro/bsnes-libretro/commit/feb8c10c672094e689ed057a278c2b354e113f32
[2] https://forums.libretro.com/t/deprecate-the-bsnes-higan-snes-forks/24732/3.