### PR TITLE
esthemes: enable default branch detection for themes repositories.

### DIFF
--- a/scriptmodules/supplementary/esthemes.sh
+++ b/scriptmodules/supplementary/esthemes.sh
@@ -24,6 +24,7 @@ function depends_esthemes() {
 function install_theme_esthemes() {
     local theme="$1"
     local repo="$2"
+    local default_branch
     if [[ -z "$repo" ]]; then
         repo="RetroPie"
     fi
@@ -31,8 +32,11 @@ function install_theme_esthemes() {
         theme="carbon"
         repo="RetroPie"
     fi
+    # Get the name of the default branch, fallback to 'master' if not found
+    default_branch=$(runCmd git ls-remote --symref --exit-code "https://github.com/$repo/es-theme-$theme.git" HEAD | grep -oP ".*/\K[^\t]+")
+    [[ -z "$default_branch" ]] && default_branch="master"
     mkdir -p "/etc/emulationstation/themes"
-    gitPullOrClone "/etc/emulationstation/themes/$theme" "https://github.com/$repo/es-theme-$theme.git"
+    gitPullOrClone "/etc/emulationstation/themes/$theme" "https://github.com/$repo/es-theme-$theme.git" "$default_branch"
 }
 
 function uninstall_theme_esthemes() {


### PR DESCRIPTION
This would enable installation of themes where the default branch is named `main`, instead of `master`.
Github changed this a while back, see the [renaming repo](https://github.com/github/renaming).

One such theme is @lipebello's new theme (https://github.com/lipebello/es-theme-retrorama-turbo).

**Note**: this is a re-worked version of #3278. While `gitPullOrClone` could be modified to detect the default main branch of a repo, its main usage is in the `_source` scriptmodules function - where the branch can be specified, so default branch detection is not strictly necessary.
`esthemes` doesn't have the ability to specify a branch when cloning a theme. Since a theme repository isn't usually multi-branched (so there's no need to add branch name support in the selection list), I added the default branch detection logic just for this scriptmodule, when installing a theme.

Not sure if the default branch name should be `main` though (instead of `master`), given the new Github defaults.