### PR TITLE
Add GLES3.x flags for Odroid XU3 and XU4.

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -369,8 +369,11 @@ function get_platform() {
             "Freescale i.MX6 Quad/DualLite (Device Tree)")
                 __platform="imx6"
                 ;;
-            ODROID-XU[34])
+            ODROID-XU)
                 __platform="odroid-xu"
+                ;;
+            ODROID-XU[34])
+                __platform="odroid-xu3"
                 ;;
             "Rockchip (Device Tree)")
                 __platform="tinker"
@@ -491,6 +494,13 @@ function platform_odroid-xu() {
     # required for mali-fbdev headers to define GL functions
     __default_cflags="-DGL_GLEXT_PROTOTYPES"
     __platform_flags+=(arm armv7 neon mali gles)
+}
+
+function platform_odroid-xu3() {
+    __default_cpu_flags="-marm -mcpu=cortex-a7 -mfpu=neon-vfpv4"
+    # required for mali-fbdev headers to define GL functions
+    __default_cflags="-DGL_GLEXT_PROTOTYPES"
+    __platform_flags+=(arm armv7 neon mali gles gles3)
 }
 
 function platform_tegra-x1() {


### PR DESCRIPTION
XU3 supports GLES 3.0: https://www.hardkernel.com/shop/odroid-xu3/
XU4 supports GLES 3.1: https://www.hardkernel.com/shop/odroid-xu4-special-price/

However, XU only supports GLES 2.0: https://www.hardkernel.com/shop/odroid-xu/, so kept that as a separate platform.

May fix https://retropie.org.uk/forum/topic/28256/odroid-xu4-lr-flycast-input-causing-graphical-bug

(untested!)