### PR TITLE
Move to associative arrays for module data

### DIFF
--- a/scriptmodules/admin/builder.sh
+++ b/scriptmodules/admin/builder.sh
@@ -22,32 +22,21 @@ function module_builder() {
 
     local id
     for id in "${ids[@]}"; do
-        # if index get mod_id from array else we look it up
-        local md_id
-        local md_idx
-        if [[ "$id" =~ ^[0-9]+$ ]]; then
-            md_id="$(rp_getIdFromIdx $id)"
-            md_idx="$id"
-        else
-            md_idx="$(rp_getIdxFromId $id)"
-            md_id="$id"
-        fi
-
         # don't build binaries for modules with flag nobin
         # eg scraper which fails as go1.8 doesn't work under qemu
-        hasFlag "${__mod_flags[$md_idx]}" "nobin" && continue
+        hasFlag "${__mod_flags[$id]}" "nobin" && continue
 
-        ! fnExists "install_${md_id}" && continue
+        ! fnExists "install_${id}" && continue
 
         # skip already built archives, so we can retry failed modules
-        [[ -f "$__tmpdir/archives/$__binary_path/${__mod_type[md_idx]}/$md_id.tar.gz" ]] && continue
+        [[ -f "$__tmpdir/archives/$__binary_path/${__mod_type[id]}/$id.tar.gz" ]] && continue
 
         # build, install and create binary archive.
         # initial clean in case anything was in the build folder when calling
         local mode
         for mode in clean remove depends sources build install create_bin clean remove "depends remove"; do
             # continue to next module if not available or an error occurs
-            rp_callModule "$md_id" $mode || break
+            rp_callModule "$id" $mode || break
         done
     done
     return 0

--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -286,6 +286,7 @@ function package_setup() {
                 rps_logInit
                 {
                     rps_logStart
+                    clear
                     rp_callModule "$id" remove
                     rps_logEnd
                 } &> >(_setup_gzip_log "$logfilename")

--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -153,6 +153,7 @@ function post_update_setup() {
 
 function package_setup() {
     local id="$1"
+    local default=""
 
     # associative array so we can pull out the messages later for the confirmation requester
     declare -A option_msgs=(
@@ -238,9 +239,9 @@ function package_setup() {
             options+=(H "Package Help")
         fi
 
-        cmd=(dialog --backtitle "$__backtitle" --cancel-label "Back" --menu "Choose an option for $id\n$status" 22 76 16)
+        cmd=(dialog --backtitle "$__backtitle" --cancel-label "Back" --default-item "$default" --menu "Choose an option for $id\n$status" 22 76 16)
         choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
-
+        default="$choice"
         local logfilename
 
         case "$choice" in

--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -456,7 +456,7 @@ function update_packages_setup() {
     local id
     for id in ${__mod_id[@]}; do
         if rp_isInstalled "$id" && [[ "${__mod_section[$id]}" != "depends" ]]; then
-            rp_installModule "$id" "_update_" || return 1
+            rp_installModule "$id" "_update_"
         fi
     done
 }

--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -152,8 +152,7 @@ function post_update_setup() {
 }
 
 function package_setup() {
-    local idx="$1"
-    local md_id="${__mod_id[$idx]}"
+    local id="$1"
 
     # associative array so we can pull out the messages later for the confirmation requester
     declare -A option_msgs=(
@@ -168,20 +167,20 @@ function package_setup() {
         local status
 
         local has_binary=0
-        rp_hasBinary "$idx"
+        rp_hasBinary "$id"
         local binary_ret="$?"
         [[ "$binary_ret" -eq 0 ]] && has_binary=1
 
         local pkg_origin=""
         local source_update=0
         local binary_update=0
-        if rp_isInstalled "$idx"; then
-            eval $(rp_getPackageInfo "$idx")
+        if rp_isInstalled "$id"; then
+            eval $(rp_getPackageInfo "$id")
             status="Installed - via $pkg_origin"
             [[ -n "$pkg_date" ]] && status+=" (built: $pkg_date)"
 
             if [[ "$pkg_origin" != "source" && "$has_binary" -eq 1 ]]; then
-                rp_hasNewerBinary "$idx"
+                rp_hasNewerBinary "$id"
                 local has_newer="$?"
                 binary_update=1
                 option_msgs["U"]="Update (from pre-built binary)"
@@ -218,28 +217,28 @@ function package_setup() {
                 options+=(B "${option_msgs["B"]}")
             fi
 
-            if [[ "$source_update" -eq 0 ]] && fnExists "sources_${md_id}"; then
+            if [[ "$source_update" -eq 0 ]] && fnExists "sources_${id}"; then
                 options+=(S "${option_msgs[S]}")
            fi
         fi
 
-        if rp_isInstalled "$idx"; then
-            if fnExists "gui_${md_id}"; then
+        if rp_isInstalled "$id"; then
+            if fnExists "gui_${id}"; then
                 options+=(C "Configuration / Options")
             fi
             options+=(X "Remove")
         fi
 
-        if [[ -d "$__builddir/$md_id" ]]; then
+        if [[ -d "$__builddir/$id" ]]; then
             options+=(Z "Clean source folder")
         fi
 
-        local help="${__mod_desc[$idx]}\n\n${__mod_help[$idx]}"
+        local help="${__mod_desc[$id]}\n\n${__mod_help[$id]}"
         if [[ -n "$help" ]]; then
             options+=(H "Package Help")
         fi
 
-        cmd=(dialog --backtitle "$__backtitle" --cancel-label "Back" --menu "Choose an option for ${__mod_id[$idx]}\n$status" 22 76 16)
+        cmd=(dialog --backtitle "$__backtitle" --cancel-label "Back" --menu "Choose an option for $id\n$status" 22 76 16)
         choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
 
         local logfilename
@@ -257,7 +256,7 @@ function package_setup() {
                 rps_logInit
                 {
                     rps_logStart
-                    rp_installModule "$idx" "$mode"
+                    rp_installModule "$id" "$mode"
                     rps_logEnd
                 } &> >(_setup_gzip_log "$logfilename")
                 rps_printInfo "$logfilename"
@@ -266,14 +265,14 @@ function package_setup() {
                 rps_logInit
                 {
                     rps_logStart
-                    rp_callModule "$idx" gui
+                    rp_callModule "$id" gui
                     rps_logEnd
                 } &> >(_setup_gzip_log "$logfilename")
                 rps_printInfo "$logfilename"
                 ;;
             X)
-                local text="Are you sure you want to remove $md_id?"
-                case "${__mod_section[$idx]}" in
+                local text="Are you sure you want to remove $id?"
+                case "${__mod_section[$id]}" in
                     core)
                         text+="\n\nWARNING - core packages are needed for RetroPie to function!"
                         ;;
@@ -286,7 +285,7 @@ function package_setup() {
                 rps_logInit
                 {
                     rps_logStart
-                    rp_callModule "$idx" remove
+                    rp_callModule "$id" remove
                     rps_logEnd
                 } &> >(_setup_gzip_log "$logfilename")
                 rps_printInfo "$logfilename"
@@ -295,8 +294,8 @@ function package_setup() {
                 printMsgs "dialog" "$help"
                 ;;
             Z)
-                rp_callModule "$idx" clean
-                printMsgs "dialog" "$__builddir/$md_id has been removed."
+                rp_callModule "$id" clean
+                printMsgs "dialog" "$__builddir/$id has been removed."
                 ;;
             *)
                 break
@@ -314,18 +313,18 @@ function section_gui_setup() {
         local options=()
         local pkgs=()
 
-        local idx
+        local id
         local pkg_origin
         local num_pkgs=0
-        for idx in $(rp_getSectionIds $section); do
-            if rp_isInstalled "$idx"; then
-                eval $(rp_getPackageInfo "$idx")
+        for id in $(rp_getSectionIds $section); do
+            if rp_isInstalled "$id"; then
+                eval $(rp_getPackageInfo "$id")
                 installed="\Zb(Installed - via $pkg_origin)\Zn"
                 ((num_pkgs++))
             else
                 installed=""
             fi
-            pkgs+=("$idx" "${__mod_id[$idx]} $installed" "$idx ${__mod_desc[$idx]}"$'\n\n'"${__mod_help[$idx]}")
+            pkgs+=("${__mod_idx[$id]}" "$id $installed" "$id - ${__mod_desc[$id]}"$'\n\n'"${__mod_help[$id]}")
         done
 
         if [[ "$num_pkgs" -gt 0 ]]; then
@@ -370,14 +369,14 @@ function section_gui_setup() {
                 rps_logInit
                 {
                     rps_logStart
-                    for idx in $(rp_getSectionIds $section); do
+                    for id in $(rp_getSectionIds $section); do
                         # if we are updating, skip packages that are not installed
                         if [[ "$mode" == "update" ]]; then
-                            if rp_isInstalled "$idx"; then
-                                rp_installModule "$idx" "_update_"
+                            if rp_isInstalled "$id"; then
+                                rp_installModule "$id" "_update_"
                             fi
                         else
-                            rp_installModule "$idx" "_auto_"
+                            rp_installModule "$id" "_auto_"
                         fi
                     done
                     rps_logEnd
@@ -391,15 +390,15 @@ function section_gui_setup() {
                 rps_logInit
                 {
                     rps_logStart
-                    for idx in $(rp_getSectionIds $section); do
-                        rp_isInstalled "$idx" && rp_callModule "$idx" remove
+                    for id in $(rp_getSectionIds $section); do
+                        rp_isInstalled "$id" && rp_callModule "$id" remove
                     done
                     rps_logEnd
                 } &> >(_setup_gzip_log "$logfilename")
                 rps_printInfo "$logfilename"
                 ;;
             *)
-                package_setup "$choice"
+                package_setup "${__mod_id[$choice]}"
                 ;;
         esac
 
@@ -410,11 +409,11 @@ function config_gui_setup() {
     local default
     while true; do
         local options=()
-        local idx
-        for idx in "${__mod_idx[@]}"; do
+        local id
+        for id in "${__mod_id[@]}"; do
             # show all configuration modules and any installed packages with a gui function
-            if [[ "${__mod_section[idx]}" == "config" ]] || rp_isInstalled "$idx" && fnExists "gui_${__mod_id[idx]}"; then
-                options+=("$idx" "${__mod_id[$idx]}  - ${__mod_desc[$idx]}" "$idx ${__mod_desc[$idx]}")
+            if [[ "${__mod_section[$id]}" == "config" ]] || rp_isInstalled "$id" && fnExists "gui_$id"; then
+                options+=("${__mod_idx[$id]}" "$id  - ${__mod_desc[$id]}" "${__mod_idx[$id]} ${__mod_desc[$id]}")
             fi
         done
 
@@ -433,17 +432,17 @@ function config_gui_setup() {
         [[ -z "$choice" ]] && break
 
         default="$choice"
-
+        id="${__mod_id[$choice]}"
         local logfilename
         rps_logInit
         {
             rps_logStart
-            if fnExists "gui_${__mod_id[choice]}"; then
-                rp_callModule "$choice" depends
-                rp_callModule "$choice" gui
+            if fnExists "gui_$id"; then
+                rp_callModule "$id" depends
+                rp_callModule "$id" gui
             else
-                rp_callModule "$idx" clean
-                rp_callModule "$choice"
+                rp_callModule "$id" clean
+                rp_callModule "$id"
             fi
             rps_logEnd
         } &> >(_setup_gzip_log "$logfilename")
@@ -453,10 +452,10 @@ function config_gui_setup() {
 
 function update_packages_setup() {
     clear
-    local idx
-    for idx in ${__mod_idx[@]}; do
-        if rp_isInstalled "$idx" && [[ "${__mod_section[$idx]}" != "depends" ]]; then
-            rp_installModule "$idx" "_update_" || return 1
+    local id
+    for id in ${__mod_id[@]}; do
+        if rp_isInstalled "$id" && [[ "${__mod_section[$id]}" != "depends" ]]; then
+            rp_installModule "$id" "_update_" || return 1
         fi
     done
 }
@@ -491,9 +490,9 @@ function update_packages_gui_setup() {
 }
 
 function basic_install_setup() {
-    local idx
-    for idx in $(rp_getSectionIds core) $(rp_getSectionIds main); do
-        rp_installModule "$idx"
+    local id
+    for id in $(rp_getSectionIds core) $(rp_getSectionIds main); do
+        rp_installModule "$id"
     done
     return 0
 }
@@ -532,16 +531,16 @@ function uninstall_setup()
     dialog --defaultno --yesno "Are you REALLY sure you want to uninstall RetroPie?\n\n$rootdir will be removed - this includes configuration files for all RetroPie components." 22 76 2>&1 >/dev/tty || return 0
     clear
     printHeading "Uninstalling RetroPie"
-    for idx in "${__mod_idx[@]}"; do
-        rp_isInstalled "$idx" && rp_callModule $idx remove
+    for id in "${__mod_id[@]}"; do
+        rp_isInstalled "$id" && rp_callModule $id remove
     done
     rm -rfv "$rootdir"
     dialog --defaultno --yesno "Do you want to remove all the files from $datadir - this includes all your installed ROMs, BIOS files and custom splashscreens." 22 76 2>&1 >/dev/tty && rm -rfv "$datadir"
     if dialog --defaultno --yesno "Do you want to remove all the system packages that RetroPie depends on? \n\nWARNING: this will remove packages like SDL even if they were installed before you installed RetroPie - it will also remove any package configurations - such as those in /etc/samba for Samba.\n\nIf unsure choose No (selected by default)." 22 76 2>&1 >/dev/tty; then
         clear
         # remove all dependencies
-        for idx in "${__mod_idx[@]}"; do
-            rp_isInstalled "$idx" && rp_callModule "$idx" depends remove
+        for id in "${__mod_id[@]}"; do
+            rp_isInstalled "$id" && rp_callModule "$id" depends remove
         done
     fi
     printMsgs "dialog" "RetroPie has been uninstalled."

--- a/scriptmodules/admin/stats.sh
+++ b/scriptmodules/admin/stats.sh
@@ -22,9 +22,9 @@ function _get_commit_data_stats() {
 
 function _get_package_data_stats() {
     local data=()
-    local idx
-    for idx in ${__mod_idx[@]}; do
-        data+=("${__mod_section[$idx]};${__mod_id[$idx]};${__mod_desc[$idx]};${__mod_licence[$idx]};${__mod_flags[$idx]};")
+    local id
+    for id in ${__mod_id[@]}; do
+        data+=("${__mod_section[$id]};$id;${__mod_desc[$id]};${__mod_licence[$id]};${__mod_flags[$id]};")
     done
     printf "%s\n" "${data[@]}"
 }

--- a/scriptmodules/supplementary/attractmode.sh
+++ b/scriptmodules/supplementary/attractmode.sh
@@ -207,10 +207,10 @@ LD_LIBRARY_PATH="$md_inst/sfml/lib" "$md_inst/bin/attract" "\$@"
 _EOF_
     chmod +x "/usr/bin/attract"
 
-    local idx
-    for idx in "${__mod_idx[@]}"; do
-        if rp_isInstalled "$idx" && [[ -n "${__mod_section[$idx]}" ]] && ! hasFlag "${__mod_flags[$idx]}" "frontend"; then
-            rp_callModule "$idx" configure
+    local id
+    for id in "${__mod_id[@]}"; do
+        if rp_isInstalled "$id" && [[ -n "${__mod_section[$id]}" ]] && ! hasFlag "${__mod_flags[$id]}" "frontend"; then
+            rp_callModule "$id" configure
         fi
     done
 }

--- a/scriptmodules/supplementary/dispmanx.sh
+++ b/scriptmodules/supplementary/dispmanx.sh
@@ -20,16 +20,16 @@ function gui_dispmanx() {
         local count=1
         local options=()
         local command=()
-        for idx in "${__mod_idx[@]}"; do
-            if [[ "${__mod_flags[$idx]}" =~ dispmanx ]] && rp_isInstalled "$idx"; then
-                local mod_id=${__mod_id[idx]}
-                iniGet "$mod_id"
+        local id
+        for id in "${__mod_id[@]}"; do
+            if [[ "${__mod_flags[$id]}" =~ dispmanx ]] && rp_isInstalled "$id"; then
+                iniGet "$id"
                 if [[ "$ini_value" == "1" ]]; then
-                    options+=($count "Disable for $mod_id (currently enabled)")
-                    command[$count]="$mod_id off"
+                    options+=($count "Disable for $id (currently enabled)")
+                    command[$count]="$id off"
                 else
-                    options+=($count "Enable for $mod_id (currently disabled)")
-                    command[$count]="$mod_id on"
+                    options+=($count "Enable for $id (currently disabled)")
+                    command[$count]="$id on"
                 fi
                 ((count++))
             fi

--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -21,7 +21,7 @@ function _get_input_cfg_emulationstation() {
 
 function _update_hook_emulationstation() {
     # make sure the input configuration scripts and launch script are always up to date
-    if rp_isInstalled "$md_idx"; then
+    if rp_isInstalled "$md_id"; then
         copy_inputscripts_emulationstation
         install_launch_emulationstation
     fi

--- a/scriptmodules/supplementary/mehstation.sh
+++ b/scriptmodules/supplementary/mehstation.sh
@@ -121,10 +121,10 @@ popd
 _EOF_
     chmod +x "/usr/bin/mehstation"
 
-    local idx
-    for idx in "${__mod_idx[@]}"; do
-        if rp_isInstalled "$idx" && [[ -n "${__mod_section[$idx]}" ]] && ! hasFlag "${__mod_flags[$idx]}" "frontend"; then
-            rp_callModule "$idx" configure
+    local id
+    for id in "${__mod_id[@]}"; do
+        if rp_isInstalled "$id" && [[ -n "${__mod_section[$id]}" ]] && ! hasFlag "${__mod_flags[$id]}" "frontend"; then
+            rp_callModule "$id" configure
         fi
     done
 }

--- a/scriptmodules/supplementary/retropiemenu.sh
+++ b/scriptmodules/supplementary/retropiemenu.sh
@@ -15,7 +15,7 @@ rp_module_section="core"
 
 function _update_hook_retropiemenu() {
     # to show as installed when upgrading to retropie-setup 4.x
-    if ! rp_isInstalled "$md_idx" && [[ -f "$home/.emulationstation/gamelists/retropie/gamelist.xml" ]]; then
+    if ! rp_isInstalled "$md_id" && [[ -f "$home/.emulationstation/gamelists/retropie/gamelist.xml" ]]; then
         mkdir -p "$md_inst"
         # to stop older scripts removing when launching from retropie menu in ES due to not using exec or exiting after running retropie-setup from this module
         touch "$md_inst/.retropie"

--- a/scriptmodules/supplementary/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand.sh
@@ -15,7 +15,7 @@ rp_module_section="core"
 
 function _update_hook_runcommand() {
     # make sure runcommand is always updated when updating retropie-setup
-    rp_isInstalled "$md_idx" && install_bin_runcommand
+    rp_isInstalled "$md_id" && install_bin_runcommand
 }
 
 function depends_runcommand() {

--- a/scriptmodules/supplementary/splashscreen.sh
+++ b/scriptmodules/supplementary/splashscreen.sh
@@ -16,7 +16,7 @@ rp_module_flags="noinstclean !all rpi !osmc !xbian !aarch64"
 
 function _update_hook_splashscreen() {
     # make sure splashscreen is always up to date if updating just RetroPie-Setup
-    if rp_isInstalled "$md_idx"; then
+    if rp_isInstalled "$md_id"; then
         install_bin_splashscreen
         configure_splashscreen
     fi

--- a/scriptmodules/supplementary/usbromservice.sh
+++ b/scriptmodules/supplementary/usbromservice.sh
@@ -18,7 +18,7 @@ function _get_ver_usbromservice() {
 }
 
 function _update_hook_usbromservice() {
-    ! rp_isInstalled "$md_idx" && return
+    ! rp_isInstalled "$md_id" && return
     [[ ! -f "$md_inst/disabled" ]] && install_scripts_usbromservice
 }
 


### PR DESCRIPTION
This reworks a lot of internal package logic and simplifies a lot of functions.

It was something I had in mind a long time ago, and the longer I left it, the messier it got.

Previously all the module data was in indexed arrays with matching offsets. Each scriptmodule folder had an initial index and it was incremented per module.

Many package functions expected an index. Indexes were never unique and could change depending on added modules etc. We also had to convert between them and module IDs.

This caused a lot of issues to extend package organisation. Eg. The idea to allow external repos with additional packages would have been messy to try and arrange the order.

Now it's all done by module id. There is a numbered index of all modules found, which increments which is used in the GUI setup menus. But it's not needed by any packaging functions.

md_idx is dropped and the few modules that used it for install checks etc now use md_id.

All packaging functions use the id.

Retropie_packages now uses the module id only.

I may have forgotten to mention some things and this isn't complete and fully tested yet. Doing an early draft PR while I finalise it before review.

But comments on the changes welcome.
