### PR TITLE
dkmsManager fixes

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -1457,9 +1457,10 @@ function dkmsManager() {
                 kernel="$(ls -1 /lib/modules | tail -n -1)"
             fi
             ln -sf "$md_inst" "/usr/src/${module_name}-${module_ver}"
-            dkms install --force -m "$module_name" -v "$module_ver" -k "$kernel"
-            if dkms status | grep -q "^$module_name"; then
-                md_ret_error+=("Failed to install $md_id")
+            dkms install -m "$module_name" -v "$module_ver" -k "$kernel"
+            if ! dkms status "$module_name"/"$module_ver" | grep -q ": installed"; then
+                dkmsManager remove "$module_name" "$module_ver"
+                md_ret_errors+=("Failed to install $md_id (missing kernel headers?)")
                 return 1
             fi
             ;;


### PR DESCRIPTION
First commit is safe, as it fixes the module error mechanism when dkms fails to build against the running kernel. This can happen if there was a kernel/header upgrade but the system hasn't rebooted to the new kernel yet.

Second commit is dodgy (hence the DNM). It tries to build for all kernels found via a search of installed Debian packages, and marks installation as successful if it detects the module marked as installed for any one of the kernel versions found... but, this is not really a guarantee that it has built/installed the module for the kernel that will be active on the next reboot.

Would appreciate feedback. The problem with only fixing the error detection is that a routine update of RetroPie's packages in combination with an OS upgrade that included a new kernel will still leave xpad in a broken state (although it will at least report the error to the user).
