### PR TITLE
runcommand.sh multiple connected devices, pi4 bugfix and speedups

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -381,7 +381,7 @@ function get_x11_mode_info() {
         
         # determine current mode id & strip brackets
         mode_id[1]="$($XRANDR --verbose | awk '
-         /primary/ && match($5,/0x[a-z0-9][a-z0-9]/) {
+         /primary/ && match($5,/0x[a-z0-9]+/) {
          print substr($5,RSTART,RLENGTH)
         }')"
     fi


### PR DESCRIPTION
As stated in [forum](https://retropie.org.uk/forum/topic/28237/runcommand-sh-line-1045-n-a-division-by-0) in raspbianOS on a pi4 you get a bash error whenever you launch a new game. This is because xrandr outputs 2 connected devices and MODE_CUR[5] array gets assigned as aspect ratio instead of resolution. This only looks for one output.