### PR TITLE
Box86, Wine, and Space Cadet 3D Pinball

### DIFF
--- a/scriptmodules/emulators/box86.sh
+++ b/scriptmodules/emulators/box86.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="box86"
+rp_module_desc="Box86 emulator"
+rp_module_help="Place your x86 binaries $romdir/box86"
+rp_module_licence="MIT https://github.com/ptitSeb/box86/blob/master/LICENSE"
+rp_module_section="exp"
+rp_module_flags="rpi4 x11"
+
+function _latest_ver_box86() {
+    # This defines the Git tag / branch which will be used. Main repository is at:
+    # https://github.com/ptitSeb/box86
+    echo v0.1.8
+    # The following is not working yet. Releases must be non-prerelease and non-draft.
+    # wget -qO- https://api.github.com/repos/ptitSeb/box86/releases/latest | grep -m 1 tag_name | cut -d\" -f4
+}
+
+function depends_box86() {
+    if compareVersions $__gcc_version lt 7; then
+        md_ret_errors+=("Sorry, you need an OS with gcc 7 or newer to compile $md_id")
+        return 1
+    fi
+
+    local dep_idx="$(rp_getIdxFromId "mesa")"
+    if [ "$dep_idx" == "" ] || ! rp_isInstalled "$dep_idx" ; then
+        md_ret_errors+=("Sorry, you need to install the Mesa scriptmodule")
+        return 1
+    fi
+
+    # Install required libraries required for compilation and running
+    getDepends binfmt-support cmake gtk2-engines-murrine libncurses5 libncursesw5 libssl1.0.2 libglu1-mesa zenity mesa-utils libinput10 libxkbcommon-x11-0 matchbox-window-manager xorg
+
+    # Restarting the binfmt service should eliminate the need to reboot the machine after installation.
+    systemctl restart systemd-binfmt
+    
+    # X11 on RPi is currently using VMWare's LLVM GL Driver for some reason. That should be removed.
+    # Recommended as per: https://www.raspberrypi.org/forums/viewtopic.php?t=196423
+    apt remove -y xserver-xorg-video-fbturbo
+}
+
+function sources_box86() {
+    gitPullOrClone "$md_build" https://github.com/ptitSeb/box86.git "$(_latest_ver_box86)"
+}
+
+function build_box86() {
+    mkdir build
+    cd build
+    cmake .. -DARM_DYNAREC=1 -DRPI4=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    make -j4
+    cd ..
+}
+
+function install_box86() {
+    md_ret_files=(
+        'build/box86'
+        'build/libdynarec.a'
+        'LICENSE'
+    )
+}
+
+function configure_box86() {
+    local system="box86"
+
+    update-binfmts --install i386 "$md_inst/${system}" --magic '\x7fELF\x01\x01\x01\x03\x00\x00\x00\x00\x00\x00\x00\x00\x03\x00\x03\x00\x01\x00\x00\x00' --mask '\xff\xff\xff\xff\xff\xff\xff\xfc\xff\xff\xff\xff\xff\xff\xff\xff\xf8\xff\xff\xff\xff\xff\xff\xff'
+}

