### PR TITLE
audiosettings: updates for Pi4 and support for discrete internal ALSA devices

### DIFF
--- a/scriptmodules/supplementary/audiosettings.sh
+++ b/scriptmodules/supplementary/audiosettings.sh
@@ -12,7 +12,7 @@
 rp_module_id="audiosettings"
 rp_module_desc="Configure audio settings"
 rp_module_section="config"
-rp_module_flags="!x86 !mali"
+rp_module_flags="!all rpi"
 
 function depends_audiosettings() {
     if [[ "$md_mode" == "install" ]]; then
@@ -21,12 +21,38 @@ function depends_audiosettings() {
 }
 
 function gui_audiosettings() {
+    # Check if the internal audio is enabled
+    if [[ `aplay -ql | grep bcm2835 | wc -l` < 1 ]]; then
+        printMsgs "dialog" "On-board audio disabled or not present"
+        return
+    fi
+
+    # The list of ALSA cards/devices depends on the 'snd-bcm2385' module parameter 'enable_compat_alsa'
+    # * enable_compat_alsa: true  - single soundcard, output is routed based on the `numid` control
+    # * enable_compat_alsa: false - one soundcard per output type (HDMI/Headphones)
+    if aplay -l | grep -q "bcm2835 ALSA"; then
+        _bcm2835_alsa_compat_audiosettings
+    else
+        _bcm2835_alsa_internal_audiosettings
+    fi
+}
+
+function _bcm2835_alsa_compat_audiosettings() {
     local cmd=(dialog --backtitle "$__backtitle" --menu "Set audio output." 22 86 16)
+    local hdmi="HDMI"
+
+    # the Pi 4 has 2 HDMI ports, so number them
+    isPlatform "rpi4" && hdmi="HDMI 1"
+
     local options=(
         1 "Auto"
         2 "Headphones - 3.5mm jack"
-        3 "HDMI"
-        4 "Mixer - adjust output volume"
+        3 "$hdmi"
+    )
+    # add 2nd HDMI port on the Pi4
+    isPlatform "rpi4" && options+=(4 "HDMI 2")
+    options+=(
+        M "Mixer - adjust output volume"
         R "Reset to default"
     )
     choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
@@ -35,27 +61,101 @@ function gui_audiosettings() {
             1)
                 amixer cset numid=3 0
                 alsactl store
-                printMsgs "dialog" "Set audio output to auto"
+                printMsgs "dialog" "Set audio output to Auto"
                 ;;
             2)
                 amixer cset numid=3 1
                 alsactl store
-                printMsgs "dialog" "Set audio output to headphones / 3.5mm jack"
+                printMsgs "dialog" "Set audio output to Headphones - 3.5mm jack"
                 ;;
             3)
                 amixer cset numid=3 2
                 alsactl store
-                printMsgs "dialog" "Set audio output to HDMI"
+                printMsgs "dialog" "Set audio output to $hdmi"
                 ;;
             4)
+                amixer cset numid=3 3
+                alsactl store
+                printMsgs "dialog" "Set audio output to HDMI 2"
+                ;;
+            M)
                 alsamixer >/dev/tty </dev/tty
                 alsactl store
                 ;;
             R)
                 /etc/init.d/alsa-utils reset
                 alsactl store
+                rm -f "$home/.asoundrc"
                 printMsgs "dialog" "Audio settings reset to defaults"
                 ;;
         esac
     fi
+}
+
+function _bcm2835_alsa_internal_audiosettings() {
+    local cmd=(dialog --backtitle "$__backtitle" --menu "Set audio output." 22 86 16)
+    local options=()
+    local card_index, card_label
+
+    # Get the list of Pi internal cards
+    while read card_no card_label; do
+        options+=("$card_no" "$card_label")
+    done < <(aplay -ql | sed -En 's/^card ([0-9]+).*\[bcm2835 ([^]]*)\].*/\1 \2/p')
+
+    options+=(
+        M "Mixer - adjust output volume"
+        R "Reset to default"
+    )
+    choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
+    if [[ -n "$choice" ]]; then
+        case "$choice" in
+            [0-9])
+                _asoundrc_save_audiosettings $choice
+                printMsgs "dialog" "Set audio output to ${options[$((choice*2+1))]}"
+                ;;
+            M)
+                alsamixer >/dev/tty </dev/tty
+                alsactl store
+                ;;
+            R)
+                /etc/init.d/alsa-utils reset
+                alsactl store
+                rm -f "$home/.asoundrc"
+                printMsgs "dialog" "Audio settings reset to defaults"
+                ;;
+        esac
+    fi
+}
+
+# configure the default ALSA soundcard based on chosen card #
+function _asoundrc_save_audiosettings() {
+    [[ -z "$1" ]] && return
+
+    local card_index=$1
+    local tmpfile=$(mktemp)
+
+    cat << EOF > "$tmpfile"
+pcm.!default {
+  type asym
+  playback.pcm {
+    type plug
+    slave.pcm "output"
+  }
+  capture.pcm {
+    type plug
+    slave.pcm "input"
+  }
+}
+pcm.output {
+  type hw
+  card $card_index
+}
+ctl.!default {
+  type hw
+  card $card_index
+}
+EOF
+
+    mv "$tmpfile" "$home/.asoundrc"
+    chown "$user:$user" "$home/.asoundrc"
 }


### PR DESCRIPTION
Modified to support the 2nd HDMI port on the Pi4 and for supporting the new upstream defaults, which use discrete ALSA cards. Handle the case when on-board audio is disabled.

On-board audio support is enabled via the `snd_bcm2835` module. Depending on the `enable_compat_alsa` parameter value (0/1), loading the module creates 1 or ~~3~~ 2/3 sound devices. 

The default so far has been `enable_compat_alsa=1`, but this will change in the new 5.4 LTS kernel (see https://github.com/raspberrypi/firmware/commit/7449540e3787cc14e9ee7f63690d6569943bce26 and the discussion in the [RPF Forums](https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=269769&start=200#p1659490)). `raspi-config` already handles this since [January](https://github.com/RPi-Distro/raspi-config/commit/629699ff9b2e73c92bafe45280515d816fbcaaf5), so I added a similar list of options to the `audiosettings` module.

