### PR TITLE
Use https instead of http for retroachievements communication

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -46,6 +46,7 @@ function sources_retroarch() {
     # revert of https://github.com/libretro/RetroArch/pull/10524/commits/9eb84728
     # see https://github.com/RetroPie/RetroPie-Setup/issues/3249
     applyPatch "$md_data/04_config_save_fix.diff"
+    applyPatch "$md_data/05_cheevos_https.diff"
 }
 
 function build_retroarch() {

--- a/scriptmodules/emulators/retroarch/05_cheevos_https.diff
+++ b/scriptmodules/emulators/retroarch/05_cheevos_https.diff
@@ -1,0 +1,94 @@
+diff --git a/deps/rcheevos/src/rurl/url.c b/deps/rcheevos/src/rurl/url.c
+index 6b7c4607b5..15e048cb85 100644
+--- a/deps/rcheevos/src/rurl/url.c
++++ b/deps/rcheevos/src/rurl/url.c
+@@ -67,7 +67,7 @@ int rc_url_award_cheevo(char* buffer, size_t size, const char* user_name, const
+   written = snprintf(
+     buffer,
+     size,
+-    "http://retroachievements.org/dorequest.php?r=awardachievement&u=%s&t=%s&a=%u&h=%d",
++    "https://retroachievements.org/dorequest.php?r=awardachievement&u=%s&t=%s&a=%u&h=%d",
+     urle_user_name,
+     urle_login_token,
+     cheevo_id,
+@@ -106,7 +106,7 @@ int rc_url_submit_lboard(char* buffer, size_t size, const char* user_name, const
+   written = snprintf(
+     buffer,
+     size,
+-    "http://retroachievements.org/dorequest.php?r=submitlbentry&u=%s&t=%s&i=%u&s=%d&v=%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
++    "https://retroachievements.org/dorequest.php?r=submitlbentry&u=%s&t=%s&i=%u&s=%d&v=%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
+     urle_user_name,
+     urle_login_token,
+     lboard_id,
+@@ -122,7 +122,7 @@ int rc_url_get_gameid(char* buffer, size_t size, const char* hash) {
+   int written = snprintf(
+     buffer,
+     size,
+-    "http://retroachievements.org/dorequest.php?r=gameid&m=%s",
++    "https://retroachievements.org/dorequest.php?r=gameid&m=%s",
+     hash
+   );
+ 
+@@ -145,7 +145,7 @@ int rc_url_get_patch(char* buffer, size_t size, const char* user_name, const cha
+   written = snprintf(
+     buffer,
+     size,
+-    "http://retroachievements.org/dorequest.php?r=patch&u=%s&t=%s&g=%u",
++    "https://retroachievements.org/dorequest.php?r=patch&u=%s&t=%s&g=%u",
+     urle_user_name,
+     urle_login_token,
+     gameid
+@@ -158,7 +158,7 @@ int rc_url_get_badge_image(char* buffer, size_t size, const char* badge_name) {
+   int written = snprintf(
+     buffer,
+     size,
+-    "http://i.retroachievements.org/Badge/%s",
++    "https://i.retroachievements.org/Badge/%s",
+     badge_name
+   );
+ 
+@@ -181,7 +181,7 @@ int rc_url_login_with_password(char* buffer, size_t size, const char* user_name,
+   written = snprintf(
+     buffer,
+     size,
+-    "http://retroachievements.org/dorequest.php?r=login&u=%s&p=%s",
++    "https://retroachievements.org/dorequest.php?r=login&u=%s&p=%s",
+     urle_user_name,
+     urle_password
+   );
+@@ -205,7 +205,7 @@ int rc_url_login_with_token(char* buffer, size_t size, const char* user_name, co
+   written = snprintf(
+     buffer,
+     size,
+-    "http://retroachievements.org/dorequest.php?r=login&u=%s&t=%s",
++    "https://retroachievements.org/dorequest.php?r=login&u=%s&t=%s",
+     urle_user_name,
+     urle_login_token
+   );
+@@ -229,7 +229,7 @@ int rc_url_get_unlock_list(char* buffer, size_t size, const char* user_name, con
+   written = snprintf(
+     buffer,
+     size,
+-    "http://retroachievements.org/dorequest.php?r=unlocks&u=%s&t=%s&g=%u&h=%d",
++    "https://retroachievements.org/dorequest.php?r=unlocks&u=%s&t=%s&g=%u&h=%d",
+     urle_user_name,
+     urle_login_token,
+     gameid,
+@@ -255,7 +255,7 @@ int rc_url_post_playing(char* buffer, size_t size, const char* user_name, const
+   written = snprintf(
+     buffer,
+     size,
+-    "http://retroachievements.org/dorequest.php?r=postactivity&u=%s&t=%s&a=3&m=%u",
++    "https://retroachievements.org/dorequest.php?r=postactivity&u=%s&t=%s&a=3&m=%u",
+     urle_user_name,
+     urle_login_token,
+     gameid
+@@ -333,7 +333,7 @@ static int rc_url_append_str(char* buffer, size_t buffer_size, size_t* buffer_of
+ static int rc_url_build_dorequest(char* url_buffer, size_t url_buffer_size, size_t* buffer_offset,
+    const char* api, const char* user_name)
+ {
+-  const char* base_url = "http://retroachievements.org/dorequest.php";
++  const char* base_url = "https://retroachievements.org/dorequest.php";
+   size_t written = strlen(base_url);
+   int failure = 0;
+ 


### PR DESCRIPTION
Communication with retro achievements happens over http, and this switches it to https (relevant pull request in retroarch: https://github.com/libretro/RetroArch/pull/11551).  Opening this since retropie is using retroarch-1.8.8, and the retroarch pull request is to get the change into master.

Verified this builds on my setup (raspberry pi4) and I can login to retro achievements like normal.

Probably a good idea to make sure it's accepted upstream before accepting this patch, but I figured eyes on the RetroPie script can't hurt.