### PR TITLE
sdltrs: switch to an active fork, build with SDL2

### DIFF
--- a/scriptmodules/emulators/sdltrs.sh
+++ b/scriptmodules/emulators/sdltrs.sh
@@ -13,47 +13,60 @@ rp_module_id="sdltrs"
 rp_module_desc="Radio Shack TRS-80 Model I/III/4/4P emulator"
 rp_module_help="ROM Extension: .dsk\n\nCopy your TRS-80 games to $romdir/trs-80\n\nCopy the required BIOS file level2.rom, level3.rom, level4.rom or level4p.rom to $biosdir"
 rp_module_section="exp"
-rp_module_flags="dispmanx !mali !kms"
+rp_module_licence="BSD https://gitlab.com/jengun/sdltrs/-/raw/master/LICENSE"
+rp_module_flags=""
 
 function depends_sdltrs() {
-    getDepends libsdl1.2-dev libxt-dev
+    getDepends libsdl2-dev libreadline-dev
 }
 
 function sources_sdltrs() {
-    gitPullOrClone "$md_build" https://github.com/RetroPie/sdltrs.git
+    gitPullOrClone "$md_build" https://gitlab.com/jengun/sdltrs.git sdl2
 }
 
 function build_sdltrs() {
-    cd src/linux
     make clean
+    ./autogen.sh
+    ./configure --prefix="$md_inst"
     make
-    md_ret_require="$md_build/src/linux/sdltrs"
+    md_ret_require="$md_build/sdl2trs"
 }
 
 function install_sdltrs() {
-    chmod 644 README
     md_ret_files=(
-        'src/linux/sdltrs'
-        'README'
+        'sdl2trs'
+        'README.md'
+        'LICENSE'
     )
 }
 
 function configure_sdltrs() {
+    local common_args
     mkRomDir "trs-80"
 
-    addEmulator 1 "$md_id-model1" "trs-80" "$md_inst/sdltrs -model 1 -romfile $biosdir/level2.rom -showled -diskdir $romdir/trs-80 -disk0 %ROM%"
-    addEmulator 0 "$md_id-model3" "trs-80" "$md_inst/sdltrs -model 3 -romfile3 $biosdir/level3.rom -showled -diskdir $romdir/trs-80 -disk0 %ROM%"
-    addEmulator 0 "$md_id-model4" "trs-80" "$md_inst/sdltrs -model 4 -romfile3 $biosdir/level4.rom -showled -diskdir $romdir/trs-80 -disk0 %ROM%"
-    addEmulator 0 "$md_id-model4p" "trs-80" "$md_inst/sdltrs -model 4p -romfile4p $biosdir/level4p.rom -showled -diskdir $romdir/trs-80 -disk0 %ROM%"
+    common_args="-fullscreen -nomousepointer -showled"
+    addEmulator 1 "$md_id-model1" "trs-80" "$md_inst/sdl2trs $common_args -m1 -romfile $biosdir/level2.rom -disk0 %ROM%"
+    addEmulator 0 "$md_id-model3" "trs-80" "$md_inst/sdl2trs $common_args -m3 -romfile3 $biosdir/level3.rom -disk0 %ROM%"
+    addEmulator 0 "$md_id-model4" "trs-80" "$md_inst/sdl2trs $common_args -m4 -romfile3 $biosdir/level4.rom -disk0 %ROM%"
+    addEmulator 0 "$md_id-model4p" "trs-80" "$md_inst/sdl2trs $common_args -m4p -romfile4p $biosdir/level4p.rom -disk0 %ROM%"
     addSystem "trs-80"
 
     [[ "$md_mode" == "remove" ]] && return
 
-    moveConfigFile "$home/sdltrs.t8c" "$md_conf_root/trs-80/sdltrs.t8c"
+    # Migrate settings from the previous version
+    if [[ -h "$home/sdltrs.t8c" || -f "$home/sdltrs.t8c" ]]; then
+       mv "$(readlink -f "$home/sdltrs.t8c")" "$home/.sdltrs.t8c"
+    fi
 
-    local rom
-    for rom in level2.rom level3.rom level4.rom level4p.rom; do
-        ln -sf "$biosdir/$rom" "$md_inst/$rom"
-    done
+    local config
+    config="$(mktemp)"
+    iniConfig "=" "" "$config"
+    iniSet "statedir"   "$romdir/trs-80"
+    iniSet "diskdir"    "$romdir/trs-80"
+    iniSet "cassdir"    "$romdir/trs-80"
+    iniSet "disksetdir" "$romdir/trs-80"
+    iniSet "harddir"    "$romdir/trs-80"
+    copyDefaultConfig "$config" "$md_conf_root/trs-80/sdltrs.t8c"
 
+    moveConfigFile "$home/.sdltrs.t8c" "$md_conf_root/trs-80/sdltrs.t8c"
 }


### PR DESCRIPTION
Switched SDLTRS to be built from https://gitlab.com/jengun/sdltrs, which is an active fork of the original SDLTRS emulator.

* use the SDL2 branch, which should be more portable (KMS/Odroid/etc.)
* set a minimum of configuration dir in the default configuration file ($HOME/.sdltrs.t8c)
* although not explicitely specified, the main license seems to be BSD-2-Clause (https://opensource.org/licenses/BSD-2-Clause)