--- a/scriptmodules/ports/spacecadet3dpinball.sh
+++ b/scriptmodules/ports/spacecadet3dpinball.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="spacecadet3dpinball"
+rp_module_desc="Space Cadet 3D Pinball"
+rp_module_help=""
+rp_module_licence="https://archive.org/details/pinballxp"
+rp_module_section="exp"
+rp_module_flags="rpi4 x86"
+
+function depends_spacecadet3dpinball() {
+    local dep_idx="$(rp_getIdxFromId "wine")"
+    if [ "$dep_idx" == "" ] || ! rp_isInstalled "$dep_idx" ; then
+        md_ret_errors+=("Sorry, you need to install the wine scriptmodule")
+        return 1
+    fi
+}
+
+function install_bin_spacecadet3dpinball() {
+    #
+    # Download and extract Space Cadet 3D Pinball ZIP file to Program Files.
+    #
+    mkdir -p /home/pi/.wine/drive_c/Program\ Files/SpaceCadet3DPinball/
+
+    wget -nv -O "$__tmpdir/PinballXP.zip" https://archive.org/download/pinballxp/PinballXP.zip
+    pushd /home/pi/.wine/drive_c/Program\ Files/SpaceCadet3DPinball/
+    unzip "$__tmpdir/PinballXP.zip"
+    popd
+    
+    chown -R pi:pi /home/pi/.wine/drive_c/Program\ Files/SpaceCadet3DPinball/
+}
+
+function configure_spacecadet3dpinball() {
+    local system="spacecadet3dpinball"
+    local spacecadet3dpinball="$md_inst/spacecadet3dpinball_xinit.sh"
+
+    #
+    # Add Space Cadet 3D Pinball entry to Ports in Emulation Station
+    #
+    cat > "$spacecadet3dpinball" << _EOFSP_
+#!/bin/bash
+xset -dpms s off s noblank
+cd "/home/pi/.wine/drive_c/Program Files/SpaceCadet3DPinball/"
+matchbox-window-manager &
+WINEDEBUG=-all LD_LIBRARY_PATH="/opt/retropie/supplementary/mesa/lib/" setarch linux32 -L /opt/retropie/ports/wine/bin/wine '/home/pi/.wine/drive_c/Program Files/SpaceCadet3DPinball/pinball.exe' -fullscreen
+_EOFSP_
+        chmod +x "$spacecadet3dpinball"
+
+    addPort "$md_id" "spacecadet3dpinball" "Space Cadet 3D Pinball (WindowsXP)" "XINIT:$spacecadet3dpinball"
+}

