### PR TITLE
bluetooth - registered / paired device logic rework

### DIFF
--- a/scriptmodules/supplementary/bluetooth.sh
+++ b/scriptmodules/supplementary/bluetooth.sh
@@ -363,7 +363,7 @@ function connect_bluetooth() {
     local mac
     local name
     while read mac; read name; do
-        $(bt-device --connect "$mac" 2>/dev/null)
+        bt-device --connect "$mac" 2>/dev/null
     done < <(list_registered_bluetooth)
 }
 


### PR DESCRIPTION
I made some changes before to hide previously registered devices from the connect menu, to make it
easier when dealing with multiple devices of the same name. However due to the way bluetoothctl works,
previously "seen" devices are added to the system, meaning devices that are not paired are registered and cached,
and then won't be shown again.

This changeset addresses the following:

Only actually paired devices will be hidden from the register and connect menu

New functions list_paired and list_connected have been added

Switched to use bt-device to check for connected devices for consistency. Private function handles
grepping for Paired or Connected via bt-device --info

display_active_and_registered function renamed to simpler status and reworked to use the new functions.
It outputs to console - the GUI menu just calls this and then outputs to a dialog menu - making this now
a more useful commandline function

remove_device shows all registered devices, even ones seen before. These previously seen devices show
up when scanning so we still want to be able to remove them. I have adjusted it though so paired devices are
shown first, followed by any known devices.