### PR TITLE
moonlight: add support for open-source GFE servers

### DIFF
--- a/scriptmodules/supplementary/moonlight.sh
+++ b/scriptmodules/supplementary/moonlight.sh
@@ -185,6 +185,35 @@ function get_resolution_moonlight() {
     fi
 }
 
+function get_host_moonlight() {
+    local sops="true"
+    local unsupported="false"
+
+    iniConfig " = " "" "$(_global_cfg_file_moonlight)"
+    iniGet "sops" && sops="$ini_value"
+    iniGet "unsupported" && unsupported="$ini_value"
+
+    if [[ -n "$sops" && -n "$unsupported" ]]; then
+        echo "$sops;$unsupported"
+    else
+        echo "true;false"
+    fi
+}
+
+function set_host_moonlight() {
+    local -r sops="$1"
+    local -r unsupported="$2"
+
+    [[ -z "$sops" || -z "$unsupported" ]] && return
+
+    iniConfig " = " "" "$(_global_cfg_file_moonlight)"
+    iniSet "sops" "$sops"
+    iniSet "unsupported" "$unsupported"
+
+    chown $user:$user "$(_global_cfg_file_moonlight)"
+}
+
+
 function set_resolution_moonlight() {
     local -r width="$1"
     local -r height="$2"
@@ -341,6 +370,47 @@ function apps_gui_moonlight() {
     done
 }
 
+function host_gui_moonlight() {
+    local options=()
+    local default
+    local cmd
+    local choice
+    local tuple
+
+    # get current host options
+    IFS=";" read -r -a tuple < <(get_host_moonlight)
+    default="U"
+    [[ "${tuple[0]}" == "false" && "${tuple[1]}" == "false" ]] && default="1"
+    [[ "${tuple[0]}" == "true"  && "${tuple[1]}" == "true"  ]] && default="2"
+    [[ "${tuple[0]}" == "false" && "${tuple[1]}" == "true"  ]] && default="3"
+
+    # create menu options
+    options=(
+        U "Unset (use default)" "Do not force host compatibility settings"
+        1 "No SOPS" "Don't allow GFE to modify game settings"
+        2 "Allow unsupported" "Try streaming if GFE version or options are unsupported"
+        3 "Open-source host compatibility" "Turn off SOPS and allow unsupported options (for Sunshine/Open-Stream GFE server)"
+    )
+
+    # show main menu
+    cmd=(dialog --backtitle "$__backtitle" --default-item "$default" --item-help --menu "Host Compatibility Options" 16 45 16)
+    choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
+    case "$choice" in
+        U)
+            set_host_moonlight "true" "false"
+            ;;
+        1)
+            set_host_moonlight "false" "false"
+            ;;
+        2)
+            set_host_moonlight "true" "true"
+            ;;
+        3)
+            set_host_moonlight "false" "true"
+            ;;
+    esac
+}
+
 function resolution_gui_moonlight() {
     local options=()
     local default
@@ -476,6 +546,7 @@ function gui_moonlight() {
             G "Configure remote apps"
             R "Configure global resolution"
             B "Configure global stream bitrate"
+            H "Configure host compatibility"
             C "Clear all pairing data"
         )
 
@@ -508,6 +579,9 @@ function gui_moonlight() {
                 ;;
             B)
                 bitrate_gui_moonlight
+                ;;
+            H)
+                host_gui_moonlight
                 ;;
             C)
                 if dialog --defaultno --yesno "Are you sure you want to CLEAR ALL pairing data?" 8 40 2>&1 >/dev/tty; then


### PR DESCRIPTION
There are open-source implementations of NVIDIA's GFE server which
expands Moonlight compatibility to other GPU manufacturers on both
Linux and Windows:

1. https://github.com/loki-47-6F-64/sunshine
(original project with CPU and NVIDIA HW encoder support)

2. https://github.com/LS3solutions/openstream-server
(forked project focused on Windows support with partial AMD HW encoding)

Unfortunately, moonlight-embedded does not work out of the box, so
provide a new host menu to assist in configuring the options needed
to attain full compatibility with these servers.