### PR TITLE
system / setup - Raspbian Stretch is no longer supported

### DIFF
--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -82,8 +82,8 @@ function depends_setup() {
         printMsgs "dialog" "Raspbian/Debian Jessie and versions of Ubuntu below 18.04 are no longer supported.\n\nPlease install RetroPie from a fresh image (or if running Ubuntu, upgrade your OS)."
     fi
 
-    if [[ "$__os_debian_ver" -eq 9 ]] && [[ "$__has_binaries" -eq 1 ]]; then
-        printMsgs "dialog" "You are currently running RetroPie on a Raspbian Stretch based distribution.\n\nWe will soon stop building binaries for your system, and recommend you switch to a newer RetroPie image.\n\nYou will still be able to update packages from source when binaries are no longer available, but due to the age of Raspbian Stretch we can't guarantee all software included will work."
+    if [[ "$__os_debian_ver" -eq 9 ]] && [[ "$__os_id" == "Raspbian" ]]; then
+        printMsgs "dialog" "Your version of RetroPie which is based on Raspbian Stretch is no longer supported.\n\nWe recommend you install the latest RetroPie image.\n\nPre-built binaries are now disabled for your system. You can still update packages from source, but due to the age of Raspbian Stretch we can't guarantee all software included will work."
     fi
 
     # make sure user has the correct group permissions

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -190,7 +190,7 @@ function get_os_version() {
             # we provide binaries for RPI on Raspbian 9/10
             if isPlatform "rpi" && \
                isPlatform "32bit" && \
-               compareVersions "$__os_debian_ver" gt 8 && compareVersions "$__os_debian_ver" lt 11; then
+               compareVersions "$__os_debian_ver" gt 9 && compareVersions "$__os_debian_ver" lt 11; then
                # only set __has_binaries if not already set
                [[ -z "$__has_binaries" ]] && __has_binaries=1
             fi


### PR DESCRIPTION
Disable binaries for Raspbian Stretch and adjust warning message accordingly.