### PR TITLE
lr-flycast - restore makefile patch and fix logic

### DIFF
--- a/scriptmodules/libretrocores/lr-flycast/01_flags_fix.diff
+++ b/scriptmodules/libretrocores/lr-flycast/01_flags_fix.diff
@@ -1,0 +1,30 @@
+diff --git a/Makefile b/Makefile
+index 36aacd6b..3226c1f3 100644
+--- a/Makefile
++++ b/Makefile
+@@ -45,8 +45,6 @@ LDFLAGS  :=
+ LDFLAGS_END :=
+ INCFLAGS :=
+ LIBS     :=
+-CFLAGS   := 
+-CXXFLAGS :=
+ 
+ GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ ifneq ($(GIT_VERSION)," unknown")
+@@ -196,6 +194,7 @@ else ifneq (,$(findstring rpi,$(platform)))
+ 		endif
+ 		CORE_DEFINES += -DLOW_END
+ 	endif
++	LDFLAGS += $(CFLAGS)
+ 	PLATFORM_EXT := unix
+ 	WITH_DYNAREC=arm
+ 	HAVE_GENERIC_JIT = 0
+@@ -892,7 +891,7 @@ else
+ 	ifneq (,$(findstring msvc,$(platform)))
+ 		OPTFLAGS       := -O2
+ 	else ifneq ($(platform), classic_armv7_a7)
+-		OPTFLAGS       := -O3
++		OPTFLAGS       := -O2
+ 	endif
+ 
+ 	CORE_DEFINES   += -DNDEBUG


### PR DESCRIPTION
 * makefile patch is still needed for our compiler flags
 * CPU_FLAGS isn't used so not sure what happened here - mistake or I missed out something.
 * use CXXFLAGS for the additional videocore flags, to override makefile logic
 * re-add make clean