### PR TITLE
lr-theodore: switch to upstream repository

### DIFF
--- a/scriptmodules/libretrocores/lr-theodore.sh
+++ b/scriptmodules/libretrocores/lr-theodore.sh
@@ -17,7 +17,7 @@ rp_module_section="exp"
 rp_module_flags=""
 
 function sources_lr-theodore() {
-    gitPullOrClone "$md_build" https://github.com/libretro/theodore
+    gitPullOrClone "$md_build" https://github.com/Zlika/theodore
 }
 
 function build_lr-theodore() {


### PR DESCRIPTION
Fixes the repository source, replacing the libretro fork with the [upstream repo](https://github.com/Zlika/theodore).
Seems like the libretro fork is used only for PR submitted upstream, the buildbot uses the same upstream repository (https://retropie.org.uk/forum/topic/3049/thomson-computers-emulator/29).