### PR TITLE
xroar: add a workaround for the crash on VC platforms

### DIFF
--- a/scriptmodules/emulators/xroar.sh
+++ b/scriptmodules/emulators/xroar.sh
@@ -47,8 +47,9 @@ function configure_xroar() {
     mkdir -p "$md_inst/share/xroar"
     ln -snf "$biosdir" "$md_inst/share/xroar/roms"
 
-    local params=(-fs)
+    local params=()
     ! isPlatform "x11" && params+=(-vo sdl -ccr simple)
+    ! isPlatform "videocore" && params+=(-fs)
     addEmulator 1 "$md_id-dragon32" "dragon32" "$md_inst/bin/xroar ${params[*]} -machine dragon32 -run %ROM%"
     addEmulator 1 "$md_id-cocous" "coco" "$md_inst/bin/xroar ${params[*]} -machine cocous -run %ROM%"
     addEmulator 0 "$md_id-coco" "coco" "$md_inst/bin/xroar ${params[*]} -machine coco -run %ROM%"


### PR DESCRIPTION
The changes in 25d6710f9275e49 lead to a crash when the emulator starts in fulscreen,
when using the RPI driver in SDL2. Looks like repeated calls to create/destroy the SDL renderer,
when resizing the window, lead to a VC driver error:

     failed to add service - already in use?

The RPI driver already starts the window in fulscreen, so there's no visible difference without the parameter removed.