### PR TITLE
gpsp / lr-gpsp - use gcc-6 to workaround segfault with gcc-8 on buster

### DIFF
--- a/scriptmodules/emulators/gpsp.sh
+++ b/scriptmodules/emulators/gpsp.sh
@@ -14,10 +14,10 @@ rp_module_desc="GameBoy Advance emulator"
 rp_module_help="ROM Extensions: .gba .zip\n\nCopy your Game Boy Advance roms to $romdir/gba\n\nCopy the required BIOS file gba_bios.bin to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/gizmo98/gpsp/master/COPYING.DOC"
 rp_module_section="opt"
-rp_module_flags="noinstclean !all arm !mali !kms"
+rp_module_flags="noinstclean !all videocore"
 
 function depends_gpsp() {
-    getDepends libsdl1.2-dev libraspberrypi-dev
+    getDepends libsdl1.2-dev libraspberrypi-dev gcc-6
 }
 
 function sources_gpsp() {
@@ -28,7 +28,7 @@ function build_gpsp() {
     cd raspberrypi
     rpSwap on 512
     make clean
-    make
+    make CC="gcc-6"
     rpSwap off
     md_ret_require="$md_build/raspberrypi/gpsp"
 }

--- a/scriptmodules/libretrocores/lr-gpsp.sh
+++ b/scriptmodules/libretrocores/lr-gpsp.sh
@@ -16,16 +16,20 @@ rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/gpsp/master/C
 rp_module_section="opt arm=main"
 rp_module_flags="!all arm"
 
+function depends_lr-gpsp() {
+    getDepends gcc-6
+}
+
 function sources_lr-gpsp() {
     gitPullOrClone "$md_build" https://github.com/libretro/gpsp.git
 }
 
 function build_lr-gpsp() {
-    make clean
     rpSwap on 512
     local params=()
     isPlatform "arm" && params+=(platform=armv)
-    make "${params[@]}"
+    make "${params[@]}" clean
+    CC="gcc-6" make "${params[@]}"
     rpSwap off
     md_ret_require="$md_build/gpsp_libretro.so"
 }


### PR DESCRIPTION
lr-gpsp:

cpu_threaded.c built with -O2 on gcc 8 produces a non working binary. This source already had
a different optimisation level from the rest of the code (O2 vs O3). However, on gcc-8 it causes
a non working binary when built with anything other than O0, but this could have some performance
issues (would need testing on a rpi1).

I compared all the different optimisation flags enabled by O1 and also with any changes from gcc-6,
but not all GCC optimisations are controllable from flags. It was not possible to produce a working
binary with O1 - even disabling all the configurable optimisations enabled by O1.

The issue is most likely undefined behaviour in this file (which has a lot of large macros), and it
probably needs some fixes. However it could be a bug in the gcc-8 optimiser code.

As the issue isn't present with gcc-6, and as gcc-6 is available on Debian buster, the easiest
workaround is to just force the code to be build with gcc-6.

Also adjusted the makefile to pass parameters for the make clean, as some platform specific objects
are not removed otherwise.

gpsp:

Forced gcc-6 as with lr-gpsp.

Simplified the module flags to just include videocore platforms.


Note: this has not yet been tested on a RPI 1 (tested working on rpi4 with lr-gpsp)