### PR TITLE
ppsspp / ppsspp-1.5.4 - added ppsspp 1.5.4 using parent ppsspp module

### DIFF
--- a/scriptmodules/emulators/ppsspp-1.5.4.sh
+++ b/scriptmodules/emulators/ppsspp-1.5.4.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="ppsspp-1.5.4"
+rp_module_desc="PlayStation Portable emulator PPSSPP v1.5.4"
+rp_module_help="ROM Extensions: .iso .pbp .cso\n\nCopy your PlayStation Portable roms to $romdir/psp"
+rp_module_licence="GPL2 https://raw.githubusercontent.com/hrydgard/ppsspp/master/LICENSE.TXT"
+rp_module_section="opt"
+rp_module_flags="!all videocore"
+
+function depends_ppsspp-1.5.4() {
+    depends_ppsspp
+}
+
+function sources_ppsspp-1.5.4() {
+    sources_ppsspp "v1.5.4"
+}
+
+function build_ppsspp-1.5.4() {
+    build_ppsspp
+}
+
+function install_ppsspp-1.5.4() {
+    install_ppsspp
+}
+
+function configure_ppsspp-1.5.4() {
+    configure_ppsspp
+}

--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -25,8 +25,10 @@ function depends_ppsspp() {
 }
 
 function sources_ppsspp() {
-    gitPullOrClone "$md_build/$md_id" https://github.com/hrydgard/ppsspp.git
-    cd "$md_id"
+    local branch="$1"
+    [[ -z "$branch" ]] && branch="master"
+    gitPullOrClone "$md_build/ppsspp" https://github.com/hrydgard/ppsspp.git "$branch"
+    cd "ppsspp"
 
     # remove the lines that trigger the ffmpeg build script functions - we will just use the variables from it
     sed -i "/^build_ARMv6$/,$ d" ffmpeg/linux_arm.sh
@@ -119,10 +121,10 @@ function build_ppsspp() {
     fi
 
     # build ffmpeg
-    build_ffmpeg_ppsspp "$md_build/$md_id/ffmpeg"
+    build_ffmpeg_ppsspp "$md_build/ppsspp/ffmpeg"
 
     # build ppsspp
-    cd "$md_build/$md_id"
+    cd "$md_build/ppsspp"
     rm -rf CMakeCache.txt CMakeFiles
     local params=()
     if isPlatform "videocore"; then
@@ -154,7 +156,7 @@ function build_ppsspp() {
     make clean
     make
 
-    md_ret_require="$md_build/$md_id/$ppsspp_binary"
+    md_ret_require="$md_build/ppsspp/$ppsspp_binary"
 }
 
 function install_ppsspp() {

--- a/scriptmodules/libretrocores/lr-ppsspp.sh
+++ b/scriptmodules/libretrocores/lr-ppsspp.sh
@@ -30,8 +30,8 @@ function build_lr-ppsspp() {
 
 function install_lr-ppsspp() {
     md_ret_files=(
-        'lr-ppsspp/lib/ppsspp_libretro.so'
-        'lr-ppsspp/assets'
+        'ppsspp/lib/ppsspp_libretro.so'
+        'ppsspp/assets'
     )
 }
 


### PR DESCRIPTION
Users reported that this version runs faster on videocore on the rpi1/2/3

Adjusted ppsspp sources to allow branch parameter and fixed build subfolder to ppsspp
so that paths are the same for md_ret_files, including adjusting lr-ppsspp in the same way.

Older code builds ok with our current ppsspp module script on rpi1/2/3 + videocore gles2,
but not rpi4, which it isn't needed on anyway. This may need changing if we have to update
ppsspp further in the future.