### PR TITLE
openmsx: added joystick autoconfiguration, config tweaks and enabled for 'mali'

### DIFF
--- a/scriptmodules/emulators/openmsx.sh
+++ b/scriptmodules/emulators/openmsx.sh
@@ -14,7 +14,7 @@ rp_module_desc="MSX emulator OpenMSX"
 rp_module_help="ROM Extensions: .rom .mx1 .mx2 .col .dsk .zip\n\nCopy your MSX/MSX2 games to $romdir/msx"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/openMSX/openMSX/master/doc/GPL.txt"
 rp_module_section="opt"
-rp_module_flags="!mali"
+rp_module_flags=""
 
 function depends_openmsx() {
     local depends=(libsdl2-dev libsdl2-ttf-dev libao-dev libogg-dev libtheora-dev libxml2-dev libvorbis-dev tcl-dev libasound2-dev)

--- a/scriptmodules/emulators/openmsx.sh
+++ b/scriptmodules/emulators/openmsx.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="openmsx"
 rp_module_desc="MSX emulator OpenMSX"
-rp_module_help="ROM Extensions: .rom .mx1 .mx2 .col .dsk .zip\n\nCopy your MSX/MSX2 games to $romdir/msx"
+rp_module_help="ROM Extensions: .rom .mx1 .mx2 .col .dsk .zip\n\nCopy your MSX/MSX2 games to $romdir/msx\nCopy the BIOS files to $biosdir/openmsx"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/openMSX/openMSX/master/doc/GPL.txt"
 rp_module_section="opt"
 rp_module_flags=""
@@ -53,5 +53,58 @@ function configure_openmsx() {
     mkRomDir "msx"
 
     addEmulator 0 "$md_id" "msx" "$md_inst/bin/openmsx %ROM%"
+    addEmulator 0 "$md_id-msx2" "msx" "$md_inst/bin/openmsx -m 'Boosted_MSX2_EN' %ROM%"
+    addEmulator 0 "$md_id-msx2+" "msx" "$md_inst/bin/openmsx -m 'Boosted_MSX2+_JP' %ROM%"
+    addEmulator 0 "$md_id-msx-turbor" "msx" "$md_inst/bin/openmsx -m 'Panasonic_FS-A1GT' %ROM%"
     addSystem "msx"
+
+    [[ $md_mode == "remove" ]] && return
+
+    # Add a minimal configuration
+    local config="$(mktemp)"
+    echo "$(_default_settings_openmsx)" > "$config"
+
+    mkUserDir "$home/.openMSX/share/scripts"
+    mkUserDir "$home/.openMSX/share/systemroms"
+    moveConfigDir "$home/.openMSX" "$configdir/msx/openmsx"
+    moveConfigDir "$configdir/msx/openmsx/share/systemroms" "$home/RetroPie/BIOS/openmsx"
+
+    copyDefaultConfig "$config" "$home/.openMSX/share/settings.xml"
+    rm "$config"
+
+    # Add an autostart script, used for joypad configuration
+    cp "$md_data/retropie-init.tcl" "$home/.openMSX/share/scripts"
+    chown -R "$user:$user" "$home/.openMSX/share/scripts"
+}
+
+function _default_settings_openmsx() {
+    local header
+    local body
+    local conf_reverse
+
+    read -r -d '' header <<_EOF_
+<!DOCTYPE settings SYSTEM 'settings.dtd'>
+<settings>
+  <settings>
+    <setting id="default_machine">C-BIOS_MSX</setting>
+    <setting id="osd_disk_path">$romdir/msx</setting>
+    <setting id="osd_rom_path">$romdir/msx</setting>
+    <setting id="osd_tape_path">$romdir/msx</setting>
+    <setting id="osd_hdd_path">$romdir/msx</setting>
+    <setting id="fullscreen">true</setting>
+    <setting id="save_settings_on_exit">false</setting>
+_EOF_
+
+    if isPlatform "armv6" ; then
+       IFS= read -r -d '' body <<_EOF_
+    <setting id="scale_factor">1</setting>
+    <setting id="horizontal_stretch">320</setting>
+    <setting id="resampler">fast</setting>
+    <setting id="scanline">0</setting>
+    <setting id="maxframeskip">5</setting>
+_EOF_
+    fi
+
+    ! isPlatform "x86" && conf_reverse="    <setting id=\"auto_enable_reverse\">off</setting\n"
+    echo -e "${header}${body}${conf_reverse}  </settings>\n</settings>"
 }

--- a/scriptmodules/emulators/openmsx/retropie-init.tcl
+++ b/scriptmodules/emulators/openmsx/retropie-init.tcl
@@ -1,0 +1,48 @@
+namespace eval retropie {
+
+proc init {} {
+    set rom_name [guess_title]
+    set config_dir [file normalize "$::env(OPENMSX_USER_DATA)/joystick"]
+
+    # Sanitize rom name
+    regsub -all {[\?\<\>\\\/:\*\|]} $rom_name "" rom_name
+
+    # Auto-configure the 1st plugged in joystick, but only if present
+    # openMSX automatically loads the plugged in joysticks in 'autoplug.tcl'
+    if {![info exists ::joystick1_config]} {
+        return
+    }
+
+    # Disable the OSD menu box added by osd_menu.tcl
+    osd destroy main_menu_pop_up_button
+
+    if { !($rom_name eq "") } {
+        if { [ file exists "$config_dir/game/$rom_name.tcl" ] } {
+            load_config_joystick $rom_name "$config_dir/game/$rom_name.tcl"
+            return
+        }
+    }
+
+    if { [catch {exec udevadm info --name=/dev/input/js0 | grep -q "ID_INPUT_JOYSTICK=1"}] == 0 } {
+        set path [exec udevadm info --name=/dev/input/js0 --query=name]
+        set joy_name [exec cat /sys/class/$path/device/name]
+        regsub -all {[\?\<\>\\\/:\*\|]} $joy_name "" joy_name$
+        if { [file exists "$config_dir/$joy_name.tcl"] } {
+                load_config_joystick $joy_name "$config_dir/$joy_name.tcl"
+        }
+    }
+}
+
+proc load_config_joystick { conf_name conf_script } {
+    source "$conf_script"
+    # Check for auto configuration function
+    if { [info procs "auto_config_joypad"] == "" } {
+        return
+    }
+    auto_config_joypad
+    message "Loaded joystick configuration for '$conf_name'"
+}
+
+}; # namespace: retropie
+
+after boot retropie::init


### PR DESCRIPTION
* added a joystick auto-configuration for Emulationstation. Joypad mappings:
  * A: MSX controller A; OSD menu: Back/Cancel
  * B: MSX controller B; OSD menu: Action (toggle/execute menu item)
  * D-Pad/Left Analog: MSX controller joystick; OSD Menu: Up/Down/Left/Right
  * Start - Toggle the openMSX OSD menu
  * Select - Show on-screen keyboard
  * Y - MSX F1
  * X - MSX F2
  * Left Trigger - MSX F3
  * Right Trigger - MSX F4

  The joystick's A/B/D-Pad are functional in the openMSX menu, however B is action and A is cancel/back for some reason.

  The joystick is loaded using the `retropie-init.tcl` script, automatically loaded and executed during startup. Per-game overrides are possible, as long as the correct configuration script for a gamepad is found (needs some documentation).

* created a minimal configuration, with some performance optimization for Pi0/Pi1 and configuring a default machine.
  Auto-saving is disabled, because it will save the joystick configuration and it might pose problems when using different joysticks.

* symlinked the configuration folder into `$configdir/msx/openmsx`.
  This is useful for adding new machines/configurations and editing the gamepad auto-configurations.

* symlinked the user's _systemroms_ folder to `$biosdir/openmsx`.
  openMSX uses file hashes to identify firmware files, so the filenames/folder structure is not important.

* added one emulator variation for each major MSX model (MSX2/MSX2+/MSX TurboR)
  They need the appropriate BIOS/firmware files, otherwise they won't run.
  NOTE: there are variations of machines using the open source C-BIOS for each major model, but C-BIOS only supports cartridges, so no tape/disk/floppy images will work.