### PR TITLE
packages - allow adding of 3rd party module repos

### DIFF
--- a/ext/README.txt
+++ b/ext/README.txt
@@ -1,0 +1,13 @@
+You can checkout additional repositories here to add 3rd party modules.
+
+Repositories should be structured so you have:
+
+ext/REPOSITORY_NAME/scriptmodules
+
+Modules are only read from the following subfolders of scriptmodules:
+ * emulators
+ * libretrocores
+ * ports
+ * supplementary
+ * admin
+

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -587,10 +587,12 @@ function rp_registerModule() {
 
 function rp_registerModuleDir() {
     local dir="$1"
+    [[ ! -d "$dir" ]] && return 1
     local module
-    for module in $(find "$scriptdir/scriptmodules/$dir" -maxdepth 1 -name "*.sh" | sort); do
+    for module in $(find "$dir" -mindepth 1 -maxdepth 1 -type f -name "*.sh" | sort); do
         rp_registerModule "$module" "$dir"
     done
+    return 0
 }
 
 function rp_registerAllModules() {
@@ -603,11 +605,13 @@ function rp_registerAllModules() {
     declare -Ag __mod_section=()
     declare -Ag __mod_flags=()
 
-    rp_registerModuleDir "emulators"
-    rp_registerModuleDir "libretrocores"
-    rp_registerModuleDir "ports"
-    rp_registerModuleDir "supplementary"
-    rp_registerModuleDir "admin"
+    local dir
+    local type
+    while read dir; do
+        for type in emulators libretrocores ports supplementary admin; do
+            rp_registerModuleDir "$dir/$type"
+        done
+    done < <(find "$scriptdir"/scriptmodules "$scriptdir"/ext/*/scriptmodules -maxdepth 0 2>/dev/null)
 }
 
 function rp_getSectionIds() {


### PR DESCRIPTION
The structure should be such that you have

ext/REPOSITORY/scriptmodules

modules are only read from the following subfolders of scriptmodules

emulators
libretrocores
ports
supplementary
admin

Tagging: @zerojay and @hiulit

This should make things easier and keep your repos separate etc. Needs testing.