### PR TITLE
lr-hatari: fix building with the capsimage libs

### DIFF
--- a/scriptmodules/emulators/hatari.sh
+++ b/scriptmodules/emulators/hatari.sh
@@ -42,6 +42,8 @@ function _build_libcapsimage_hatari() {
     mkdir -p "$md_build/src/includes/caps"
     cp -R "../LibIPF/"*.h "$md_build/src/includes/caps/"
     cp "../Core/CommonTypes.h" "$md_build/src/includes/caps/"
+    # 'lr-hatari' expects a 'caps5' include path
+    ln -sf "$md_build/src/includes/caps" "$md_build/src/includes/caps5"
 }
 
 function build_hatari() {


### PR DESCRIPTION
Upstream `hatari` has dropped support for CAPS4, so it's not looking for `caps5`, but the libretro core still looks for [`caps5`](https://github.com/libretro/hatari/blob/c05015c395a17af12e1eb7e9e4fb876f74b00122/src/uae-cpu/newcpu.c#L166).