### PR TITLE
platform updates - add new supported extensions

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -1,10 +1,10 @@
-3do_exts=".cue .iso"
+3do_exts=".chd .cue .iso"
 3do_fullname="3DO Interactive Multiplayer"
 
 ags_exts=".exe"
 ags_fullname="Adventure Game Studio"
 
-amiga_exts=".adf .adz .cue .dms .ipf .lha .sh .uae .zip"
+amiga_exts=".adf .adz .cue .dms .ipf .lha .m3u .sh .uae .zip"
 amiga_fullname="Commodore Amiga"
 
 amstradcpc_exts=".cdt .cpc .dsk .zip"
@@ -37,10 +37,10 @@ atarijaguar_fullname="Atari Jaguar"
 atarilynx_exts=".7z .lnx .zip"
 atarilynx_fullname="Atari Lynx"
 
-atarist_exts=".st .stx .img .rom .raw .ipf .ctr .zip"
+atarist_exts=".st .stx .img .m3u .rom .raw .ipf .ctr .zip"
 atarist_fullname="Atari ST"
 
-c64_exts=".crt .d64 .g64 .prg .t64 .tap .x64 .zip .vsf"
+c64_exts=".cmd .crt .d64 .d71 .d80 .d81 .g64 .prg .m3u .t64 .tap .x64 .zip .vsf"
 c64_fullname="Commodore 64"
 
 channelf_exts=".bin .rom .zip .7z"
@@ -91,7 +91,7 @@ gb_fullname="Game Boy"
 gbc_exts=".7z .gbc .zip"
 gbc_fullname="Game Boy Color"
 
-gc_exts=".ciso .gcm .gcz .iso"
+gc_exts=".ciso .gcm .gcz .iso .rvz"
 gc_fullname="Nintendo Gamecube"
 
 intellivision_exts=".7z .bin .int .itv .rom .zip"
@@ -131,7 +131,7 @@ megadrive_fullname="Sega Mega Drive"
 megadrive_theme="megadrive"
 megadrive_platform="megadrive"
 
-msx_exts=".rom .mx1 .mx2 .col .dsk .zip .m3u"
+msx_exts=".cas .rom .mx1 .mx2 .col .dsk .zip .m3u"
 msx_fullname="MSX"
 
 moto_exts=".fd .k7 .m5 .m7 .rom .sap"
@@ -161,7 +161,7 @@ np2pi_fullname="NEC PC-9801"
 oric_exts=".dsk .tap"
 oric_fullname="Oric 1"
 
-pc88_exts=".d88 .cmt .t88"
+pc88_exts=".d88 .cmt .m3u .t88"
 pc88_fullname="NEC PC-8801"
 
 pc98_exts=".d88 .d98 .88d .98d .fdi .xdf .hdm .dup .2hd .tfd .hdi .thd .nhd .hdd"
@@ -232,7 +232,7 @@ videopac_fullname="Videopac"
 virtualboy_exts=".7z .vb .zip"
 virtualboy_fullname="Virtual Boy"
 
-wii_exts=".ciso .gcm .gcz .iso .wbfs"
+wii_exts=".ciso .gcm .gcz .iso .rvz .wbfs"
 wii_fullname="Nintendo Wii"
 
 wonderswan_exts=".7z .ws .zip"

--- a/scriptmodules/emulators/dolphin.sh
+++ b/scriptmodules/emulators/dolphin.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="dolphin"
 rp_module_desc="Gamecube/Wii emulator Dolphin"
-rp_module_help="ROM Extensions: .gcm .iso .wbfs .ciso .gcz\n\nCopy your gamecube roms to $romdir/gc and Wii roms to $romdir/wii"
+rp_module_help="ROM Extensions: .gcm .iso .wbfs .ciso .gcz .rvz\n\nCopy your Gamecube roms to $romdir/gc and Wii roms to $romdir/wii"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/dolphin-emu/dolphin/master/license.txt"
 rp_module_section="exp"
 rp_module_flags="!all 64bit"

--- a/scriptmodules/emulators/openmsx.sh
+++ b/scriptmodules/emulators/openmsx.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="openmsx"
 rp_module_desc="MSX emulator OpenMSX"
-rp_module_help="ROM Extensions: .rom .mx1 .mx2 .col .dsk .zip\n\nCopy your MSX/MSX2 games to $romdir/msx\nCopy the BIOS files to $biosdir/openmsx"
+rp_module_help="ROM Extensions: .cas .rom .mx1 .mx2 .col .dsk .zip\n\nCopy your MSX/MSX2 games to $romdir/msx\nCopy the BIOS files to $biosdir/openmsx"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/openMSX/openMSX/master/doc/GPL.txt"
 rp_module_section="opt"
 rp_module_flags=""

