### PR TITLE
Add .mdf to Saturn extensions

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -191,7 +191,7 @@ psx_fullname="PlayStation"
 samcoupe_exts=".dsk .mgt .sbt .sad"
 samcoupe_fullname="SAM Coupe"
 
-saturn_exts=".chd .cue .zip"
+saturn_exts=".chd .cue .mdf .zip"
 saturn_fullname="Sega Saturn"
 
 scummvm_exts=".sh .svm"


### PR DESCRIPTION
As documented on the wiki, .mdf is a valid extension for the Saturn emulators. Tested that the change allows loading these files on my local installation.