### PR TITLE
lr-mame, mame: use python3 to build recent mame versions

### DIFF
--- a/scriptmodules/emulators/mame.sh
+++ b/scriptmodules/emulators/mame.sh
@@ -53,10 +53,7 @@ function build_mame() {
     fi
 
     # Compile MAME
-    local params=(NOWERROR=1 ARCHOPTS=-U_FORTIFY_SOURCE)
-    # Prefer python3 for building, when available
-    command -v python3 >/dev/null 2>&1 && params+=(PYTHON_EXECUTABLE=python3)
-
+    local params=(NOWERROR=1 ARCHOPTS=-U_FORTIFY_SOURCE PYTHON_EXECUTABLE=python3)
     make "${params[@]}"
 
     local binary_name="$(_get_binary_name_${md_id})"

--- a/scriptmodules/libretrocores/lr-mame.sh
+++ b/scriptmodules/libretrocores/lr-mame.sh
@@ -17,7 +17,7 @@ rp_module_section="exp"
 rp_module_flags=""
 
 function _get_params_lr-mame() {
-    local params=(OSD=retro RETRO=1 NOWERROR=1 OS=linux TARGETOS=linux CONFIG=libretro NO_USE_MIDI=1 TARGET=mame)
+    local params=(OSD=retro RETRO=1 NOWERROR=1 OS=linux TARGETOS=linux CONFIG=libretro NO_USE_MIDI=1 TARGET=mame PYTHON_EXECUTABLE=python3)
     isPlatform "64bit" && params+=(PTR64=1)
     echo "${params[@]}"
 }


### PR DESCRIPTION
The change impacts `lr-mame`,`lr-mess`,`lr-mame2016`,`lr-mess2016` and `mame`.
It should fix building on new Ubuntu 20.04+ installations, which don't have a default `python` executable.
Since `python3` is automatically needed by the installation (via `python3-pyudev` for `joy2key`), no explicit dependency for `python3` was added.