### PR TITLE
Default Core Options for lr-mupen64plus-next

### DIFF
--- a/scriptmodules/libretrocores/lr-mupen64plus-next.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus-next.sh
@@ -73,6 +73,16 @@ function configure_lr-mupen64plus-next() {
     mkRomDir "n64"
     ensureSystemretroconfig "n64"
 
+    if isPlatform "rpi"; then
+        # Disable hybrid upscaling filter (needs better GPU)
+        setRetroArchCoreOption "mupen64plus-next-HybridFilter" "False"
+        # Disable overscan/VI emulation (slight performance drain)
+        setRetroArchCoreOption "mupen64plus-next-EnableOverscan" "Disabled"
+        # Enable Threaded GL calls
+        setRetroArchCoreOption "mupen64plus-next-ThreadedRenderer" "True"
+    fi
+    setRetroArchCoreOption "mupen64plus-next-EnableNativeResFactor" "1"
+
     addEmulator 1 "$md_id" "n64" "$md_inst/mupen64plus_next_libretro.so"
     addSystem "n64"
 }


### PR DESCRIPTION
Parity with the defaults for mupen64plus-GLideN64 standalone. 