### PR TITLE
Wget to curl

### DIFF
--- a/scriptmodules/admin/image.sh
+++ b/scriptmodules/admin/image.sh
@@ -53,7 +53,7 @@ function create_chroot_image() {
     local base="raspbian-${dist}-lite"
     local image="$base.img"
     if [[ ! -f "$image" ]]; then
-        wget -c -O "$base.zip" "$url"
+        download "$url" "$base.zip"
         unzip -o "$base.zip"
         mv "$(unzip -Z -1 "$base.zip")" "$image"
         rm "$base.zip"

--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -208,7 +208,7 @@ function package_setup() {
         fi
 
         # if we had a network error don't display install options
-        if [[ "$binary_ret" -eq 4 ]]; then
+        if [[ "$binary_ret" -eq 6 || "$binary_ret" -eq 7 ]]; then
             status+="\nInstall options disabled (Unable to access internet)"
         else
             if [[ "$source_update" -eq 1 || "$binary_update" -eq 1 ]]; then

--- a/scriptmodules/emulators/ags.sh
+++ b/scriptmodules/emulators/ags.sh
@@ -43,7 +43,9 @@ function configure_ags() {
     mkRomDir "ags"
 
     # install Eawpatches GUS patch set (see: http://liballeg.org/digmid.html)
-    [[ "$md_mode" == "install" ]] && wget -qO- "http://www.eglebbk.dds.nl/program/download/digmid.dat" | bzcat >"$md_inst/bin/patches.dat"
+    if [[ "$md_mode" == "install" ]]; then
+        download "http://www.eglebbk.dds.nl/program/download/digmid.dat" - | bzcat >"$md_inst/bin/patches.dat"
+    fi
 
     addEmulator 1 "$md_id" "ags" "$binary ${params[*]}" "Adventure Game Studio" ".exe"
 

--- a/scriptmodules/emulators/frotz.sh
+++ b/scriptmodules/emulators/frotz.sh
@@ -30,17 +30,18 @@ function remove_frotz() {
 }
 
 function game_data_frotz() {
-    if [[ ! -f "$romdir/zmachine/zork1.dat" ]]; then
-        cd "$__tmpdir"
+    local dest="$romdir/zmachine"
+    if [[ ! -f "$dest/zork1.dat" ]]; then
+        mkUserDir "$dest"
+        local temp="$(mktemp -d)"
         local file
         for file in zork1 zork2 zork3; do
-            wget -nv -O "$file.zip" "$__archive_url/$file.zip"
-            unzip -L -n "$file.zip" "data/$file.dat"
-            mv "data/$file.dat" "$romdir/zmachine/"
-            chown $user:$user "$romdir/zmachine/$file.dat"
-            rm "$file.zip"
+            downloadAndExtract "$__archive_url/$file.zip" "$temp" -L
+            cp "$temp/data/$file.dat" "$dest"
+            rm -rf "$temp"
         done
-        rmdir data
+        rm -rf "$temp"
+        chown -R $user:$user "$romdir/zmachine"
     fi
 }
 

--- a/scriptmodules/emulators/fs-uae.sh
+++ b/scriptmodules/emulators/fs-uae.sh
@@ -37,7 +37,7 @@ function depends_fs-uae() {
                 # add repository and key
                 local repo="http://download.opensuse.org/repositories/home:/FrodeSolheim:/stable/$name"
                 echo "deb $repo/ /" > "$apt_file"
-                wget -q -O- "$repo/Release.key" | apt-key add -
+                download "$repo/Release.key" - | apt-key add -
             else
                 # remove repository and key
                 rm -f "$apt_file"

--- a/scriptmodules/emulators/mame.sh
+++ b/scriptmodules/emulators/mame.sh
@@ -17,7 +17,7 @@ rp_module_section="exp"
 rp_module_flags="!mali !armv6"
 
 function _latest_ver_mame() {
-    wget -qO- https://api.github.com/repos/mamedev/mame/releases/latest | grep -m 1 tag_name | cut -d\" -f4
+    download https://api.github.com/repos/mamedev/mame/releases/latest - | grep -m 1 tag_name | cut -d\" -f4
 }
 
 function _get_binary_name_mame() {

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -1011,10 +1011,7 @@ function download() {
     set -o pipefail
     printMsgs "console" "Downloading $url ..."
     # capture stderr - while passing both stdout and stderr to terminal
-    # wget by default outputs the progress to stderr - if we force it to log to stdout, we get no useful error msgs
-    # however this code will be useful when switching away from wget to curl. For now it's best left with -nv
-    # no progress, but less log spam, and output can be useful on failure
-    cmd_err=$(wget -nv -O"$dest" "$url" 2>&1 1>&3 | tee /dev/stderr)
+    cmd_err=$(curl -o"$dest" "$url" 2>&1 1>&3 | tee /dev/stderr)
     ret="$?"
     set +o pipefail
     # remove stdin copy

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -1023,6 +1023,10 @@ function download() {
         printMsgs "console" "Downloading $url to $dest ..."
         params+=(-o "$dest")
     fi
+    params+=(--connect-timeout 60 --speed-limit 1 --speed-time 60)
+    # add any user supplied curl opts - timeouts can be overridden as curl uses the last parameters given
+    [[ -z "$__curl_opts" ]] && params+=($__curl_opts)
+    # add the url
     params+=("$url")
     # capture stderr - while passing both stdout and stderr to terminal
     cmd_err=$(curl "${params[@]}" 2>&1 1>&3 | tee /dev/stderr)

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -1016,7 +1016,7 @@ function download() {
     local ret
     # get the last non zero exit status (ignoring tee)
     set -o pipefail
-    local params=()
+    local params=(--location)
     if [[ "$dest" == "-" ]]; then
         params+=(-s)
     else

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -995,14 +995,19 @@ function applyPatch() {
 ## @brief Download a file
 ## @details Download a file - if the dest parameter is omitted, the file will be downloaded to the current directory.
 ## If the destination name is a hyphen (-), then the file will be outputted to stdout, for piping to another command
-## or retrieving the contents directly to a variable.
+## or retrieving the contents directly to a variable. If the destination is a folder, extract with the basename from
+## the url to the destination folder.
 ## @retval 0 on success
 function download() {
     local url="$1"
     local dest="$2"
+    local file="${url##*/}"
 
-    # if no destination, get the basename from the url (supported by GNU basename)
-    [[ -z "$dest" ]] && dest="${PWD}/$(basename "$url")"
+    # if no destination, get the basename from the url
+    [[ -z "$dest" ]] && dest="${PWD}/$file"
+
+    # if the destination is a folder, download to that with filename from url
+    [[ -d "$dest" ]] && dest="$dest/$file"
 
     # set up additional file descriptor for stdin
     exec 3>&1
@@ -1046,9 +1051,10 @@ function download() {
 function downloadAndVerify() {
     local url="$1"
     local dest="$2"
+    local file="${url##*/}"
 
     # if no destination, get the basename from the url (supported by GNU basename)
-    [[ -z "$dest" ]] && dest="${PWD}/$(basename "$url")"
+    [[ -z "$dest" ]] && dest="${PWD}/$file"
 
     local cmd_out
     local ret=1

--- a/scriptmodules/libretrocores/lr-prboom.sh
+++ b/scriptmodules/libretrocores/lr-prboom.sh
@@ -32,18 +32,20 @@ function install_lr-prboom() {
 }
 
 function game_data_lr-prboom() {
-    if [[ ! -f "$romdir/ports/doom/doom1.wad" ]]; then
+    local dest="$romdir/ports/doom"
+    mkUserDir "$dest"
+    if [[ ! -f "$dest/doom1.wad" ]]; then
         # download doom 1 shareware
-        wget -nv -O "$romdir/ports/doom/doom1.wad" "$__archive_url/doom1.wad"
+        download "$__archive_url/doom1.wad" "$dest/doom1.wad"
     fi
 
     if ! echo "e9bf428b73a04423ea7a0e9f4408f71df85ab175 $romdir/ports/doom/freedoom1.wad" | sha1sum -c &>/dev/null; then
         # download (or update) freedoom
-        downloadAndExtract "https://github.com/freedoom/freedoom/releases/download/v0.12.1/freedoom-0.12.1.zip" "$romdir/ports/doom/" -j -LL
+        downloadAndExtract "https://github.com/freedoom/freedoom/releases/download/v0.12.1/freedoom-0.12.1.zip" "$dest" -j -LL
     fi
 
-    mkdir -p "$romdir/ports/doom/addon"
-    chown -R $user:$user "$romdir/ports/doom"
+    mkUserDir "$dest/addon"
+    chown -R $user:$user "$dest"
 }
 
 function _add_games_lr-prboom() {

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -92,9 +92,9 @@ function rp_callModule() {
             rp_hasBinary "$md_id"
             local ret="$?"
 
-            # check if we had a network failure from wget
-            if [[ "$ret" -eq 4 ]]; then
-                __ERRMSGS+=("Unable to connect to the internet")
+            # check if we get a couldn't resolve host or failed to connect to host from curl
+            if [[ "$ret" -eq 6 || "$ret" -eq 7 ]]; then
+                __ERRMSGS+=("Unable to connect to the internet - curl returned $ret")
                 return 1
             fi
 
@@ -370,7 +370,7 @@ function rp_hasBinary() {
     [[ -z "$url" ]] && return 1
 
     if rp_hasBinaries; then
-        wget --spider -q "$url"
+        curl -o /dev/null -sfI "$url"
         return $?
     fi
     return 1
@@ -381,11 +381,7 @@ function rp_getBinaryDate() {
     local url="$(rp_getBinaryUrl $id)"
     [[ -z "$url" || "$url" == "notest" ]] && return 1
 
-    local bin_date=$(wget \
-        --server-response --spider -q \
-        "$url" 2>&1 \
-        | grep -i "Last-Modified" \
-        | cut -d" " -f4-)
+    local bin_date=$(curl -sfI $url | grep -i "last-modified" | cut -d" " -f2-)
     echo "$bin_date"
     return 0
 }

--- a/scriptmodules/ports/dxx-rebirth.sh
+++ b/scriptmodules/ports/dxx-rebirth.sh
@@ -76,40 +76,44 @@ function install_dxx-rebirth() {
 }
 
 function game_data_dxx-rebirth() {
-    local D1X_SHARE_URL='http://www.dxx-rebirth.com/download/dxx/content/descent-pc-shareware.zip'
-    local D2X_SHARE_URL='http://www.dxx-rebirth.com/download/dxx/content/descent2-pc-demo.zip'
-    local D1X_HIGH_TEXTURE_URL='http://www.dxx-rebirth.com/download/dxx/res/d1xr-hires.dxa'
-    local D1X_OGG_URL='http://www.dxx-rebirth.com/download/dxx/res/d1xr-sc55-music.dxa'
-    local D2X_OGG_URL='http://www.dxx-rebirth.com/download/dxx/res/d2xr-sc55-music.dxa'
+    local D1X_SHARE_URL='https://www.dxx-rebirth.com/download/dxx/content/descent-pc-shareware.zip'
+    local D2X_SHARE_URL='https://www.dxx-rebirth.com/download/dxx/content/descent2-pc-demo.zip'
+    local D1X_HIGH_TEXTURE_URL='https://www.dxx-rebirth.com/download/dxx/res/d1xr-hires.dxa'
+    local D1X_OGG_URL='https://www.dxx-rebirth.com/download/dxx/res/d1xr-sc55-music.dxa'
+    local D2X_OGG_URL='https://www.dxx-rebirth.com/download/dxx/res/d2xr-sc55-music.dxa'
 
-    cd "$__tmpdir"
+    local dest_d1="$romdir/ports/descent1"
+    local dest_d2="$romdir/ports/descent2"
+
+    mkUserDir "$dest_d1"
+    mkUserDir "$dest_d2"
 
     # Download / unpack / install Descent shareware files
-    if [[ ! -f "$romdir/ports/descent1/descent.hog" ]]; then
-        downloadAndExtract "$D1X_SHARE_URL" "$romdir/ports/descent1"
+    if [[ ! -f "$dest_d1/descent.hog" ]]; then
+        downloadAndExtract "$D1X_SHARE_URL" "$dest_d1"
     fi
 
     # High Res Texture Pack
-    if [[ ! -f "$romdir/ports/descent1/d1xr-hires.dxa" ]]; then
-        wget -nv -P "$romdir/ports/descent1" "$D1X_HIGH_TEXTURE_URL"
+    if [[ ! -f "$dest_d1/d1xr-hires.dxa" ]]; then
+        download "$D1X_HIGH_TEXTURE_URL" "$dest_d1"
     fi
 
     # Ogg Sound Replacement (Roland Sound Canvas SC-55 MIDI)
-    if [[ ! -f "$romdir/ports/descent1/d1xr-sc55-music.dxa" ]]; then
-        wget -nv -P "$romdir/ports/descent1" "$D1X_OGG_URL"
+    if [[ ! -f "$dest_d1/d1xr-sc55-music.dxa" ]]; then
+        download "$D1X_OGG_URL" "$dest_d1"
     fi
 
     # Download / unpack / install Descent 2 shareware files
-    if [[ ! -f "$romdir/ports/descent2/D2DEMO.HOG" ]]; then
-        downloadAndExtract "$D2X_SHARE_URL" "$romdir/ports/descent2"
+    if [[ ! -f "$dest_d2/D2DEMO.HOG" ]]; then
+        downloadAndExtract "$D2X_SHARE_URL" "$dest_d2"
     fi
 
     # Ogg Sound Replacement (Roland Sound Canvas SC-55 MIDI)
-    if [[ ! -f "$romdir/ports/descent2/d2xr-sc55-music.dxa" ]]; then
-        wget -nv -P "$romdir/ports/descent2" "$D2X_OGG_URL"
+    if [[ ! -f "$dest_d2/d2xr-sc55-music.dxa" ]]; then
+        download "$D2X_OGG_URL" "$dest_d2"
     fi
 
-    chown -R $user:$user "$romdir/ports/descent1" "$romdir/ports/descent2"
+    chown -R $user:$user "$dest_d1" "$dest_d2"
 }
 
 function configure_dxx-rebirth() {

--- a/scriptmodules/ports/eduke32.sh
+++ b/scriptmodules/ports/eduke32.sh
@@ -75,15 +75,16 @@ function install_eduke32() {
 }
 
 function game_data_eduke32() {
-    cd "$_tmpdir"
-
+    local dest="$romdir/ports/duke3d"
     if [[ "$md_id" == "eduke32" ]]; then
-        if [[ ! -f "$romdir/ports/duke3d/duke3d.grp" ]]; then
-            wget -O 3dduke13.zip "$__archive_url/3dduke13.zip"
-            unzip -L -o 3dduke13.zip dn3dsw13.shr
-            unzip -L -o dn3dsw13.shr -d "$romdir/ports/duke3d" duke3d.grp duke.rts
-            rm 3dduke13.zip dn3dsw13.shr
-            chown -R $user:$user "$romdir/ports/duke3d"
+        if [[ ! -f "$dest/duke3d.grp" ]]; then
+            mkUserDir "$dest"
+            local temp="$(mktemp -d)"
+            download "$__archive_url/3dduke13.zip" "$temp"
+            unzip -L -o "$temp/3dduke13.zip" -d "$temp" dn3dsw13.shr
+            unzip -L -o "$temp/dn3dsw13.shr" -d "$dest" duke3d.grp duke.rts
+            rm -rf "$temp"
+            chown -R $user:$user "$dest"
         fi
     fi
 }

--- a/scriptmodules/ports/kodi.sh
+++ b/scriptmodules/ports/kodi.sh
@@ -27,7 +27,7 @@ function depends_kodi() {
             # remove old repository
             rm -f /etc/apt/sources.list.d/mene.list
             echo "deb http://pipplware.pplware.pt/pipplware/dists/$__os_codename/main/binary/ ./" >/etc/apt/sources.list.d/pipplware.list
-            wget -q -O- http://pipplware.pplware.pt/pipplware/key.asc | apt-key add - &>/dev/null
+            download http://pipplware.pplware.pt/pipplware/key.asc - | apt-key add - &>/dev/null
         else
             rm -f /etc/apt/sources.list.d/pipplware.list
             apt-key del 4096R/BAA567BB >/dev/null

--- a/scriptmodules/ports/openpht.sh
+++ b/scriptmodules/ports/openpht.sh
@@ -12,7 +12,7 @@
 rp_module_id="openpht"
 rp_module_desc="OpenPHT is a community driven fork of Plex Home Theater"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/RasPlex/OpenPHT/openpht-1.7/LICENSE.GPL"
-rp_module_section="opt"
+rp_module_section="exp"
 rp_module_flags="!arm"
 
 function depends_openpht() {
@@ -23,17 +23,18 @@ function depends_openpht() {
 function install_bin_openpht() {
     local version="1.7.1.137-b604995c"
     local package="openpht_${version}-${__os_codename}_amd64.deb"
-    local getdeb="https://github.com/RasPlex/OpenPHT/releases/download/v$version/$package"
+    local url="https://github.com/RasPlex/OpenPHT/releases/download/v$version/$package"
 
-    wget -nv -O "$__tmpdir/$package" $getdeb
+    local temp="$(mktemp -d)"
+    download "$url" "$temp/$package"
     if hasPackage "apt" "1.1" "ge"; then
-        apt install -y --allow-downgrades "$__tmpdir/$package"
+        apt install -y --allow-downgrades "$temp/$package"
     else
         # Falling back to dpkg
-        dpkg -i "$__tmpdir/$package"
+        dpkg -i "$temp/$package"
         apt-get -f -y install
     fi
-    rm "$__tmpdir/$package"
+    rm -rf "$temp"
 }
 
 function remove_openpht() {

--- a/scriptmodules/ports/steamlink.sh
+++ b/scriptmodules/ports/steamlink.sh
@@ -17,7 +17,7 @@ rp_module_flags="!all rpi3 rpi4"
 rp_module_help="Stream games from your computer with Steam"
 
 function depends_steamlink() {
-    getDepends python3-dev curl libinput10 libxkbcommon-x11-0 matchbox-window-manager xorg zenity
+    getDepends python3-dev libinput10 libxkbcommon-x11-0 matchbox-window-manager xorg zenity
 }
 
 function install_bin_steamlink() {

--- a/scriptmodules/ports/uqm.sh
+++ b/scriptmodules/ports/uqm.sh
@@ -38,7 +38,7 @@ function sources_uqm() {
     local ver="$(_get_ver_uqm)"
     local url="http://http.debian.net/debian/pool/contrib/u/uqm"
     for file in uqm_$ver.dsc uqm_0.6.2.dfsg.orig.tar.gz uqm_$ver.debian.tar.xz; do
-        wget -nv -O"$file" "$url/$file"
+        download "$url/$file"
     done
 }
 

--- a/scriptmodules/supplementary/customhidsony.sh
+++ b/scriptmodules/supplementary/customhidsony.sh
@@ -48,8 +48,8 @@ _EOF_
 #!/bin/bash
 rpi_kernel_ver="rpi-4.19.y"
 mkdir -p "drivers/hid/" "patches"
-wget https://raw.githubusercontent.com/raspberrypi/linux/"\$rpi_kernel_ver"/drivers/hid/hid-sony.c -O "drivers/hid/hid-sony.c"
-wget https://raw.githubusercontent.com/raspberrypi/linux/"\$rpi_kernel_ver"/drivers/hid/hid-ids.h -O "drivers/hid/hid-ids.h"
+curl -s https://raw.githubusercontent.com/raspberrypi/linux/"\$rpi_kernel_ver"/drivers/hid/hid-sony.c -o "drivers/hid/hid-sony.c"
+curl -s https://raw.githubusercontent.com/raspberrypi/linux/"\$rpi_kernel_ver"/drivers/hid/hid-ids.h -o "drivers/hid/hid-ids.h"
 patch -p1 <"patches/0001-hidsony-gasiafix.diff"
 _EOF_
     chmod +x "hidsony_source.sh"

--- a/scriptmodules/supplementary/pegasus-fe.sh
+++ b/scriptmodules/supplementary/pegasus-fe.sh
@@ -32,7 +32,7 @@ function depends_pegasus-fe() {
 function install_bin_pegasus-fe() {
     # get all asset urls for the latest continuous release
     local all_assets
-    all_assets="$(wget -q -O - https://api.github.com/repos/mmatyas/pegasus-frontend/releases/tags/continuous)" || return
+    all_assets="$(download https://api.github.com/repos/mmatyas/pegasus-frontend/releases/tags/continuous -)" || return
     all_assets="$(echo "${all_assets}" | jq -r '.assets[] | .browser_download_url')"
 
     printMsgs "console" "Available releases:"

--- a/scriptmodules/supplementary/raspbiantools.sh
+++ b/scriptmodules/supplementary/raspbiantools.sh
@@ -77,7 +77,7 @@ function install_firmware_raspbiantools() {
     for pkg in "${pkgs[@]}"; do
         if hasPackage "$pkg" "$ver" ne; then
             deb="${pkg}_${ver}_armhf.deb"
-            if ! wget -O"$deb" "$url/$deb"; then
+            if ! download "$url/$deb"; then
                md_ret_errors+=("Failed to download $deb")
                return 1
             fi

--- a/scriptmodules/supplementary/retronetplay.sh
+++ b/scriptmodules/supplementary/retronetplay.sh
@@ -89,7 +89,7 @@ function gui_retronetplay() {
     rps_retronet_loadconfig
 
     local ip_int=$(ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
-    local ip_ext=$(wget -O- -q http://ipecho.net/plain)
+    local ip_ext=$(download http://ipecho.net/plain -)
 
     while true; do
         cmd=(dialog --backtitle "$__backtitle" --menu "Configure RetroArch Netplay.\nInternal IP: $ip_int External IP: $ip_ext" 22 76 16)

--- a/scriptmodules/supplementary/scraper.sh
+++ b/scriptmodules/supplementary/scraper.sh
@@ -47,7 +47,7 @@ function get_ver_scraper() {
 }
 
 function latest_ver_scraper() {
-    wget -qO- https://api.github.com/repos/sselph/scraper/releases/latest | grep -m 1 tag_name | cut -d\" -f4
+    download https://api.github.com/repos/sselph/scraper/releases/latest - | grep -m 1 tag_name | cut -d\" -f4
 }
 
 function list_systems_scraper() {

--- a/scriptmodules/supplementary/skyscraper.sh
+++ b/scriptmodules/supplementary/skyscraper.sh
@@ -127,7 +127,7 @@ function _get_ver_skyscraper() {
 }
 
 function _latest_ver_skyscraper() {
-    wget -qO- https://api.github.com/repos/muldjord/skyscraper/releases/latest | grep -m 1 tag_name | cut -d\" -f4
+    download https://api.github.com/repos/muldjord/skyscraper/releases/latest - | grep -m 1 tag_name | cut -d\" -f4
 }
 
 function _check_ver_skyscraper() {

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -286,7 +286,7 @@ function get_os_version() {
 }
 
 function get_retropie_depends() {
-    local depends=(git dialog wget gcc g++ build-essential unzip xmlstarlet python3-pyudev ca-certificates dirmngr)
+    local depends=(git dialog wget curl gcc g++ build-essential unzip xmlstarlet python3-pyudev ca-certificates dirmngr)
 
     [[ -n "$DISTCC_HOSTS" ]] && depends+=(distcc)
 

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -286,7 +286,7 @@ function get_os_version() {
 }
 
 function get_retropie_depends() {
-    local depends=(git dialog wget curl gcc g++ build-essential unzip xmlstarlet python3-pyudev ca-certificates dirmngr)
+    local depends=(git dialog curl gcc g++ build-essential unzip xmlstarlet python3-pyudev ca-certificates dirmngr)
 
     [[ -n "$DISTCC_HOSTS" ]] && depends+=(distcc)
 


### PR DESCRIPTION
Move RetroPie to use curl rather than wget.

This changeset switches the helpers download function to use curl (including some function enhancements such as stdout support) and makes downloadAndExtract also use the core download function.

In addition almost all module code using wget has been switched to use the download or downloadAndExtract function excluding one case where wget was used in an external script which has been switched to curl.

Packaging and setup functions have been adjusted to curl also.

This is left as draft as there's a few things I want to look at still, such as the stderr output capturing and some additional tweaks here and there perhaps. But feel free to test.

