### PR TITLE
Fix systemd-nspawn detection

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -1406,7 +1406,10 @@ function dkmsManager() {
             ;;
         reload)
             dkmsManager unload "$module_name" "$module_ver"
-            modprobe "$module_name"
+            # No reason to load modules in chroot
+            if [[ "$__chroot" -eq 0 ]]; then
+                modprobe "$module_name"
+            fi
             ;;
         unload)
             if [[ -n "$(lsmod | grep ${module_name/-/_})" ]]; then

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -38,6 +38,9 @@ function test_chroot() {
     if [[ "$(stat -c %d:%i /)" != "$(stat -c %d:%i /proc/1/root/.)" ]]; then
         [[ -z "$QEMU_CPU" && -n "$__qemu_cpu" ]] && export QEMU_CPU=$__qemu_cpu
         __chroot=1
+    # detect the usage of systemd-nspawn
+    elif [[ -n "$(systemd-detect-virt)" && "$(systemd-detect-virt)" == "systemd-nspawn" ]]; then
+        __chroot=1
     else
         __chroot=0
     fi


### PR DESCRIPTION
I am building an image based on RPi 0/1 4.5.1 utilizing systemd-nspawn.  The existing logic to determine chroot environments doesn't seem to hold true when utilizing systemd-nspawn container instead of the traditional chroot command.

I also ran into an issue when updating/compiling the xpad kernel driver.  I believe there is no reason to modprobe the kernel driver in a chroot environment.