### PR TITLE
Bluetooth updates

### DIFF
--- a/scriptmodules/supplementary/bluetooth/connect.sh
+++ b/scriptmodules/supplementary/bluetooth/connect.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+configdir="CONFIGDIR"
+
+source "ROOTDIR/lib/inifuncs.sh"
+
+mode="$1"
+if [[ -z "$mode" ]]; then
+    iniConfig "=" '"' "$configdir/all/bluetooth.cfg"
+    iniGet "connect_mode"
+    [[ -n "$ini_value" ]] && mode="$ini_value"
+fi
+
+function connect() {
+    local line
+    local mac
+    local conn
+    while read line; do
+        if [[ "$line" =~ ^(.+)\ \((.+)\)$ ]]; then
+            mac="${BASH_REMATCH[2]}"
+            conn=$(bt-device -i "$mac" | grep "Connected:" | tail -c 2 2>/dev/null)
+            [[ "$conn" -eq 0 ]] && bt-device --connect "$mac" &>/dev/null
+        fi
+    done < <(bt-device --list)
+}
+
+case "$mode" in
+    boot)
+        connect
+        ;;
+    background)
+        while true; do
+            connect
+            sleep 10
+        done
+esac
+
+exit 0


### PR DESCRIPTION
 bluetooth - use bt-device from bluez-tools over old python code

 * added bluez-tools dependency
 * use bt-device for Trusting / Connecting / Removing of devices

 bluetooth - split out boot bluetooth connect script from main code

 * running RetroPie-Setup on boot isn't efficient / it should work without RetroPie-Setup present.
 * running it as root on boot causes /opt/retropie/configs/all to be chowned to root due to setupDirectories call

@psyke83 
This needs some testing - but works ok here. I did touch a bit of the Playstation pairing code with the first commit - perhaps I should have split out the second commit - I can do that if there's issues

the code relating to the platstation code was the following

```diff
 -       $(get_script_bluetooth bluez-test-device) disconnect "$mac_address" 2>&1
 -       $(get_script_bluetooth bluez-test-device) trusted "$mac_address" yes 2>&1
 -       local trusted=$($(get_script_bluetooth bluez-test-device) trusted "$mac_address" 2>&1)
 -       if [[ "$trusted" -eq 1 ]]; then
 +       bt-device --disconnect="$mac_address" 2>&1
 +       bt-device --set "$mac_address" Trusted 1 2>&1
 +       if [[ "$?" -eq 0 ]]; then
```

My plan is to use the bluez-tools commandline tools for more stuff - and get rid of the old python. This is a first step - we may not be able to replace everything of course.
