### PR TITLE
retroarch: version 1.8.8 update

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -39,7 +39,7 @@ function depends_retroarch() {
 }
 
 function sources_retroarch() {
-    gitPullOrClone "$md_build" https://github.com/libretro/RetroArch.git v1.8.6
+    gitPullOrClone "$md_build" https://github.com/libretro/RetroArch.git v1.8.8
     applyPatch "$md_data/01_hotkey_hack.diff"
     applyPatch "$md_data/02_disable_search.diff"
     applyPatch "$md_data/03_shader_path_config_enable.diff"
@@ -166,6 +166,7 @@ function configure_retroarch() {
 
     iniSet "video_font_size" "24"
     iniSet "core_options_path" "$configdir/all/retroarch-core-options.cfg"
+    iniSet "global_core_options" "true"
     isPlatform "x11" && iniSet "video_fullscreen" "true"
     isPlatform "mesa" && iniSet "video_fullscreen" "true"
 
@@ -260,6 +261,9 @@ function configure_retroarch() {
 
     # enable video shaders on existing configs
     _set_config_option_retroarch "video_shader_enable" "true"
+
+    # (compat) keep all core options in a single file
+    _set_config_option_retroarch "global_core_options" "true"
 
     # remapping hack for old 8bitdo firmware
     addAutoConf "8bitdo_hack" 0

--- a/scriptmodules/emulators/retroarch/01_hotkey_hack.diff
+++ b/scriptmodules/emulators/retroarch/01_hotkey_hack.diff
@@ -1,19 +1,19 @@
 diff --git a/retroarch.c b/retroarch.c
-index be36eaf141..dcccdaff47 100644
+index 79be7cc927..c20ddae412 100644
 --- a/retroarch.c
 +++ b/retroarch.c
-@@ -1191,6 +1191,10 @@ static char current_valid_extensions[1024]                      = {0};
- static char error_string[255]                                   = {0};
- static char cached_video_driver[32]                             = {0};
- 
+@@ -1024,6 +1024,10 @@ static const camera_driver_t *camera_drivers[] = {
+ #define SHADER_FILE_WATCH_DELAY_MSEC 500
+ #define HOLD_START_DELAY_SEC 2
+
 +/* number of frames required to trigger the hotkey */
 +#define HOTKEY_DELAY 5
 +static unsigned hotkey_counter = 0;
 +
- /* PATHS */
- struct rarch_dir_list
- {
-@@ -18086,9 +18090,16 @@ static void input_keys_pressed(input_bits_t *p_new_state,
+ #define QUIT_DELAY_USEC 3 * 1000000 /* 3 seconds */
+
+ #define DEBUG_INFO_FILENAME "debug_info.txt"
+@@ -16980,9 +16984,16 @@ static void input_keys_pressed(input_bits_t *p_new_state,
                 current_input_data, joypad_info,
                 &binds, port,
                 RETRO_DEVICE_JOYPAD, 0, RARCH_ENABLE_HOTKEY))
@@ -31,5 +31,5 @@ index be36eaf141..dcccdaff47 100644
 +               input_driver_block_hotkey = true;
 +            }
     }
- 
+
     if (binds[RARCH_GAME_FOCUS_TOGGLE].valid)

--- a/scriptmodules/emulators/retroarch/02_disable_search.diff
+++ b/scriptmodules/emulators/retroarch/02_disable_search.diff
@@ -1,8 +1,8 @@
 diff --git a/menu/menu_driver.c b/menu/menu_driver.c
-index 39e8e23527..4f673a2554 100644
+index 9e4cc200f0..184fe12885 100644
 --- a/menu/menu_driver.c
 +++ b/menu/menu_driver.c
-@@ -415,7 +415,8 @@ int generic_menu_entry_action(
+@@ -514,7 +514,8 @@ int generic_menu_entry_action(
                    entry->label, entry->type, i, entry->entry_idx);
           break;
        case MENU_ACTION_SEARCH:

--- a/scriptmodules/emulators/retroarch/03_shader_path_config_enable.diff
+++ b/scriptmodules/emulators/retroarch/03_shader_path_config_enable.diff
@@ -1,5 +1,5 @@
 diff --git a/configuration.c b/configuration.c
-index 7ddc5c13af..b487f9a18e 100644
+index 46995c0aee..26951db746 100644
 --- a/configuration.c
 +++ b/configuration.c
 @@ -1210,6 +1210,8 @@ static struct config_path_setting *populate_settings_path(settings_t *settings,
@@ -11,7 +11,7 @@ index 7ddc5c13af..b487f9a18e 100644
     SETTING_PATH("content_database_path",
           settings->paths.path_content_database, false, NULL, true);
     SETTING_PATH("cheat_database_path",
-@@ -2267,6 +2269,7 @@ void config_set_defaults(void *data)
+@@ -2270,6 +2272,7 @@ void config_set_defaults(void *data)
     *settings->paths.path_content_image_history   = '\0';
     *settings->paths.path_content_video_history   = '\0';
     *settings->paths.path_cheat_settings    = '\0';
@@ -19,8 +19,8 @@ index 7ddc5c13af..b487f9a18e 100644
  #ifndef IOS
     *settings->arrays.bundle_assets_src = '\0';
     *settings->arrays.bundle_assets_dst = '\0';
-@@ -4167,6 +4170,10 @@ bool config_save_overrides(enum override_type type, void *data)
- 
+@@ -4170,6 +4173,10 @@ bool config_save_overrides(enum override_type type, void *data)
+
        for (i = 0; i < (unsigned)path_settings_size; i++)
        {
 +         /* blacklist video_shader, better handled by shader presets*/
@@ -31,33 +31,33 @@ index 7ddc5c13af..b487f9a18e 100644
              config_set_path(conf, path_overrides[i].ident,
                    path_overrides[i].ptr);
 diff --git a/configuration.h b/configuration.h
-index 0363cb7121..6d17a81b42 100644
+index 75b2eb4db0..b07108a2bc 100644
 --- a/configuration.h
 +++ b/configuration.h
-@@ -703,6 +703,7 @@ typedef struct settings
+@@ -706,6 +706,7 @@ typedef struct settings
        char path_libretro_info[PATH_MAX_LENGTH];
        char path_cheat_settings[PATH_MAX_LENGTH];
        char path_font[PATH_MAX_LENGTH];
 +      char path_shader[PATH_MAX_LENGTH];
        char path_rgui_theme_preset[PATH_MAX_LENGTH];
- 
+
        char directory_audio_filter[PATH_MAX_LENGTH];
 diff --git a/retroarch.c b/retroarch.c
-index dcccdaff47..1cd8af78eb 100644
+index c20ddae412..abcabd8494 100644
 --- a/retroarch.c
 +++ b/retroarch.c
-@@ -28778,6 +28778,7 @@ static bool retroarch_load_shader_preset_internal(
+@@ -27716,6 +27716,7 @@ static bool retroarch_load_shader_preset_internal(
  {
     unsigned i;
     char *shader_path = (char*)malloc(PATH_MAX_LENGTH);
 +   settings_t *settings = configuration_settings;
- 
+
     static enum rarch_shader_type types[] =
     {
-@@ -28805,11 +28806,13 @@ static bool retroarch_load_shader_preset_internal(
+@@ -27743,11 +27744,13 @@ static bool retroarch_load_shader_preset_internal(
           if (string_is_empty(special_name))
              break;
- 
+
 -         fill_pathname_join(shader_path, shader_directory, special_name, PATH_MAX_LENGTH);
 -         strlcat(shader_path,
 -               video_shader_get_preset_extension(types[i]),
@@ -70,27 +70,30 @@ index dcccdaff47..1cd8af78eb 100644
 +             strlcpy(shader_path, settings->paths.path_shader, PATH_MAX_LENGTH);
 +         }
 +       }
- 
+
        if (!path_is_valid(shader_path))
           continue;
-@@ -28833,6 +28836,7 @@ static bool retroarch_load_shader_preset_internal(
+@@ -27771,6 +27774,7 @@ static bool retroarch_load_shader_preset_internal(
   * Tries to load a supported core-, game-, folder-specific or global
   * shader preset from its respective location:
   *
-+ * config:          preset from the configuration file
-  * global:          $SHADER_DIR/presets/global.$PRESET_EXT
-  * core-specific:   $SHADER_DIR/presets/$CORE_NAME/$CORE_NAME.$PRESET_EXT
-  * folder-specific: $SHADER_DIR/presets/$CORE_NAME/$FOLDER_NAME.$PRESET_EXT
-@@ -28906,6 +28910,13 @@ static bool retroarch_load_shader_preset(void)
-       goto success;
-    }
- 
-+   if (retroarch_load_shader_preset_internal(shader_directory, NULL,
-+         "config"))
-+   {
-+      RARCH_LOG("[Shaders]: configuration file shader preset found.\n");
-+      goto success;
-+   }
++ * config:          preset from the configuration file, configured via 'video_shader'
+  * global:          $CONFIG_DIR/global.$PRESET_EXT
+  * core-specific:   $CONFIG_DIR/$CORE_NAME/$CORE_NAME.$PRESET_EXT
+  * folder-specific: $CONFIG_DIR/$CORE_NAME/$FOLDER_NAME.$PRESET_EXT
+@@ -27879,6 +27883,15 @@ static bool retroarch_load_shader_preset(void)
+          RARCH_LOG("[Shaders]: global shader preset found.\n");
+          break;
+       }
 +
-    free(shader_directory);
-    return false;
++      ret = retroarch_load_shader_preset_internal(dirs[i], NULL,
++         "config");
++
++      if (ret)
++      {
++         RARCH_LOG("[Shaders]: configuration file shader preset found.\n");
++         break;
++      }
+    }
+
+ end:


### PR DESCRIPTION
Rebased RetroPie patched for 1.8.8 and added - for now - the option to keep the global core options in a single file.

NOTE: tested on Pi4 only at the moment.