### PR TITLE
image: update the URL for latest Buster image

### DIFF
--- a/scriptmodules/admin/image.sh
+++ b/scriptmodules/admin/image.sh
@@ -42,7 +42,7 @@ function create_chroot_image() {
             url="https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-04-09/2019-04-08-raspbian-stretch-lite.zip"
             ;;
         buster)
-            url="https://downloads.raspberrypi.org/raspbian_lite_latest"
+            url="https://downloads.raspberrypi.org/raspios_lite_armhf_latest"
             ;;
         *)
             md_ret_errors+=("Unknown/unsupported Raspbian version")


### PR DESCRIPTION
Latest Buster Raspberry Pi OS image has changed location. Previous URL returns older (Feb 2020) release.