### PR TITLE
gemrb: switch to SDL2 for rendering

### DIFF
--- a/scriptmodules/ports/gemrb.sh
+++ b/scriptmodules/ports/gemrb.sh
@@ -16,7 +16,7 @@ rp_module_section="exp"
 rp_module_flags="!mali dispmanx"
 
 function depends_gemrb() {
-    getDepends python2-dev libopenal-dev libsdl1.2-dev cmake libpng-dev libfreetype6-dev libvorbis-dev libvlc-dev libvlccore-dev
+    getDepends python2-dev libopenal-dev cmake libpng-dev libfreetype6-dev libsdl2-dev libvorbis-dev libvlc-dev libvlccore-dev
 }
 
 function sources_gemrb() {
@@ -27,7 +27,7 @@ function build_gemrb() {
     mkdir -p build
     cd build
     make clean
-    cmake .. -DCMAKE_INSTALL_PREFIX="$md_inst" -DCMAKE_BUILD_TYPE=Release -DFREETYPE_INCLUDE_DIRS=/usr/include/freetype2/ -DSDL_BACKEND=SDL -DUSE_SDLMIXER=OFF
+    cmake .. -DCMAKE_INSTALL_PREFIX="$md_inst" -DCMAKE_BUILD_TYPE=Release -DFREETYPE_INCLUDE_DIRS=/usr/include/freetype2/ -DSDL_BACKEND=SDL2 -DUSE_SDLMIXER=OFF
     make
     md_ret_require="$md_build/build/gemrb/gemrb"
 }


### PR DESCRIPTION
GemRB supports both SDL1 and SDL2 for graphic rendering, SDL2 being now the preferred one.

This commit adds a `-sdl2` version for `gemrb` that builds the port with SDL2 and modifies the original scriptmodule so we can build both versions using the same functions.