### PR TITLE
ti99sim: update to version 0.16.0, switch to SDL2

### DIFF
--- a/scriptmodules/emulators/ti99sim.sh
+++ b/scriptmodules/emulators/ti99sim.sh
@@ -12,25 +12,35 @@
 rp_module_id="ti99sim"
 rp_module_desc="TI-99/SIM - Texas Instruments Home Computer Emulator"
 rp_module_help="ROM Extension: .ctg\n\nCopy your TI-99 games to $romdir/ti99\n\nCopy the required BIOS file TI-994A.ctg (case sensitive) to $biosdir"
-rp_module_licence="GPL2 http://www.mrousseau.org/programs/ti99sim/"
+rp_module_licence="GPL2 https://www.mrousseau.org/programs/ti99sim"
 rp_module_section="exp"
-rp_module_flags="dispmanx !mali"
+rp_module_flags=""
 
 function depends_ti99sim() {
-    getDepends libsdl1.2-dev libssl-dev
+    getDepends libsd2-dev libssl-dev
 }
 
 function sources_ti99sim() {
-    downloadAndExtract "$__archive_url/ti99sim-0.13.0.src.tar.gz" "$md_build" --strip-components 1
+    downloadAndExtract "$__archive_url/ti99sim-0.16.0.src.tar.gz" "$md_build" --strip-components 1
 }
 
 function build_ti99sim() {
+    make clean
     make
 }
 
 function install_ti99sim() {
     md_ret_files=(
-        'src/sdl/Release/ti99sim-sdl'
+        'bin/ti99sim-sdl'
+        'bin/convert-ctg'
+        'bin/catalog'
+        'bin/disk'
+        'bin/dumpgrom'
+        'bin/mkcart'
+        'bin/ti99sim-console'
+        'doc/COPYING'
+        'doc/main.css'
+        'doc/README.html'
     )
 }
 
@@ -41,8 +51,6 @@ function configure_ti99sim() {
     addSystem "ti99"
 
     [[ "$md_mode" == "remove" ]] && return
-
-    setDispmanx "$md_id" 1
 
     moveConfigDir "$home/.ti99sim" "$md_conf_root/ti99/"
     ln -sf "$biosdir/TI-994A.ctg" "$md_inst/TI-994A.ctg"


### PR DESCRIPTION
Updated the emulator to the latest version, which is using SDL2, so `dispmanx` is not necessary mandatory.

Modified the installation to include some utilities (might be useful for disc/cartridge manipulation) and to include the docs and license.