### PR TITLE
Replace Raspbian with Raspberry Pi OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ General Usage
 
 Shell script to setup the Raspberry Pi, Vero4K, ODroid-C1 or a PC running Ubuntu with many emulators and games, using EmulationStation as the graphical front end. Bootable pre-made images for the Raspberry Pi are available for those that want a ready-to-go system, downloadable from the releases section of GitHub or via our website at https://retropie.org.uk.
 
-This script is designed for use on Raspbian on the Raspberry Pi, OSMC on the Vero4K or Ubuntu on the ODroid-C1 or a PC.
+This script is designed for use on Raspberry Pi OS (previously called Raspbian) on the Raspberry Pi, OSMC on the Vero4K or Ubuntu on the ODroid-C1 or a PC.
 
 To run the RetroPie Setup Script make sure that your APT repositories are up-to-date and that Git is installed:
 


### PR DESCRIPTION
Update the `README` to be in-sync with the official documentation from RaspberryPi [1]

> Raspberry Pi OS (previously called Raspbian) is the Foundation’s official supported operating system.

[1] https://www.raspberrypi.org/downloads/raspberry-pi-os/