### PR TITLE
Adds new Angular Artwork theme

### DIFF
--- a/scriptmodules/supplementary/esthemes.sh
+++ b/scriptmodules/supplementary/esthemes.sh
@@ -245,6 +245,7 @@ function gui_esthemes() {
         'Zechariel VectorPie'
         'KALEL1981 nes-box'
         'KALEL1981 super-arcade1up-5x4'
+        'Elratauru angular-artwork'
     )
     while true; do
         local theme


### PR DESCRIPTION
This adds a new theme I made for my retro cabinet based on a fork/variation of es-theme-angular by lilbud.
The theme repository is here: https://github.com/Elratauru/es-theme-angular-artwork

It's mostly for 5:4 screens, as the cabinet I'm using has one of these, but 4:3 support could probably be added if requested later down the line.

I updated the readme of the theme repo with more detailed information along with screenshot of how it looks since I was at it. 
Is there anything else I should do besides the modification on this file to point to the repository?

Thanks!