### PR TITLE
add callback before launch but after menu, useful for xboxdrv

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -1322,6 +1322,8 @@ function runcommand() {
         build_xinitrc build
     fi
 
+    user_script "runcommand-onlaunch.sh"
+
     local ret
     launch_command
     ret=$?


### PR DESCRIPTION
Needed another callback after the joy2key menu but before the emulator launch. This is to make it easier to start xboxdrvstart without interfering with joy2key. They serve a similar purpose - turning joystick events into keyboard strokes - so if they both run simultaneously it's a problem. Currently xboxdrvstart uses a combination of sleep commands and a busy loop to make sure it's not starting too early but this additional callback in runcommand.sh is a lot simpler.

Proposed name is runcommand-onlaunch.sh and it sits directly above launch_command. I've got a modified version of xboxdrvstart using this callback which I'll push separately if this pull request succeeds.