### PR TITLE
usbromservice - fix mounting ext3/ext4 partitions

### DIFF
--- a/scriptmodules/supplementary/usbromservice.sh
+++ b/scriptmodules/supplementary/usbromservice.sh
@@ -84,11 +84,16 @@ function configure_usbromservice() {
     done
 
     # set our mount options (usbmount has sync by default which we don't want)
-    local uid=$(id -u $user)
-    local gid=$(id -g $user)
-    local mount_options="nodev,noexec,noatime,uid=$uid,gid=$gid"
+    iniSet "MOUNTOPTIONS" "nodev,noexec,noatime"
 
-    iniSet "MOUNTOPTIONS" "$mount_options"
+    # set per filesytem mount options
+    local options="uid=$(id -u $user),gid=$(id -g $user)"
+    local fs_options
+    local fs
+    for fs in vfat hfsplus ntfs exfat; do
+        fs_options+=("-fstype=${fs},${options}")
+    done
+    iniSet "FS_MOUNTOPTIONS" "${fs_options[*]}"
 }
 
 function gui_usbromservice() {


### PR DESCRIPTION
Mounting ext3/ext4 and other native filesystems was broken due to having uid=X,gid=X in the default mount options.
Now we just set these options on a per filesystem basis via FS_MOUNTOPTIONS

This is not yet tested.