### PR TITLE
Merge module arrays and include all modules in setup

### DIFF
--- a/scriptmodules/admin/builder.sh
+++ b/scriptmodules/admin/builder.sh
@@ -29,7 +29,7 @@ function module_builder() {
         ! fnExists "install_${id}" && continue
 
         # skip already built archives, so we can retry failed modules
-        [[ -f "$__tmpdir/archives/$__binary_path/${__mod_type[$id]}/$id.tar.gz" ]] && continue
+        [[ -f "$__tmpdir/archives/$__binary_path/${__mod_info[$id/type]}/$id.tar.gz" ]] && continue
 
         # build, install and create binary archive.
         # initial clean in case anything was in the build folder when calling

--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -329,11 +329,12 @@ function section_gui_setup() {
             if ! rp_isEnabled "$id"; then
                 info="\Zb*$id - Not available for your system\Zn"
             else
-                info="$id"
                 if rp_isInstalled "$id"; then
                     eval $(rp_getPackageInfo "$id")
-                    info+=" \Zb(Installed - via $pkg_origin)\Zn"
+                    info="\Zb\Z7$id\Zn \Zb(Installed - via $pkg_origin)"
                     ((num_pkgs++))
+                else
+                    info="$id"
                 fi
             fi
             pkgs+=("${__mod_idx[$id]}" "$info" "$id - ${__mod_info[$id/desc]}"$'\n\n'"${__mod_info[$id/help]}")

--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -235,7 +235,7 @@ function package_setup() {
             options+=(Z "Clean source folder")
         fi
 
-        local help="${__mod_desc[$id]}\n\n${__mod_help[$id]}"
+        local help="${__mod_info[$id/desc]}\n\n${__mod_info[$id/help]}"
         if [[ -n "$help" ]]; then
             options+=(H "Package Help")
         fi
@@ -274,7 +274,7 @@ function package_setup() {
                 ;;
             X)
                 local text="Are you sure you want to remove $id?"
-                case "${__mod_section[$id]}" in
+                case "${__mod_info[$id/section]}" in
                     core)
                         text+="\n\nWARNING - core packages are needed for RetroPie to function!"
                         ;;
@@ -327,7 +327,7 @@ function section_gui_setup() {
             else
                 installed=""
             fi
-            pkgs+=("${__mod_idx[$id]}" "$id $installed" "$id - ${__mod_desc[$id]}"$'\n\n'"${__mod_help[$id]}")
+            pkgs+=("${__mod_idx[$id]}" "$id $installed" "$id - ${__mod_info[$id/desc]}"$'\n\n'"${__mod_info[$id/help]}")
         done
 
         if [[ "$num_pkgs" -gt 0 ]]; then
@@ -415,8 +415,8 @@ function config_gui_setup() {
         local id
         for id in "${__mod_id[@]}"; do
             # show all configuration modules and any installed packages with a gui function
-            if [[ "${__mod_section[$id]}" == "config" ]] || rp_isInstalled "$id" && fnExists "gui_$id"; then
-                options+=("${__mod_idx[$id]}" "$id  - ${__mod_desc[$id]}" "${__mod_idx[$id]} ${__mod_desc[$id]}")
+            if [[ "${__mod_info[$id/section]}" == "config" ]] || rp_isInstalled "$id" && fnExists "gui_$id"; then
+                options+=("${__mod_idx[$id]}" "$id  - ${__mod_info[$id/desc]}" "${__mod_idx[$id]} ${__mod_info[$id/desc]}")
             fi
         done
 
@@ -457,7 +457,7 @@ function update_packages_setup() {
     clear
     local id
     for id in ${__mod_id[@]}; do
-        if rp_isInstalled "$id" && [[ "${__mod_section[$id]}" != "depends" ]]; then
+        if rp_isInstalled "$id" && [[ "${__mod_info[$id/section]}" != "depends" ]]; then
             rp_installModule "$id" "_update_"
         fi
     done

--- a/scriptmodules/admin/stats.sh
+++ b/scriptmodules/admin/stats.sh
@@ -24,7 +24,7 @@ function _get_package_data_stats() {
     local data=()
     local id
     for id in ${__mod_id[@]}; do
-        data+=("${__mod_section[$id]};$id;${__mod_desc[$id]};${__mod_licence[$id]};${__mod_flags[$id]};")
+        data+=("${__mod_info[$id/section]};$id;${__mod_info[$id/desc]};${__mod_info[$id/licence]};${__mod_info[$id/flags]};")
     done
     printf "%s\n" "${data[@]}"
 }

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -9,14 +9,15 @@
 # at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
 #
 
-declare -A __sections
-__sections[core]="core"
-__sections[main]="main"
-__sections[opt]="optional"
-__sections[exp]="experimental"
-__sections[driver]="driver"
-__sections[config]="configuration"
-__sections[depends]="dependency"
+declare -A __sections=(
+    [core]="core"
+    [main]="main"
+    [opt]="optional"
+    [exp]="experimental"
+    [driver]="driver"
+    [config]="configuration"
+    [depends]="dependency"
+)
 
 function rp_listFunctions() {
     local id

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -28,7 +28,7 @@ function rp_listFunctions() {
     echo -e "ID:                 Description:                                 List of available functions"
     echo "-----------------------------------------------------------------------------------------------------------------------------------"
     for id in ${__mod_id[@]}; do
-        printf "%-20s: %-42s :" "$id" "${__mod_desc[$id]}"
+        printf "%-20s: %-42s :" "$id" "${__mod_info[$id/desc]}"
         while read mode; do
             # skip private module functions (start with an underscore)
             [[ "$mode" = _* ]] && continue
@@ -128,10 +128,10 @@ function rp_callModule() {
     esac
 
     # create variables that can be used in modules
-    local md_desc="${__mod_desc[$md_id]}"
-    local md_help="${__mod_help[$md_id]}"
-    local md_type="${__mod_type[$md_id]}"
-    local md_flags="${__mod_flags[$md_id]}"
+    local md_desc="${__mod_info[$md_id/desc]}"
+    local md_help="${__mod_info[$md_id/help]}"
+    local md_type="${__mod_info[$md_id/type]}"
+    local md_flags="${__mod_info[$md_id/flags]}"
     local md_build="$__builddir/$md_id"
     local md_inst="$(rp_getInstallPath $md_id)"
     local md_data="$scriptdir/scriptmodules/$md_type/$md_id"
@@ -254,7 +254,7 @@ function rp_callModule() {
         install)
             action="Installing"
             # remove any previous install folder unless noinstclean flag is set
-            if ! hasFlag "${__mod_flags[$md_id]}" "noinstclean"; then
+            if ! hasFlag "${__mod_info[$md_id/flags]}" "noinstclean"; then
                 rmDirExists "$md_inst"
             fi
             mkdir -p "$md_inst"
@@ -342,7 +342,7 @@ function rp_hasBinaries() {
 
 function rp_getBinaryUrl() {
     local id="$1"
-    local url="$__binary_url/${__mod_type[$id]}/$id.tar.gz"
+    local url="$__binary_url/${__mod_info[$id/type]}/$id.tar.gz"
     if fnExists "install_bin_${id}"; then
         if fnExists "__binary_url_${id}"; then
             url="$(__binary_url_${id})"
@@ -405,7 +405,7 @@ function rp_hasNewerBinary() {
 
 function rp_getInstallPath() {
     local id="$1"
-    echo "$rootdir/${__mod_type[$id]}/$id"
+    echo "$rootdir/${__mod_info[$id/type]}/$id"
 }
 
 function rp_installBin() {
@@ -462,7 +462,7 @@ function rp_createBin() {
 
 function rp_hasModule() {
     local id="$1"
-    [[ -n "${__mod_type[$id]}" ]] && return 0
+    [[ -n "${__mod_idx[$id]}" ]] && return 0
     return 1
 }
 
@@ -577,12 +577,12 @@ function rp_registerModule() {
         # create numerical index for each module id from nunber of added modules
         __mod_idx["$rp_module_id"]="${#__mod_id[@]}"
         __mod_id+=("$rp_module_id")
-        __mod_type["$rp_module_id"]="$type"
-        __mod_desc["$rp_module_id"]="$rp_module_desc"
-        __mod_help["$rp_module_id"]="$rp_module_help"
-        __mod_licence["$rp_module_id"]="$rp_module_licence"
-        __mod_section["$rp_module_id"]="$rp_module_section"
-        __mod_flags["$rp_module_id"]="$rp_module_flags"
+        __mod_info["$rp_module_id/type"]="$type"
+        __mod_info["$rp_module_id/desc"]="$rp_module_desc"
+        __mod_info["$rp_module_id/help"]="$rp_module_help"
+        __mod_info["$rp_module_id/licence"]="$rp_module_licence"
+        __mod_info["$rp_module_id/section"]="$rp_module_section"
+        __mod_info["$rp_module_id/flags"]="$rp_module_flags"
     fi
 }
 
@@ -597,12 +597,7 @@ function rp_registerModuleDir() {
 function rp_registerAllModules() {
     __mod_id=()
     declare -Ag __mod_idx=()
-    declare -Ag __mod_type=()
-    declare -Ag __mod_desc=()
-    declare -Ag __mod_help=()
-    declare -Ag __mod_licence=()
-    declare -Ag __mod_section=()
-    declare -Ag __mod_flags=()
+    declare -Ag __mod_info=()
 
     rp_registerModuleDir "emulators"
     rp_registerModuleDir "libretrocores"
@@ -617,7 +612,7 @@ function rp_getSectionIds() {
     local ids=()
     for id in "${__mod_id[@]}"; do
         for section in "$@"; do
-            [[ "${__mod_section[$id]}" == "$section" ]] && ids+=("$id")
+            [[ "${__mod_info[$id/section]}" == "$section" ]] && ids+=("$id")
         done
     done
     echo "${ids[@]}"
@@ -625,7 +620,7 @@ function rp_getSectionIds() {
 
 function rp_isInstalled() {
     local id="$1"
-    local md_inst="$rootdir/${__mod_type[$id]}/$id"
+    local md_inst="$rootdir/${__mod_info[$id/type]}/$id"
     [[ -d "$md_inst" ]] && return 0
     return 1
 }

--- a/scriptmodules/supplementary/dispmanx.sh
+++ b/scriptmodules/supplementary/dispmanx.sh
@@ -22,7 +22,7 @@ function gui_dispmanx() {
         local command=()
         local id
         for id in "${__mod_id[@]}"; do
-            if [[ "${__mod_flags[$id]}" =~ dispmanx ]] && rp_isInstalled "$id"; then
+            if [[ "${__mod_info[$id/flags]}" =~ dispmanx ]] && rp_isInstalled "$id"; then
                 iniGet "$id"
                 if [[ "$ini_value" == "1" ]]; then
                     options+=($count "Disable for $id (currently enabled)")


### PR DESCRIPTION
rather than multiple arrays for each module info we now use a single array with

__mod_info(ID/KEY) where key is type/desc/help/licence/flags etc

we still keep __mod_id() - a standard indexed array with every module id (used for setup menus etc) and
__mod_idx() which references the index # from the id

this will make it easier to extend in the future