### PR TITLE
Update autostart.sh

### DIFF
--- a/scriptmodules/supplementary/autostart.sh
+++ b/scriptmodules/supplementary/autostart.sh
@@ -40,7 +40,7 @@ _EOF_
     sed -i '$a\' "$script"
     case "$mode" in
         kodi)
-            echo -e "kodi-standalone #auto\nemulationstation #auto" >>"$script"
+            echo -e "while pgrep omxplayer >/dev/null; do sleep 1; done #auto\nkodi #auto\nemulationstation #auto" >>"$script"
             ;;
         es|*)
             echo "emulationstation #auto" >>"$script"


### PR DESCRIPTION
Rpi2, rpi3, rpi3b+, in rpi4 don't know
Bug in kodi when select kodi at system startup, play a video locally, it allows pause with pause, space, etc., but it does not allow to exit the video that is being played.
 It does not show the typical pause stop bar, the esc, return is as if they will not work.
 I managed with the letter x to stop the playback but the screen remains black while the interface sounds.
I don't known is the best solution by the moment is working.
Possible solution
echo -e "kodi-standalone #auto\nemulationstation #auto" >>"$script"
Change by 
echo -e "while pgrep omxplayer >/dev/null; do sleep 1; done #auto\nkodi #auto\nemulationstation #auto" >>"$script"
Thanks Re_Tux
Thanks for all