### PR TITLE
drastic: disable cursor under KMS

### DIFF
--- a/scriptmodules/emulators/drastic.sh
+++ b/scriptmodules/emulators/drastic.sh
@@ -52,7 +52,7 @@ function configure_drastic() {
 #!/bin/bash
 # Don't start a window manager on x11 platforms
 if [[ -n \$DISPLAY && "\$2" == "kms" ]]; then
-    matchbox-window-manager &
+    matchbox-window-manager -use_cursor no &
     sleep 0.5
 fi
 pushd "$md_conf_root/nds/drastic"


### PR DESCRIPTION
After the changes in #3121, starting `drastic` on a Pi4 shows the X11 cursor.

Since there's no way to remove it for users that don't have a mouse/touchpad available and `drastic` has its own input stylus handling for those input devices, disable the cursor via the WM.