### PR TITLE
lr-np2kai: update build instructions

### DIFF
--- a/scriptmodules/libretrocores/lr-np2kai.sh
+++ b/scriptmodules/libretrocores/lr-np2kai.sh
@@ -20,14 +20,15 @@ function sources_lr-np2kai() {
 }
 
 function build_lr-np2kai() {
-    cd ./sdl2
-    make
-    md_ret_require="$md_build/sdl2/np2kai_libretro.so"
+    cd "$md_build/sdl"
+    make -f Makefile.libretro clean
+    make -f Makefile.libretro
+    md_ret_require="$md_build/sdl/np2kai_libretro.so"
 }
 
 function install_lr-np2kai() {
     md_ret_files=(
-        'sdl2/np2kai_libretro.so'
+        'sdl/np2kai_libretro.so'
     )
 }
 


### PR DESCRIPTION
Looks like upstream renamed the build folder (`sdl2` renamed to `sdl`), so the build instructions have been updated. 
Similar upstream change at https://github.com/libretro/libretro-super/commit/0c7dde6c4d3ffff3fe1fcb5af5a9813319254a67.