--- a/scriptmodules/libretrocores/lr-bluemsx.sh
+++ b/scriptmodules/libretrocores/lr-bluemsx.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="lr-bluemsx"
 rp_module_desc="MSX/MSX2/Colecovision emu - blueMSX port for libretro"
-rp_module_help="ROM Extensions: .rom .mx1 .mx2 .col .dsk .zip\n\nCopy your MSX/MSX2 games to $romdir/msx\nCopy your Colecovision games to $romdir/coleco\n\nlr-bluemsx requires the BIOS files from the full standalone package of BlueMSX to be copied to '$biosdir/Machines' folder.\nColecovision BIOS needs to be copied to '$biosdir/Machines/COL - ColecoVision\coleco.rom'"
+rp_module_help="ROM Extensions: .cas .rom .mx1 .mx2 .col .dsk .zip\n\nCopy your MSX/MSX2 games to $romdir/msx\nCopy your Colecovision games to $romdir/coleco\n\nlr-bluemsx requires the BIOS files from the full standalone package of BlueMSX to be copied to '$biosdir/Machines' folder.\nColecovision BIOS needs to be copied to '$biosdir/Machines/COL - ColecoVision\coleco.rom'"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/blueMSX-libretro/master/license.txt"
 rp_module_section="opt"
 

--- a/scriptmodules/libretrocores/lr-opera.sh
+++ b/scriptmodules/libretrocores/lr-opera.sh
@@ -11,8 +11,8 @@
 
 rp_module_id="lr-opera"
 rp_module_desc="3DO emulator - fork of 4DO/FreeDO for libretro"
-rp_module_help="ROM Extension: .iso\n\nCopy your 3do roms to $romdir/3do\n\nCopy the required BIOS file panazf10.bin to $biosdir"
-rp_module_licence="LGPL https://raw.githubusercontent.com/libretro/opera-libretro/master/libfreedo/freedo_3do.c"
+rp_module_help="ROM Extension: .cue .chd .iso\n\nCopy your 3do roms to $romdir/3do\n\nCopy the required BIOS file panazf10.bin to $biosdir"
+rp_module_licence="LGPL https://raw.githubusercontent.com/libretro/opera-libretro/master/libopera/opera_3do.c"
 rp_module_section="exp"
 
 function sources_lr-opera() {

--- a/scriptmodules/libretrocores/lr-quasi88.sh
+++ b/scriptmodules/libretrocores/lr-quasi88.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="lr-quasi88"
 rp_module_desc="NEC PC-8801 emu - Quasi88 port for libretro"
-rp_module_help="ROM Extensions: .d88 .88d .cmt .t88\n\nCopy your pc88 games to to $romdir/pc88\n\nCopy bios files n88.rom, n88_0.rom, n88_1.rom, n88_2.rom, n88_3.rom, n88n.rom, disk.rom, n88knj1.rom, n88knj2.rom, and n88jisho.rom to $biosdir/quasi88"
+rp_module_help="ROM Extensions: .d88 .88d .cmt .m3u .t88\n\nCopy your pc88 games to to $romdir/pc88\n\nCopy bios files n88.rom, n88_0.rom, n88_1.rom, n88_2.rom, n88_3.rom, n88n.rom, disk.rom, n88knj1.rom, n88knj2.rom, and n88jisho.rom to $biosdir/quasi88"
 rp_module_licence="BSD https://raw.githubusercontent.com/libretro/quasi88-libretro/master/LICENSE"
 rp_module_section="exp"
 

--- a/scriptmodules/libretrocores/lr-vice.sh
+++ b/scriptmodules/libretrocores/lr-vice.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="lr-vice"
 rp_module_desc="C64 emulator - port of VICE for libretro"
-rp_module_help="ROM Extensions: .crt .d64 .g64 .prg .t64 .tap .x64 .zip .vsf\n\nCopy your Commodore 64 games to $romdir/c64"
+rp_module_help="ROM Extensions: .cmd .crt .d64 .d71 .d80 .d81 .g64 .m3u .prg .t64 .tap .x64 .zip .vsf\n\nCopy your Commodore 64 games to $romdir/c64"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/vice-libretro/master/vice/COPYING"
 rp_module_section="exp"
 rp_module_flags=""


### PR DESCRIPTION
* Amiga - new extensions supported by `lr-puae`
* C64 - new extensions supported by `lr-vice`
* 3DO - added `.chd`, supported by the Opera Libretro core; updated license URL for the core.
* GC/Wii - added `.rvz`, supported by Dolphin
* MSX - added `.cas`, supported by both `lr-bluesmsx` and `openmsx`

Should fix #3261.