### PR TITLE
packages - allow adding of 3rd party module repos

### DIFF
--- a/ext/README.txt
+++ b/ext/README.txt
@@ -1,0 +1,13 @@
+You can checkout additional repositories here to add 3rd party modules.
+
+Repositories should be structured so you have:
+
+ext/REPOSITORY_NAME/scriptmodules
+
+Modules are only read from the following subfolders of scriptmodules:
+ * emulators
+ * libretrocores
+ * ports
+ * supplementary
+ * admin
+

--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -325,7 +325,14 @@ function section_gui_setup() {
         local pkg_origin
         local num_pkgs=0
         local info
+        local type
         for id in $(rp_getSectionIds $section); do
+            # do a heading for each origin and module type
+            if [[ "$type" != "${__mod_info[$id/type]}" ]]; then
+                info="${__mod_info[$id/vendor]} - ${__mod_info[$id/type]}"
+                pkgs+=("----" "$info ----" "Packages from $info")
+                type="${__mod_info[$id/type]}"
+            fi
             if ! rp_isEnabled "$id"; then
                 info="\Zb*$id - Not available for your system\Zn"
             else
@@ -410,6 +417,8 @@ function section_gui_setup() {
                     rps_logEnd
                 } &> >(_setup_gzip_log "$logfilename")
                 rps_printInfo "$logfilename"
+                ;;
+            ----)
                 ;;
             *)
                 package_setup "${__mod_id[$choice]}"

--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -102,6 +102,9 @@ function depends_setup() {
 
     # set a global __setup to 1 which is used to adjust package function behaviour if called from the setup gui
     __setup=1
+
+    # print any pending msgs - eg during module scanning which wouldn't be seen otherwise
+    rps_printInfo
 }
 
 function updatescript_setup()

--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -330,7 +330,7 @@ function section_gui_setup() {
             # do a heading for each origin and module type
             if [[ "$type" != "${__mod_info[$id/type]}" ]]; then
                 info="${__mod_info[$id/vendor]} - ${__mod_info[$id/type]}"
-                pkgs+=("----" "$info ----" "Packages from $info")
+                pkgs+=("----" "\Z4$info ----\Zn" "Packages from $info")
                 type="${__mod_info[$id/type]}"
             fi
             if ! rp_isEnabled "$id"; then

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -526,6 +526,7 @@ function rp_getPackageInfo() {
 function rp_registerModule() {
     local path="$1"
     local type="$2"
+    local vendor="$3"
     # type is the last folder in the path as we now send a full path to rp_registerModule
     type="${type##*/}"
     local rp_module_id=""
@@ -591,6 +592,7 @@ function rp_registerModule() {
     __mod_idx["$rp_module_id"]="${#__mod_id[@]}"
     __mod_id+=("$rp_module_id")
     __mod_info["$rp_module_id/enabled"]="$enabled"
+    __mod_info["$rp_module_id/vendor"]="$vendor"
     __mod_info["$rp_module_id/type"]="$type"
     __mod_info["$rp_module_id/desc"]="$rp_module_desc"
     __mod_info["$rp_module_id/help"]="$rp_module_help"
@@ -602,10 +604,12 @@ function rp_registerModule() {
 function rp_registerModuleDir() {
     local dir="$1"
     [[ ! -d "$dir" ]] && return 1
+    local vendor="$2"
+    [[ -z "$vendor" ]] && return 1
     local module
-
+    local vendor
     while read module; do
-        rp_registerModule "$module" "$dir"
+        rp_registerModule "$module" "$dir" "$vendor"
     done < <(find "$dir" -mindepth 1 -maxdepth 1 -type f -name "*.sh" | sort)
     return 0
 }
@@ -617,9 +621,19 @@ function rp_registerAllModules() {
 
     local dir
     local type
+    local origin
     while read dir; do
+        # get parent folder
+        vendor="${dir%/*}"
+        # if the folder isn't RetroPie-Setup then get the repo name which will be used for module vendor
+        if [[ "$vendor" != "$scriptdir" ]]; then
+            vendor="${vendor##*/}"
+        else
+            vendor="RetroPie"
+        fi
+
         for type in emulators libretrocores ports supplementary admin; do
-            rp_registerModuleDir "$dir/$type"
+            rp_registerModuleDir "$dir/$type" "$vendor"
         done
     done < <(find "$scriptdir"/scriptmodules "$scriptdir"/ext/*/scriptmodules -maxdepth 0 2>/dev/null)
 }

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -538,6 +538,14 @@ function rp_registerModule() {
 
     local error=0
 
+    # extract the module id and make sure it is unique - also we don't want 3rd party
+    # repos overriding our built in modules as it will cause issues when debugging
+    rp_module_id=$(grep -oP "rp_module_id=\"\K([^\"]+)" "$path")
+    if [[ -n "${__mod_idx[$rp_module_id]}" ]]; then
+        __INFMSGS+=("Module $path was skipped as $rp_module_id is already used by ${__mod_info[$rp_module_id/path]}")
+        return
+    fi
+
     source "$path"
 
     local var
@@ -592,6 +600,7 @@ function rp_registerModule() {
     __mod_idx["$rp_module_id"]="${#__mod_id[@]}"
     __mod_id+=("$rp_module_id")
     __mod_info["$rp_module_id/enabled"]="$enabled"
+    __mod_info["$rp_module_id/path"]="$path"
     __mod_info["$rp_module_id/vendor"]="$vendor"
     __mod_info["$rp_module_id/type"]="$type"
     __mod_info["$rp_module_id/desc"]="$rp_module_desc"


### PR DESCRIPTION
3rd party repositories can be checked out to RetroPie-Setup/ext

Repositories should be structured so you have:

ext/REPOSITORY/scriptmodules

Modules are only read from the following subfolders of scriptmodules
 * emulators
 * libretrocores
 * ports
 * supplementary
 * admin