### PR TITLE
runcommand: validate the CrtcId/ModeId values for SDL2 env vars

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -970,8 +970,12 @@ function mode_switch() {
     if [[ "$HAS_MODESET" == "kms" ]]; then
         # update the target resolution even though the underlying fb hasn't changed
         MODE_CUR=($(get_${HAS_MODESET}_mode_info "${mode_id[*]}"))
-        # inject the environment variables to do modesetting for SDL2 applications
-        command_prefix="SDL_VIDEO_KMSDRM_CRTCID=${MODE_CUR[0]} SDL_VIDEO_KMSDRM_MODEID=${MODE_CUR[1]}"
+
+        # check the mode tuple against the list of current available CRCTID/MODEID values
+        if [[ -n ${MODE["${MODE_CUR[0]}-${MODE_CUR[1]}"]} ]]; then
+            # inject the environment variables to do modesetting for SDL2 applications
+            command_prefix="SDL_VIDEO_KMSDRM_CRTCID=${MODE_CUR[0]} SDL_VIDEO_KMSDRM_MODEID=${MODE_CUR[1]}"
+        fi
         COMMAND="$(echo "$command_prefix $COMMAND" | sed -e "s/;/; $command_prefix /g")"
 
         return 0


### PR DESCRIPTION
Before setting the SDL2 env variables that configure the modesetting for DRM/KMS, validate the CrtcId/ModeId tuple against the current list reported by `modetest`. Changes in the kernel DRM driver could make the existing modesetting configuration (stored in `videomodes.cfg`) invalid because of different CrtcId and/or ModeId in new versions of the driver.