### PR TITLE
system / packages - added signing of binary packages

### DIFF
--- a/scriptmodules/admin/builder.sh
+++ b/scriptmodules/admin/builder.sh
@@ -96,7 +96,13 @@ function chroot_build_builder() {
         [[ ! -d "$md_build/$dist" ]] && rp_callModule image create_chroot "$dist" "$md_build/$dist"
         if [[ ! -d "$md_build/$dist/home/pi/RetroPie-Setup" ]]; then
             sudo -u $user git clone "$home/RetroPie-Setup" "$md_build/$dist/home/pi/RetroPie-Setup"
-            rp_callModule image chroot "$md_build/$dist" bash -c "sudo apt-get update; sudo apt-get install -y git"
+            gpg --export-secret-keys "$__gpg_signing_key" >"$md_build/$dist/retropie.key"
+            rp_callModule image chroot "$md_build/$dist" bash -c "\
+                sudo gpg --import "/retropie.key"; \
+                sudo rm "/retropie.key"; \
+                sudo apt-get update; \
+                sudo apt-get install -y git; \
+                "
         else
             sudo -u $user git -C "$md_build/$dist/home/pi/RetroPie-Setup" pull
         fi

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -1528,3 +1528,18 @@ function adminRsync() {
 
     rsync -av --delay-updates -e "ssh -p $remote_port" "${params[@]}" "$src" "$remote_user@$remote_host:$dest"
 }
+
+## @fn signFile()
+## @param file path to file to sign
+## @brief signs file with $__gpg_signing_key
+## @details signs file with $__gpg_signing_key creating corresponding .asc file in the same folder
+function signFile() {
+    local file="$1"
+    local cmd_out
+    cmd_out=$(gpg --default-key "$__gpg_signing_key" --detach-sign --armor --yes "$1" 2>&1)
+    if [[ "$?" -ne 0 ]]; then
+        md_ret_errors+=("Failed to sign $1\n\n$cmd_out")
+        return 1
+    fi
+    return 0
+}

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -1022,6 +1022,31 @@ function download() {
     return 0
 }
 
+## @fn downloadAndVerify()
+## @param url url of file
+## @param dest destination file
+## @brief Download a file and a corresponding .asc signature and verify the contents
+## @details Download a file and a corresponding .asc signature and verify the contents.
+## The .asc file will be downloaded to verify the file, but will be removed after downloading.
+## @retval 0 on success
+function downloadAndVerify() {
+    local url="$1"
+    local dest="$2"
+
+    local cmd_out
+    local ret=1
+    if download "${url}.asc" "${dest}.asc"; then
+        if download "$url" "$dest"; then
+            cmd_out="$(gpg --verify "${dest}.asc" 2>&1)"
+            ret="$?"
+            if [[ "$ret" -ne 0 ]]; then
+                md_ret_errors+=("$dest failed signature check:\n\n$cmd_out")
+            fi
+        fi
+    fi
+    return "$ret"
+}
+
 ## @fn downloadAndExtract()
 ## @param url url of archive
 ## @param dest destination folder for the archive

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -987,13 +987,16 @@ function applyPatch() {
 
 ## @fn download()
 ## @param url url of file
-## @param dest destination file
+## @param dest destination name (optional)
 ## @brief Download a file
-## @details Download a file.
+## @details Download a file - if the dest parameter is ommitted, the file will be downloaded to the current directory
 ## @retval 0 on success
 function download() {
     local url="$1"
     local dest="$2"
+
+    # if no destination, get the basename from the url (supported by GNU basename)
+    [[ -z "$dest" ]] && dest="${PWD}/$(basename "$url")"
 
     # set up additional file descriptor for stdin
     exec 3>&1
@@ -1024,14 +1027,18 @@ function download() {
 
 ## @fn downloadAndVerify()
 ## @param url url of file
-## @param dest destination file
+## @param dest destination file (optional)
 ## @brief Download a file and a corresponding .asc signature and verify the contents
 ## @details Download a file and a corresponding .asc signature and verify the contents.
 ## The .asc file will be downloaded to verify the file, but will be removed after downloading.
+## If the dest parameter is omitted, the file will be downloaded to the current directory
 ## @retval 0 on success
 function downloadAndVerify() {
     local url="$1"
     local dest="$2"
+
+    # if no destination, get the basename from the url (supported by GNU basename)
+    [[ -z "$dest" ]] && dest="${PWD}/$(basename "$url")"
 
     local cmd_out
     local ret=1

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -170,7 +170,7 @@ function rp_callModule() {
             ;;
         # create binary archive
         create_bin)
-            rp_createBin
+            rp_createBin || return 1
             return 0
             ;;
         # echo module help to console
@@ -427,10 +427,33 @@ function rp_getInstallPath() {
 
 function rp_installBin() {
     rp_hasBinaries || fatalError "There are no binary archives for platform $__platform"
-    local archive="$md_type/$md_id.tar.gz";
+    local archive="$md_id.tar.gz";
     local dest="$rootdir/$md_type"
-    mkdir -p "$dest"
-    wget -O- -q "$__binary_url/$archive" | tar -xvz -C "$dest"
+
+    local cmd_out
+
+    # create temporary folder
+    local tmp=$(mktemp -d)
+
+    if download "$__binary_url/$md_type/$archive.asc" "$tmp/$archive.asc"; then
+        if download "$__binary_url/$md_type/$archive" "$tmp/$archive"; then
+            cmd_out="$(gpg --verify "$tmp/$archive.asc" 2>&1)"
+            if [[ "$?" -eq 0 ]]; then
+                mkdir -p "$dest"
+                if ! tar -xvf "$tmp/$archive" -C "$dest"; then
+                    md_ret_errors+=("Archive $archive failed to unpack correctly to $dest")
+                else
+                    rm -rf "$tmp"
+                    return 0
+                fi
+            else
+                md_ret_errors+=("Archive $archive failed signature check:\n\n$cmd_out")
+            fi
+        fi
+    fi
+
+    rm -rf "$tmp"
+    return 1
 }
 
 function rp_createBin() {
@@ -448,10 +471,16 @@ function rp_createBin() {
 
     local archive="$md_id.tar.gz"
     local dest="$__tmpdir/archives/$__binary_path/$md_type"
-    rm -f "$dest/$archive"
     mkdir -p "$dest"
-    tar cvzf "$dest/$archive" -C "$rootdir/$md_type" "$md_id"
-    chown $user:$user "$dest/$archive"
+    rm -f "$dest/$archive"
+    if tar cvzf "$dest/$archive" -C "$rootdir/$md_type" "$md_id"; then
+        if gpg --default-key "$__gpg_signing_key" --detach-sign --armor --yes "$dest/$archive"; then
+            chown $user:$user "$dest/$archive" "$dest/$archive.asc"
+            return 0
+        fi
+    fi
+    rm -f "$dest/$archive" "$dest/$archive.asc"
+    return 1
 }
 
 function rp_hasModule() {

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -435,20 +435,13 @@ function rp_installBin() {
     # create temporary folder
     local tmp=$(mktemp -d)
 
-    if download "$__binary_url/$md_type/$archive.asc" "$tmp/$archive.asc"; then
-        if download "$__binary_url/$md_type/$archive" "$tmp/$archive"; then
-            cmd_out="$(gpg --verify "$tmp/$archive.asc" 2>&1)"
-            if [[ "$?" -eq 0 ]]; then
-                mkdir -p "$dest"
-                if ! tar -xvf "$tmp/$archive" -C "$dest"; then
-                    md_ret_errors+=("Archive $archive failed to unpack correctly to $dest")
-                else
-                    rm -rf "$tmp"
-                    return 0
-                fi
-            else
-                md_ret_errors+=("Archive $archive failed signature check:\n\n$cmd_out")
-            fi
+    if downloadAndVerify "$__binary_url/$md_type/$archive" "$tmp/$archive"; then
+        mkdir -p "$dest"
+        if tar -xvf "$tmp/$archive" -C "$dest"; then
+            rm -rf "$tmp"
+            return 0
+        else
+            md_ret_errors+=("Archive $archive failed to unpack correctly to $dest")
         fi
     fi
 

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -467,7 +467,7 @@ function rp_createBin() {
     mkdir -p "$dest"
     rm -f "$dest/$archive"
     if tar cvzf "$dest/$archive" -C "$rootdir/$md_type" "$md_id"; then
-        if gpg --default-key "$__gpg_signing_key" --detach-sign --armor --yes "$dest/$archive"; then
+        if signFile "$dest/$archive"; then
             chown $user:$user "$dest/$archive" "$dest/$archive.asc"
             return 0
         fi

--- a/scriptmodules/supplementary/sdl1.sh
+++ b/scriptmodules/supplementary/sdl1.sh
@@ -50,14 +50,14 @@ function depends_sdl1() {
 
 function sources_sdl1() {
     local file
-    for file in libsdl1.2_$(get_pkg_ver_sdl1 base).orig.tar.xz libsdl1.2_$(get_pkg_ver_sdl1 base).orig.tar.gz libsdl1.2_$(get_pkg_ver_sdl1 source).dsc libsdl1.2_$(get_pkg_ver_sdl1 source).debian.tar.xz; do
-        wget -q -O "$file" "http://mirrordirector.raspbian.org/raspbian/pool/main/libs/libsdl1.2/$file" || rm -f "$file"
+    for file in libsdl1.2_$(get_pkg_ver_sdl1 base).orig.tar.gz libsdl1.2_$(get_pkg_ver_sdl1 source).dsc libsdl1.2_$(get_pkg_ver_sdl1 source).debian.tar.xz; do
+        download "http://mirrordirector.raspbian.org/raspbian/pool/main/libs/libsdl1.2/$file" "$file"
     done
     dpkg-source -x libsdl1.2_$(get_pkg_ver_sdl1 source).dsc
 
     cd libsdl1.2-$(get_pkg_ver_sdl1 base)
     # add fixes from https://github.com/RetroPie/sdl1/compare/master...rpi
-    wget https://github.com/RetroPie/sdl1/compare/master...rpi.diff -O debian/patches/rpi.diff
+    download "https://github.com/RetroPie/sdl1/compare/master...rpi.diff" "debian/patches/rpi.diff"
     echo "rpi.diff" >>debian/patches/series
     # force building without tslib on Jessie (as Raspbian Jessie has tslib, but Debian Jessie doesn't and we want cross compatibility
     sed -i "s/--enable-video-caca/--enable-video-caca --disable-input-tslib/" debian/rules
@@ -69,7 +69,15 @@ function build_sdl1() {
     dpkg-buildpackage
     local dest="$__tmpdir/archives/$__binary_path"
     mkdir -p "$dest"
-    cp ../*.deb "$dest/"
+
+    local file
+    for file in ../*.deb; do
+        if gpg --list-secret-keys "$__gpg_signing_key" &>/dev/null; then
+            signFile "$file" || return 1
+            cp "${file}.asc" "$dest/"
+        fi
+        cp ../*.deb "$dest/"
+    done
 }
 
 function install_sdl1() {
@@ -88,10 +96,17 @@ function __binary_url_sdl1() {
 
 function install_bin_sdl1() {
     local arch="$(_get_arch_sdl1)"
-    wget "$__binary_url/libsdl1.2debian_$(get_pkg_ver_sdl1)_${arch}.deb"
-    wget "$__binary_url/libsdl1.2-dev_$(get_pkg_ver_sdl1)_${arch}.deb"
-    install_sdl1
-    rm ./*.deb
+    local tmp="$(mktemp -d)"
+    pushd "$tmp" >/dev/null
+    local ret=1
+    if downloadAndVerify "$__binary_url/libsdl1.2debian_$(get_pkg_ver_sdl1)_${arch}.deb" && \
+       downloadAndVerify "$__binary_url/libsdl1.2-dev_$(get_pkg_ver_sdl1)_${arch}.deb"; then
+        install_sdl1
+        ret=0
+    fi
+    popd >/dev/null
+    rm -rf "$tmp"
+    return "$ret"
 }
 
 function remove_sdl1() {

--- a/scriptmodules/supplementary/sdl2.sh
+++ b/scriptmodules/supplementary/sdl2.sh
@@ -109,7 +109,15 @@ function build_sdl2() {
     md_ret_require="$md_build/libsdl2-dev_$(get_pkg_ver_sdl2)_$(get_arch_sdl2).deb"
     local dest="$__tmpdir/archives/$__binary_path"
     mkdir -p "$dest"
-    cp ../*.deb "$dest/"
+
+    local file
+    for file in ../*.deb; do
+        if gpg --list-secret-keys "$__gpg_signing_key" &>/dev/null; then
+            signFile "$file" || return 1
+            cp "${file}.asc" "$dest/"
+        fi
+        cp ../*.deb "$dest/"
+    done
 }
 
 function remove_old_sdl2() {
@@ -131,10 +139,17 @@ function __binary_url_sdl2() {
 }
 
 function install_bin_sdl2() {
-    wget -c "$__binary_url/libsdl2-dev_$(get_pkg_ver_sdl2)_armhf.deb"
-    wget -c "$__binary_url/libsdl2-2.0-0_$(get_pkg_ver_sdl2)_armhf.deb"
-    install_sdl2
-    rm ./*.deb
+    local tmp="$(mktemp -d)"
+    pushd "$tmp" >/dev/null
+    local ret=1
+    if downloadAndVerify "$__binary_url/libsdl2-dev_$(get_pkg_ver_sdl2)_armhf.deb" && \
+       downloadAndVerify "$__binary_url/libsdl2-2.0-0_$(get_pkg_ver_sdl2)_armhf.deb"; then
+        install_sdl2
+        ret=0
+    fi
+    popd >/dev/null
+    rm -rf "$tmp"
+    return "$ret"
 }
 
 function revert_sdl2() {

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -73,6 +73,11 @@ function conf_binary_vars() {
     __binary_url="$__binary_base_url/$__binary_path"
 
     __archive_url="https://files.retropie.org.uk/archives"
+
+    [[ -z "$__gpg_signing_key" ]] && __gpg_signing_key="retropieproject@gmail.com"
+    if ! gpg --list-keys "$__gpg_signing_key" &>/dev/null; then
+        gpg --keyserver keyserver.ubuntu.com --recv-keys DC9D77FF8208FFC51D8F50CCF1B030906A3B0D31
+    fi
 }
 
 function conf_build_vars() {
@@ -281,7 +286,7 @@ function get_os_version() {
 }
 
 function get_retropie_depends() {
-    local depends=(git dialog wget gcc g++ build-essential unzip xmlstarlet python3-pyudev ca-certificates)
+    local depends=(git dialog wget gcc g++ build-essential unzip xmlstarlet python3-pyudev ca-certificates dirmngr)
 
     [[ -n "$DISTCC_HOSTS" ]] && depends+=(distcc)
 


### PR DESCRIPTION
 * default signing key can be overridden with __gpg_signing_key
 * added gpg dependency by default
 * download retropie key from ubuntu keyserver if it doesn't exist in keyring
 * added download helper function
 * rework logic for rp_installBin and rp_createBin
 * copy secret key to chroots for package building

All core/opt bins are now signed. Some experimental packages are still being built still but all bins will be signed soon.

After this is included I may switch away from wget to curl due to wget limitations with its use of  stderr (see download function).

But first will reduce number of modules handling downloads themselves to use the download function. Also the download and extract function will be reworked etc.

But the main premise behind this is to reduce the risk of installing prebuilt binaries, for example if our server was exploited and someone replaced a core binary with something malicious.