### PR TITLE
own_sdl2=0 was being ignored

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -240,6 +240,7 @@ function _mapPackage() {
                 iniConfig " = " '"' "$configdir/all/retropie.cfg"
                 iniGet "own_sdl2"
                 [[ "$ini_value" == "1" ]] && own_sdl2=1
+                [[ "$ini_value" == "0" ]] && own_sdl2=0
                 [[ "$own_sdl2" -eq 1 ]] && pkg="RP sdl2 $pkg"
             fi
             ;;


### PR DESCRIPTION
The inivar own_sdl2 in /opt/retropie/configs/all/retropie.cfg was ignored for value "0". 