### PR TITLE
lr-vecx: update build for GPU rendering support

### DIFF
--- a/scriptmodules/libretrocores/lr-vecx.sh
+++ b/scriptmodules/libretrocores/lr-vecx.sh
@@ -20,8 +20,12 @@ function sources_lr-vecx() {
 }
 
 function build_lr-vecx() {
+    local params
+    isPlatform "videocore" && params+="platform=rpi"
+    isPlatform "gles" && params+=" HAS_GLES=1"
+
     make clean
-    make -f Makefile.libretro
+    make -f Makefile.libretro $params
     md_ret_require="$md_build/vecx_libretro.so"
 }
 


### PR DESCRIPTION
The core now uses GPU rendering and it needs additional parameters for compilation.

Not sure  how it works on other GLES platforms (Odroid/Tinker/etc), it assumes that `libGLESv2` is the name of the GLES lib. Would be useful to test at least on Odroid.