### PR TITLE
Show correct video mode selection screen for multiple displays

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -281,7 +281,9 @@ function get_all_x11_modes()
         local info
         local line
         local verbose_info=()
-        local output="$($XRANDR --verbose | grep " connected" | awk '{ print $1 }')"
+        
+        # will print the first output found
+        local output="$($XRANDR --verbose | awk '/ connected/ { print $1;exit }' )"
 
         while read -r line; do
             # scan for line that contains bracketed mode id


### PR DESCRIPTION
This will show (and select) the correct video mode selection screen when you have multiple output displays connected on runcommand.


(instead of only output-id without aspect ratio or resolution information.)