### PR TITLE
runcommand - fix aspect ratio using dispmanx backend with sdl1 on fkms

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -1019,7 +1019,12 @@ function config_dispmanx() {
     if [[ -f "$DISPMANX_CONF" ]]; then
         iniConfig " = " '"' "$DISPMANX_CONF"
         iniGet "$name"
-        [[ "$ini_value" == "1" ]] && COMMAND="SDL1_VIDEODRIVER=dispmanx $COMMAND"
+        if [[ "$ini_value" == "1" ]]; then
+            if [[ "$HAS_MODESET" == "kms" ]]; then
+                COMMAND="SDL_DISPMANX_WIDTH=${MODE_CUR[2]} SDL_DISPMANX_HEIGHT=${MODE_CUR[3]} $COMMAND"
+            fi
+            COMMAND="SDL1_VIDEODRIVER=dispmanx $COMMAND"
+        fi
     fi
 }
 

--- a/scriptmodules/supplementary/sdl1.sh
+++ b/scriptmodules/supplementary/sdl1.sh
@@ -35,7 +35,7 @@ function get_pkg_ver_sdl1() {
     elif [[ "$1" == "base" ]]; then
         echo "$basever"
     else
-        echo "$basever-$(($revision + 2))rpi"
+        echo "$basever-$(($revision + 3))rpi"
     fi
 }
 


### PR DESCRIPTION
Added sdl1 patch to allow overriding of graphics_get_display_size as it returns 0 on fkms for width and height,
which skips the scaling code and ability to adjust aspect ratio.

New ENV vars are SDL_DISPMANX_WIDTH and SDL_DISPMANX_HEIGHT which we now set manually in runcommand on fkms
when a dispmanx backend is used with sdl1.

This should resolve aspect ratio issues rpi4 users were having with some sdl1 emulators that worked with the dispmanx
backend, but always stretched to fill the entire screen.

This also enables the use of SDL_DISPMANX_RATIO to tweak the ratio when scaling - from 0.2 to 6 - currently
unused in any RetroPie modules by default, but used to be used for tweaking the vice scaling, to more accurately
produce a correct aspect ratio for the C64. But can be used by users manually via emulators.cfg if required.

bumped sdl1 version to force an update - including for Stretch, although this is primarily a buster/rpi4 issue