### PR TITLE
Joy2key improvements

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 # This file is part of The RetroPie Project
 #

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # This file is part of The RetroPie Project
 #
@@ -1078,19 +1078,19 @@ function joy2keyStart() {
 
     local params=("$@")
     if [[ "${#params[@]}" -eq 0 ]]; then
-        params=(kcub1 kcuf1 kcuu1 kcud1 0x0a 0x20 0x1b)
+        # axes=arrows, b0=enter, b1=space, b2=escape
+        params=(kcub1 kcuf1 kcuu1 kcud1 0x0b 0x20 0x1b)
     fi
 
-    # get the first joystick device (if not already set)
-    [[ -c "$__joy2key_dev" ]] || __joy2key_dev="/dev/input/jsX"
-
-    # if no joystick device, or joy2key is already running exit
-    [[ -z "$__joy2key_dev" ]] || pgrep -f joy2key.py >/dev/null && return 1
-
-    # if joy2key.py is installed run it with cursor keys for axis/dpad, and enter + space for buttons 0 and 1
-    if "$scriptdir/scriptmodules/supplementary/runcommand/joy2key.py" "$__joy2key_dev" "${params[@]}" 2>/dev/null; then
-        __joy2key_pid=$(pgrep -f joy2key.py)
-        return 0
+    # if joy2key.py is installed and not already running, run it
+    if [[ -z "$__joy2key_pid" && -x "$scriptdir/scriptmodules/supplementary/runcommand/joy2key.py" ]]; then
+        "$scriptdir/scriptmodules/supplementary/runcommand/joy2key.py" "${params[@]}" &
+        if [[ "$?" == "0" ]]; then
+            __joy2key_pid=$!
+            # ensure coherency between on-screen prompts and actual button mapping functionality
+            sleep 0.3
+            return 0
+        fi
     fi
 
     return 1
@@ -1099,10 +1099,10 @@ function joy2keyStart() {
 ## @fn joy2keyStop()
 ## @brief Stop previously started joy2key.py process.
 function joy2keyStop() {
-    if [[ -n $__joy2key_pid ]]; then
+    if [[ -n "$__joy2key_pid" ]]; then
         kill $__joy2key_pid 2>/dev/null
-        __joy2key_pid=""
-        sleep 1
+        while ps -A -o pid,cmd | grep -vF grep | grep -F joy2key | grep -qF $__joy2key_pid; do sleep 0.2; done
+        unset __joy2key_pid
     fi
 }
 

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -1079,7 +1079,7 @@ function joy2keyStart() {
     local params=("$@")
     if [[ "${#params[@]}" -eq 0 ]]; then
         # axes=arrows, b0=enter, b1=space, b2=escape
-        params=(kcub1 kcuf1 kcuu1 kcud1 0x0b 0x20 0x1b)
+        params=(kcub1 kcuf1 kcuu1 kcud1 0x0d 0x20 0x1b)
     fi
 
     # if joy2key.py is installed and not already running, run it

--- a/scriptmodules/supplementary/runcommand/joy2key.py
+++ b/scriptmodules/supplementary/runcommand/joy2key.py
@@ -10,9 +10,10 @@
 #
 
 import os, sys, struct, time, fcntl, termios, signal
-import curses, errno, re
+import curses, errno, logging, re
 from pyudev import Context
 
+logging.basicConfig(level=os.environ.get("JOY2KEY_LOGLEVEL", "INFO"))
 
 #    struct js_event {
 #        __u32 time;     /* event timestamp in milliseconds */
@@ -33,6 +34,13 @@ JS_EVENT_INIT = 0x80
 
 CONFIG_DIR = '/opt/retropie/configs/'
 RETROARCH_CFG = CONFIG_DIR + 'all/retroarch.cfg'
+
+_TTY_FD = []
+_JS_DEVICES = set()
+_AXIS_CODES = []
+_EVENT_FORMAT = 'IhBB'
+_EVENT_SIZE = struct.calcsize(_EVENT_FORMAT)
+
 
 def ini_get(key, cfg_file):
     pattern = r'[ |\t]*' + key + r'[ |\t]*=[ |\t]*'
@@ -59,7 +67,7 @@ def sysdev_get(key, sysdev_path):
         break
     return value
 
-def get_button_codes(dev_path):
+def get_button_codes(dev_path, default_button_codes):
     js_cfg_dir = CONFIG_DIR + 'all/retroarch-joypads/'
     js_cfg = ''
     dev_name = ''
@@ -76,6 +84,7 @@ def get_button_codes(dev_path):
         # getting joystick product ID
         dev_product_id = int(sysdev_get('id/product', sysdev_path), 16)
     if not dev_name:
+        logging.debug("Unable to find " + sysdev_path)
         return dev_button_codes
 
     # getting retroarch config file for joystick
@@ -131,64 +140,123 @@ def get_button_codes(dev_path):
     return btn_codes
 
 def signal_handler(signum, frame):
+    _exit(0)
+
+def _exit(code):
     signal.signal(signal.SIGINT, signal.SIG_IGN)
     signal.signal(signal.SIGTERM, signal.SIG_IGN)
-    if (js_fds):
-        close_fds(js_fds)
-    if (tty_fd):
-        os.close(tty_fd)
-    sys.exit(0)
+    close_devices(_JS_DEVICES)
+    if (_TTY_FD):
+        os.close(_TTY_FD)
+    sys.exit(code)
 
 def get_hex_chars(key_str):
     if (key_str.startswith("0x")):
         out = bytes.fromhex(key_str[2:])
     else:
         out = curses.tigetstr(key_str)
-    return out.decode('utf-8')
+    if type(out) is bytes:
+        out = out.decode('utf-8')
+    return out
 
-def get_devices():
-    devs = []
-    if sys.argv[1] == '/dev/input/jsX':
-        for dev in os.listdir('/dev/input'):
-            if dev.startswith('js'):
-                devs.append('/dev/input/' + dev)
-    else:
-        devs.append(sys.argv[1])
 
-    return devs
+class _JoystickDevice(object):
+    def __init__(self, name, default_button_codes):
+        self._name = name
+        dev_path = os.path.join('/dev/input', name)
+        self._fd = os.open(dev_path, os.O_RDONLY | os.O_NONBLOCK)
+        self._button_codes = get_button_codes(dev_path, default_button_codes)
+        self._last_event_time = 0
 
-def open_devices():
-    devs = get_devices()
+    @property
+    def name(self):
+        return None if self._name is None else str(self._name)
 
-    fds = []
-    for dev in devs:
+    @property
+    def fd(self):
+        return None if self._fd is None else self._fd
+
+    @property
+    def button_codes(self):
+        return None if self._button_codes is None else dict(self._button_codes)
+
+    def process_event(self):
+        event = _read_event(self._fd)
+        if event:
+            # TODO: There are at least two remaining problems with the
+            # following "repeat prevention" logic:
+            #
+            #   1) Joysticks don't send a continuous stream of "pressed"
+            #      events for dpad/buttons.  They only send a "pressed"
+            #      event when the button is first pressed down and a
+            #      "released" event when the button is released, with no
+            #      other events in between for that button.  It's up to
+            #      us to generate repeated keystrokes at a sensible
+            #      rate during that interval.  Therefore, we don't need
+            #      to prevent repetition at all!
+            #
+            #   2) This logic completely neglects to make the repeat
+            #      check specific to each button... so it also has the
+            #      annoying side effect of blocking consecutive presses
+            #      of two different buttons that occur too quickly.
+            #
+            # For both of the above reasons, I am leaving this commented
+            # out for now.
+            #if time.time() - self._last_event_time > JS_REP:
+            if True:
+                if _process_event(event, self._button_codes):
+                    self._last_event_time = time.time()
+        return event != False
+
+    def close(self):
+        self._name = None
+        os.close(self._fd)
+        self._fd = None
+        self._button_codes = None
+
+
+def rescan_devices(devices, default_button_codes):
+    logging.debug("Rescanning devices...")
+    devices = devices.copy()
+    known_names = set([dev.name for dev in devices])
+    current_names = set([name for name in os.listdir('/dev/input') if name.startswith('js')])
+
+    deleted_names = known_names.difference(current_names)
+    for dev in devices.copy():
+        if dev.name in deleted_names:
+            devices.remove(dev)
+            logging.debug("  Removed " + dev.name)
+            dev.close()
+
+    added_names = current_names.difference(known_names)
+    for name in added_names:
         try:
-            fds.append(os.open(dev, os.O_RDONLY | os.O_NONBLOCK ))
-            js_button_codes[fds[-1]] = get_button_codes(dev)
+            devices.add(_JoystickDevice(name, default_button_codes))
+            logging.debug("  Added " + name)
         except (OSError, ValueError):
             pass
 
-    return devs, fds
+    logging.debug("Done rescanning devices.")
+    return devices
 
-def close_fds(fds):
-    for fd in fds:
-        os.close(fd)
 
-def read_event(fd):
-    while True:
-        try:
-            event = os.read(fd, event_size)
-        except OSError as e:
-            if e.errno == errno.EWOULDBLOCK:
-                return None
-            return False
+def close_devices(devices):
+    for device in devices.copy():
+        devices.remove(device)
+        device.close()
 
-        else:
-            return event
 
-def process_event(event):
+def _read_event(fd):
+    try:
+        return os.read(fd, _EVENT_SIZE)
+    except OSError as e:
+        if e.errno == errno.EWOULDBLOCK:
+            return None
+        return False
 
-    (js_time, js_value, js_type, js_number) = struct.unpack(event_format, event)
+
+def _process_event(event, button_codes):
+    (js_time, js_value, js_type, js_number) = struct.unpack(_EVENT_FORMAT, event)
 
     # ignore init events
     if js_type & JS_EVENT_INIT:
@@ -203,95 +271,74 @@ def process_event(event):
     if js_type == JS_EVENT_AXIS and js_number <= 7:
         if js_number % 2 == 0:
             if js_value <= JS_MIN * JS_THRESH:
-                hex_chars = axis_codes[0]
+                hex_chars = _AXIS_CODES[0]
             if js_value >= JS_MAX * JS_THRESH:
-                hex_chars = axis_codes[1]
+                hex_chars = _AXIS_CODES[1]
         if js_number % 2 == 1:
             if js_value <= JS_MIN * JS_THRESH:
-                hex_chars = axis_codes[2]
+                hex_chars = _AXIS_CODES[2]
             if js_value >= JS_MAX * JS_THRESH:
-                hex_chars = axis_codes[3]
+                hex_chars = _AXIS_CODES[3]
 
     if hex_chars:
         for c in hex_chars:
-            fcntl.ioctl(tty_fd, termios.TIOCSTI, c)
+            fcntl.ioctl(_TTY_FD, termios.TIOCSTI, c)
         return True
 
     return False
 
-js_fds = []
-tty_fd = []
 
-signal.signal(signal.SIGINT, signal_handler)
-signal.signal(signal.SIGTERM, signal_handler)
+def _main():
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
 
-# daemonize when signal handlers are registered
-if os.fork():
-    os._exit(0)
+    # NOTE: We cannot use os.fork() to make this script effectively
+    # rerun itself as a background process, because that API doesn't
+    # work correctly when run within certain contexts, such as from
+    # inside of a bash subshell command, i.e. "$(joy2key.py)".
 
-js_button_codes = {}
-button_codes = []
-default_button_codes = []
-axis_codes = []
+    default_button_codes = []
+    curses.setupterm()
+    i = 0
+    for arg in sys.argv[1:]:
+        chars = get_hex_chars(arg)
+        if i < 4:
+            _AXIS_CODES.append(chars)
 
-curses.setupterm()
+        logging.debug("Adding default button code " + str(chars.encode('utf-8')))
+        default_button_codes.append(chars)
+        i += 1
 
-i = 0
-for arg in sys.argv[2:]:
-    chars = get_hex_chars(arg)
-    if i < 4:
-        axis_codes.append(chars)
+    try:
+        global _TTY_FD
+        _TTY_FD = os.open('/dev/tty', os.O_WRONLY)
+    except IOError:
+        print('Unable to open /dev/tty', file = sys.stderr)
+        _exit(1)
 
-    default_button_codes.append(chars)
-    i += 1
+    global _JS_DEVICES
+    rescan_time = 0
+    while True:
+        if time.time() - rescan_time > 2:
+            _JS_DEVICES = rescan_devices(_JS_DEVICES, default_button_codes)
+            rescan_time = time.time()
 
-event_format = 'IhBB'
-event_size = struct.calcsize(event_format)
+        while not _JS_DEVICES:
+            _JS_DEVICES = rescan_devices(_JS_DEVICES, default_button_codes)
+            if _JS_DEVICES:
+                rescan_time = time.time()
+            else:
+                time.sleep(1)
+                continue
+        
+        for jsdev in _JS_DEVICES.copy():
+            if not jsdev.process_event():
+                logging.debug("Removing " + jsdev.name + " due to process_event() failure")
+                _JS_DEVICES.remove(jsdev)
+                jsdev.close()
 
-try:
-    tty_fd = os.open('/dev/tty', os.O_WRONLY)
-except IOError:
-    print('Unable to open /dev/tty', file = sys.stderr)
-    sys.exit(1)
-
-rescan_time = time.time()
-while True:
-    do_sleep = True
-    if not js_fds:
-        js_devs, js_fds = open_devices()
-        if js_fds:
-            i = 0
-            current = time.time()
-            js_last = [None] * len(js_fds)
-            for js in js_fds:
-                js_last[i] = current
-                i += 1
-        else:
-            time.sleep(1)
-    else:
-        i = 0
-        for fd in js_fds:
-            event = read_event(fd)
-            if event:
-                do_sleep = False
-                if time.time() - js_last[i] > JS_REP:
-                    if fd in js_button_codes:
-                        button_codes = js_button_codes[fd]
-                    else:
-                        button_codes = default_button_codes
-                    if process_event(event):
-                        js_last[i] = time.time()
-            elif event == False:
-                close_fds(js_fds)
-                js_fds = []
-                break
-            i += 1
-
-    if time.time() - rescan_time > 2:
-        rescan_time = time.time()
-        if js_devs != get_devices():
-            close_fds(js_fds)
-            js_fds = []
-
-    if do_sleep:
         time.sleep(0.01)
+
+
+if __name__ == '__main__':
+    _main()

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -127,7 +127,7 @@ function start_joy2key() {
         # arguments are curses capability names or hex values starting with '0x'
         # see: http://pubs.opengroup.org/onlinepubs/7908799/xcurses/terminfo.html
         # axes=arrows, b0=enter, b1=space, b2=escape
-        local params=(kcub1 kcuf1 kcuu1 kcud1 0x0b 0x20 0x1b)
+        local params=(kcub1 kcuf1 kcuu1 kcud1 0x0d 0x20 0x1b)
         "$ROOTDIR/supplementary/runcommand/joy2key.py" "${params[@]}" &
         if [[ "$?" == "0" ]]; then
             __joy2key_pid=$!


### PR DESCRIPTION
joy2key improvements

  * joy2key.py: fix decode error (that occurred whenever return value was anything other than bytes)
  * joy2key.py: remove usage of os.fork() that was preventing shell scripts from using $! to get definitive pid
  * joy2key.py: combine disparate lists into a single set of class objects, so related state can no longer get out of sync
  * joy2key.py: create a _main() function to get things out of global scope
  * joy2key.py: rename global variables per coding conventions and move them near the top
  * joy2key.py: comment out the totally broken repeated event filtering (joystick control is now much more responsive)
  * joy2key.py: simplify timing and tighten up responsiveness by removing/shortening some now-unnecessary sleeps
  * joy2key.py: restructured and simplified the main loop for clarity and maintainability
  * helpers.sh, runcommand.sh: stop guessing at the joy2key.py pid using pgrep, and just definitively obtain it via $!
  * helpers.sh, runcommand.sh: fix functional inconsistencies (use same variable name, use same timings, etc)