### PR TITLE
Recent change in cannonball cmake files makes RetroPie build/installation process no longer function

### DIFF
--- a/scriptmodules/ports/cannonball.sh
+++ b/scriptmodules/ports/cannonball.sh
@@ -23,7 +23,7 @@ function depends_cannonball() {
 }
 
 function sources_cannonball() {
-    gitPullOrClone "$md_build" https://github.com/djyt/cannonball.git
+    gitPullOrClone "$md_build" https://github.com/djyt/cannonball.git "master" "2b3839dd34c1b4263ec5006fdeeb1ae2689cd401"
     sed -i "s/-march=armv6 -mfpu=vfp -mfloat-abi=hard//" "$md_build/cmake/sdl2_rpi.cmake" "$md_build/cmake/sdl2gles_rpi.cmake"
 }
 


### PR DESCRIPTION
This commit: https://github.com/djyt/cannonball/commit/ffac08c25c2937d046e376ed59a5f0154c38d969 broke the build and installation process for the cannonball engine as designed in RetroPie-Setup. By updating the arguments to gitPullOrClone to lock the version at a previously-buildable version, cannonball is now able to build and install correctly.

A better solution would be to update the build process here to work with the new cmake files in the master version of their repository, but this fix will at least allow the engine to function.