### PR TITLE
Update cpu flags for tegra x1 devices.

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -494,7 +494,7 @@ function platform_odroid-xu() {
 }
 
 function platform_tegra-x1() {
-    __default_cpu_flags="-mcpu=cortex-a57"
+    __default_cpu_flags="-march=armv8-a+crc -mtune=cortex-a57 -mcpu=cortex-a57+crc+fp+simd"
     __platform_flags+=(aarch64 x11 gl)
 }
 


### PR DESCRIPTION
Add cpu specific flags for tegra tx1 devices  (crc+fp+simd)