### PR TITLE
lzdoom: update to 3.86a

### DIFF
--- a/scriptmodules/libretrocores/lr-prboom.sh
+++ b/scriptmodules/libretrocores/lr-prboom.sh
@@ -37,9 +37,9 @@ function game_data_lr-prboom() {
         wget -nv -O "$romdir/ports/doom/doom1.wad" "$__archive_url/doom1.wad"
     fi
 
-    if [[ ! -f "$romdir/ports/doom/freedoom1.wad" ]]; then
-        # download freedoom
-        downloadAndExtract "https://github.com/freedoom/freedoom/releases/download/v0.11.3/freedoom-0.11.3.zip" "$romdir/ports/doom/" -j -LL
+    if ! echo "e9bf428b73a04423ea7a0e9f4408f71df85ab175 $romdir/ports/doom/freedoom1.wad" | sha1sum -c &>/dev/null; then
+        # download (or update) freedoom
+        downloadAndExtract "https://github.com/freedoom/freedoom/releases/download/v0.12.1/freedoom-0.12.1.zip" "$romdir/ports/doom/" -j -LL
     fi
 
     mkdir -p "$romdir/ports/doom/addon"

--- a/scriptmodules/ports/lzdoom.sh
+++ b/scriptmodules/ports/lzdoom.sh
@@ -25,7 +25,7 @@ function depends_lzdoom() {
 }
 
 function sources_lzdoom() {
-    gitPullOrClone "$md_build" https://github.com/drfrag666/gzdoom "3.84"
+    gitPullOrClone "$md_build" https://github.com/drfrag666/gzdoom "3.86a"
 }
 
 function build_lzdoom() {


### PR DESCRIPTION
* This was announced as the final lzdoom release to support GL2 rendering.
* Update Freedoom to v0.12.1 with checksum check to update older versions.

---
Tested on RPI4.