### PR TITLE
runcommand.sh: Fixes x11 multiple output/display error

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -382,9 +382,9 @@ function get_x11_mode_info() {
 
     if [[ -z "$mode_id" ]]; then
         # determine current output
-        mode_id[0]="$($XRANDR --verbose | grep " connected" | awk '{ print $1 }')"
+        mode_id[0]="$($XRANDR --verbose | awk '/ connected/ { print $1;exit }')"
         # determine current mode id & strip brackets
-        mode_id[1]="$($XRANDR --verbose | grep " connected" | grep -o "(0x[a-f0-9]\{1,\})")"
+        mode_id[1]="$($XRANDR --verbose | awk '/ connected/ {print;exit}' | grep -o "(0x[a-f0-9]\{1,\})")"
         mode_id[1]="$(echo ${mode_id[1]:1:-1})"
     fi
 


### PR DESCRIPTION
Ok, small change of which you can actually see.


using {exit} on awk is equivalent to a | head -n1. So it exits at the first /connected/. thus filling the array with only one output.


Also why does grep -o even have {1,}, that's what + is for