--- a/scriptmodules/ports/wine.sh
+++ b/scriptmodules/ports/wine.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="wine"
+rp_module_desc="WINEHQ - Wine Is Not an Emulator"
+rp_module_help="Use your app's Installer or place your x86 Windows binaries into $romdir/wine"
+rp_module_licence="LGPL https://wiki.winehq.org/Licensing"
+rp_module_section="exp"
+rp_module_flags="rpi4"
+# TODO: Currently only tested on RPI4 platform. Other RPI platforms should also work.
+#       X86 platform requires some modification in the Ports scripts so that the custom Mesa path is removed.
+
+function _latest_ver_wine() {
+    echo "6.0~rc5"
+}
+
+function _release_type_wine() {
+    echo devel
+}
+
+function depends_wine() {
+    # On RPI systems, we need to make sure Box86 is installed.
+    if isPlatform "rpi"; then
+        local dep_idx="$(rp_getIdxFromId "box86")"
+        if [ "$dep_idx" == "" ] || ! rp_isInstalled "$dep_idx" ; then
+            md_ret_errors+=("Sorry, you need to install the Box86 scriptmodule")
+            return 1
+        fi
+    fi
+    
+    # Timidity is to enable MIDI output from Wine
+    getDepends timidity-daemon timidity fluid-soundfont-gm
+}
+
+function install_bin_wine() {
+    local version="$(_latest_ver_wine)"
+    local releaseType="$(_release_type_wine)"
+    local baseURL="https://dl.winehq.org/wine-builds/debian/dists/buster/main/binary-i386/"
+
+    local workingDir="$__tmpdir/wine-${releaseType}-${version}/"
+
+    mkdir -p ${workingDir}
+    pushd ${workingDir}
+
+    for i in wine-${releaseType}-i386 wine-${releaseType}
+    do
+      local package="${i}_${version}~buster_i386.deb"
+      local getdeb="${baseURL}${package}"
+      
+      wget -nv -O "${workingDir}/$package" $getdeb
+
+      mkdir "$i"
+      pushd "$i"
+  
+      ar x ../${i}_${version}~buster_i386.deb
+      tar xvf data.tar.xz
+
+      cp -R opt/wine-${releaseType}/* $md_inst
+      popd
+    done
+    popd
+}
+
+function configure_wine() {
+    local system="wine"
+    
+    local winedesktop_xinit="$md_inst/winedesktop_xinit.sh"
+    local wineexplorer_xinit="$md_inst/wineexplorer_xinit.sh"
+    local winecfg_xinit="$md_inst/winecfg_xinit.sh"
+    
+    #
+    # Create a new Wine prefix directory
+    #
+    sudo -u pi WINEDEBUG=-all LD_LIBRARY_PATH="/opt/retropie/supplementary/mesa/lib/" setarch linux32 -L /opt/retropie/ports/wine/bin/wine winecfg /v win7
+    
+    #
+    # Install Emulation Station scripts for Wine
+    #
+    cat > "$winedesktop_xinit" << _EOFDESKTOP_
+#!/bin/bash
+xset -dpms s off s noblank
+matchbox-window-manager &
+WINEDEBUG=-all LD_LIBRARY_PATH="/opt/retropie/supplementary/mesa/lib/" setarch linux32 -L /opt/retropie/ports/wine/bin/wine explorer /desktop=shell,\`xrandr | grep current | sed 's/.*current //; s/,.*//; s/ //g'\`
+_EOFDESKTOP_
+        chmod +x "$winedesktop_xinit"
+
+    cat > "$wineexplorer_xinit" << _EOFEXPLORER_
+#!/bin/bash
+xset -dpms s off s noblank
+matchbox-window-manager &
+WINEDEBUG=-all LD_LIBRARY_PATH="/opt/retropie/supplementary/mesa/lib/" setarch linux32 -L /opt/retropie/ports/wine/bin/wine explorer /desktop=shell,\`xrandr | grep current | sed 's/.*current //; s/,.*//; s/ //g'\` explorer
+_EOFEXPLORER_
+        chmod +x "$wineexplorer_xinit"
+
+    cat > "$winecfg_xinit" << _EOFCONFIG_
+#!/bin/bash
+xset -dpms s off s noblank
+matchbox-window-manager &
+WINEDEBUG=-all LD_LIBRARY_PATH="/opt/retropie/supplementary/mesa/lib/" setarch linux32 -L /opt/retropie/ports/wine/bin/wine explorer /desktop=shell,\`xrandr | grep current | sed 's/.*current //; s/,.*//; s/ //g'\` winecfg
+_EOFCONFIG_
+        chmod +x "$winecfg_xinit"
+
+    addPort "$md_id" "winedesktop" "Wine Desktop" "XINIT:$winedesktop_xinit"
+    addPort "$md_id" "wineexplorer" "Wine Explorer" "XINIT:$wineexplorer_xinit"
+    addPort "$md_id" "winecfg" "Wine Config" "XINIT:$winecfg_xinit"
+}

--- a/scriptmodules/supplementary/mesa.sh
+++ b/scriptmodules/supplementary/mesa.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="mesa"
+rp_module_desc="Mesa3d OpenGL and Vulkan Drivers"
+rp_module_licence="MIT https://www.mesa3d.org/license.html"
+rp_module_section="depends"
+rp_module_flags="rpi4 x11"
+
+# Based on instructions from: https://www.reddit.com/r/RetroPie/comments/egjqw2/how_to_manually_compile_newest_mesa_drivers_for/
+# Research for Vulkan:
+# https://blogs.igalia.com/apinheiro/2020/06/v3dv-quick-guide-to-build-and-run-some-demos/
+# https://www.youtube.com/watch?v=TLzFPIoHhS8
+# https://www.raspberrypi.org/blog/vulkan-update-merged-to-mesa/
+# https://www.raspberrypi.org/forums/viewtopic.php?t=277125
+# https://www.raspberrypi.org/forums/viewtopic.php?t=289168
+
+function _latest_ver_mesa() {
+    # This defines the Git tag / branch which will be used. Main repository is at:
+    # https://gitlab.freedesktop.org/mesa/mesa/
+    echo mesa-20.3.2
+}
+
+function depends_mesa() {
+    #local depends=(meson ninja-build libgbm-dev libdrm-dev libpciaccess-dev)
+    local depends=(vulkan-tools libxcb-shm0-dev)
+
+    getDepends "${depends[@]}"
+    
+    # 1: Exit emulationstation (F4 or the command below should do it)
+    # kill $(ps -ef|grep '/opt/retropie/supplementary/emulationstation/emulationstation'|grep -v grep|tail -1|awk '{print $2}')
+
+    # 2: Run the following command to setup source code repositories on your pi:
+    sed -i -e 's/#deb-src http:\/\/archive.raspberrypi.org\/debian\/.*/deb-src http:\/\/archive.raspberrypi.org\/debian\/ buster main/' /etc/apt/sources.list.d/raspi.list
+
+    # 3: Run the following command to get the needed dependencies for building MESA from source:
+    apt update
+    apt build-dep mesa -y
+
+    # 4: Run the following command to remove source code repositories on your pi:
+    sed -i -e 's/deb-src http:\/\/archive.raspberrypi.org\/debian\/.*/#deb-src http:\/\/archive.raspberrypi.org\/debian\/ buster main/' /etc/apt/sources.list.d/raspi.list
+    apt update
+}
+
+function sources_mesa() {
+    # 5: Run the following command to clone the MESA git repo to your pi:
+    gitPullOrClone "$md_build" https://gitlab.freedesktop.org/mesa/mesa/ "$(_latest_ver_mesa)"
+}
+
+function build_mesa() {
+    #TODO: Research if there are any RPi specific optimization flags. Check mesa-drm.sh scriptmodule.
+    #TODO: Also check https://github.com/anholt/mesa/wiki/Raspberry-Pi-cross-compile for optimization possibilities
+    # 6: Create the build directory and change to that directory:
+    #mkdir $md_build/builddir
+    #cd /home/pi/mesa/build
+
+    # 7: Now compile the new version of MESA:
+    meson builddir --prefix="$md_inst" --libdir lib -Dplatforms=x11     -Dvulkan-drivers=broadcom -Ddri-drivers= -Dgallium-drivers=v3d,kmsro,vc4,virgl --buildtype debug
+    ninja -C builddir
+}
+
+function install_mesa() {
+    # 8: Install new MESA version (You'll see various warnings, these are safe and can be ignored)
+    echo "Installing into $md_inst"
+    cd builddir
+    ninja install
+    cd ..
+
+    # The following line is to configure the location of Vulkan
+    echo export VK_ICD_FILENAMES="$md_inst"/share/vulkan/icd.d/broadcom_icd.armv7l.json >> /home/pi/.profile
+}

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -231,7 +231,7 @@ function get_os_version() {
                 fi
             fi
             ;;
-        Ubuntu|neon|Pop)
+        Ubuntu|[Nn]eon|Pop)
             if compareVersions "$__os_release" lt 16.04; then
                 error="You need Ubuntu 16.04 or newer"
             # although ubuntu 16.04/16.10 report as being based on stretch it is before some


### PR DESCRIPTION
Thank you in advance for reviewing my pull request. Attached are four scripts with the intention of being able to run x86 and Windows games through RetroPie on a Raspberry Pi 4. Other Raspberry Pi's may be compatible, but will require further testing.

For further details, see: https://retropie.org.uk/forum/topic/28528/box86-and-wine-on-rpi4/

The scripts must be run in order, and they will check to make sure the preceding dependencies have been met.

- mesa.sh - This is an updated Mesa driver, which is required by Box86. The version that is installed with the RetroPie distribution is not yet compatible.
- box86.sh - This is set as an emulator because it is.
- wine.sh - This is the x86 version of Wine and requires box86 in order to run. It is installed as a Port, because as the name says, Wine Is Not an Emulator.
- spacecadet3dpinball.sh - This is the original Windows XP game, hosted on the Internet Archive. It is also installed as a Port as it is more like a rom and not an emulator. It is included mostly as a reference to installing other games. One note - you must not hit the Escape key to quit or you will be in a hung state in the game. Use Alt-F4 instead.

These could be split into separate pull requests, but I haven't because of the dependency chain. 

Looking forward to any questions or feedback you might have!

Thanks again,

\- George