### PR TITLE
mame: use python3 to build, when available

### DIFF
--- a/scriptmodules/emulators/mame.sh
+++ b/scriptmodules/emulators/mame.sh
@@ -54,6 +54,9 @@ function build_mame() {
 
     # Compile MAME
     local params=(NOWERROR=1 ARCHOPTS=-U_FORTIFY_SOURCE)
+    # Prefer python3 for building, when available
+    command -v python3 >/dev/null 2>&1 && params+=(PYTHON_EXECUTABLE=python3)
+
     make "${params[@]}"
 
     local binary_name="$(_get_binary_name_${md_id})"


### PR DESCRIPTION
Should fix the situation when there is not default 'python', but python3
is installed, like default installation of Ubuntu 20.04 LTS.

Fixes #3228.