### PR TITLE
lr-parallel-n64: Added aarch64 flags

### DIFF
--- a/scriptmodules/libretrocores/lr-parallel-n64.sh
+++ b/scriptmodules/libretrocores/lr-parallel-n64.sh
@@ -41,6 +41,10 @@ function build_lr-parallel-n64() {
             params+=(WITH_DYNAREC=arm)
             isPlatform "neon" && params+=(HAVE_NEON=1)
         fi
+        if isPlatform "aarch64"; then
+            params+=(CPUFLAGS="-DNO_ASM -DARM64 -D__arm64__ -DARM_ASM -D__NEON_OPT -DNOSSE -DARM_FIX")
+            params+=(WITH_DYNAREC=aarch64)
+        fi
     fi
     make clean
     make "${params[@]}"


### PR DESCRIPTION
These new flags will allow ARM64 distros to install Parallel N64 through normal setup scripts.