### PR TITLE
nestopia: don't try to copy the NstDatabase.xml on configuration.

### DIFF
--- a/scriptmodules/libretrocores/lr-nestopia.sh
+++ b/scriptmodules/libretrocores/lr-nestopia.sh
@@ -41,9 +41,6 @@ function configure_lr-nestopia() {
     ensureSystemretroconfig "nes"
     ensureSystemretroconfig "fds"
 
-    cp NstDatabase.xml "$biosdir/"
-    chown $user:$user "$biosdir/NstDatabase.xml"
-
     addEmulator 0 "$md_id" "nes" "$md_inst/nestopia_libretro.so"
     addEmulator 1 "$md_id" "fds" "$md_inst/nestopia_libretro.so"
     addSystem "nes"


### PR DESCRIPTION
The `NstDatabase.xml` is not bundled anymore, it's built-in and it's not part of the binary install since 372c7cf7f1.