### PR TITLE
audiosettings: add PulseAudio configuration support.

### DIFF
--- a/scriptmodules/supplementary/audiosettings.sh
+++ b/scriptmodules/supplementary/audiosettings.sh
@@ -30,7 +30,10 @@ function gui_audiosettings() {
     # The list of ALSA cards/devices depends on the 'snd-bcm2385' module parameter 'enable_compat_alsa'
     # * enable_compat_alsa: true  - single soundcard, output is routed based on the `numid` control
     # * enable_compat_alsa: false - one soundcard per output type (HDMI/Headphones)
-    if aplay -l | grep -q "bcm2835 ALSA"; then
+    # If PulseAudio is enabled, then try to configure it and leave ALSA alone
+    if _pa_cmd_audiosettings systemctl -q --user is-enabled pulseaudio.socket; then
+        _pulseaudio_audiosettings
+    elif aplay -l | grep -q "bcm2835 ALSA"; then
         _bcm2835_alsa_compat_audiosettings
     else
         _bcm2835_alsa_internal_audiosettings
@@ -38,7 +41,7 @@ function gui_audiosettings() {
 }
 
 function _bcm2835_alsa_compat_audiosettings() {
-    local cmd=(dialog --backtitle "$__backtitle" --menu "Set audio output." 22 86 16)
+    local cmd=(dialog --backtitle "$__backtitle" --menu "Set audio output (ALSA - compat)." 22 86 16)
     local hdmi="HDMI"
 
     # the Pi 4 has 2 HDMI ports, so number them
@@ -55,6 +58,9 @@ function _bcm2835_alsa_compat_audiosettings() {
         M "Mixer - adjust output volume"
         R "Reset to default"
     )
+    # If PulseAudio is installed, add an option to enable it
+    hasPackage "pulseaudio" && options+=(P "Enable PulseAudio")
+
     choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
     if [[ -n "$choice" ]]; then
         case "$choice" in
@@ -88,14 +94,19 @@ function _bcm2835_alsa_compat_audiosettings() {
                 rm -f "$home/.asoundrc"
                 printMsgs "dialog" "Audio settings reset to defaults"
                 ;;
+            P)
+                _toggle_pulseaudio_audiosettings "on"
+                printMsgs "dialog" "PulseAudio enabled"
+                ;;
         esac
     fi
 }
 
 function _bcm2835_alsa_internal_audiosettings() {
-    local cmd=(dialog --backtitle "$__backtitle" --menu "Set audio output." 22 86 16)
+    local cmd=(dialog --backtitle "$__backtitle" --menu "Set audio output (ALSA)." 22 86 16)
     local options=()
-    local card_index, card_label
+    local card_index
+    local card_label
 
     # Get the list of Pi internal cards
     while read card_no card_label; do
@@ -106,6 +117,10 @@ function _bcm2835_alsa_internal_audiosettings() {
         M "Mixer - adjust output volume"
         R "Reset to default"
     )
+
+    # If PulseAudio is installed, add an option to enable it
+    hasPackage "pulseaudio" && options+=(P "Enable PulseAudio")
+
     choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
     if [[ -n "$choice" ]]; then
         case "$choice" in
@@ -123,6 +138,10 @@ function _bcm2835_alsa_internal_audiosettings() {
                 rm -f "$home/.asoundrc"
                 printMsgs "dialog" "Audio settings reset to defaults"
                 ;;
+            P)
+                _toggle_pulseaudio_audiosettings "on"
+                printMsgs "dialog" "PulseAudio enabled"
+                ;;
         esac
     fi
 }
@@ -132,7 +151,7 @@ function _asoundrc_save_audiosettings() {
     [[ -z "$1" ]] && return
 
     local card_index=$1
-    local tmpfile=$(mktemp)
+    local tmpfile="$(mktemp)"
 
     cat << EOF > "$tmpfile"
 pcm.!default {
@@ -158,4 +177,73 @@ EOF
 
     mv "$tmpfile" "$home/.asoundrc"
     chown "$user:$user" "$home/.asoundrc"
+}
+
+function _pulseaudio_audiosettings() {
+    local cmd=(dialog --backtitle "$__backtitle" --menu "Set audio output (PulseAudio)." 22 86 16)
+    local options=()
+    local sink_index
+    local sink_label
+
+    # Check if PulseAudio is running, otherwise 'pacmd' will not work
+    if ! _pa_cmd_audiosettings pacmd stat>/dev/null; then
+        printMsgs "dialog" "PulseAudio is enabled, but not running\nAudio settings cannot be set right now"
+        return
+    fi
+    while read sink_index sink_label; do
+        options+=("$sink_index" "$sink_label")
+    done < <(_pa_cmd_audiosettings pacmd list-sinks | \
+            awk -F [:=] '/index/ { idx=$2;
+                         do {getline} while($0 !~ "alsa.name");
+                         print idx,gensub(/"|bcm2835\s+/,"","g", $2) }'
+            )
+
+    options+=(
+        M "Mixer - adjust output volume"
+        R "Reset to default"
+        P "Disable PulseAudio"
+    )
+    choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
+    if [[ -n "$choice" ]]; then
+        case "$choice" in
+            [1-9])
+                _pa_cmd_audiosettings pactl set-default-sink $choice
+                rm -f "$home/.asoundrc"
+                printMsgs "dialog" "Set audio output to ${options[$((choice*2-1))]}"
+                ;;
+            M)
+                alsamixer >/dev/tty </dev/tty
+                alsactl store
+                ;;
+            R)
+                rm -fr "$home/.config/pulse"
+                /etc/init.d/alsa-utils reset
+                alsactl store
+                printMsgs "dialog" "Audio settings reset to defaults"
+                ;;
+            P)
+                _toggle_pulseaudio_audiosettings "off"
+                printMsgs "dialog" "PulseAudio disabled"
+                ;;
+        esac
+    fi
+}
+
+function _toggle_pulseaudio_audiosettings() {
+    local state=$1
+
+    if [[ "$state" == "on" ]]; then
+        _pa_cmd_audiosettings systemctl --user unmask pulseaudio.socket
+        _pa_cmd_audiosettings systemctl --user start  pulseaudio.service
+    fi
+
+    if [[ "$state" == "off" ]]; then
+        _pa_cmd_audiosettings systemctl --user mask pulseaudio.socket
+        _pa_cmd_audiosettings systemctl --user stop pulseaudio.service
+    fi
+}
+
+# Run PulseAudio commands as the calling user
+function _pa_cmd_audiosettings() {
+    [[ -n "$@" ]] && sudo -u "$user" XDG_RUNTIME_DIR=/run/user/$SUDO_UID "$@" 2>/dev/null
 }


### PR DESCRIPTION
When PulseAudio is installed and active, it takes over as the default ALSA device.
Remove any `.asoundrc` when it's enabled and configure the PulseAudio default output sink instead.

Added the option to enable/disable PulseAudio, depending on the running configuration.