### PR TITLE
LZDOOM - Added joypad support for menus

### DIFF
--- a/scriptmodules/ports/lzdoom.sh
+++ b/scriptmodules/ports/lzdoom.sh
@@ -26,6 +26,9 @@ function depends_lzdoom() {
 
 function sources_lzdoom() {
     gitPullOrClone "$md_build" https://github.com/drfrag666/gzdoom "3.86a"
+	if isPlatform "rpi"; then
+		applyPatch "$md_data/01_rpi_fixes.diff" # Enables use of joypad to control menus so you don't need a keyboard!
+	fi
 }
 
 function build_lzdoom() {

--- a/scriptmodules/ports/lzdoom.sh
+++ b/scriptmodules/ports/lzdoom.sh
@@ -26,8 +26,10 @@ function depends_lzdoom() {
 
 function sources_lzdoom() {
     gitPullOrClone "$md_build" https://github.com/drfrag666/gzdoom "3.86a"
-	if isPlatform "rpi"; then
+	if isPlatform "rpi" && ! grep -q CNTRLMNU_OPEN_MAIN "$md_build/wadsrc/static/language.enu"; then
+		# Failsafe to apply joypad patch if it hasn't been added upstream yet https://github.com/coelckers/gzdoom/pull/1072
 		applyPatch "$md_data/01_rpi_fixes.diff" # Enables use of joypad to control menus so you don't need a keyboard!
+		# Safe to remove this patch if LZDOOM gets updated beyond 3.86a and includes joypad support for menus
 	fi
 }
 

--- a/scriptmodules/ports/lzdoom/01_rpi_fixes.diff
+++ b/scriptmodules/ports/lzdoom/01_rpi_fixes.diff
@@ -1,0 +1,167 @@
+diff --git a/src/doomdef.h b/src/doomdef.h
+index ac3a87c8e0..2260259708 100644
+--- a/src/doomdef.h
++++ b/src/doomdef.h
+@@ -184,6 +184,8 @@ enum ESkillLevels
+ #define KEY_JOY6				(KEY_FIRSTJOYBUTTON+5)
+ #define KEY_JOY7				(KEY_FIRSTJOYBUTTON+6)
+ #define KEY_JOY8				(KEY_FIRSTJOYBUTTON+7)
++#define KEY_JOY14				(KEY_FIRSTJOYBUTTON+13)	// PS3 button
++#define KEY_JOY15				(KEY_FIRSTJOYBUTTON+14)	// PS3 button
+ #define KEY_LASTJOYBUTTON		0x187
+ #define KEY_JOYPOV1_UP			0x188
+ #define KEY_JOYPOV1_RIGHT		0x189
+diff --git a/src/menu/menu.cpp b/src/menu/menu.cpp
+index 1097ae6f76..ef4c987566 100644
+--- a/src/menu/menu.cpp
++++ b/src/menu/menu.cpp
+@@ -662,16 +662,19 @@ bool M_Responder (event_t *ev)
+ 			switch (ch)
+ 			{
+ 			case KEY_JOY1:
++			case KEY_JOY3:
++			case KEY_JOY15:
+ 			case KEY_PAD_A:
+ 				mkey = MKEY_Enter;
+ 				break;
+ 
+ 			case KEY_JOY2:
++			case KEY_JOY14:
+ 			case KEY_PAD_B:
+ 				mkey = MKEY_Back;
+ 				break;
+ 
+-			case KEY_JOY3:
++			case KEY_JOY4:
+ 			case KEY_PAD_X:
+ 				mkey = MKEY_Clear;
+ 				break;
+@@ -688,28 +691,28 @@ bool M_Responder (event_t *ev)
+ 
+ 			case KEY_PAD_DPAD_UP:
+ 			case KEY_PAD_LTHUMB_UP:
+-			case KEY_JOYAXIS1MINUS:
++			case KEY_JOYAXIS2MINUS:
+ 			case KEY_JOYPOV1_UP:
+ 				mkey = MKEY_Up;
+ 				break;
+ 
+ 			case KEY_PAD_DPAD_DOWN:
+ 			case KEY_PAD_LTHUMB_DOWN:
+-			case KEY_JOYAXIS1PLUS:
++			case KEY_JOYAXIS2PLUS:
+ 			case KEY_JOYPOV1_DOWN:
+ 				mkey = MKEY_Down;
+ 				break;
+ 
+ 			case KEY_PAD_DPAD_LEFT:
+ 			case KEY_PAD_LTHUMB_LEFT:
+-			case KEY_JOYAXIS2MINUS:
++			case KEY_JOYAXIS1MINUS:
+ 			case KEY_JOYPOV1_LEFT:
+ 				mkey = MKEY_Left;
+ 				break;
+ 
+ 			case KEY_PAD_DPAD_RIGHT:
+ 			case KEY_PAD_LTHUMB_RIGHT:
+-			case KEY_JOYAXIS2PLUS:
++			case KEY_JOYAXIS1PLUS:
+ 			case KEY_JOYPOV1_RIGHT:
+ 				mkey = MKEY_Right;
+ 				break;
+diff --git a/src/posix/sdl/i_gui.cpp b/src/posix/sdl/i_gui.cpp
+index 1a895a6766..72585a862f 100644
+--- a/src/posix/sdl/i_gui.cpp
++++ b/src/posix/sdl/i_gui.cpp
+@@ -52,6 +52,7 @@ bool I_SetCursor(FTexture *cursorpic)
+ 			return false;
+ 		}
+ 
++		SDL_ShowCursor(SDL_DISABLE);
+ 		if (cursorSurface == NULL)
+ 			cursorSurface = SDL_CreateRGBSurface (0, 32, 32, 32, MAKEARGB(0,255,0,0), MAKEARGB(0,0,255,0), MAKEARGB(0,0,0,255), MAKEARGB(255,0,0,0));
+ 
+@@ -67,6 +68,7 @@ bool I_SetCursor(FTexture *cursorpic)
+ 			SDL_FreeCursor (cursor);
+ 		cursor = SDL_CreateColorCursor (cursorSurface, 0, 0);
+ 		SDL_SetCursor (cursor);
++		SDL_ShowCursor(SDL_ENABLE);
+ 	}
+ 	else
+ 	{
+diff --git a/src/posix/sdl/i_input.cpp b/src/posix/sdl/i_input.cpp
+index 1454ce7934..864f35dd91 100644
+--- a/src/posix/sdl/i_input.cpp
++++ b/src/posix/sdl/i_input.cpp
+@@ -203,12 +203,10 @@ void I_SetMouseCapture()
+ {
+ 	// Clear out any mouse movement.
+ 	SDL_GetRelativeMouseState (NULL, NULL);
+-	SDL_SetRelativeMouseMode (SDL_TRUE);
+ }
+ 
+ void I_ReleaseMouseCapture()
+ {
+-	SDL_SetRelativeMouseMode (SDL_FALSE);
+ }
+ 
+ static void PostMouseMove (int x, int y)
+@@ -279,7 +277,6 @@ static bool inGame()
+ static void I_CheckNativeMouse ()
+ {
+ 	bool focus = SDL_GetKeyboardFocus() != NULL;
+-	bool fs = screen->IsFullscreen();
+ 	
+ 	bool wantNative = !focus || (!use_mouse || GUICapture || paused || demoplayback || !inGame());
+ 
+@@ -547,13 +544,10 @@ void MessagePump (const SDL_Event &sev)
+ 
+ 	case SDL_JOYBUTTONDOWN:
+ 	case SDL_JOYBUTTONUP:
+-		if (!GUICapture)
+-		{
+-			event.type = sev.type == SDL_JOYBUTTONDOWN ? EV_KeyDown : EV_KeyUp;
+-			event.data1 = KEY_FIRSTJOYBUTTON + sev.jbutton.button;
+-			if(event.data1 != 0)
+-				D_PostEvent(&event);
+-		}
++		event.type = sev.type == SDL_JOYBUTTONDOWN ? EV_KeyDown : EV_KeyUp;
++		event.data1 = KEY_FIRSTJOYBUTTON + sev.jbutton.button;
++		if(event.data1 != 0)
++			D_PostEvent(&event);
+ 		break;
+ 	}
+ }
+diff --git a/wadsrc/static/language.enu b/wadsrc/static/language.enu
+index 968201efab..eb70ecc1ad 100644
+--- a/wadsrc/static/language.enu
++++ b/wadsrc/static/language.enu
+@@ -1787,6 +1787,7 @@ CNTRLMNU_OPEN_SAVE				= "Open Save Menu";
+ CNTRLMNU_OPEN_LOAD				= "Open Load Menu";
+ CNTRLMNU_OPEN_OPTIONS				= "Open Options Menu";
+ CNTRLMNU_OPEN_DISPLAY				= "Open Display Menu";
++CNTRLMNU_OPEN_MAIN				= "Open Main Menu";
+ CNTRLMNU_QUICKSAVE				= "Quicksave";
+ CNTRLMNU_QUICKLOAD				= "Quickload";
+ CNTRLMNU_EXIT_TO_MAIN				= "Exit to Main Menu";
+diff --git a/src/m_joy.cpp b/src/m_joy.cpp
+index 7b78d8266f..1d7207a71b 100644
+--- a/src/m_joy.cpp
++++ b/src/m_joy.cpp
+@@ -58,3 +58,3 @@ // PUBLIC DATA DEFINITIONS -------------------------------------------------
+
+-CUSTOM_CVAR(Bool, use_joystick, false, CVAR_ARCHIVE|CVAR_GLOBALCONFIG|CVAR_NOINITCALL)
++CUSTOM_CVAR(Bool, use_joystick, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG|CVAR_NOINITCALL)
+ {
+diff --git a/src/posix/sdl/i_joystick.cpp b/src/posix/sdl/i_joystick.cpp
+index 968201efab..eb70ecc1ad 100644
+--- a/src/posix/sdl/i_joystick.cpp
++++ b/src/posix/sdl/i_joystick.cpp
+@@ -147,6 +147,6 @@ info.Name.Format("Axis %d", i+1);
+ 			else
+ 				info.Name.Format("Hat %d (%c)", (i-NumAxes)/2 + 1, (i-NumAxes)%2 == 0 ? 'x' : 'y');
+-			info.DeadZone = MIN_DEADZONE;
++			info.DeadZone = 0.1;
+ 			info.Multiplier = 1.0f;
+ 			info.Value = 0.0;
+ 			info.ButtonValue = 0;

--- a/scriptmodules/ports/lzdoom/01_rpi_fixes.diff
+++ b/scriptmodules/ports/lzdoom/01_rpi_fixes.diff
@@ -177,3 +177,15 @@ index 94efc110f0..4314781900 100644
  pad_start pause
  pad_back menu_main
  lthumb crouch
+diff --git a/wadsrc/static/menudef.txt b/wadsrc/static/menudef.txt
+index 7b78d8266f..1d7207a71b 100644
+--- a/wadsrc/static/menudef.txt
++++ b/wadsrc/static/menudef.txt
+@@ -625,6 +625,7 @@ OptionMenu "OtherControlsMenu" protected
+ 	Control    "$CNTRLMNU_SCREENSHOT"      , "screenshot"
+ 	Control    "$CNTRLMNU_CONSOLE"         , "toggleconsole"
+ 	Control    "$CNTRLMNU_PAUSE"           , "pause"
++	Control    "$CNTRLMNU_OPEN_MAIN"       , "menu_main"
+ 
+ 	StaticText ""
+ 	Control    "$CNTRLMNU_DISPLAY_INC"     , "sizeup"

--- a/scriptmodules/ports/lzdoom/01_rpi_fixes.diff
+++ b/scriptmodules/ports/lzdoom/01_rpi_fixes.diff
@@ -161,7 +161,7 @@ index 968201efab..eb70ecc1ad 100644
  			else
  				info.Name.Format("Hat %d (%c)", (i-NumAxes)/2 + 1, (i-NumAxes)%2 == 0 ? 'x' : 'y');
 -			info.DeadZone = MIN_DEADZONE;
-+			info.DeadZone = 0.1;
++			info.DeadZone = 0.15;
  			info.Multiplier = 1.0f;
  			info.Value = 0.0;
  			info.ButtonValue = 0;

--- a/scriptmodules/ports/lzdoom/01_rpi_fixes.diff
+++ b/scriptmodules/ports/lzdoom/01_rpi_fixes.diff
@@ -161,7 +161,19 @@ index 968201efab..eb70ecc1ad 100644
  			else
  				info.Name.Format("Hat %d (%c)", (i-NumAxes)/2 + 1, (i-NumAxes)%2 == 0 ? 'x' : 'y');
 -			info.DeadZone = MIN_DEADZONE;
-+			info.DeadZone = 0.15;
++			info.DeadZone = 0.1;
  			info.Multiplier = 1.0f;
  			info.Value = 0.0;
  			info.ButtonValue = 0;
+diff --git a/wadsrc/static/defbinds.txt b/wadsrc/static/defbinds.txt
+index 94efc110f0..4314781900 100644
+--- a/wadsrc/static/defbinds.txt
++++ b/wadsrc/static/defbinds.txt
+@@ -60,6 +60,7 @@ dpadleft invprev
+ dpadright invnext
+ dpaddown invuse
+ dpadup togglemap
++joy9 menu_main
+ pad_start pause
+ pad_back menu_main
+ lthumb crouch


### PR DESCRIPTION
Added fixes from https://github.com/protocultor/gzdoom/commit/ce79b391f7f6fc8417b98a1caeae9b1affd55024
Also enabled joypads by default for raspberry pi (I set the default deadzones to 0.1 instead of 0 so the analog sticks don't spam the menu controls, it can still be adjusted lower than 0.1 if wanted).
You can also map the menu button to whatever you want.
Now you don't need a keyboard at all to set up or play the game.

Tested and working on RPI 4 with lzdoom 3.86a (running retropie 4.6)