### PR TITLE
Repo version check

### DIFF
--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -182,6 +182,9 @@ function package_setup() {
         local ip="$(getIPAddress)"
         [[ -n "$ip" ]] && has_net=1
 
+        # for modules with nonet flag that don't need to download data, we force has_net to 1, so we get install options
+        hasFlag "${__mod_info[$id/flags]}" "nonet" && has_net=1
+
         if [[ "$has_net" -eq 1 ]]; then
             rp_hasBinary "$id"
             local ret="$?"
@@ -237,7 +240,6 @@ function package_setup() {
             fi
         fi
 
-        # if we had a network error don't display install options
         if [[ "$has_net" -eq 1 ]]; then
             if [[ "$is_installed" -eq 1 ]]; then
                 options+=(U "${option_msgs["U"]}")

--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -522,9 +522,19 @@ function update_packages_setup() {
     done
 }
 
+function check_connection_gui_setup() {
+    local ip="$(getIPAddress)"
+    if [[ -z "$ip" ]]; then
+        printMsgs "dialog" "Sorry, you don't seem to be connected to the internet, so installing/updating is not available."
+        return 1
+    fi
+    return 0
+}
+
 function update_packages_gui_setup() {
     local update="$1"
     if [[ "$update" != "update" ]]; then
+        ! check_connection_gui_setup && return 1
         dialog --defaultno --yesno "Are you sure you want to update installed packages?" 22 76 2>&1 >/dev/tty || return 1
         updatescript_setup || return 1
         # restart at post_update and then call "update_packages_gui_setup update" afterwards
@@ -658,6 +668,7 @@ function gui_setup() {
 
         case "$choice" in
             I)
+                ! check_connection_gui_setup && continue
                 dialog --defaultno --yesno "Are you sure you want to do a basic install?\n\nThis will install all packages from the 'Core' and 'Main' package sections." 22 76 2>&1 >/dev/tty || continue
                 clear
                 local logfilename
@@ -679,6 +690,7 @@ function gui_setup() {
                 config_gui_setup
                 ;;
             S)
+                ! check_connection_gui_setup && continue
                 dialog --defaultno --yesno "Are you sure you want to update the RetroPie-Setup script ?" 22 76 2>&1 >/dev/tty || continue
                 if updatescript_setup; then
                     joy2keyStop

--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -201,10 +201,11 @@ function package_setup() {
             rp_loadPackageInfo "$id"
             pkg_origin="${__mod_info[$id/pkg_origin]}"
             pkg_date="${__mod_info[$id/pkg_date]}"
+            [[ -n "$pkg_date" ]] && pkg_date="$(date -u -d "$pkg_date" 2>/dev/null)"
 
             status="Installed - via $pkg_origin"
 
-            [[ -n "$pkg_date" ]] && status+=" (built: $(date -u -d "$pkg_date"))"
+            [[ -n "$pkg_date" ]] && status+=" (built: $pkg_date)"
 
             if [[ "$has_net" -eq 1 ]]; then
                 rp_hasNewerModule "$id" "$pkg_origin"

--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -181,12 +181,15 @@ function package_setup() {
         local binary_ret="$?"
         [[ "$binary_ret" -eq 0 ]] && has_binary=1
 
-        local pkg_origin
         local is_installed=0
 
         if rp_isInstalled "$id"; then
             is_installed=1
-            eval $(rp_getPackageInfo "$id")
+
+            rp_loadPackageInfo "$id"
+            local pkg_origin="${__mod_info[$id/pkg_origin]}"
+            local pkg_date="${__mod_info[$id/pkg_date]}"
+
             status="Installed - via $pkg_origin"
 
             [[ -n "$pkg_date" ]] && status+=" (built: $(date -u -d "$pkg_date"))"
@@ -328,7 +331,6 @@ function section_gui_setup() {
         local pkgs=()
 
         local id
-        local pkg_origin
         local num_pkgs=0
         local info
         local type
@@ -345,7 +347,9 @@ function section_gui_setup() {
                 info="\Z1$id\Zn - Not available for your system"
             else
                 if rp_isInstalled "$id"; then
-                    eval $(rp_getPackageInfo "$id")
+                    rp_loadPackageInfo "$id" "pkg_origin"
+                    local pkg_origin="${__mod_info[$id/pkg_origin]}"
+
                     info="$id (Installed - via $pkg_origin)"
                     ((num_pkgs++))
                 else

--- a/scriptmodules/admin/tools.sh
+++ b/scriptmodules/admin/tools.sh
@@ -32,7 +32,7 @@ function check_repos_tools() {
         case "$md_repo_type" in
             git|svn)
                 out=$(rp_getRemoteRepoHash "$md_repo_type" "$md_repo_url" "$md_repo_branch" "$md_repo_commit")
-                if [[ -z "$out" ]]; then
+                if [[ "$?" -ne 0 || -z "$out" ]]; then
                     printMsgs "console" "$id repository failed - $md_repo_url $md_repo_branch"
                     ret=1
                 fi

--- a/scriptmodules/admin/tools.sh
+++ b/scriptmodules/admin/tools.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="tools"
+rp_module_desc="Various RetroPie development/administration tools"
+rp_module_section=""
+
+function check_repos_tools() {
+    local id
+    local ret=0
+    for id in "${__mod_id[@]}"; do
+        eval "$(rp_moduleVars $id)"
+        local out
+        [[ -z "$md_repo_type" ]] && continue
+        printMsgs "console" "Checking $id repository source ..."
+        case "$md_repo_type" in
+            git)
+                out="$(git ls-remote --symref "$md_repo_url" "$md_repo_branch")"
+                if [[ -z "$out" ]]; then
+                    printMsgs "console" "$id repository failed - $md_repo_url $md_repo_branch"
+                    ret=1
+                fi
+                ;;
+            svn)
+                if ! out="$(svn info -r"$md_repo_commit" "$md_repo_url" 2>&1)"; then
+                    printMsgs "console" "$id repository failed - $md_repo_url $md_repo_commit\n$out"
+                    ret=1
+                fi
+                ;;
+           file)
+                if ! rp_getFileDate "$md_repo_url" >/dev/null; then
+                    printMsgs "console" "$id file archive failed - $md_repo_url"
+                    ret=1
+                fi
+                ;;
+        esac
+    done
+    return "$ret"
+}

--- a/scriptmodules/admin/tools.sh
+++ b/scriptmodules/admin/tools.sh
@@ -14,13 +14,21 @@ rp_module_desc="Various RetroPie development/administration tools"
 rp_module_section=""
 
 function check_repos_tools() {
+    local ids
+    if [[ -n "$1" ]]; then
+        ids=("$@")
+    else
+        ids=("${__mod_id[@]}")
+    fi
     local id
     local ret=0
-    for id in "${__mod_id[@]}"; do
+    for id in "${ids[@]}"; do
         eval "$(rp_moduleVars $id)"
         local out
         [[ -z "$md_repo_type" ]] && continue
-        printMsgs "console" "Checking $id repository source ..."
+        md_repo_url="$(rp_resolveRepoParam "$md_repo_url")"
+        md_repo_branch="$(rp_resolveRepoParam "$md_repo_branch")"
+        printMsgs "console" "Checking $id repository ($md_repo_url / $md_repo_branch) ..."
         case "$md_repo_type" in
             git)
                 out="$(git ls-remote --symref "$md_repo_url" "$md_repo_branch")"

--- a/scriptmodules/emulators/advmame-0.94.sh
+++ b/scriptmodules/emulators/advmame-0.94.sh
@@ -13,6 +13,7 @@ rp_module_id="advmame-0.94"
 rp_module_desc="AdvanceMAME v0.94.0"
 rp_module_help="ROM Extension: .zip\n\nCopy your AdvanceMAME roms to either $romdir/mame-advmame or\n$romdir/arcade"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/amadvance/advancemame/master/COPYING"
+rp_module_repo="file $__archive_url/advancemame-0.94.0.tar.gz"
 rp_module_section="opt"
 rp_module_flags="!mali !kms"
 
@@ -22,7 +23,7 @@ function depends_advmame-0.94() {
 }
 
 function sources_advmame-0.94() {
-    downloadAndExtract "$__archive_url/advancemame-0.94.0.tar.gz" "$md_build" --strip-components 1
+    downloadAndExtract "$md_repo_url" "$md_build" --strip-components 1
     _sources_patch_advmame-1.4
 }
 

--- a/scriptmodules/emulators/advmame-1.4.sh
+++ b/scriptmodules/emulators/advmame-1.4.sh
@@ -13,6 +13,7 @@ rp_module_id="advmame-1.4"
 rp_module_desc="AdvanceMAME v1.4"
 rp_module_help="ROM Extension: .zip\n\nCopy your AdvanceMAME roms to either $romdir/mame-advmame or\n$romdir/arcade"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/amadvance/advancemame/master/COPYING"
+rp_module_repo="file $__archive_url/advancemame-1.4.tar.gz"
 rp_module_section="opt"
 rp_module_flags="!mali !kms"
 
@@ -43,7 +44,7 @@ function _sources_patch_advmame-1.4() {
 }
 
 function sources_advmame-1.4() {
-    downloadAndExtract "$__archive_url/advancemame-1.4.tar.gz" "$md_build" --strip-components 1
+    downloadAndExtract "$md_repo_url" "$md_build" --strip-components 1
     _sources_patch_advmame-1.4 1.4
 }
 

--- a/scriptmodules/emulators/advmame.sh
+++ b/scriptmodules/emulators/advmame.sh
@@ -13,6 +13,7 @@ rp_module_id="advmame"
 rp_module_desc="AdvanceMAME v3.9"
 rp_module_help="ROM Extension: .zip\n\nCopy your AdvanceMAME roms to either $romdir/mame-advmame or\n$romdir/arcade"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/amadvance/advancemame/master/COPYING"
+rp_module_repo="git https://github.com/amadvance/advancemame v3.9"
 rp_module_section="opt"
 rp_module_flags=""
 
@@ -36,7 +37,7 @@ function depends_advmame() {
 }
 
 function sources_advmame() {
-    gitPullOrClone "$md_build" https://github.com/amadvance/advancemame v3.9
+    gitPullOrClone
 }
 
 function build_advmame() {

--- a/scriptmodules/emulators/ags.sh
+++ b/scriptmodules/emulators/ags.sh
@@ -13,6 +13,7 @@ rp_module_id="ags"
 rp_module_desc="Adventure Game Studio - Adventure game engine"
 rp_module_help="ROM Extension: .exe\n\nCopy your Adventure Game Studio roms to $romdir/ags"
 rp_module_licence="OTHER https://raw.githubusercontent.com/adventuregamestudio/ags/master/License.txt"
+rp_module_repo="git https://github.com/adventuregamestudio/ags.git ags3"
 rp_module_section="opt"
 rp_module_flags="!mali"
 
@@ -21,7 +22,7 @@ function depends_ags() {
 }
 
 function sources_ags() {
-    gitPullOrClone "$md_build" https://github.com/adventuregamestudio/ags.git ags3
+    gitPullOrClone
 }
 
 function build_ags() {

--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -13,6 +13,7 @@ rp_module_id="amiberry"
 rp_module_desc="Amiga emulator with JIT support (forked from uae4arm)"
 rp_module_help="ROM Extension: .adf .ipf .zip\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/midwan/amiberry/master/COPYING"
+rp_module_repo="git https://github.com/midwan/amiberry master"
 rp_module_section="opt"
 rp_module_flags="!all arm"
 
@@ -42,7 +43,7 @@ function depends_amiberry() {
 }
 
 function sources_amiberry() {
-    gitPullOrClone "$md_build" https://github.com/midwan/amiberry
+    gitPullOrClone
     # use our default optimisation level
     sed -i "s/-Ofast//" "$md_build/Makefile"
 }

--- a/scriptmodules/emulators/atari800.sh
+++ b/scriptmodules/emulators/atari800.sh
@@ -13,6 +13,7 @@ rp_module_id="atari800"
 rp_module_desc="Atari 8-bit/800/5200 emulator"
 rp_module_help="ROM Extensions: .a52 .bas .bin .car .xex .atr .xfd .dcm .atr.gz .xfd.gz\n\nCopy your Atari800 games to $romdir/atari800\n\nCopy your Atari 5200 roms to $romdir/atari5200 You need to copy the Atari 800/5200 BIOS files (5200.ROM, ATARIBAS.ROM, ATARIOSB.ROM and ATARIXL.ROM) to the folder $biosdir and then on first launch configure it to scan that folder for roms (F1 -> Emulator Configuration -> System Rom Settings)"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/atari800/atari800/master/COPYING"
+rp_module_repo="git https://github.com/atari800/atari800.git ATARI800_4_2_0"
 rp_module_section="opt"
 rp_module_flags="!mali"
 
@@ -23,7 +24,7 @@ function depends_atari800() {
 }
 
 function sources_atari800() {
-    gitPullOrClone "$md_build" "https://github.com/atari800/atari800.git" ATARI800_4_2_0
+    gitPullOrClone
     if isPlatform "rpi"; then
         applyPatch "$md_data/01_rpi_fixes.diff"
     fi

--- a/scriptmodules/emulators/basilisk.sh
+++ b/scriptmodules/emulators/basilisk.sh
@@ -13,6 +13,7 @@ rp_module_id="basilisk"
 rp_module_desc="Macintosh emulator"
 rp_module_help="ROM Extensions: .img .rom\n\nCopy your Macintosh roms mac.rom and disk.img to $romdir/macintosh"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/cebix/macemu/master/BasiliskII/COPYING"
+rp_module_repo="git https://github.com/cebix/macemu.git master"
 rp_module_section="opt"
 rp_module_flags="dispmanx !mali"
 
@@ -23,7 +24,7 @@ function depends_basilisk() {
 }
 
 function sources_basilisk() {
-    gitPullOrClone "$md_build" https://github.com/cebix/macemu.git
+    gitPullOrClone
 }
 
 function build_basilisk() {

--- a/scriptmodules/emulators/capricerpi.sh
+++ b/scriptmodules/emulators/capricerpi.sh
@@ -13,6 +13,7 @@ rp_module_id="capricerpi"
 rp_module_desc="Amstrad CPC emulator - port of Caprice32 for the RPI"
 rp_module_help="ROM Extensions: .cdt .cpc .dsk\n\nCopy your Amstrad CPC games to $romdir/amstradcpc"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/KaosOverride/CapriceRPI/master/COPYING.txt"
+rp_module_repo="git https://github.com/KaosOverride/CapriceRPI.git master"
 rp_module_section="opt"
 rp_module_flags="dispmanx !all videocore"
 
@@ -21,7 +22,7 @@ function depends_capricerpi() {
 }
 
 function sources_capricerpi() {
-    gitPullOrClone "$md_build" https://github.com/KaosOverride/CapriceRPI.git
+    gitPullOrClone
     sed -i "s/-lpng12/-lpng/" src/makefile
 }
 

--- a/scriptmodules/emulators/coolcv.sh
+++ b/scriptmodules/emulators/coolcv.sh
@@ -13,6 +13,7 @@ rp_module_id="coolcv"
 rp_module_desc="CoolCV Colecovision Emulator"
 rp_module_help="ROM Extensions: .bin .col .rom .zip\n\nCopy your Colecovision roms to $romdir/coleco"
 rp_module_licence="PROP"
+rp_module_repo="file $__archive_url/coolcv.tar.gz"
 rp_module_section="opt"
 rp_module_flags="!all videocore"
 
@@ -21,7 +22,7 @@ function depends_coolcv() {
 }
 
 function install_bin_coolcv() {
-    downloadAndExtract "$__archive_url/coolcv.tar.gz" "$md_inst" --strip-components 1
+    downloadAndExtract "$md_repo_url" "$md_inst" --strip-components 1
     patchVendorGraphics "$md_inst/coolcv_pi"
 }
 

--- a/scriptmodules/emulators/daphne.sh
+++ b/scriptmodules/emulators/daphne.sh
@@ -13,6 +13,7 @@ rp_module_id="daphne"
 rp_module_desc="Daphne - Laserdisc Emulator"
 rp_module_help="ROM Extension: .daphne\n\nCopy your Daphne roms to $romdir/daphne"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/RetroPie/daphne-emu/master/COPYING"
+rp_module_repo="git https://github.com/RetroPie/daphne-emu.git retropie"
 rp_module_section="opt"
 rp_module_flags="dispmanx !x86 !mali"
 
@@ -21,7 +22,7 @@ function depends_daphne() {
 }
 
 function sources_daphne() {
-    gitPullOrClone "$md_build" https://github.com/RetroPie/daphne-emu.git retropie
+    gitPullOrClone
 }
 
 function build_daphne() {

--- a/scriptmodules/emulators/dgen.sh
+++ b/scriptmodules/emulators/dgen.sh
@@ -13,6 +13,7 @@ rp_module_id="dgen"
 rp_module_desc="Megadrive/Genesis emulator DGEN"
 rp_module_help="ROM Extensions: .32x .iso .cue .smd .bin .gen .md .sg .zip\n\nCopy your  Megadrive / Genesis roms to $romdir/megadrive\nSega 32X roms to $romdir/sega32x\nand SegaCD roms to $romdir/segacd\nThe Sega CD requires the BIOS files bios_CD_U.bin, bios_CD_E.bin, and bios_CD_J.bin copied to $biosdir"
 rp_module_licence="GPL2 https://sourceforge.net/p/dgen/dgen/ci/master/tree/COPYING"
+rp_module_repo="file $__archive_url/dgen-sdl-1.33.tar.gz"
 rp_module_section="opt"
 rp_module_flags="dispmanx !mali !kms"
 
@@ -21,7 +22,7 @@ function depends_dgen() {
 }
 
 function sources_dgen() {
-    downloadAndExtract "$__archive_url/dgen-sdl-1.33.tar.gz" "$md_build" --strip-components 1
+    downloadAndExtract "$md_repo_url" "$md_build" --strip-components 1
 }
 
 function build_dgen() {

--- a/scriptmodules/emulators/dolphin.sh
+++ b/scriptmodules/emulators/dolphin.sh
@@ -13,6 +13,7 @@ rp_module_id="dolphin"
 rp_module_desc="Gamecube/Wii emulator Dolphin"
 rp_module_help="ROM Extensions: .gcm .iso .wbfs .ciso .gcz .rvz\n\nCopy your Gamecube roms to $romdir/gc and Wii roms to $romdir/wii"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/dolphin-emu/dolphin/master/license.txt"
+rp_module_repo="git https://github.com/dolphin-emu/dolphin.git master"
 rp_module_section="exp"
 rp_module_flags="!all 64bit"
 
@@ -28,7 +29,7 @@ function sources_dolphin() {
     # current HEAD of dolphin doesn't build on Ubuntu 16.04 (with  gcc 5.4)
     compareVersions $__gcc_version lt 6 && branch="5.0"
 
-    gitPullOrClone "$md_build" https://github.com/dolphin-emu/dolphin.git "$branch"
+    gitPullOrClone "$md_build" "$md_repo_url" "$branch"
 }
 
 function build_dolphin() {

--- a/scriptmodules/emulators/dolphin.sh
+++ b/scriptmodules/emulators/dolphin.sh
@@ -13,9 +13,16 @@ rp_module_id="dolphin"
 rp_module_desc="Gamecube/Wii emulator Dolphin"
 rp_module_help="ROM Extensions: .gcm .iso .wbfs .ciso .gcz .rvz\n\nCopy your Gamecube roms to $romdir/gc and Wii roms to $romdir/wii"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/dolphin-emu/dolphin/master/license.txt"
-rp_module_repo="git https://github.com/dolphin-emu/dolphin.git master"
+rp_module_repo="git https://github.com/dolphin-emu/dolphin.git master :_get_branch_dolphin"
 rp_module_section="exp"
 rp_module_flags="!all 64bit"
+
+function _get_branch_dolphin() {
+    local branch="master"
+    # current HEAD of dolphin doesn't build on Ubuntu 16.04 (with  gcc 5.4)
+    compareVersions $__gcc_version lt 6 && branch="5.0"
+    echo "$branch"
+}
 
 function depends_dolphin() {
     local depends=(cmake pkg-config libao-dev libasound2-dev libavcodec-dev libavformat-dev libbluetooth-dev libenet-dev liblzo2-dev libminiupnpc-dev libopenal-dev libpulse-dev libreadline-dev libsfml-dev libsoil-dev libsoundtouch-dev libswscale-dev libusb-1.0-0-dev libxext-dev libxi-dev libxrandr-dev portaudio19-dev zlib1g-dev libudev-dev libevdev-dev libmbedtls-dev libcurl4-openssl-dev libegl1-mesa-dev qtbase5-private-dev)
@@ -25,11 +32,7 @@ function depends_dolphin() {
 }
 
 function sources_dolphin() {
-    local branch="master"
-    # current HEAD of dolphin doesn't build on Ubuntu 16.04 (with  gcc 5.4)
-    compareVersions $__gcc_version lt 6 && branch="5.0"
-
-    gitPullOrClone "$md_build" "$md_repo_url" "$branch"
+    gitPullOrClone
 }
 
 function build_dolphin() {

--- a/scriptmodules/emulators/dosbox-sdl2.sh
+++ b/scriptmodules/emulators/dosbox-sdl2.sh
@@ -13,6 +13,7 @@ rp_module_id="dosbox-sdl2"
 rp_module_desc="DOS emulator (enhanced DOSBox fork)"
 rp_module_help="ROM Extensions: .bat .com .exe .sh .conf\n\nCopy your DOS games to $romdir/pc"
 rp_module_licence="GPL2 https://sourceforge.net/p/dosbox/code-0/HEAD/tree/dosbox/trunk/COPYING"
+rp_module_repo="git https://github.com/duganchen/dosbox.git master"
 rp_module_section="exp"
 
 function depends_dosbox-sdl2() {
@@ -21,7 +22,7 @@ function depends_dosbox-sdl2() {
 }
 
 function sources_dosbox-sdl2() {
-    gitPullOrClone "$md_build" "https://github.com/duganchen/dosbox.git"
+    gitPullOrClone
     # use custom config filename & path to allow coexistence with regular dosbox
     sed -i "src/misc/cross.cpp" -e 's/~\/.dosbox/~\/.'$md_id'/g' \
        -e 's/DEFAULT_CONFIG_FILE "dosbox-"/DEFAULT_CONFIG_FILE "'$md_id'-"/g'

--- a/scriptmodules/emulators/dosbox.sh
+++ b/scriptmodules/emulators/dosbox.sh
@@ -13,6 +13,7 @@ rp_module_id="dosbox"
 rp_module_desc="DOS emulator"
 rp_module_help="ROM Extensions: .bat .com .exe .sh .conf\n\nCopy your DOS games to $romdir/pc"
 rp_module_licence="GPL2 https://sourceforge.net/p/dosbox/code-0/HEAD/tree/dosbox/trunk/COPYING"
+rp_module_repo="svn https://svn.code.sf.net/p/dosbox/code-0/dosbox/trunk - 4252"
 rp_module_section="opt"
 rp_module_flags="dispmanx !mali"
 
@@ -27,7 +28,7 @@ function sources_dosbox() {
     local revision="$1"
     [[ -z "$revision" ]] && revision="4252"
 
-    svn checkout https://svn.code.sf.net/p/dosbox/code-0/dosbox/trunk "$md_build" -r "$revision"
+    svn checkout "$md_repo_url" "$md_build" -r "$revision"
     applyPatch "$md_data/01-fully-bindable-joystick.diff"
 }
 

--- a/scriptmodules/emulators/fbzx.sh
+++ b/scriptmodules/emulators/fbzx.sh
@@ -13,19 +13,23 @@ rp_module_id="fbzx"
 rp_module_desc="ZXSpectrum emulator FBZX"
 rp_module_help="ROM Extensions: .sna .szx .z80 .tap .tzx .gz .udi .mgt .img .trd .scl .dsk .zip\n\nCopy your ZX Spectrum to $romdir/zxspectrum"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/rastersoft/fbzx/master/COPYING"
-rp_module_repo="git https://github.com/rastersoft/fbzx master"
+rp_module_repo="git https://github.com/rastersoft/fbzx master :_get_branch_fbzx"
 rp_module_section="opt"
 rp_module_flags="dispmanx !mali !kms"
+
+function _get_branch_fbzx() {
+    local branch
+    # use older version for non x86 systems (faster)
+    ! isPlatform "x86" && branch="2.11.1"
+    echo "$branch"
+}
 
 function depends_fbzx() {
     getDepends libasound2-dev libsdl1.2-dev
 }
 
 function sources_fbzx() {
-    local branch
-    # use older version for non x86 systems (faster)
-    ! isPlatform "x86" && branch="2.11.1"
-    gitPullOrClone "$md_build" "$md_repo_url" "$branch"
+    gitPullOrClone
     ! isPlatform "x86" && sed -i 's|PREFIX2=$(PREFIX)/usr|PREFIX2=$(PREFIX)|' Makefile
 }
 

--- a/scriptmodules/emulators/fbzx.sh
+++ b/scriptmodules/emulators/fbzx.sh
@@ -13,6 +13,7 @@ rp_module_id="fbzx"
 rp_module_desc="ZXSpectrum emulator FBZX"
 rp_module_help="ROM Extensions: .sna .szx .z80 .tap .tzx .gz .udi .mgt .img .trd .scl .dsk .zip\n\nCopy your ZX Spectrum to $romdir/zxspectrum"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/rastersoft/fbzx/master/COPYING"
+rp_module_repo="git https://github.com/rastersoft/fbzx master"
 rp_module_section="opt"
 rp_module_flags="dispmanx !mali !kms"
 
@@ -24,7 +25,7 @@ function sources_fbzx() {
     local branch
     # use older version for non x86 systems (faster)
     ! isPlatform "x86" && branch="2.11.1"
-    gitPullOrClone "$md_build" https://github.com/rastersoft/fbzx "$branch"
+    gitPullOrClone "$md_build" "$md_repo_url" "$branch"
     ! isPlatform "x86" && sed -i 's|PREFIX2=$(PREFIX)/usr|PREFIX2=$(PREFIX)|' Makefile
 }
 

--- a/scriptmodules/emulators/fuse.sh
+++ b/scriptmodules/emulators/fuse.sh
@@ -13,6 +13,7 @@ rp_module_id="fuse"
 rp_module_desc="ZX Spectrum emulator Fuse"
 rp_module_help="ROM Extensions: .sna .szx .z80 .tap .tzx .gz .udi .mgt .img .trd .scl .dsk .zip\n\nCopy your ZX Spectrum games to $romdir/zxspectrum"
 rp_module_licence="GPL2 https://sourceforge.net/p/fuse-emulator/fuse/ci/master/tree/COPYING"
+rp_module_repo="file $__archive_url/fuse-1.5.7.tar.gz"
 rp_module_section="opt"
 rp_module_flags="dispmanx !mali"
 

--- a/scriptmodules/emulators/gngeopi.sh
+++ b/scriptmodules/emulators/gngeopi.sh
@@ -13,6 +13,7 @@ rp_module_id="gngeopi"
 rp_module_desc="NeoGeo emulator GnGeoPi"
 rp_module_help="ROM Extension: .zip\n\nCopy your GnGeoPi roms to $romdir/neogeo\n\nCopy the required BIOS file neogeo.zip BIOS to $romdir/neogeo"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/ymartel06/GnGeo-Pi/master/gngeo/COPYING"
+rp_module_repo="git https://github.com/ymartel06/GnGeo-Pi.git master"
 rp_module_section="opt"
 rp_module_flags="!all arm !mali !kms"
 
@@ -21,7 +22,7 @@ function depends_gngeopi() {
 }
 
 function sources_gngeopi() {
-    gitPullOrClone "$md_build" https://github.com/ymartel06/GnGeo-Pi.git
+    gitPullOrClone
 }
 
 function build_gngeopi() {

--- a/scriptmodules/emulators/gpsp.sh
+++ b/scriptmodules/emulators/gpsp.sh
@@ -13,6 +13,7 @@ rp_module_id="gpsp"
 rp_module_desc="GameBoy Advance emulator"
 rp_module_help="ROM Extensions: .gba .zip\n\nCopy your Game Boy Advance roms to $romdir/gba\n\nCopy the required BIOS file gba_bios.bin to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/gizmo98/gpsp/master/COPYING.DOC"
+rp_module_repo="git https://github.com/gizmo98/gpsp.git master"
 rp_module_section="opt"
 rp_module_flags="noinstclean !all videocore"
 
@@ -21,7 +22,7 @@ function depends_gpsp() {
 }
 
 function sources_gpsp() {
-    gitPullOrClone "$md_build" https://github.com/gizmo98/gpsp.git
+    gitPullOrClone
 }
 
 function build_gpsp() {

--- a/scriptmodules/emulators/hatari.sh
+++ b/scriptmodules/emulators/hatari.sh
@@ -12,7 +12,8 @@
 rp_module_id="hatari"
 rp_module_desc="Atari emulator Hatari"
 rp_module_help="ROM Extensions: .st .stx .img .rom .raw .ipf .ctr .zip\n\nCopy your Atari ST games to $romdir/atarist\n\nCopy Atari ST BIOS (tos.img) to $biosdir"
-rp_module_licence="GPL2 https://hg.tuxfamily.org/mercurialroot/hatari/hatari/file/9ee1235233e9/gpl.txt"
+rp_module_licence="GPL2 https://git.tuxfamily.org/hatari/hatari.git/plain/gpl.txt"
+rp_module_repo="git git://git.tuxfamily.org/gitroot/hatari/hatari.git v2.3.1"
 rp_module_section="opt"
 rp_module_flags=""
 
@@ -28,7 +29,7 @@ function _sources_libcapsimage_hatari() {
 
 function sources_hatari() {
     # shallow clone isn't supported via https:// on this repo
-    gitPullOrClone "$md_build" "git://git.tuxfamily.org/gitroot/hatari/hatari.git" "v2.3.1"
+    gitPullOrClone
     _sources_libcapsimage_hatari
 }
 

--- a/scriptmodules/emulators/jzintv.sh
+++ b/scriptmodules/emulators/jzintv.sh
@@ -13,6 +13,7 @@ rp_module_id="jzintv"
 rp_module_desc="Intellivision emulator"
 rp_module_help="ROM Extensions: .int .bin\n\nCopy your Intellivision roms to $romdir/intellivision\n\nCopy the required BIOS files exec.bin and grom.bin to $biosdir"
 rp_module_licence="GPL2 http://spatula-city.org/%7Eim14u2c/intv/"
+rp_module_repo="file $__archive_url/jzintv-20181225.zip"
 rp_module_section="opt"
 rp_module_flags="dispmanx !mali"
 
@@ -21,7 +22,7 @@ function depends_jzintv() {
 }
 
 function sources_jzintv() {
-    downloadAndExtract "$__archive_url/jzintv-20181225.zip" "$md_build"
+    downloadAndExtract "$md_repo_url" "$md_build"
     cd jzintv/src
     # aarch64 doesn't include sys/io.h - we can just remove it in this case
     isPlatform "aarch64" && grep -rl "include.*sys/io.h" | xargs sed -i "/include.*sys\/io.h/d"

--- a/scriptmodules/emulators/linapple.sh
+++ b/scriptmodules/emulators/linapple.sh
@@ -13,6 +13,7 @@ rp_module_id="linapple"
 rp_module_desc="Apple 2 emulator LinApple"
 rp_module_help="ROM Extensions: .dsk\n\nCopy your Apple 2 games to $romdir/apple2"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/dabonetn/linapple-pie/master/LICENSE"
+rp_module_repo="git https://github.com/dabonetn/linapple-pie.git master"
 rp_module_section="opt"
 rp_module_flags="dispmanx !mali"
 
@@ -21,7 +22,7 @@ function depends_linapple() {
 }
 
 function sources_linapple() {
-    gitPullOrClone "$md_build" https://github.com/dabonetn/linapple-pie.git
+    gitPullOrClone
 }
 
 function build_linapple() {

--- a/scriptmodules/emulators/mame.sh
+++ b/scriptmodules/emulators/mame.sh
@@ -13,10 +13,11 @@ rp_module_id="mame"
 rp_module_desc="MAME emulator"
 rp_module_help="ROM Extensions: .zip .7z\n\nCopy your MAME roms to either $romdir/mame or\n$romdir/arcade"
 rp_module_licence="GPL2 https://github.com/mamedev/mame/blob/master/COPYING"
+rp_module_repo="git https://github.com/mamedev/mame.git :_get_branch_mame"
 rp_module_section="exp"
 rp_module_flags="!mali !armv6"
 
-function _latest_ver_mame() {
+function _get_branch_mame() {
     download https://api.github.com/repos/mamedev/mame/releases/latest - | grep -m 1 tag_name | cut -d\" -f4
 }
 
@@ -41,7 +42,7 @@ function depends_mame() {
 }
 
 function sources_mame() {
-    gitPullOrClone "$md_build" https://github.com/mamedev/mame.git "$(_latest_ver_mame)"
+    gitPullOrClone
 }
 
 function build_mame() {

--- a/scriptmodules/emulators/mame4all.sh
+++ b/scriptmodules/emulators/mame4all.sh
@@ -13,6 +13,7 @@ rp_module_id="mame4all"
 rp_module_desc="MAME emulator MAME4All-Pi"
 rp_module_help="ROM Extension: .zip\n\nCopy your MAME4all-Pi roms to either $romdir/mame-mame4all or\n$romdir/arcade"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/RetroPie/mame4all-pi/master/readme.txt"
+rp_module_repo="git https://github.com/RetroPie/mame4all-pi.git master"
 rp_module_section="opt armv6=main"
 rp_module_flags="!all videocore"
 
@@ -21,7 +22,7 @@ function depends_mame4all() {
 }
 
 function sources_mame4all() {
-    gitPullOrClone "$md_build" https://github.com/RetroPie/mame4all-pi.git
+    gitPullOrClone
 }
 
 function build_mame4all() {

--- a/scriptmodules/emulators/minivmac.sh
+++ b/scriptmodules/emulators/minivmac.sh
@@ -13,6 +13,7 @@ rp_module_id="minivmac"
 rp_module_desc="Macintosh Plus Emulator"
 rp_module_help="ROM Extensions: .dsk \n\nCopy your Macintosh Plus disks to $romdir/macintosh \n\n You need to copy the Macintosh bios file vMac.ROM into "$biosdir" and System Tools.dsk to $romdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/vanfanel/minivmac_sdl2/master/COPYING.txt"
+rp_module_repo="git https://github.com/vanfanel/minivmac_sdl2.git master"
 rp_module_section="exp"
 rp_module_flags=""
 
@@ -21,7 +22,7 @@ function depends_minivmac() {
 }
 
 function sources_minivmac() {
-    gitPullOrClone "$md_build" https://github.com/vanfanel/minivmac_sdl2.git
+    gitPullOrClone
 }
 
 function build_minivmac() {

--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -100,7 +100,10 @@ function _pkg_info_mupen64plus() {
                 if [[ -n "${repo[3]}" ]]; then
                     hash="${repo[3]}"
                 else
-                    hash="$(rp_getRemoteRepoHash git https://github.com/${repo[0]}/${repo[1]} ${repo[2]})"
+                    if ! hash="$(rp_getRemoteRepoHash git https://github.com/${repo[0]}/${repo[1]} ${repo[2]})"; then
+                        __ERRMSGS+=("$hash")
+                        return 3
+                    fi
                 fi
                 hashes+=("$hash")
             done < <(_get_repos_mupen64plus)

--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -13,6 +13,7 @@ rp_module_id="mupen64plus"
 rp_module_desc="N64 emulator MUPEN64Plus"
 rp_module_help="ROM Extensions: .z64 .n64 .v64\n\nCopy your N64 roms to $romdir/n64"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/mupen64plus/mupen64plus-core/master/LICENSES"
+rp_module_repo=":_pkg_info_mupen64plus"
 rp_module_section="main"
 rp_module_flags=""
 
@@ -28,52 +29,114 @@ function depends_mupen64plus() {
     getDepends "${depends[@]}"
 }
 
-function sources_mupen64plus() {
-    local commit
-
+function _get_repos_mupen64plus() {
     local repos=(
-        'mupen64plus core'
-        'mupen64plus ui-console'
-        'mupen64plus audio-sdl'
-        'mupen64plus input-sdl'
-        'mupen64plus rsp-hle'
+        'mupen64plus mupen64plus-core master'
+        'mupen64plus mupen64plus-ui-console master'
+        'mupen64plus mupen64plus-audio-sdl master'
+        'mupen64plus mupen64plus-input-sdl master'
+        'mupen64plus mupen64plus-rsp-hle master'
     )
     if isPlatform "videocore" && isPlatform "32bit"; then
-        repos+=('gizmo98 audio-omx')
+        repos+=('gizmo98 mupen64plus-audio-omx master')
     fi
     if isPlatform "gles"; then
-        ! isPlatform "rpi" && repos+=('mupen64plus video-glide64mk2')
+        ! isPlatform "rpi" && repos+=('mupen64plus mupen64plus-video-glide64mk2 master')
         if isPlatform "32bit"; then
-            repos+=('ricrpi video-gles2rice pandora-backport')
-            repos+=('ricrpi video-gles2n64')
+            repos+=('ricrpi mupen64plus-video-gles2rice pandora-backport')
+            repos+=('ricrpi mupen64plus-video-gles2n64 master')
         fi
     fi
     if isPlatform "gl"; then
         repos+=(
-            'mupen64plus video-glide64mk2'
-            'mupen64plus rsp-cxd4'
-            'mupen64plus rsp-z64'
+            'mupen64plus mupen64plus-video-glide64mk2 master'
+            'mupen64plus mupen64plus-rsp-cxd4 master'
+            'mupen64plus mupen64plus-rsp-z64 master'
         )
     fi
-    local repo
-    local dir
-    for repo in "${repos[@]}"; do
-        repo=($repo)
-        dir="$md_build/mupen64plus-${repo[1]}"
-        gitPullOrClone "$dir" https://github.com/${repo[0]}/mupen64plus-${repo[1]} ${repo[2]} ${repo[3]}
-    done
+
     local commit=""
     # GLideN64 now requires cmake 3.9 so use an older commit as a workaround for systems with older cmake
     if hasPackage cmake 3.9 lt; then
-        commit="8a9d52b4"
+        commit="8a9d52b41b33d853445f0779dd2b9f5ec4ecdda8"
     fi
-    gitPullOrClone "$md_build/GLideN64" https://github.com/gonetz/GLideN64.git master "$commit"
+    repos+=("gonetz GLideN64 master $commit")
 
-    if [[ -d "GLideN64" ]]; then
-        if isPlatform "videocore"; then
-            # workaround for shader cache crash issue on Raspbian stretch. See: https://github.com/gonetz/GLideN64/issues/1665
-            applyPatch "$md_data/0001-GLideN64-use-emplace.patch"
-        fi
+    local repo
+    for repo in "${repos[@]}"; do
+        echo "$repo"
+    done
+}
+
+function _pkg_info_mupen64plus() {
+    local mode="$1"
+    local repo
+    case "$mode" in
+        get)
+            local hashes=()
+            local hash
+            local date
+            local newest_date
+            while read repo; do
+                repo=($repo)
+                date=$(git -C "$md_build/${repo[1]}" log -1 --format=%aI)
+                hash="$(git -C "$md_build/${repo[1]}" log -1 --format=%H)"
+                hashes+=("$hash")
+                if rp_dateIsNewer "$newest_date" "$date"; then
+                    newest_date="$date"
+                fi
+            done < <(_get_repos_mupen64plus)
+            # store an md5sum of the various last commit hashes to be used to check for changes
+            local hash="$(echo "${hashes[@]}" | md5sum | cut -d" " -f1)"
+            echo "local pkg_repo_date=\"$newest_date\""
+            echo "local pkg_repo_extra=\"$hash\""
+            ;;
+        newer)
+            local hashes=()
+            local hash
+            while read repo; do
+                repo=($repo)
+                # if we have any repos set to a specific git hash (eg GLideN64 then we use that) otherwise check
+                if [[ -n "${repo[3]}" ]]; then
+                    hash="${repo[3]}"
+                else
+                    hash="$(rp_getRemoteRepoHash git https://github.com/${repo[0]}/${repo[1]} ${repo[2]})"
+                fi
+                hashes+=("$hash")
+            done < <(_get_repos_mupen64plus)
+            # store an md5sum of the various last commit hashes to be used to check for changes
+            local hash="$(echo "${hashes[@]}" | md5sum | cut -d" " -f1)"
+            if [[ "$hash" != "$pkg_repo_extra" ]]; then
+                return 0
+            fi
+            return 1
+            ;;
+        check)
+            local ret=0
+            while read repo; do
+                repo=($repo)
+                out=$(rp_getRemoteRepoHash git https://github.com/${repo[0]}/${repo[1]} ${repo[2]})
+                if [[ -z "$out" ]]; then
+                    printMsgs "console" "$id repository failed - https://github.com/${repo[0]}/${repo[1]} ${repo[2]}"
+                    ret=1
+                fi
+            done < <(_get_repos_mupen64plus)
+            return "$ret"
+            ;;
+    esac
+}
+
+function sources_mupen64plus() {
+    local commit
+    local repo
+    while read repo; do
+        repo=($repo)
+        gitPullOrClone "$md_build/${repo[1]}" https://github.com/${repo[0]}/${repo[1]} ${repo[2]} ${repo[3]}
+    done < <(_get_repos_mupen64plus)
+
+    if isPlatform "videocore"; then
+        # workaround for shader cache crash issue on Raspbian stretch. See: https://github.com/gonetz/GLideN64/issues/1665
+        applyPatch "$md_data/0001-GLideN64-use-emplace.patch"
     fi
 
     local config_version=$(grep -oP '(?<=CONFIG_VERSION_CURRENT ).+?(?=U)' GLideN64/src/Config.h)

--- a/scriptmodules/emulators/np2pi.sh
+++ b/scriptmodules/emulators/np2pi.sh
@@ -12,6 +12,7 @@
 rp_module_id="np2pi"
 rp_module_desc="NEC PC-9801 emulator"
 rp_module_help="ROM Extensions: .d88 .d98 .88d .98d .fdi .xdf .hdm .dup .2hd .tfd .hdi .thd .nhd .hdd\n\nCopy your pc98 games to to $romdir/pc88\n\nCopy bios files 2608_bd.wav, 2608_hh.wav, 2608_rim.wav, 2608_sd.wav, 2608_tom.wav 2608_top.wav, bios.rom, FONT.ROM and sound.rom to $biosdir/pc98"
+rp_module_repo="git https://github.com/eagle0wl/np2pi.git master"
 rp_module_section="exp"
 rp_module_flags="!all dispmanx rpi !aarch64"
 
@@ -20,7 +21,7 @@ function depends_np2pi() {
 }
 
 function sources_np2pi() {
-    gitPullOrClone "$md_build" https://github.com/eagle0wl/np2pi.git
+    gitPullOrClone
 }
 
 function build_np2pi() {

--- a/scriptmodules/emulators/openmsx.sh
+++ b/scriptmodules/emulators/openmsx.sh
@@ -13,9 +13,17 @@ rp_module_id="openmsx"
 rp_module_desc="MSX emulator OpenMSX"
 rp_module_help="ROM Extensions: .cas .rom .mx1 .mx2 .col .dsk .zip\n\nCopy your MSX/MSX2 games to $romdir/msx\nCopy the BIOS files to $biosdir/openmsx"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/openMSX/openMSX/master/doc/GPL.txt"
-rp_module_repo="git https://github.com/openMSX/openMSX.git master"
+rp_module_repo="git https://github.com/openMSX/openMSX.git master :_get_commit_openmsx"
 rp_module_section="opt"
 rp_module_flags=""
+
+function _get_commit_openmsx() {
+    local commit
+    # latest code requires at least GCC 7 as it contains C++17 code
+    # build from earlier commit before C++17 changes for GCC < 7
+    compareVersions $__gcc_version lt 7 && commit="5ee25b62"
+    echo "$commit"
+}
 
 function depends_openmsx() {
     local depends=(libsdl2-dev libsdl2-ttf-dev libao-dev libogg-dev libtheora-dev libxml2-dev libvorbis-dev tcl-dev libasound2-dev)
@@ -25,12 +33,7 @@ function depends_openmsx() {
 }
 
 function sources_openmsx() {
-    local commit
-    # latest code requires at least GCC 7 as it contains C++17 code
-    # build from earlier commit before C++17 changes for GCC < 7
-    compareVersions $__gcc_version lt 7 && commit="5ee25b62"
-
-    gitPullOrClone "$md_build" "$md_repo_url" "master" "$commit"
+    gitPullOrClone
     sed -i "s|INSTALL_BASE:=/opt/openMSX|INSTALL_BASE:=$md_inst|" build/custom.mk
     sed -i "s|SYMLINK_FOR_BINARY:=true|SYMLINK_FOR_BINARY:=false|" build/custom.mk
 }

--- a/scriptmodules/emulators/openmsx.sh
+++ b/scriptmodules/emulators/openmsx.sh
@@ -13,6 +13,7 @@ rp_module_id="openmsx"
 rp_module_desc="MSX emulator OpenMSX"
 rp_module_help="ROM Extensions: .cas .rom .mx1 .mx2 .col .dsk .zip\n\nCopy your MSX/MSX2 games to $romdir/msx\nCopy the BIOS files to $biosdir/openmsx"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/openMSX/openMSX/master/doc/GPL.txt"
+rp_module_repo="git https://github.com/openMSX/openMSX.git master"
 rp_module_section="opt"
 rp_module_flags=""
 
@@ -29,7 +30,7 @@ function sources_openmsx() {
     # build from earlier commit before C++17 changes for GCC < 7
     compareVersions $__gcc_version lt 7 && commit="5ee25b62"
 
-    gitPullOrClone "$md_build" https://github.com/openMSX/openMSX.git "" "$commit"
+    gitPullOrClone "$md_build" "$md_repo_url" "master" "$commit"
     sed -i "s|INSTALL_BASE:=/opt/openMSX|INSTALL_BASE:=$md_inst|" build/custom.mk
     sed -i "s|SYMLINK_FOR_BINARY:=true|SYMLINK_FOR_BINARY:=false|" build/custom.mk
 }

--- a/scriptmodules/emulators/oricutron.sh
+++ b/scriptmodules/emulators/oricutron.sh
@@ -13,6 +13,7 @@ rp_module_id="oricutron"
 rp_module_desc="Oricutron Oric 1/Oric Atmos emulator"
 rp_module_help="ROM Extensions: .dsk .tap\n\nCopy your Oric games to $romdir/oric"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/pete-gordon/oricutron/4c359acfb6bd36d44e6d37891d7b6453324faf7d/main.h"
+rp_module_repo="git https://github.com/HerbFargus/oricutron.git extras"
 rp_module_section="exp"
 
 function depends_oricutron() {
@@ -22,7 +23,7 @@ function depends_oricutron() {
 }
 
 function sources_oricutron() {
-    gitPullOrClone "$md_build" https://github.com/HerbFargus/oricutron.git extras
+    gitPullOrClone
 }
 
 function build_oricutron() {

--- a/scriptmodules/emulators/osmose.sh
+++ b/scriptmodules/emulators/osmose.sh
@@ -13,6 +13,7 @@ rp_module_id="osmose"
 rp_module_desc="Gamegear emulator Osmose"
 rp_module_help="ROM Extensions: .bin .gg .sms .zip\nCopy your Game Gear roms to $romdir/gamegear\n\nMasterSystem roms to $romdir/mastersystem"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/RetroPie/osmose-rpi/master/license.txt"
+rp_module_repo="git https://github.com/RetroPie/osmose-rpi.git master"
 rp_module_section="opt"
 rp_module_flags="!mali !kms"
 
@@ -21,7 +22,7 @@ function depends_osmose() {
 }
 
 function sources_osmose() {
-    gitPullOrClone "$md_build" https://github.com/RetroPie/osmose-rpi.git
+    gitPullOrClone
 }
 
 function build_osmose() {

--- a/scriptmodules/emulators/pcsx-rearmed.sh
+++ b/scriptmodules/emulators/pcsx-rearmed.sh
@@ -13,6 +13,7 @@ rp_module_id="pcsx-rearmed"
 rp_module_desc="Playstation emulator - PCSX (arm optimised)"
 rp_module_help="ROM Extensions: .bin .cue .cbn .img .iso .m3u .mdf .pbp .toc .z .znx\n\nCopy your PSX roms to $romdir/psx\n\nCopy the required BIOS file SCPH1001.BIN to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/notaz/pcsx_rearmed/master/COPYING"
+rp_module_repo="git https://github.com/notaz/pcsx_rearmed.git master"
 rp_module_section="opt"
 rp_module_flags="dispmanx !all videocore"
 
@@ -21,7 +22,7 @@ function depends_pcsx-rearmed() {
 }
 
 function sources_pcsx-rearmed() {
-    gitPullOrClone "$md_build" https://github.com/notaz/pcsx_rearmed.git
+    gitPullOrClone
 }
 
 function build_pcsx-rearmed() {

--- a/scriptmodules/emulators/pifba.sh
+++ b/scriptmodules/emulators/pifba.sh
@@ -13,6 +13,7 @@ rp_module_id="pifba"
 rp_module_desc="FBA emulator PiFBA"
 rp_module_help="ROM Extension: .zip\n\nCopy your FBA roms to\n$romdir/fba or\n$romdir/neogeo or\n$romdir/arcade\n\nFor NeoGeo games the neogeo.zip BIOS is required and must be placed in the same directory as your FBA roms."
 rp_module_licence="GPL2 https://raw.githubusercontent.com/RetroPie/pifba/master/FBAcapex_src/COPYING"
+rp_module_repo="git https://github.com/RetroPie/pifba.git master"
 rp_module_section="opt armv6=main"
 rp_module_flags="!all videocore"
 
@@ -21,7 +22,7 @@ function depends_pifba() {
 }
 
 function sources_pifba() {
-    gitPullOrClone "$md_build" https://github.com/RetroPie/pifba.git
+    gitPullOrClone
 }
 
 function build_pifba() {

--- a/scriptmodules/emulators/pisnes.sh
+++ b/scriptmodules/emulators/pisnes.sh
@@ -13,6 +13,7 @@ rp_module_id="pisnes"
 rp_module_desc="SNES emulator PiSNES"
 rp_module_help="ROM Extensions: .bin .smc .sfc .fig .swc .mgd .zip\n\nCopy your SNES roms to $romdir/snes"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/RetroPie/pisnes/master/snes9x.h"
+rp_module_repo="git https://github.com/RetroPie/pisnes.git master"
 rp_module_section="opt"
 rp_module_flags="!all videocore"
 
@@ -21,7 +22,7 @@ function depends_pisnes() {
 }
 
 function sources_pisnes() {
-    gitPullOrClone "$md_build" https://github.com/RetroPie/pisnes.git
+    gitPullOrClone
 }
 
 function build_pisnes() {

--- a/scriptmodules/emulators/ppsspp-1.5.4.sh
+++ b/scriptmodules/emulators/ppsspp-1.5.4.sh
@@ -22,7 +22,7 @@ function depends_ppsspp-1.5.4() {
 }
 
 function sources_ppsspp-1.5.4() {
-    sources_ppsspp "v1.5.4"
+    sources_ppsspp
 }
 
 function build_ppsspp-1.5.4() {

--- a/scriptmodules/emulators/ppsspp-1.5.4.sh
+++ b/scriptmodules/emulators/ppsspp-1.5.4.sh
@@ -13,6 +13,7 @@ rp_module_id="ppsspp-1.5.4"
 rp_module_desc="PlayStation Portable emulator PPSSPP v1.5.4"
 rp_module_help="ROM Extensions: .iso .pbp .cso\n\nCopy your PlayStation Portable roms to $romdir/psp"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/hrydgard/ppsspp/master/LICENSE.TXT"
+rp_module_repo="git https://github.com/hrydgard/ppsspp.git v1.5.4"
 rp_module_section="opt"
 rp_module_flags="!all videocore"
 

--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -13,6 +13,7 @@ rp_module_id="ppsspp"
 rp_module_desc="PlayStation Portable emulator PPSSPP"
 rp_module_help="ROM Extensions: .iso .pbp .cso\n\nCopy your PlayStation Portable roms to $romdir/psp"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/hrydgard/ppsspp/master/LICENSE.TXT"
+rp_module_repo="git https://github.com/hrydgard/ppsspp.git master"
 rp_module_section="opt"
 rp_module_flags=""
 
@@ -27,7 +28,7 @@ function depends_ppsspp() {
 function sources_ppsspp() {
     local branch="$1"
     [[ -z "$branch" ]] && branch="master"
-    gitPullOrClone "$md_build/ppsspp" https://github.com/hrydgard/ppsspp.git "$branch"
+    gitPullOrClone "$md_build" "$md_repo_url" "$branch"
     cd "ppsspp"
 
     # remove the lines that trigger the ffmpeg build script functions - we will just use the variables from it

--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -26,9 +26,7 @@ function depends_ppsspp() {
 }
 
 function sources_ppsspp() {
-    local branch="$1"
-    [[ -z "$branch" ]] && branch="master"
-    gitPullOrClone "$md_build" "$md_repo_url" "$branch"
+    gitPullOrClone "$md_build/ppsspp"
     cd "ppsspp"
 
     # remove the lines that trigger the ffmpeg build script functions - we will just use the variables from it

--- a/scriptmodules/emulators/px68k.sh
+++ b/scriptmodules/emulators/px68k.sh
@@ -12,6 +12,7 @@
 rp_module_id="px68k"
 rp_module_desc="SHARP X68000 Emulator"
 rp_module_help="You need to copy a X68000 bios file (iplrom30.dat, iplromco.dat, iplrom.dat, or iplromxv.dat), and the font file (cgrom.dat or cgrom.tmp) to $biosdir/keropi. Use F12 to access the in emulator menu."
+rp_module_repo="git https://github.com/hissorii/px68k.git master"
 rp_module_section="exp"
 rp_module_flags="!mali !kms"
 
@@ -20,7 +21,7 @@ function depends_px68k() {
 }
 
 function sources_px68k() {
-    gitPullOrClone "$md_build" https://github.com/hissorii/px68k.git
+    gitPullOrClone
 }
 
 function build_px68k() {

--- a/scriptmodules/emulators/quasi88.sh
+++ b/scriptmodules/emulators/quasi88.sh
@@ -12,6 +12,7 @@
 rp_module_id="quasi88"
 rp_module_desc="NEC PC-8801 emulator"
 rp_module_help="ROM Extensions: .d88 .88d .cmt .t88\n\nCopy your pc88 games to to $romdir/pc88\n\nCopy bios files FONT.ROM, N88.ROM, N88KNJ1.ROM, N88KNJ2.ROM, and N88SUB.ROM to $biosdir/pc88"
+rp_module_repo="file $__archive_url/quasi88-0.6.4.tgz"
 rp_module_section="exp"
 rp_module_flags="dispmanx !mali !kms"
 
@@ -20,7 +21,7 @@ function depends_quasi88() {
 }
 
 function sources_quasi88() {
-    downloadAndExtract "$__archive_url/quasi88-0.6.4.tgz" "$md_build" --strip-components 1
+    downloadAndExtract "$md_repo_url" "$md_build" --strip-components 1
     applyPatch "$md_data/01_fixes.diff"
 }
 

--- a/scriptmodules/emulators/reicast.sh
+++ b/scriptmodules/emulators/reicast.sh
@@ -13,6 +13,7 @@ rp_module_id="reicast"
 rp_module_desc="Dreamcast emulator Reicast"
 rp_module_help="ROM Extensions: .cdi .gdi\n\nCopy your Dreamcast roms to $romdir/dreamcast\n\nCopy the required BIOS files dc_boot.bin and dc_flash.bin to $biosdir/dc"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/reicast/reicast-emulator/master/LICENSE"
+rp_module_repo="git https://github.com/reicast/reicast-emulator.git master"
 rp_module_section="opt"
 rp_module_flags="!armv6"
 
@@ -26,7 +27,7 @@ function depends_reicast() {
 }
 
 function sources_reicast() {
-    gitPullOrClone "$md_build" https://github.com/reicast/reicast-emulator.git master
+    gitPullOrClone
     applyPatch "$md_data/0001-enable-rpi4-sdl2-target.patch"
     applyPatch "$md_data/0002-enable-vsync.patch"
     applyPatch "$md_data/0003-fix-sdl2-sighandler-conflict.patch"

--- a/scriptmodules/emulators/residualvm.sh
+++ b/scriptmodules/emulators/residualvm.sh
@@ -13,6 +13,7 @@ rp_module_id="residualvm"
 rp_module_desc="ResidualVM - A 3D Game Interpreter"
 rp_module_help="Copy your ResidualVM games to $romdir/residualvm"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/residualvm/residualvm/master/COPYING"
+rp_module_repo="git https://github.com/ResidualVM/ResidualVM.git master"
 rp_module_section="exp"
 rp_module_flags="dispmanx !mali"
 
@@ -28,7 +29,7 @@ function depends_residualvm() {
 }
 
 function sources_residualvm() {
-    gitPullOrClone "$md_build" https://github.com/ResidualVM/ResidualVM.git
+    gitPullOrClone
 }
 
 function build_residualvm() {

--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -12,6 +12,7 @@
 rp_module_id="retroarch"
 rp_module_desc="RetroArch - frontend to the libretro emulator cores - required by all lr-* emulators"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/RetroArch/master/COPYING"
+rp_module_repo="git https://github.com/libretro/RetroArch.git v1.8.8"
 rp_module_section="core"
 
 function depends_retroarch() {
@@ -39,7 +40,7 @@ function depends_retroarch() {
 }
 
 function sources_retroarch() {
-    gitPullOrClone "$md_build" https://github.com/libretro/RetroArch.git v1.8.8
+    gitPullOrClone
     applyPatch "$md_data/01_hotkey_hack.diff"
     applyPatch "$md_data/02_disable_search.diff"
     applyPatch "$md_data/03_shader_path_config_enable.diff"

--- a/scriptmodules/emulators/scummvm-sdl1.sh
+++ b/scriptmodules/emulators/scummvm-sdl1.sh
@@ -13,6 +13,7 @@ rp_module_id="scummvm-sdl1"
 rp_module_desc="ScummVM - built with legacy SDL1 support."
 rp_module_help="Copy your ScummVM games to $romdir/scummvm"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/scummvm/scummvm/master/COPYING"
+rp_module_repo="git https://github.com/scummvm/scummvm.git v2.2.0"
 rp_module_section="opt"
 rp_module_flags="dispmanx !mali !x11"
 

--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -13,6 +13,7 @@ rp_module_id="scummvm"
 rp_module_desc="ScummVM"
 rp_module_help="Copy your ScummVM games to $romdir/scummvm"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/scummvm/scummvm/master/COPYING"
+rp_module_repo="git https://github.com/scummvm/scummvm.git v2.2.0"
 rp_module_section="opt"
 rp_module_flags=""
 
@@ -34,7 +35,7 @@ function depends_scummvm() {
 }
 
 function sources_scummvm() {
-    gitPullOrClone "$md_build" https://github.com/scummvm/scummvm.git v2.2.0
+    gitPullOrClone
 }
 
 function build_scummvm() {

--- a/scriptmodules/emulators/sdltrs.sh
+++ b/scriptmodules/emulators/sdltrs.sh
@@ -14,6 +14,7 @@ rp_module_desc="Radio Shack TRS-80 Model I/III/4/4P emulator"
 rp_module_help="ROM Extension: .dsk\n\nCopy your TRS-80 games to $romdir/trs-80\n\nCopy the required BIOS file level2.rom, level3.rom, level4.rom or level4p.rom to $biosdir"
 rp_module_section="exp"
 rp_module_licence="BSD https://gitlab.com/jengun/sdltrs/-/raw/master/LICENSE"
+rp_module_repo="git https://gitlab.com/jengun/sdltrs.git sdl2"
 rp_module_flags=""
 
 function depends_sdltrs() {
@@ -21,7 +22,7 @@ function depends_sdltrs() {
 }
 
 function sources_sdltrs() {
-    gitPullOrClone "$md_build" https://gitlab.com/jengun/sdltrs.git sdl2
+    gitPullOrClone
 }
 
 function build_sdltrs() {

--- a/scriptmodules/emulators/simcoupe.sh
+++ b/scriptmodules/emulators/simcoupe.sh
@@ -13,6 +13,7 @@ rp_module_id="simcoupe"
 rp_module_desc="SimCoupe SAM Coupe emulator"
 rp_module_help="ROM Extensions: .dsk .mgt .sbt .sad\n\nCopy your SAM Coupe games to $romdir/samcoupe."
 rp_module_licence="GPL2 https://raw.githubusercontent.com/simonowen/simcoupe/master/License.txt"
+rp_module_repo="git https://github.com/simonowen/simcoupe.git master"
 rp_module_section="opt"
 rp_module_flags=""
 
@@ -26,7 +27,7 @@ function sources_simcoupe() {
     # dialect support but actually seem to build ok. Lock systems with older cmake to 20200711 tag,
     # which builds ok on Raspbian Stretch and hopefully Ubuntu 18.04.
     hasPackage cmake 3.8.2 lt && branch="20200711"
-    gitPullOrClone "$md_build" https://github.com/simonowen/simcoupe.git "$branch"
+    gitPullOrClone "$md_build" "$md_repo_url" "$branch"
 }
 
 function build_simcoupe() {

--- a/scriptmodules/emulators/simcoupe.sh
+++ b/scriptmodules/emulators/simcoupe.sh
@@ -13,21 +13,25 @@ rp_module_id="simcoupe"
 rp_module_desc="SimCoupe SAM Coupe emulator"
 rp_module_help="ROM Extensions: .dsk .mgt .sbt .sad\n\nCopy your SAM Coupe games to $romdir/samcoupe."
 rp_module_licence="GPL2 https://raw.githubusercontent.com/simonowen/simcoupe/master/License.txt"
-rp_module_repo="git https://github.com/simonowen/simcoupe.git master"
+rp_module_repo="git https://github.com/simonowen/simcoupe.git :_get_branch_simcoupe"
 rp_module_section="opt"
 rp_module_flags=""
+
+function _get_branch_simcoupe() {
+    local branch="master"
+    # latest simcoupe requires cmake 3.8.2 - on Stretch older versions throw a cmake error about CXX17
+    # dialect support but actually seem to build ok. Lock systems with older cmake to 20200711 tag,
+    # which builds ok on Raspbian Stretch and hopefully Ubuntu 18.04.
+    hasPackage cmake 3.8.2 lt && branch="20200711"
+    echo "$branch"
+}
 
 function depends_simcoupe() {
     getDepends cmake libsdl2-dev zlib1g-dev libbz2-dev libspectrum-dev
 }
 
 function sources_simcoupe() {
-    local branch="master"
-    # latest simcoupe requires cmake 3.8.2 - on Stretch older versions throw a cmake error about CXX17
-    # dialect support but actually seem to build ok. Lock systems with older cmake to 20200711 tag,
-    # which builds ok on Raspbian Stretch and hopefully Ubuntu 18.04.
-    hasPackage cmake 3.8.2 lt && branch="20200711"
-    gitPullOrClone "$md_build" "$md_repo_url" "$branch"
+    gitPullOrClone
 }
 
 function build_simcoupe() {

--- a/scriptmodules/emulators/snes9x.sh
+++ b/scriptmodules/emulators/snes9x.sh
@@ -13,6 +13,7 @@ rp_module_id="snes9x"
 rp_module_desc="SNES emulator SNES9X-RPi"
 rp_module_help="ROM Extensions: .bin .smc .sfc .fig .swc .mgd .zip\n\nCopy your SNES roms to $romdir/snes"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/RetroPie/snes9x-rpi/master/snes9x.h"
+rp_module_repo="git https://github.com/RetroPie/snes9x-rpi.git retropie"
 rp_module_section="opt"
 rp_module_flags="dispmanx !all videocore"
 
@@ -21,7 +22,7 @@ function depends_snes9x() {
 }
 
 function sources_snes9x() {
-    gitPullOrClone "$md_build" https://github.com/RetroPie/snes9x-rpi.git retropie
+    gitPullOrClone
 }
 
 function build_snes9x() {

--- a/scriptmodules/emulators/stella.sh
+++ b/scriptmodules/emulators/stella.sh
@@ -13,6 +13,7 @@ rp_module_id="stella"
 rp_module_desc="Atari2600 emulator STELLA"
 rp_module_help="ROM Extensions: .a26 .bin .rom .zip .gz\n\nCopy your Atari 2600 roms to $romdir/atari2600"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/stella-emu/stella/master/License.txt"
+rp_module_repo="git https://github.com/stella-emu/stella.git 6.0.1"
 rp_module_section="opt"
 rp_module_flags=""
 
@@ -21,7 +22,7 @@ function depends_stella() {
 }
 
 function sources_stella() {
-    gitPullOrClone "$md_build" "https://github.com/stella-emu/stella.git" 6.0.1
+    gitPullOrClone
 }
 
 function build_stella() {

--- a/scriptmodules/emulators/stratagus.sh
+++ b/scriptmodules/emulators/stratagus.sh
@@ -13,6 +13,7 @@ rp_module_id="stratagus"
 rp_module_desc="Stratagus - A strategy game engine to play Warcraft I or II, Starcraft, and some similar open-source games"
 rp_module_help="Copy your Stratagus games to $romdir/stratagus"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/Wargus/stratagus/master/COPYING"
+rp_module_repo="git https://github.com/Wargus/stratagus.git v2.4.3"
 rp_module_section="opt"
 rp_module_flags="!mali !kms"
 
@@ -21,7 +22,7 @@ function depends_stratagus() {
 }
 
 function sources_stratagus() {
-    gitPullOrClone "$md_build" https://github.com/Wargus/stratagus.git v2.4.3
+    gitPullOrClone
 }
 
 function build_stratagus() {

--- a/scriptmodules/emulators/ti99sim-sdl1.sh
+++ b/scriptmodules/emulators/ti99sim-sdl1.sh
@@ -13,6 +13,7 @@ rp_module_id="ti99sim-sdl1"
 rp_module_desc="TI-99/SIM - Texas Instruments Home Computer Emulator (SDL1 version)"
 rp_module_help="ROM Extension: .ctg\n\nCopy your TI-99 games to $romdir/ti99\n\nCopy the required BIOS file TI-994A.ctg (case sensitive) to $biosdir"
 rp_module_licence="GPL2 http://www.mrousseau.org/programs/ti99sim/"
+rp_module_repo="file $__archive_url/ti99sim-0.15.0.src.tar.gz"
 rp_module_section="exp"
 rp_module_flags="dispmanx !mali"
 
@@ -21,7 +22,7 @@ function depends_ti99sim-sdl1() {
 }
 
 function sources_ti99sim-sdl1() {
-    downloadAndExtract "$__archive_url/ti99sim-0.15.0.src.tar.gz" "$md_build" --strip-components 1
+    downloadAndExtract "$md_repo_url" "$md_build" --strip-components 1
 }
 
 function build_ti99sim-sdl1() {

--- a/scriptmodules/emulators/ti99sim.sh
+++ b/scriptmodules/emulators/ti99sim.sh
@@ -13,6 +13,7 @@ rp_module_id="ti99sim"
 rp_module_desc="TI-99/SIM - Texas Instruments Home Computer Emulator"
 rp_module_help="ROM Extension: .ctg\n\nCopy your TI-99 games to $romdir/ti99\n\nCopy the required BIOS file TI-994A.ctg (case sensitive) to $biosdir"
 rp_module_licence="GPL2 https://www.mrousseau.org/programs/ti99sim"
+rp_module_repo="file $__archive_url/ti99sim-0.16.0.src.tar.gz"
 rp_module_section="exp"
 rp_module_flags=""
 
@@ -25,7 +26,7 @@ function depends_ti99sim() {
 }
 
 function sources_ti99sim() {
-    downloadAndExtract "$__archive_url/ti99sim-0.16.0.src.tar.gz" "$md_build" --strip-components 1
+    downloadAndExtract "$md_repo_url" "$md_build" --strip-components 1
 }
 
 function build_ti99sim() {

--- a/scriptmodules/emulators/uae4all.sh
+++ b/scriptmodules/emulators/uae4all.sh
@@ -13,6 +13,7 @@ rp_module_id="uae4all"
 rp_module_desc="Amiga emulator UAE4All"
 rp_module_help="ROM Extension: .adf\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/RetroPie/uae4all2/retropie/copying"
+rp_module_repo="git https://github.com/RetroPie/uae4all2.git retropie"
 rp_module_section="opt"
 rp_module_flags="dispmanx !all videocore"
 
@@ -21,7 +22,7 @@ function depends_uae4all() {
 }
 
 function sources_uae4all() {
-    gitPullOrClone "$md_build" https://github.com/RetroPie/uae4all2.git retropie
+    gitPullOrClone
     mkdir guichan
     downloadAndExtract "$__archive_url/guichan-0.8.2.tar.gz" "$md_build/guichan" --strip-components 1
     cd guichan

--- a/scriptmodules/emulators/uae4arm.sh
+++ b/scriptmodules/emulators/uae4arm.sh
@@ -13,6 +13,7 @@ rp_module_id="uae4arm"
 rp_module_desc="Amiga emulator with JIT support"
 rp_module_help="ROM Extension: .adf\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir"
 rp_module_licence="GPL2"
+rp_module_repo="git https://github.com/Chips-fr/uae4arm-rpi.git master"
 rp_module_section="opt"
 rp_module_flags="!all videocore"
 
@@ -21,7 +22,7 @@ function depends_uae4arm() {
 }
 
 function sources_uae4arm() {
-    gitPullOrClone "$md_build" https://github.com/Chips-fr/uae4arm-rpi/
+    gitPullOrClone
 }
 
 function build_uae4arm() {

--- a/scriptmodules/emulators/vice.sh
+++ b/scriptmodules/emulators/vice.sh
@@ -13,6 +13,7 @@ rp_module_id="vice"
 rp_module_desc="C64 emulator VICE"
 rp_module_help="ROM Extensions: .crt .d64 .g64 .prg .t64 .tap .x64 .zip .vsf\n\nCopy your Commodore 64 games to $romdir/c64"
 rp_module_licence="GPL2 http://svn.code.sf.net/p/vice-emu/code/trunk/vice/COPYING"
+rp_module_repo="svn svn://svn.code.sf.net/p/vice-emu/code/trunk/vice - HEAD"
 rp_module_section="opt"
 rp_module_flags=""
 
@@ -23,7 +24,7 @@ function depends_vice() {
 }
 
 function sources_vice() {
-    svn checkout svn://svn.code.sf.net/p/vice-emu/code/trunk/vice/ "$md_build"
+    svn checkout "$md_repo_url" "$md_build"
 }
 
 function build_vice() {

--- a/scriptmodules/emulators/xm7.sh
+++ b/scriptmodules/emulators/xm7.sh
@@ -13,6 +13,7 @@ rp_module_id="xm7"
 rp_module_desc="Fujitsu FM-7 series emulator"
 rp_module_help="ROM Extensions: .d77 .t77 .d88 .2d \n\nCopy your FM-7 games to to $romdir/xm7\n\nCopy bios files DICROM.ROM, EXTSUB.ROM, FBASIC30.ROM, INITIATE.ROM, KANJI1.ROM, KANJI2.ROM, SUBSYS_A.ROM, SUBSYS_B.ROM, SUBSYSCG.ROM, SUBSYS_C.ROM, fddseek.wav, relayoff.wav and relay_on.wav to $biosdir/xm7"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/nakatamaho/XM7-for-SDL/master/Doc/mess/license.txt"
+rp_module_repo="git https://github.com/nakatamaho/XM7-for-SDL.git master"
 rp_module_section="exp"
 rp_module_flags="!mali !kms"
 
@@ -21,7 +22,7 @@ function depends_xm7() {
 }
 
 function sources_xm7() {
-    gitPullOrClone "$md_build" https://github.com/nakatamaho/XM7-for-SDL.git
+    gitPullOrClone
     mkdir -p "$md_build/agar"
     downloadAndExtract "http://stable.hypertriton.com/agar/agar-1.5.0.tar.gz" "$md_build/agar" --strip-components 1
     # _BSD_SOURCE is deprecated and will throw an error during configure

--- a/scriptmodules/emulators/xroar.sh
+++ b/scriptmodules/emulators/xroar.sh
@@ -13,6 +13,7 @@ rp_module_id="xroar"
 rp_module_desc="Dragon / CoCo emulator XRoar"
 rp_module_help="ROM Extensions: .cas .wav .bas .asc .dmk .jvc .os9 .dsk .vdk .rom .ccc .sna\n\nCopy your Dragon roms to $romdir/dragon32\n\nCopy your CoCo games to $romdir/coco\n\nCopy the required BIOS files d32.rom (Dragon 32) and bas13.rom (CoCo) to $biosdir"
 rp_module_licence="GPL2 http://www.6809.org.uk/xroar/"
+rp_module_repo="git http://www.6809.org.uk/git/xroar.git 0.36"
 rp_module_section="opt"
 rp_module_flags=""
 
@@ -21,7 +22,8 @@ function depends_xroar() {
 }
 
 function sources_xroar() {
-    gitPullOrClone "$md_build" http://www.6809.org.uk/git/xroar.git 0.36 "" 0
+    gitPullOrClone "$md_build" "$md_repo_url" "$md_repo_branch" "" 0
+
 }
 
 function build_xroar() {

--- a/scriptmodules/emulators/zesarux.sh
+++ b/scriptmodules/emulators/zesarux.sh
@@ -13,6 +13,7 @@ rp_module_id="zesarux"
 rp_module_desc="ZX Spectrum emulator ZEsarUX"
 rp_module_help="ROM Extensions: .sna .szx .z80 .tap .tzx .gz .udi .mgt .img .trd .scl .dsk .zip\n\nCopy your ZX Spectrum games to $romdir/zxspectrum"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/chernandezba/zesarux/master/src/LICENSE"
+rp_module_repo="git https://github.com/chernandezba/zesarux.git 9.1"
 rp_module_section="opt"
 rp_module_flags="dispmanx !mali"
 
@@ -30,7 +31,7 @@ function depends_zesarux() {
 }
 
 function sources_zesarux() {
-    gitPullOrClone "$md_build" https://github.com/chernandezba/zesarux.git 9.1
+    gitPullOrClone
 }
 
 function build_zesarux() {

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -396,9 +396,9 @@ function gitPullOrClone() {
     local depth="$5"
     # if repo is blank then use the rp_module_repo info
     if [[ -z "$repo" && -n "$md_repo_url" ]]; then
-        repo="$md_repo_url"
-        branch="$md_repo_branch"
-        commit="$md_repo_commit"
+        repo="$(rp_resolveRepoParam "$md_repo_url")"
+        branch="$(rp_resolveRepoParam "$md_repo_branch")"
+        commit="$(rp_resolveRepoParam "$md_repo_commit")"
     fi
     [[ -z "$repo" ]] && return 1
     [[ -z "$branch" ]] && branch="master"

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -389,11 +389,19 @@ function rpSwap() {
 ## A depth parameter of 0 will do a full clone with all history.
 function gitPullOrClone() {
     local dir="$1"
+    [[ -z "$dir" ]] && dir="$md_build"
     local repo="$2"
     local branch="$3"
-    [[ -z "$branch" ]] && branch="master"
     local commit="$4"
     local depth="$5"
+    # if repo is blank then use the rp_module_repo info
+    if [[ -z "$repo" && -n "$md_repo_url" ]]; then
+        repo="$md_repo_url"
+        branch="$md_repo_branch"
+        commit="$md_repo_commit"
+    fi
+    [[ -z "$repo" ]] && return 1
+    [[ -z "$branch" ]] && branch="master"
     if [[ -z "$depth" && "$__persistent_repos" -ne 1 && -z "$commit" ]]; then
         depth=1
     else

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -408,6 +408,12 @@ function gitPullOrClone() {
         depth=0
     fi
 
+    # record the source directory in __mod_info[ID/repo_dir] if not previously set which will be used
+    # by the packaging functions later to grab repository information
+    if [[ -z "${__mod_info[$md_id/repo_dir]}" ]]; then
+        __mod_info[$md_id/repo_dir]="$dir"
+    fi
+
     if [[ -d "$dir/.git" ]]; then
         pushd "$dir" > /dev/null
         runCmd git checkout "$branch"

--- a/scriptmodules/libretrocores/lr-81.sh
+++ b/scriptmodules/libretrocores/lr-81.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-81"
 rp_module_desc="Sinclair ZX81 emulator - EightyOne port for libretro"
 rp_module_help="ROM Extensions: .p .tzx .t81\n\nCopy your ZX81 roms to $romdir/zx81"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/81-libretro/master/LICENSE"
+rp_module_repo="git https://github.com/libretro/81-libretro.git master"
 rp_module_section="exp"
 
 function sources_lr-81() {
-    gitPullOrClone "$md_build" https://github.com/libretro/81-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-81() {

--- a/scriptmodules/libretrocores/lr-atari800.sh
+++ b/scriptmodules/libretrocores/lr-atari800.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-atari800"
 rp_module_desc="Atari 8-bit/800/5200 emulator - Atari800 port for libretro"
 rp_module_help="ROM Extensions: .a52 .bas .bin .car .xex .atr .xfd .dcm .atr.gz .xfd.gz\n\nCopy your Atari800 games to $romdir/atari800\n\nCopy your Atari 5200 roms to $romdir/atari5200 You need to copy the Atari 800/5200 BIOS files (5200.ROM, ATARIBAS.ROM, ATARIOSB.ROM and ATARIXL.ROM) to the folder $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/libretro-atari800/master/atari800/COPYING"
+rp_module_repo="git https://github.com/libretro/libretro-atari800.git master"
 rp_module_section="main"
 
 function sources_lr-atari800() {
-    gitPullOrClone "$md_build" https://github.com/libretro/libretro-atari800.git
+    gitPullOrClone
 }
 
 function build_lr-atari800() {

--- a/scriptmodules/libretrocores/lr-beetle-lynx.sh
+++ b/scriptmodules/libretrocores/lr-beetle-lynx.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-beetle-lynx"
 rp_module_desc="Atari Lynx emulator - Mednafen Lynx Port for libretro, itself a fork of Handy"
 rp_module_help="ROM Extensions: .lnx .zip\n\nCopy your Atari Lynx roms to $romdir/atarilynx\n\nCopy the required BIOS file lynxboot.img to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/beetle-lynx-libretro/master/COPYING"
+rp_module_repo="git https://github.com/libretro/beetle-lynx-libretro.git master"
 rp_module_section="opt"
 
 function sources_lr-beetle-lynx() {
-    gitPullOrClone "$md_build" https://github.com/libretro/beetle-lynx-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-beetle-lynx() {

--- a/scriptmodules/libretrocores/lr-beetle-ngp.sh
+++ b/scriptmodules/libretrocores/lr-beetle-ngp.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-beetle-ngp"
 rp_module_desc="Neo Geo Pocket(Color)emu - Mednafen Neo Geo Pocket core port for libretro"
 rp_module_help="ROM Extensions: .ngc .ngp .zip\n\nCopy your Neo Geo Pocket roms to $romdir/ngp\n\nCopy your Neo Geo Pocket Color roms to $romdir/ngpc"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/beetle-ngp-libretro/master/COPYING"
+rp_module_repo="git https://github.com/libretro/beetle-ngp-libretro.git master"
 rp_module_section="main"
 
 function _update_hook_lr-beetle-ngp() {
@@ -21,7 +22,7 @@ function _update_hook_lr-beetle-ngp() {
 }
 
 function sources_lr-beetle-ngp() {
-    gitPullOrClone "$md_build" https://github.com/libretro/beetle-ngp-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-beetle-ngp() {

--- a/scriptmodules/libretrocores/lr-beetle-pce-fast.sh
+++ b/scriptmodules/libretrocores/lr-beetle-pce-fast.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-beetle-pce-fast"
 rp_module_desc="PCEngine emu - Mednafen PCE Fast port for libretro"
 rp_module_help="ROM Extensions: .pce .ccd .cue .zip\n\nCopy your PC Engine / TurboGrafx roms to $romdir/pcengine\n\nCopy the required BIOS file syscard3.pce to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/beetle-pce-fast-libretro/master/COPYING"
+rp_module_repo="git https://github.com/libretro/beetle-pce-fast-libretro.git master"
 rp_module_section="main"
 
 function _update_hook_lr-beetle-pce-fast() {
@@ -21,7 +22,7 @@ function _update_hook_lr-beetle-pce-fast() {
 }
 
 function sources_lr-beetle-pce-fast() {
-    gitPullOrClone "$md_build" https://github.com/libretro/beetle-pce-fast-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-beetle-pce-fast() {

--- a/scriptmodules/libretrocores/lr-beetle-pcfx.sh
+++ b/scriptmodules/libretrocores/lr-beetle-pcfx.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-beetle-pcfx"
 rp_module_desc="PCFX emulator - Mednafen PCFX Port for libretro"
 rp_module_help="ROM Extensions: .img .iso .ccd .cue\n\nCopy the required BIOS file pcfx.rom to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/beetle-pcfx-libretro/master/COPYING"
+rp_module_repo="git https://github.com/libretro/beetle-pcfx-libretro master"
 rp_module_section="exp"
 
 function sources_lr-beetle-pcfx() {
-    gitPullOrClone "$md_build" https://github.com/libretro/beetle-pcfx-libretro
+    gitPullOrClone
 }
 
 function build_lr-beetle-pcfx() {

--- a/scriptmodules/libretrocores/lr-beetle-psx.sh
+++ b/scriptmodules/libretrocores/lr-beetle-psx.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-beetle-psx"
 rp_module_desc="PlayStation emulator - Mednafen PSX Port for libretro"
 rp_module_help="ROM Extensions: .bin .cue .cbn .img .iso .m3u .mdf .pbp .toc .z .znx\n\nCopy your PlayStation roms to $romdir/psx\n\nCopy the required BIOS files\n\nscph5500.bin and\nscph5501.bin and\nscph5502.bin to\n\n$biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/beetle-psx-libretro/master/COPYING"
+rp_module_repo="git https://github.com/libretro/beetle-psx-libretro.git master"
 rp_module_section="opt x86=main"
 rp_module_flags="!arm"
 
@@ -22,7 +23,7 @@ function depends_lr-beetle-psx() {
 }
 
 function sources_lr-beetle-psx() {
-    gitPullOrClone "$md_build" https://github.com/libretro/beetle-psx-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-beetle-psx() {

--- a/scriptmodules/libretrocores/lr-beetle-saturn.sh
+++ b/scriptmodules/libretrocores/lr-beetle-saturn.sh
@@ -13,11 +13,12 @@ rp_module_id="lr-beetle-saturn"
 rp_module_desc="Saturn emulator - Mednafen Saturn port for libretro"
 rp_module_help="ROM Extensions: .chd .cue\n\nCopy your Saturn roms to $romdir/saturn\n\nCopy the required BIOS files sega_101.bin / mpr-17933.bin to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/beetle-saturn-libretro/master/COPYING"
+rp_module_repo="git https://github.com/libretro/beetle-saturn-libretro.git master"
 rp_module_section="exp"
 rp_module_flags="!armv6"
 
 function sources_lr-beetle-saturn() {
-    gitPullOrClone "$md_build" https://github.com/libretro/beetle-saturn-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-beetle-saturn() {

--- a/scriptmodules/libretrocores/lr-beetle-supergrafx.sh
+++ b/scriptmodules/libretrocores/lr-beetle-supergrafx.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-beetle-supergrafx"
 rp_module_desc="SuperGrafx TG-16 emulator - Mednafen PCE Fast port for libretro"
 rp_module_help="ROM Extensions: .pce .ccd .cue .zip\n\nCopy your PC Engine / TurboGrafx roms to $romdir/pcengine\n\nCopy the required BIOS file syscard3.pce to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/beetle-supergrafx-libretro/master/COPYING"
+rp_module_repo="git https://github.com/libretro/beetle-supergrafx-libretro.git master"
 rp_module_section="main"
 
 function sources_lr-beetle-supergrafx() {
-    gitPullOrClone "$md_build" https://github.com/libretro/beetle-supergrafx-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-beetle-supergrafx() {

--- a/scriptmodules/libretrocores/lr-beetle-vb.sh
+++ b/scriptmodules/libretrocores/lr-beetle-vb.sh
@@ -13,11 +13,12 @@ rp_module_id="lr-beetle-vb"
 rp_module_desc="Virtual Boy emulator - Mednafen VB (optimised) port for libretro"
 rp_module_help="ROM Extensions: .vb .zip\n\nCopy your Virtual Boy roms to $romdir/virtualboy"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/beetle-vb-libretro/master/COPYING"
+rp_module_repo="git https://github.com/libretro/beetle-vb-libretro.git master"
 rp_module_section="opt"
 rp_module_flags=""
 
 function sources_lr-beetle-vb() {
-    gitPullOrClone "$md_build" https://github.com/libretro/beetle-vb-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-beetle-vb() {

--- a/scriptmodules/libretrocores/lr-beetle-wswan.sh
+++ b/scriptmodules/libretrocores/lr-beetle-wswan.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-beetle-wswan"
 rp_module_desc="Wonderswan emu - Mednafen WonderSwan core port for libretro"
 rp_module_help="ROM Extensions: .ws .wsc .zip\n\nCopy your Wonderswan roms to $romdir/wonderswan\n\nCopy your Wonderswan Color roms to $romdir/wonderswancolor"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/beetle-wswan-libretro/master/COPYING"
+rp_module_repo="git https://github.com/libretro/beetle-wswan-libretro.git master"
 rp_module_section="opt"
 
 function _update_hook_lr-beetle-wswan() {
@@ -21,7 +22,7 @@ function _update_hook_lr-beetle-wswan() {
 }
 
 function sources_lr-beetle-wswan() {
-    gitPullOrClone "$md_build" https://github.com/libretro/beetle-wswan-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-beetle-wswan() {

--- a/scriptmodules/libretrocores/lr-bluemsx.sh
+++ b/scriptmodules/libretrocores/lr-bluemsx.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-bluemsx"
 rp_module_desc="MSX/MSX2/Colecovision emu - blueMSX port for libretro"
 rp_module_help="ROM Extensions: .cas .rom .mx1 .mx2 .col .dsk .zip\n\nCopy your MSX/MSX2 games to $romdir/msx\nCopy your Colecovision games to $romdir/coleco\n\nlr-bluemsx requires the BIOS files from the full standalone package of BlueMSX to be copied to '$biosdir/Machines' folder.\nColecovision BIOS needs to be copied to '$biosdir/Machines/COL - ColecoVision\coleco.rom'"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/blueMSX-libretro/master/license.txt"
+rp_module_repo="git https://github.com/libretro/blueMSX-libretro.git master"
 rp_module_section="opt"
 
 function sources_lr-bluemsx() {
-    gitPullOrClone "$md_build" https://github.com/libretro/blueMSX-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-bluemsx() {

--- a/scriptmodules/libretrocores/lr-bsnes.sh
+++ b/scriptmodules/libretrocores/lr-bsnes.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-bsnes"
 rp_module_desc="Super Nintendo Emulator - bsnes port for libretro (v115)"
 rp_module_help="ROM Extensions: .bml .smc .sfc .zip\n\nCopy your SNES roms to $romdir/snes"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/bsnes/master/LICENSE.txt"
+rp_module_repo="git https://github.com/libretro/bsnes.git master"
 rp_module_section="opt"
 rp_module_flags="!armv6"
 
@@ -24,7 +25,7 @@ function depends_lr-bsnes() {
 }
 
 function sources_lr-bsnes() {
-    gitPullOrClone "$md_build" https://github.com/libretro/bsnes.git
+    gitPullOrClone
 }
 
 function build_lr-bsnes() {

--- a/scriptmodules/libretrocores/lr-caprice32.sh
+++ b/scriptmodules/libretrocores/lr-caprice32.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-caprice32"
 rp_module_desc="Amstrad CPC emu - Caprice32 port for libretro"
 rp_module_help="ROM Extensions: .cdt .cpc .dsk\n\nCopy your Amstrad CPC games to $romdir/amstradcpc"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/libretro-cap32/master/cap32/COPYING.txt"
+rp_module_repo="git https://github.com/libretro/libretro-cap32.git master"
 rp_module_section="main"
 
 function sources_lr-caprice32() {
-    gitPullOrClone "$md_build" https://github.com/libretro/libretro-cap32.git
+    gitPullOrClone
 }
 
 function build_lr-caprice32() {

--- a/scriptmodules/libretrocores/lr-desmume.sh
+++ b/scriptmodules/libretrocores/lr-desmume.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-desmume"
 rp_module_desc="NDS emu - DESMUME"
 rp_module_help="ROM Extensions: .nds .zip\n\nCopy your Nintendo DS roms to $romdir/nds"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/desmume/master/desmume/COPYING"
+rp_module_repo="git https://github.com/libretro/desmume.git master"
 rp_module_section="exp"
 
 function _params_lr-desmume() {
@@ -27,7 +28,7 @@ function depends_lr-desmume() {
 }
 
 function sources_lr-desmume() {
-    gitPullOrClone "$md_build" https://github.com/libretro/desmume.git
+    gitPullOrClone
 }
 
 function build_lr-desmume() {

--- a/scriptmodules/libretrocores/lr-desmume2015.sh
+++ b/scriptmodules/libretrocores/lr-desmume2015.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-desmume2015"
 rp_module_desc="NDS emu - DESMUME (2015 version)"
 rp_module_help="ROM Extensions: .nds .zip\n\nCopy your Nintendo DS roms to $romdir/nds"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/desmume/master/desmume/COPYING"
+rp_module_repo="git https://github.com/libretro/desmume2015.git master"
 rp_module_section="exp"
 
 function depends_lr-desmume2015() {
@@ -20,7 +21,7 @@ function depends_lr-desmume2015() {
 }
 
 function sources_lr-desmume2015() {
-    gitPullOrClone "$md_build" https://github.com/libretro/desmume2015.git
+    gitPullOrClone
 }
 
 function build_lr-desmume2015() {

--- a/scriptmodules/libretrocores/lr-dinothawr.sh
+++ b/scriptmodules/libretrocores/lr-dinothawr.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-dinothawr"
 rp_module_desc="Dinothawr - standalone libretro puzzle game"
 rp_module_help="Dinothawr game assets are automatically installed to $romdir/ports/dinothawr/"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/Dinothawr/master/LICENSE"
+rp_module_repo="git https://github.com/libretro/Dinothawr.git master"
 rp_module_section="exp"
 
 function sources_lr-dinothawr() {
-    gitPullOrClone "$md_build" https://github.com/libretro/Dinothawr.git
+    gitPullOrClone
 }
 
 function build_lr-dinothawr() {

--- a/scriptmodules/libretrocores/lr-dolphin.sh
+++ b/scriptmodules/libretrocores/lr-dolphin.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-dolphin"
 rp_module_desc="Gamecube/Wii emulator - Dolphin port for libretro"
 rp_module_help="ROM Extensions: .gcm .iso .wbfs .ciso .gcz\n\nCopy your gamecube roms to $romdir/gc and Wii roms to $romdir/wii"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/dolphin/master/license.txt"
+rp_module_repo="git https://github.com/libretro/dolphin master"
 rp_module_section="exp"
 rp_module_flags="!all 64bit"
 
@@ -21,7 +22,7 @@ function depends_lr-dolphin() {
 }
 
 function sources_lr-dolphin() {
-    gitPullOrClone "$md_build" https://github.com/libretro/dolphin
+    gitPullOrClone
 }
 
 function build_lr-dolphin() {

--- a/scriptmodules/libretrocores/lr-dosbox-pure.sh
+++ b/scriptmodules/libretrocores/lr-dosbox-pure.sh
@@ -13,11 +13,12 @@ rp_module_id="lr-dosbox-pure"
 rp_module_desc="DOS emulator"
 rp_module_help="ROM Extensions: .bat .com .cue .dosz .exe .ins .ima .img .iso .m3u .m3u8 .vhd .zip\n\nCopy your DOS games to $ROMDIR/pc"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/dosbox-pure/main/LICENSE"
+rp_module_repo="git https://github.com/libretro/dosbox-pure.git main"
 rp_module_section="exp"
 rp_module_flags=""
 
 function sources_lr-dosbox-pure() {
-    gitPullOrClone "$md_build" https://github.com/libretro/dosbox-pure.git main
+    gitPullOrClone
 }
 
 function build_lr-dosbox-pure() {

--- a/scriptmodules/libretrocores/lr-dosbox.sh
+++ b/scriptmodules/libretrocores/lr-dosbox.sh
@@ -13,11 +13,12 @@ rp_module_id="lr-dosbox"
 rp_module_desc="DOS emulator"
 rp_module_help="ROM Extensions: .bat .com .exe .sh\n\nCopy your DOS games to $ROMDIR/pc"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/dosbox-libretro/master/COPYING"
+rp_module_repo="git https://github.com/libretro/dosbox-libretro.git master"
 rp_module_section="exp"
 rp_module_flags=""
 
 function sources_lr-dosbox() {
-    gitPullOrClone "$md_build" https://github.com/libretro/dosbox-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-dosbox() {

--- a/scriptmodules/libretrocores/lr-fbalpha2012.sh
+++ b/scriptmodules/libretrocores/lr-fbalpha2012.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-fbalpha2012"
 rp_module_desc="Arcade emu - Final Burn Alpha (0.2.97.30) port for libretro"
 rp_module_help="Previously called lr-fba\n\nROM Extension: .zip\n\nCopy your FBA roms to\n$romdir/fba or\n$romdir/neogeo or\n$romdir/arcade\n\nFor NeoGeo games the neogeo.zip BIOS is required and must be placed in the same directory as your FBA roms."
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/fbalpha2012/master/docs/license.txt"
+rp_module_repo="git https://github.com/libretro/fbalpha2012.git master"
 rp_module_section="opt armv6=main"
 
 function _update_hook_lr-fbalpha2012() {
@@ -21,7 +22,7 @@ function _update_hook_lr-fbalpha2012() {
 }
 
 function sources_lr-fbalpha2012() {
-    gitPullOrClone "$md_build" https://github.com/libretro/fbalpha2012.git
+    gitPullOrClone
 }
 
 function build_lr-fbalpha2012() {

--- a/scriptmodules/libretrocores/lr-fbneo.sh
+++ b/scriptmodules/libretrocores/lr-fbneo.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-fbneo"
 rp_module_desc="Arcade emu - FinalBurn Neo v1.0.0.01 (Upstream) port for libretro"
 rp_module_help="Previously called lr-fba-next and fbalpha\n\ROM Extension: .zip\n\nCopy your FBA roms to\n$romdir/fba or\n$romdir/neogeo or\n$romdir/arcade\n\nFor NeoGeo games the neogeo.zip BIOS is required and must be placed in the same directory as your FBA roms."
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/FBNeo/master/src/license.txt"
+rp_module_repo="git https://github.com/libretro/FBNeo.git master"
 rp_module_section="main armv6=opt"
 
 function _update_hook_lr-fbneo() {
@@ -22,7 +23,7 @@ function _update_hook_lr-fbneo() {
 }
 
 function sources_lr-fbneo() {
-    gitPullOrClone "$md_build" https://github.com/libretro/FBNeo.git
+    gitPullOrClone
 }
 
 function build_lr-fbneo() {

--- a/scriptmodules/libretrocores/lr-fceumm.sh
+++ b/scriptmodules/libretrocores/lr-fceumm.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-fceumm"
 rp_module_desc="NES emu - FCEUmm port for libretro"
 rp_module_help="ROM Extensions: .nes .zip\n\nCopy your NES roms to $romdir/nes\n\nFor the Famicom Disk System copy your roms to $romdir/fds\n\nFor the Famicom Disk System copy the required BIOS file disksys.rom to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/libretro-fceumm/master/Copying"
+rp_module_repo="git https://github.com/libretro/libretro-fceumm.git master"
 rp_module_section="main"
 
 function sources_lr-fceumm() {
-    gitPullOrClone "$md_build" https://github.com/libretro/libretro-fceumm.git
+    gitPullOrClone
 }
 
 function build_lr-fceumm() {

--- a/scriptmodules/libretrocores/lr-flycast.sh
+++ b/scriptmodules/libretrocores/lr-flycast.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-flycast"
 rp_module_desc="Dreamcast emulator - Reicast port for libretro"
 rp_module_help="Previously named lr-reicast then lr-beetle-dc\n\nDreamcast ROM Extensions: .cdi .gdi .chd, Naomi/Atomiswave ROM Extension: .zip\n\nCopy your Dreamcast/Naomi roms to $romdir/dreamcast\n\nCopy the required Dreamcast BIOS files dc_boot.bin and dc_flash.bin to $biosdir/dc\n\nCopy the required Naomi/Atomiswave BIOS files naomi.zip and awbios.zip to $biosdir/dc"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/flycast/master/LICENSE"
+rp_module_repo="git https://github.com/libretro/flycast.git master"
 rp_module_section="opt"
 rp_module_flags="!armv6"
 
@@ -29,7 +30,7 @@ function _update_hook_lr-flycast() {
 }
 
 function sources_lr-flycast() {
-    gitPullOrClone "$md_build" https://github.com/libretro/flycast.git
+    gitPullOrClone
     # don't override our C/CXXFLAGS and set LDFLAGS to CFLAGS to avoid warnings on linking
     applyPatch "$md_data/01_flags_fix.diff"
 }

--- a/scriptmodules/libretrocores/lr-fmsx.sh
+++ b/scriptmodules/libretrocores/lr-fmsx.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-fmsx"
 rp_module_desc="MSX/MSX2 emu - fMSX port for libretro"
 rp_module_help="ROM Extensions: .rom .mx1 .mx2 .col .dsk .zip\n\nCopy the fmsx BIOS files to '$biosdir'\n\nCopy your MSX/MSX2 games to $romdir/msx"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/fmsx-libretro/master/LICENSE"
+rp_module_repo="git https://github.com/libretro/fmsx-libretro.git master"
 rp_module_section="opt"
 
 function sources_lr-fmsx() {
-    gitPullOrClone "$md_build" https://github.com/libretro/fmsx-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-fmsx() {

--- a/scriptmodules/libretrocores/lr-freechaf.sh
+++ b/scriptmodules/libretrocores/lr-freechaf.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-freechaf"
 rp_module_desc="ChannelF emulator for libretro"
 rp_module_help="ROM Extensions: .bin .rom\n\nCopy your ChannelF roms to $romdir/channelf\n\nCopy the required BIOS files sl31245.bin and sl31253.bin or sl90025.bin to $biosdir"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/FreeChaF/master/LICENSE"
+rp_module_repo="git https://github.com/libretro/FreeChaF.git master"
 rp_module_section="exp"
 
 function sources_lr-freechaf() {
-    gitPullOrClone "$md_build" https://github.com/libretro/FreeChaF.git
+    gitPullOrClone
 }
 
 function build_lr-freechaf() {

--- a/scriptmodules/libretrocores/lr-freeintv.sh
+++ b/scriptmodules/libretrocores/lr-freeintv.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-freeintv"
 rp_module_desc="Intellivision emulator for libretro"
 rp_module_help="ROM Extensions: .int .bin\n\nCopy your Intellivision roms to $romdir/intellivision\n\nCopy the required BIOS files exec.bin and grom.bin to $biosdir"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/FreeIntv/master/LICENSE"
+rp_module_repo="git https://github.com/libretro/FreeIntv.git master"
 rp_module_section="opt"
 
 function sources_lr-freeintv() {
-    gitPullOrClone "$md_build" https://github.com/libretro/FreeIntv.git
+    gitPullOrClone
 }
 
 function build_lr-freeintv() {

--- a/scriptmodules/libretrocores/lr-fuse.sh
+++ b/scriptmodules/libretrocores/lr-fuse.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-fuse"
 rp_module_desc="ZX Spectrum emu - Fuse port for libretro"
 rp_module_help="ROM Extensions: .sna .szx .z80 .tap .tzx .gz .udi .mgt .img .trd .scl .dsk .zip\n\nCopy your ZX Spectrum games to $romdir/zxspectrum"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/fuse-libretro/master/LICENSE"
+rp_module_repo="git https://github.com/libretro/fuse-libretro.git master"
 rp_module_section="main"
 
 function sources_lr-fuse() {
-    gitPullOrClone "$md_build" https://github.com/libretro/fuse-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-fuse() {

--- a/scriptmodules/libretrocores/lr-gambatte.sh
+++ b/scriptmodules/libretrocores/lr-gambatte.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-gambatte"
 rp_module_desc="Gameboy Color emu - libgambatte port for libretro"
 rp_module_help="ROM Extensions: .gb .gbc .zip\n\nCopy your GameBoy roms to $romdir/gb\n\nCopy your GameBoy Color roms to $romdir/gbc"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/gambatte-libretro/master/COPYING"
+rp_module_repo="git https://github.com/libretro/gambatte-libretro.git master"
 rp_module_section="main"
 
 function sources_lr-gambatte() {
-    gitPullOrClone "$md_build" https://github.com/libretro/gambatte-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-gambatte() {

--- a/scriptmodules/libretrocores/lr-gearsystem.sh
+++ b/scriptmodules/libretrocores/lr-gearsystem.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-gearsystem"
 rp_module_desc="Sega 8 bit emu - Gearsystem port for libretro"
 rp_module_help="ROM Extensions: .gg .sg .sms .bin .zip\nCopy your Game Gear roms to $romdir/gamegear\nMasterSystem roms to $romdir/mastersystem\nSG-1000 roms to $romdir/sg-1000"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/drhelius/Gearsystem/master/LICENSE"
+rp_module_repo="git https://github.com/drhelius/Gearsystem.git master"
 rp_module_section="exp"
 
 function sources_lr-gearsystem() {
-    gitPullOrClone "$md_build" https://github.com/drhelius/Gearsystem.git
+    gitPullOrClone
 }
 
 function build_lr-gearsystem() {

--- a/scriptmodules/libretrocores/lr-genesis-plus-gx.sh
+++ b/scriptmodules/libretrocores/lr-genesis-plus-gx.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-genesis-plus-gx"
 rp_module_desc="Sega 8/16 bit emu - Genesis Plus (enhanced) port for libretro"
 rp_module_help="ROM Extensions: .bin .cue .gen .gg .iso .md .sg .smd .sms .zip\nCopy your Game Gear roms to $romdir/gamegear\nMasterSystem roms to $romdir/mastersystem\nMegadrive / Genesis roms to $romdir/megadrive\nSG-1000 roms to $romdir/sg-1000\nSegaCD roms to $romdir/segacd\nThe Sega CD requires the BIOS files bios_CD_U.bin and bios_CD_E.bin and bios_CD_J.bin copied to $biosdir"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/Genesis-Plus-GX/master/LICENSE.txt"
+rp_module_repo="git https://github.com/libretro/Genesis-Plus-GX.git master"
 rp_module_section="main"
 
 function sources_lr-genesis-plus-gx() {
-    gitPullOrClone "$md_build" https://github.com/libretro/Genesis-Plus-GX.git
+    gitPullOrClone
 }
 
 function build_lr-genesis-plus-gx() {

--- a/scriptmodules/libretrocores/lr-gpsp.sh
+++ b/scriptmodules/libretrocores/lr-gpsp.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-gpsp"
 rp_module_desc="GBA emu - gpSP port for libretro"
 rp_module_help="ROM Extensions: .gba .zip\n\nCopy your Game Boy Advance roms to $romdir/gba\n\nCopy the required BIOS file gba_bios.bin to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/gpsp/master/COPYING"
+rp_module_repo="git https://github.com/libretro/gpsp.git master"
 rp_module_section="opt arm=main"
 rp_module_flags="!all arm"
 
@@ -21,7 +22,7 @@ function depends_lr-gpsp() {
 }
 
 function sources_lr-gpsp() {
-    gitPullOrClone "$md_build" https://github.com/libretro/gpsp.git
+    gitPullOrClone
 }
 
 function build_lr-gpsp() {

--- a/scriptmodules/libretrocores/lr-gw.sh
+++ b/scriptmodules/libretrocores/lr-gw.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-gw"
 rp_module_desc="Game and Watch simulator"
 rp_module_help="ROM Extension: .mgw\n\nCopy your Game and Watch games to $romdir/gameandwatch"
 rp_module_licence="ZLIB https://raw.githubusercontent.com/libretro/gw-libretro/master/LICENSE"
+rp_module_repo="git https://github.com/libretro/gw-libretro.git master"
 rp_module_section="opt"
 
 function sources_lr-gw() {
-    gitPullOrClone "$md_build" https://github.com/libretro/gw-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-gw() {

--- a/scriptmodules/libretrocores/lr-handy.sh
+++ b/scriptmodules/libretrocores/lr-handy.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-handy"
 rp_module_desc="Atari Lynx emulator - Handy port for libretro"
 rp_module_help="ROM Extensions: .lnx .zip\n\nCopy your Atari Lynx roms to $romdir/atarilynx"
 rp_module_licence="ZLIB https://raw.githubusercontent.com/libretro/libretro-handy/master/lynx/license.txt"
+rp_module_repo="git https://github.com/libretro/libretro-handy.git master"
 rp_module_section="main"
 
 function sources_lr-handy() {
-    gitPullOrClone "$md_build" https://github.com/libretro/libretro-handy.git
+    gitPullOrClone
 }
 
 function build_lr-handy() {

--- a/scriptmodules/libretrocores/lr-hatari.sh
+++ b/scriptmodules/libretrocores/lr-hatari.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-hatari"
 rp_module_desc="Atari emulator - Hatari port for libretro"
 rp_module_help="ROM Extensions: .st .stx .img .rom .raw .ipf .ctr .zip\n\nCopy your Atari ST games to $romdir/atarist"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/hatari/master/gpl.txt"
+rp_module_repo="git https://github.com/libretro/hatari.git master"
 rp_module_section="exp"
 
 function depends_lr-hatari() {
@@ -20,7 +21,7 @@ function depends_lr-hatari() {
 }
 
 function sources_lr-hatari() {
-    gitPullOrClone "$md_build" https://github.com/libretro/hatari.git
+    gitPullOrClone
     applyPatch "$md_data/01_libcapsimage.diff"
     _sources_libcapsimage_hatari
 }

--- a/scriptmodules/libretrocores/lr-kronos.sh
+++ b/scriptmodules/libretrocores/lr-kronos.sh
@@ -13,11 +13,12 @@ rp_module_id="lr-kronos"
 rp_module_desc="Saturn & ST-V emulator - Kronos port for libretro"
 rp_module_help="ROM Extensions: .iso .cue .zip .ccd .mds\n\nCopy your Sega Saturn & ST-V roms to $romdir/saturn\n\nCopy the required BIOS file saturn_bios.bin / stvbios.zip to $biosdir/kronos"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/yabause/kronos/yabause/COPYING"
+rp_module_repo="git https://github.com/libretro/yabause.git kronos"
 rp_module_section="exp"
 rp_module_flags="!arm !aarch64"
 
 function sources_lr-kronos() {
-    gitPullOrClone "$md_build" https://github.com/libretro/yabause.git kronos
+    gitPullOrClone
 }
 
 function build_lr-kronos() {

--- a/scriptmodules/libretrocores/lr-mame.sh
+++ b/scriptmodules/libretrocores/lr-mame.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-mame"
 rp_module_desc="MAME emulator - MAME (current) port for libretro"
 rp_module_help="ROM Extension: .zip\n\nCopy your MAME roms to either $romdir/mame-libretro or\n$romdir/arcade"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame/master/LICENSE.md"
+rp_module_repo="git https://github.com/libretro/mame.git master"
 rp_module_section="exp"
 rp_module_flags=""
 
@@ -34,7 +35,7 @@ function depends_lr-mame() {
 }
 
 function sources_lr-mame() {
-    gitPullOrClone "$md_build" https://github.com/libretro/mame.git
+    gitPullOrClone
 }
 
 function build_lr-mame() {

--- a/scriptmodules/libretrocores/lr-mame2000.sh
+++ b/scriptmodules/libretrocores/lr-mame2000.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-mame2000"
 rp_module_desc="Arcade emu - MAME 0.37b5 port for libretro"
 rp_module_help="ROM Extension: .zip\n\nCopy your MAME 0.37b5 roms to either $romdir/mame-mame4all or\n$romdir/arcade"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/mame2000-libretro/master/readme.txt"
+rp_module_repo="git https://github.com/libretro/mame2000-libretro.git master"
 rp_module_section="opt armv6=main"
 
 function _update_hook_lr-mame2000() {
@@ -21,7 +22,7 @@ function _update_hook_lr-mame2000() {
 }
 
 function sources_lr-mame2000() {
-    gitPullOrClone "$md_build" https://github.com/libretro/mame2000-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-mame2000() {

--- a/scriptmodules/libretrocores/lr-mame2003-plus.sh
+++ b/scriptmodules/libretrocores/lr-mame2003-plus.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-mame2003-plus"
 rp_module_desc="Arcade emu - updated MAME 0.78 port for libretro with added game support"
 rp_module_help="ROM Extension: .zip\n\nCopy your MAME roms to either $romdir/mame-libretro or\n$romdir/arcade"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/mame2003-plus-libretro/master/LICENSE.md"
+rp_module_repo="git https://github.com/libretro/mame2003-plus-libretro.git master"
 rp_module_section="opt"
 
 function _get_dir_name_lr-mame2003-plus() {
@@ -24,7 +25,7 @@ function _get_so_name_lr-mame2003-plus() {
 }
 
 function sources_lr-mame2003-plus() {
-    gitPullOrClone "$md_build" https://github.com/libretro/mame2003-plus-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-mame2003-plus() {

--- a/scriptmodules/libretrocores/lr-mame2003.sh
+++ b/scriptmodules/libretrocores/lr-mame2003.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-mame2003"
 rp_module_desc="Arcade emu - MAME 0.78 port for libretro"
 rp_module_help="ROM Extension: .zip\n\nCopy your MAME roms to either $romdir/mame-libretro or\n$romdir/arcade"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/mame2003-libretro/master/LICENSE.md"
+rp_module_repo="git https://github.com/libretro/mame2003-libretro.git master"
 rp_module_section="main armv6=opt"
 
 function _get_dir_name_lr-mame2003() {
@@ -24,7 +25,7 @@ function _get_so_name_lr-mame2003() {
 }
 
 function sources_lr-mame2003() {
-    gitPullOrClone "$md_build" https://github.com/libretro/mame2003-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-mame2003() {

--- a/scriptmodules/libretrocores/lr-mame2010.sh
+++ b/scriptmodules/libretrocores/lr-mame2010.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-mame2010"
 rp_module_desc="Arcade emu - MAME 0.139 port for libretro"
 rp_module_help="ROM Extension: .zip\n\nCopy your MAME roms to either $romdir/mame-libretro or\n$romdir/arcade"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/mame2010-libretro/master/docs/license.txt"
+rp_module_repo="git https://github.com/libretro/mame2010-libretro.git master"
 rp_module_section="opt"
 
 function depends_lr-mame2010() {
@@ -20,7 +21,7 @@ function depends_lr-mame2010() {
 }
 
 function sources_lr-mame2010() {
-    gitPullOrClone "$md_build" https://github.com/libretro/mame2010-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-mame2010() {

--- a/scriptmodules/libretrocores/lr-mame2015.sh
+++ b/scriptmodules/libretrocores/lr-mame2015.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-mame2015"
 rp_module_desc="Arcade emu - MAME 0.160 port for libretro"
 rp_module_help="ROM Extension: .zip\n\nCopy your MAME roms to either $romdir/mame-libretro or\n$romdir/arcade"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/mame2015-libretro/master/docs/license.txt"
+rp_module_repo="git https://github.com/libretro/mame2015-libretro.git master"
 rp_module_section="exp"
 
 function _update_hook_lr-mame2015() {
@@ -21,7 +22,7 @@ function _update_hook_lr-mame2015() {
 }
 
 function sources_lr-mame2015() {
-    gitPullOrClone "$md_build" https://github.com/libretro/mame2015-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-mame2015() {

--- a/scriptmodules/libretrocores/lr-mame2016.sh
+++ b/scriptmodules/libretrocores/lr-mame2016.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-mame2016"
 rp_module_desc="MAME emulator - MAME 0.174 port for libretro"
 rp_module_help="ROM Extension: .zip\n\nCopy your MAME roms to either $romdir/mame-libretro or\n$romdir/arcade"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame2016-libretro/master/LICENSE.md"
+rp_module_repo="git https://github.com/libretro/mame2016-libretro.git master"
 rp_module_section="exp"
 rp_module_flags=""
 
@@ -21,7 +22,7 @@ function depends_lr-mame2016() {
 }
 
 function sources_lr-mame2016() {
-    gitPullOrClone "$md_build" https://github.com/libretro/mame2016-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-mame2016() {

--- a/scriptmodules/libretrocores/lr-mesen.sh
+++ b/scriptmodules/libretrocores/lr-mesen.sh
@@ -13,11 +13,12 @@ rp_module_id="lr-mesen"
 rp_module_desc="High-accuracy NES and Famicom emulator"
 rp_module_help="ROM Extensions: .nes .fds .unf .unif .zip\n\nCopy your NES roms to $romdir/nes\nFamicom roms to $romdir/fds\nCopy the recommended BIOS file disksys.rom to $biosdir"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/sourmesen/mesen/master/LICENSE"
+rp_module_repo="git https://github.com/libretro/Mesen.git master"
 rp_module_section="exp"
 rp_module_flags="!armv6"
 
 function sources_lr-mesen() {
-    gitPullOrClone "$md_build" https://github.com/SourMesen/Mesen.git
+    gitPullOrClone
 }
 
 function build_lr-mesen() {

--- a/scriptmodules/libretrocores/lr-mess.sh
+++ b/scriptmodules/libretrocores/lr-mess.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-mess"
 rp_module_desc="MESS emulator - MESS Port for libretro"
 rp_module_help="see wiki for detailed explanation"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame/master/LICENSE.md"
+rp_module_repo="git https://github.com/libretro/mame.git master"
 rp_module_section="exp"
 rp_module_flags=""
 
@@ -21,7 +22,7 @@ function depends_lr-mess() {
 }
 
 function sources_lr-mess() {
-    gitPullOrClone "$md_build" https://github.com/libretro/mame.git
+    gitPullOrClone
 }
 
 function build_lr-mess() {

--- a/scriptmodules/libretrocores/lr-mess2016.sh
+++ b/scriptmodules/libretrocores/lr-mess2016.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-mess2016"
 rp_module_desc="MESS emulator - MESS Port for libretro"
 rp_module_help="see wiki for detailed explanation"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame2016-libretro/master/LICENSE.md"
+rp_module_repo="git https://github.com/libretro/mame2016-libretro.git master"
 rp_module_section="exp"
 rp_module_flags=""
 
@@ -21,7 +22,7 @@ function depends_lr-mess2016() {
 }
 
 function sources_lr-mess2016() {
-    gitPullOrClone "$md_build" https://github.com/libretro/mame2016-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-mess2016() {

--- a/scriptmodules/libretrocores/lr-mgba.sh
+++ b/scriptmodules/libretrocores/lr-mgba.sh
@@ -13,11 +13,12 @@ rp_module_id="lr-mgba"
 rp_module_desc="(Super) Game Boy Color/GBA emulator - MGBA (optimised) port for libretro"
 rp_module_help="ROM Extensions: .gb .gbc .gba .zip\n\nCopy your Game Boy roms to $romdir/gb\nGame Boy Color roms to $romdir/gbc\nGame Boy Advance roms to $romdir/gba\n\nCopy the recommended BIOS files gb_bios.bin, gbc_bios.bin, sgb_bios.bin and gba_bios.bin to $biosdir"
 rp_module_licence="MPL2 https://raw.githubusercontent.com/libretro/mgba/master/LICENSE"
+rp_module_repo="git https://github.com/libretro/mgba.git master"
 rp_module_section="main"
 rp_module_flags=""
 
 function sources_lr-mgba() {
-    gitPullOrClone "$md_build" https://github.com/libretro/mgba.git
+    gitPullOrClone
 }
 
 function build_lr-mgba() {

--- a/scriptmodules/libretrocores/lr-mrboom.sh
+++ b/scriptmodules/libretrocores/lr-mrboom.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-mrboom"
 rp_module_desc="Mr.Boom - 8 players Bomberman clone for libretro."
 rp_module_help="8 players Bomberman clone for libretro."
 rp_module_licence="MIT https://raw.githubusercontent.com/libretro/mrboom-libretro/master/LICENSE"
+rp_module_repo="git https://github.com/libretro/mrboom-libretro.git master"
 rp_module_section="opt"
 
 function sources_lr-mrboom() {
-    gitPullOrClone "$md_build" https://github.com/libretro/mrboom-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-mrboom() {

--- a/scriptmodules/libretrocores/lr-mupen64plus-next.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus-next.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-mupen64plus-next"
 rp_module_desc="N64 emulator - Mupen64Plus + GLideN64 for libretro (next version)"
 rp_module_help="ROM Extensions: .z64 .n64 .v64\n\nCopy your N64 roms to $romdir/n64"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mupen64plus-libretro-nx/master/LICENSE"
+rp_module_repo="git https://github.com/libretro/mupen64plus-libretro-nx.git develop"
 rp_module_section="opt kms=main"
 rp_module_flags=""
 
@@ -26,7 +27,7 @@ function depends_lr-mupen64plus-next() {
 }
 
 function sources_lr-mupen64plus-next() {
-    gitPullOrClone "$md_build" https://github.com/libretro/mupen64plus-libretro-nx.git develop
+    gitPullOrClone
 }
 
 function build_lr-mupen64plus-next() {

--- a/scriptmodules/libretrocores/lr-mupen64plus.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-mupen64plus"
 rp_module_desc="N64 emu - Mupen64Plus + GLideN64 for libretro"
 rp_module_help="ROM Extensions: .z64 .n64 .v64\n\nCopy your N64 roms to $romdir/n64"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mupen64plus-libretro/master/LICENSE"
+rp_module_repo="git https://github.com/RetroPie/mupen64plus-libretro.git master"
 rp_module_section="main"
 rp_module_flags="!aarch64"
 
@@ -39,7 +40,7 @@ function depends_lr-mupen64plus() {
 }
 
 function sources_lr-mupen64plus() {
-    gitPullOrClone "$md_build" https://github.com/RetroPie/mupen64plus-libretro.git
+    gitPullOrClone
 
     # mesa workaround; see: https://github.com/libretro/libretro-common/issues/98
     if hasPackage libgles2-mesa-dev 18.2 ge; then

--- a/scriptmodules/libretrocores/lr-neocd.sh
+++ b/scriptmodules/libretrocores/lr-neocd.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-neocd"
 rp_module_desc="Neo Geo CD Emulator - rewrite of NeoCD for libretro"
 rp_module_help="ROM Extension: .chd .cue\n\nCopy your roms to\n$romdir/neogeo\n\nYou will need a minimum of two BIOS files (eg. ng-lo.rom, uni-bioscd.rom) which should be copied to $biosdir/neocd"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/neocd_libretro/master/LICENSE.md"
+rp_module_repo="git https://github.com/libretro/neocd_libretro.git master"
 rp_module_section="exp"
 
 function sources_lr-neocd() {
-    gitPullOrClone "$md_build" https://github.com/libretro/neocd_libretro.git
+    gitPullOrClone
 }
 
 function build_lr-neocd() {

--- a/scriptmodules/libretrocores/lr-nestopia.sh
+++ b/scriptmodules/libretrocores/lr-nestopia.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-nestopia"
 rp_module_desc="NES emu - Nestopia (enhanced) port for libretro"
 rp_module_help="ROM Extensions: .nes .zip\n\nCopy your NES roms to $romdir/nes\n\nFor the Famicom Disk System copy your roms to $romdir/fds\n\nFor the Famicom Disk System copy the required BIOS file disksys.rom to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/nestopia/master/COPYING"
+rp_module_repo="git https://github.com/libretro/nestopia.git master"
 rp_module_section="main"
 
 function sources_lr-nestopia() {
-    gitPullOrClone "$md_build" https://github.com/libretro/nestopia.git
+    gitPullOrClone
 }
 
 function build_lr-nestopia() {

--- a/scriptmodules/libretrocores/lr-np2kai.sh
+++ b/scriptmodules/libretrocores/lr-np2kai.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-np2kai"
 rp_module_desc="PC98 emu - Modified Neko Project II port for libretro"
 rp_module_help="ROM Extensions: .d88 .d98 .88d .98d .fdi .xdf .hdm .dup .2hd .tfd .hdi .thd .nhd .hdd\n\nCopy your pc98 games to to $romdir/pc98\n\nCopy bios files 2608_bd.wav, 2608_hh.wav, 2608_rim.wav, 2608_sd.wav, 2608_tom.wav 2608_top.wav, bios.rom, FONT.ROM and sound.rom to $biosdir/np2kai"
 rp_module_licence="MIT https://raw.githubusercontent.com/libretro/NP2kai/master/LICENSE"
+rp_module_repo="git https://github.com/AZO234/NP2kai.git master"
 rp_module_section="exp"
 
 function sources_lr-np2kai() {
-    gitPullOrClone "$md_build" https://github.com/AZO234/NP2kai.git
+    gitPullOrClone
 }
 
 function build_lr-np2kai() {

--- a/scriptmodules/libretrocores/lr-nxengine.sh
+++ b/scriptmodules/libretrocores/lr-nxengine.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-nxengine"
 rp_module_desc="Cave Story engine clone - NxEngine port for libretro"
 rp_module_help="Copy the original Cave Story game files to $romdir/ports/CaveStory so you have the file $romdir/ports/CaveStory/Doukutsu.exe present."
 rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/nxengine-libretro/master/nxengine/LICENSE"
+rp_module_repo="git https://github.com/libretro/nxengine-libretro.git master"
 rp_module_section="opt"
 
 function sources_lr-nxengine() {
-    gitPullOrClone "$md_build" https://github.com/libretro/nxengine-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-nxengine() {

--- a/scriptmodules/libretrocores/lr-o2em.sh
+++ b/scriptmodules/libretrocores/lr-o2em.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-o2em"
 rp_module_desc="Odyssey 2 / Videopac emu - O2EM port for libretro"
 rp_module_help="ROM Extensions: .bin .zip\n\nCopy your Odyssey 2 / Videopac roms to $romdir/videopac\n\nCopy the required BIOS file o2rom.bin to $biosdir"
 rp_module_licence="OTHER"
+rp_module_repo="git https://github.com/libretro/libretro-o2em master"
 rp_module_section="opt"
 
 function sources_lr-o2em() {
-    gitPullOrClone "$md_build" https://github.com/libretro/libretro-o2em
+    gitPullOrClone
 }
 
 function build_lr-o2em() {

--- a/scriptmodules/libretrocores/lr-opera.sh
+++ b/scriptmodules/libretrocores/lr-opera.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-opera"
 rp_module_desc="3DO emulator - fork of 4DO/FreeDO for libretro"
 rp_module_help="ROM Extension: .cue .chd .iso\n\nCopy your 3do roms to $romdir/3do\n\nCopy the required BIOS file panazf10.bin to $biosdir"
 rp_module_licence="LGPL https://raw.githubusercontent.com/libretro/opera-libretro/master/libopera/opera_3do.c"
+rp_module_repo="git https://github.com/libretro/opera-libretro.git master"
 rp_module_section="exp"
 
 function sources_lr-opera() {
-    gitPullOrClone "$md_build" https://github.com/libretro/opera-libretro.git
+    gitPullOrClone
 }
 
 function _update_hook_lr-opera() {

--- a/scriptmodules/libretrocores/lr-parallel-n64.sh
+++ b/scriptmodules/libretrocores/lr-parallel-n64.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-parallel-n64"
 rp_module_desc="N64 emu - Highly modified Mupen64Plus port for libretro"
 rp_module_help="ROM Extensions: .z64 .n64 .v64\n\nCopy your N64 roms to $romdir/n64"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/parallel-n64/master/mupen64plus-core/LICENSES"
+rp_module_repo="git https://github.com/libretro/parallel-n64.git master"
 rp_module_section="exp x86=main"
 
 function depends_lr-parallel-n64() {
@@ -24,7 +25,7 @@ function depends_lr-parallel-n64() {
 }
 
 function sources_lr-parallel-n64() {
-    gitPullOrClone "$md_build" https://github.com/libretro/parallel-n64.git
+    gitPullOrClone
     # avoid conflicting typedefs for GLfloat on rpi4/kms
     isPlatform "kms" && isPlatform "gles" && sed -i "/^typedef GLfloat GLdouble/d" "$md_build/libretro-common/include/glsm/glsm.h"
 }

--- a/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
+++ b/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-pcsx-rearmed"
 rp_module_desc="Playstation emulator - PCSX (arm optimised) port for libretro"
 rp_module_help="ROM Extensions: .bin .cue .cbn .img .iso .m3u .mdf .pbp .toc .z .znx\n\nCopy your PSX roms to $romdir/psx\n\nCopy the required BIOS file SCPH1001.BIN to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/pcsx_rearmed/master/COPYING"
+rp_module_repo="git https://github.com/libretro/pcsx_rearmed.git master"
 rp_module_section="opt arm=main"
 
 function depends_lr-pcsx-rearmed() {
@@ -22,7 +23,7 @@ function depends_lr-pcsx-rearmed() {
 }
 
 function sources_lr-pcsx-rearmed() {
-    gitPullOrClone "$md_build" https://github.com/libretro/pcsx_rearmed.git
+    gitPullOrClone
 }
 
 function build_lr-pcsx-rearmed() {

--- a/scriptmodules/libretrocores/lr-picodrive.sh
+++ b/scriptmodules/libretrocores/lr-picodrive.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-picodrive"
 rp_module_desc="Sega 8/16 bit emu - picodrive arm optimised libretro core"
 rp_module_help="ROM Extensions: .32x .iso .cue .sms .smd .bin .gen .md .sg .zip\n\nCopy your Megadrive / Genesis roms to $romdir/megadrive\nMasterSystem roms to $romdir/mastersystem\nSega 32X roms to $romdir/sega32x and\nSegaCD roms to $romdir/segacd\nThe Sega CD requires the BIOS files us_scd1_9210.bin, eu_mcd1_9210.bin, jp_mcd1_9112.bin copied to $biosdir"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/picodrive/master/COPYING"
+rp_module_repo="git https://github.com/libretro/picodrive.git master"
 rp_module_section="main"
 
 function sources_lr-picodrive() {
-    gitPullOrClone "$md_build" https://github.com/libretro/picodrive.git
+    gitPullOrClone
 }
 
 function build_lr-picodrive() {

--- a/scriptmodules/libretrocores/lr-pokemini.sh
+++ b/scriptmodules/libretrocores/lr-pokemini.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-pokemini"
 rp_module_desc="Pokemon Mini emulator - PokeMini port for libretro"
 rp_module_help="ROM Extensions: .min .zip\n\nCopy your Pokemon Mini roms to $romdir/pokemini"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/PokeMini/master/LICENSE"
+rp_module_repo="git https://github.com/libretro/pokemini.git master"
 rp_module_section="exp"
 
 function sources_lr-pokemini() {
-    gitPullOrClone "$md_build" https://github.com/libretro/pokemini.git
+    gitPullOrClone
 }
 
 function build_lr-pokemini() {

--- a/scriptmodules/libretrocores/lr-ppsspp.sh
+++ b/scriptmodules/libretrocores/lr-ppsspp.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-ppsspp"
 rp_module_desc="PlayStation Portable emu - PPSSPP port for libretro"
 rp_module_help="ROM Extensions: .iso .pbp .cso\n\nCopy your PlayStation Portable roms to $romdir/psp"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/RetroPie/ppsspp/master/LICENSE.TXT"
+rp_module_repo="git https://github.com/hrydgard/ppsspp.git master"
 rp_module_section="opt"
 rp_module_flags=""
 

--- a/scriptmodules/libretrocores/lr-prboom.sh
+++ b/scriptmodules/libretrocores/lr-prboom.sh
@@ -12,10 +12,11 @@
 rp_module_id="lr-prboom"
 rp_module_desc="Doom/Doom II engine - PrBoom port for libretro"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/libretro-prboom/master/COPYING"
+rp_module_repo="git https://github.com/libretro/libretro-prboom.git master"
 rp_module_section="opt"
 
 function sources_lr-prboom() {
-    gitPullOrClone "$md_build" https://github.com/libretro/libretro-prboom.git
+    gitPullOrClone
 }
 
 function build_lr-prboom() {

--- a/scriptmodules/libretrocores/lr-prosystem.sh
+++ b/scriptmodules/libretrocores/lr-prosystem.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-prosystem"
 rp_module_desc="Atari 7800 ProSystem emu - ProSystem port for libretro"
 rp_module_help="ROM Extensions: .a78 .bin .zip\n\nCopy your Atari 7800 roms to $romdir/atari7800\n\nCopy the optional BIOS file 7800 BIOS (U).rom to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/prosystem-libretro/master/License.txt"
+rp_module_repo="git https://github.com/libretro/prosystem-libretro.git master"
 rp_module_section="main"
 
 function sources_lr-prosystem() {
-    gitPullOrClone "$md_build" https://github.com/libretro/prosystem-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-prosystem() {

--- a/scriptmodules/libretrocores/lr-puae.sh
+++ b/scriptmodules/libretrocores/lr-puae.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-puae"
 rp_module_desc="P-UAE Amiga emulator port for libretro"
 rp_module_help="ROM Extensions: .adf .uae\n\nCopy your roms to $romdir/amiga and create configs as .uae"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/PUAE/master/COPYING"
+rp_module_repo="git https://github.com/libretro/libretro-uae.git master"
 rp_module_section="opt"
 
 function sources_lr-puae() {
-    gitPullOrClone "$md_build" https://github.com/libretro/libretro-uae.git
+    gitPullOrClone
 }
 
 function build_lr-puae() {

--- a/scriptmodules/libretrocores/lr-px68k.sh
+++ b/scriptmodules/libretrocores/lr-px68k.sh
@@ -12,11 +12,12 @@
 rp_module_id="lr-px68k"
 rp_module_desc="SHARP X68000 Emulator"
 rp_module_help="You need to copy a X68000 bios file (iplrom30.dat, iplromco.dat, iplrom.dat, or iplromxv.dat), and the font file (cgrom.dat or cgrom.tmp) to $biosdir/keropi. Use F12 to access the in emulator menu."
+rp_module_repo="git https://github.com/libretro/px68k-libretro.git master"
 rp_module_section="exp"
 rp_module_flags=""
 
 function sources_lr-px68k() {
-    gitPullOrClone "$md_build" https://github.com/libretro/px68k-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-px68k() {

--- a/scriptmodules/libretrocores/lr-quasi88.sh
+++ b/scriptmodules/libretrocores/lr-quasi88.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-quasi88"
 rp_module_desc="NEC PC-8801 emu - Quasi88 port for libretro"
 rp_module_help="ROM Extensions: .d88 .88d .cmt .m3u .t88\n\nCopy your pc88 games to to $romdir/pc88\n\nCopy bios files n88.rom, n88_0.rom, n88_1.rom, n88_2.rom, n88_3.rom, n88n.rom, disk.rom, n88knj1.rom, n88knj2.rom, and n88jisho.rom to $biosdir/quasi88"
 rp_module_licence="BSD https://raw.githubusercontent.com/libretro/quasi88-libretro/master/LICENSE"
+rp_module_repo="git https://github.com/libretro/quasi88-libretro.git master"
 rp_module_section="exp"
 
 function sources_lr-quasi88() {
-    gitPullOrClone "$md_build" https://github.com/libretro/quasi88-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-quasi88() {

--- a/scriptmodules/libretrocores/lr-quicknes.sh
+++ b/scriptmodules/libretrocores/lr-quicknes.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-quicknes"
 rp_module_desc="NES emulator - QuickNES Port for libretro"
 rp_module_help="ROM Extensions: .nes .zip\n\nCopy your NES roms to $romdir/nes"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/QuickNES_Core/master/LICENSE"
+rp_module_repo="git https://github.com/libretro/QuickNES_Core.git master"
 rp_module_section="main"
 
 function sources_lr-quicknes() {
-    gitPullOrClone "$md_build" https://github.com/libretro/QuickNES_Core.git
+    gitPullOrClone
 }
 
 function build_lr-quicknes() {

--- a/scriptmodules/libretrocores/lr-scummvm.sh
+++ b/scriptmodules/libretrocores/lr-scummvm.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-scummvm"
 rp_module_desc="ScummVM port for libretro"
 rp_module_help="Copy your ScummVM games to $romdir/scummvm\n\nThe name of your game directories must be suffixed with '.svm' for direct launch in EmulationStation."
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/scummvm/master/COPYING"
+rp_module_repo="git https://github.com/libretro/scummvm.git master"
 rp_module_section="exp"
 
 function sources_lr-scummvm() {
-    gitPullOrClone "$md_build" https://github.com/libretro/scummvm.git
+    gitPullOrClone
 }
 
 function build_lr-scummvm() {

--- a/scriptmodules/libretrocores/lr-smsplus-gx.sh
+++ b/scriptmodules/libretrocores/lr-smsplus-gx.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-smsplus-gx"
 rp_module_desc="Sega Master System & Game Gear emu - SMSPlus (enhanced) port for libretro"
 rp_module_help="ROM Extensions: .gg .sms .bin .zip\nCopy your Game Gear roms to $romdir/gamegear\nMasterSystem roms to $romdir/mastersystem"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/smsplus-gx/master/docs/license"
+rp_module_repo="git https://github.com/libretro/smsplus-gx.git master"
 rp_module_section="exp"
 
 function sources_lr-smsplus-gx() {
-    gitPullOrClone "$md_build" https://github.com/libretro/smsplus-gx.git
+    gitPullOrClone
 }
 
 function build_lr-smsplus-gx() {

--- a/scriptmodules/libretrocores/lr-snes9x.sh
+++ b/scriptmodules/libretrocores/lr-snes9x.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-snes9x"
 rp_module_desc="Super Nintendo emu - Snes9x (current) port for libretro"
 rp_module_help="ROM Extensions: .bin .smc .sfc .fig .swc .mgd .zip\n\nCopy your SNES roms to $romdir/snes"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/snes9x/master/LICENSE"
+rp_module_repo="git https://github.com/libretro/snes9x.git master"
 rp_module_section="opt armv8=main x86=main"
 
 function sources_lr-snes9x() {
-    gitPullOrClone "$md_build" https://github.com/libretro/snes9x.git
+    gitPullOrClone
 }
 
 function build_lr-snes9x() {

--- a/scriptmodules/libretrocores/lr-snes9x2002.sh
+++ b/scriptmodules/libretrocores/lr-snes9x2002.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-snes9x2002"
 rp_module_desc="Super Nintendo emu - ARM optimised Snes9x 1.39 port for libretro"
 rp_module_help="Previously called lr-pocketsnes\n\nROM Extensions: .bin .smc .sfc .fig .swc .mgd .zip\n\nCopy your SNES roms to $romdir/snes"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/snes9x2002/master/src/copyright.h"
+rp_module_repo="git https://github.com/libretro/snes9x2002.git master"
 rp_module_section="opt armv6=main"
 rp_module_flags="!all arm"
 
@@ -22,7 +23,7 @@ function _update_hook_lr-snes9x2002() {
 }
 
 function sources_lr-snes9x2002() {
-    gitPullOrClone "$md_build" https://github.com/libretro/snes9x2002.git
+    gitPullOrClone
 }
 
 function build_lr-snes9x2002() {

--- a/scriptmodules/libretrocores/lr-snes9x2005.sh
+++ b/scriptmodules/libretrocores/lr-snes9x2005.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-snes9x2005"
 rp_module_desc="Super Nintendo emu - Snes9x 1.43 based port for libretro"
 rp_module_help="Previously called lr-catsfc\n\nROM Extensions: .bin .smc .sfc .fig .swc .mgd .zip\n\nCopy your SNES roms to $romdir/snes"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/snes9x2005/master/copyright"
+rp_module_repo="git https://github.com/libretro/snes9x2005.git master"
 rp_module_section="opt arm=main"
 
 function _update_hook_lr-snes9x2005() {
@@ -21,7 +22,7 @@ function _update_hook_lr-snes9x2005() {
 }
 
 function sources_lr-snes9x2005() {
-    gitPullOrClone "$md_build" https://github.com/libretro/snes9x2005.git
+    gitPullOrClone
 }
 
 function build_lr-snes9x2005() {

--- a/scriptmodules/libretrocores/lr-snes9x2010.sh
+++ b/scriptmodules/libretrocores/lr-snes9x2010.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-snes9x2010"
 rp_module_desc="Super Nintendo emu - Snes9x 1.52 based port for libretro"
 rp_module_help="Previously called lr-snes9x-next\n\nROM Extensions: .bin .smc .sfc .fig .swc .mgd .zip\n\nCopy your SNES roms to $romdir/snes"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/snes9x2010/master/docs/snes9x-license.txt"
+rp_module_repo="git https://github.com/libretro/snes9x2010.git master"
 rp_module_section="opt arm=main"
 
 function _update_hook_lr-snes9x2010() {
@@ -21,7 +22,7 @@ function _update_hook_lr-snes9x2010() {
 }
 
 function sources_lr-snes9x2010() {
-    gitPullOrClone "$md_build" https://github.com/libretro/snes9x2010.git
+    gitPullOrClone
 }
 
 function build_lr-snes9x2010() {

--- a/scriptmodules/libretrocores/lr-stella2014.sh
+++ b/scriptmodules/libretrocores/lr-stella2014.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-stella2014"
 rp_module_desc="Atari 2600 emulator - Stella port for libretro"
 rp_module_help="ROM Extensions: .a26 .bin .rom .zip .gz\n\nCopy your Atari 2600 roms to $romdir/atari2600"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/stella2014-libretro/master/stella/license.txt"
+rp_module_repo="git https://github.com/libretro/stella2014-libretro.git master"
 rp_module_section="main"
 
 function _update_hook_lr-stella2014() {
@@ -21,7 +22,7 @@ function _update_hook_lr-stella2014() {
 }
 
 function sources_lr-stella2014() {
-    gitPullOrClone "$md_build" https://github.com/libretro/stella2014-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-stella2014() {

--- a/scriptmodules/libretrocores/lr-superflappybirds.sh
+++ b/scriptmodules/libretrocores/lr-superflappybirds.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-superflappybirds"
 rp_module_desc="Super Flappy Birds - Multiplayer Flappy Bird Clone"
 rp_module_help="https://github.com/IgniparousTempest/libretro-superflappybirds/wiki"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/IgniparousTempest/libretro-superflappybirds/master/LICENSE"
+rp_module_repo="git https://github.com/IgniparousTempest/libretro-superflappybirds.git master"
 rp_module_section="exp"
 
 function depends_lr-superflappybirds() {
@@ -20,7 +21,7 @@ function depends_lr-superflappybirds() {
 }
 
 function sources_lr-superflappybirds() {
-    gitPullOrClone "$md_build" https://github.com/IgniparousTempest/libretro-superflappybirds.git
+    gitPullOrClone
 }
 
 function build_lr-superflappybirds() {

--- a/scriptmodules/libretrocores/lr-tgbdual.sh
+++ b/scriptmodules/libretrocores/lr-tgbdual.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-tgbdual"
 rp_module_desc="Gameboy Color emu - TGB Dual port for libretro"
 rp_module_help="ROM Extensions: .gb .gbc .zip\n\nCopy your GameBoy roms to $romdir/gb\n\nCopy your GameBoy Color roms to $romdir/gbc"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/tgbdual-libretro/master/docs/COPYING-2.0.txt"
+rp_module_repo="git https://github.com/libretro/tgbdual-libretro.git master"
 rp_module_section="opt"
 
 function sources_lr-tgbdual() {
-    gitPullOrClone "$md_build" https://github.com/libretro/tgbdual-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-tgbdual() {

--- a/scriptmodules/libretrocores/lr-theodore.sh
+++ b/scriptmodules/libretrocores/lr-theodore.sh
@@ -13,11 +13,12 @@ rp_module_id="lr-theodore"
 rp_module_desc="Thomson MO/TO system emulator"
 rp_module_help="ROM Extensions: *.fd, *.sap, *.k7, *.m5, *.m7, *.rom\n\nAdd your game files in $romdir/moto"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/theodore/master/LICENSE"
+rp_module_repo="git https://github.com/Zlika/theodore master"
 rp_module_section="exp"
 rp_module_flags=""
 
 function sources_lr-theodore() {
-    gitPullOrClone "$md_build" https://github.com/Zlika/theodore
+    gitPullOrClone
 }
 
 function build_lr-theodore() {

--- a/scriptmodules/libretrocores/lr-tyrquake.sh
+++ b/scriptmodules/libretrocores/lr-tyrquake.sh
@@ -12,10 +12,11 @@
 rp_module_id="lr-tyrquake"
 rp_module_desc="Quake 1 engine - Tyrquake port for libretro"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/tyrquake/master/gnu.txt"
+rp_module_repo="git https://github.com/libretro/tyrquake.git master"
 rp_module_section="opt"
 
 function sources_lr-tyrquake() {
-    gitPullOrClone "$md_build" https://github.com/libretro/tyrquake.git
+    gitPullOrClone
 }
 
 function build_lr-tyrquake() {

--- a/scriptmodules/libretrocores/lr-vba-next.sh
+++ b/scriptmodules/libretrocores/lr-vba-next.sh
@@ -13,11 +13,12 @@ rp_module_id="lr-vba-next"
 rp_module_desc="GBA emulator - VBA-M (optimised) port for libretro"
 rp_module_help="ROM Extensions: .gba .zip\n\nCopy your Game Boy Advance roms to $romdir/gba\n\nCopy the required BIOS file gba_bios.bin to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/vba-next/master/LICENSE"
+rp_module_repo="git https://github.com/libretro/vba-next.git master"
 rp_module_section="main"
 rp_module_flags="!armv6"
 
 function sources_lr-vba-next() {
-    gitPullOrClone "$md_build" https://github.com/libretro/vba-next.git
+    gitPullOrClone
 }
 
 function build_lr-vba-next() {

--- a/scriptmodules/libretrocores/lr-vecx.sh
+++ b/scriptmodules/libretrocores/lr-vecx.sh
@@ -13,6 +13,7 @@ rp_module_id="lr-vecx"
 rp_module_desc="Vectrex emulator - vecx port for libretro"
 rp_module_help="ROM Extensions: .vec .gam .bin .zip\n\nCopy your Vectrex roms to $romdir/vectrex"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/libretro-vecx/master/LICENSE.md"
+rp_module_repo="git https://github.com/libretro/libretro-vecx.git master"
 rp_module_section="main"
 
 function depends_lr-vecx() {
@@ -23,7 +24,7 @@ function depends_lr-vecx() {
 }
 
 function sources_lr-vecx() {
-    gitPullOrClone "$md_build" https://github.com/libretro/libretro-vecx.git
+    gitPullOrClone
 }
 
 function build_lr-vecx() {

--- a/scriptmodules/libretrocores/lr-vice.sh
+++ b/scriptmodules/libretrocores/lr-vice.sh
@@ -13,11 +13,12 @@ rp_module_id="lr-vice"
 rp_module_desc="C64 emulator - port of VICE for libretro"
 rp_module_help="ROM Extensions: .cmd .crt .d64 .d71 .d80 .d81 .g64 .m3u .prg .t64 .tap .x64 .zip .vsf\n\nCopy your Commodore 64 games to $romdir/c64"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/vice-libretro/master/vice/COPYING"
+rp_module_repo="git https://github.com/libretro/vice-libretro.git master"
 rp_module_section="opt"
 rp_module_flags=""
 
 function sources_lr-vice() {
-    gitPullOrClone "$md_build" https://github.com/libretro/vice-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-vice() {

--- a/scriptmodules/libretrocores/lr-virtualjaguar.sh
+++ b/scriptmodules/libretrocores/lr-virtualjaguar.sh
@@ -13,11 +13,12 @@ rp_module_id="lr-virtualjaguar"
 rp_module_desc="Atari Jaguar emu - Virtual Jaguar (optimised) port for libretro"
 rp_module_help="ROM Extensions: .j64 .jag .zip\n\nCopy your Atari Jaguar roms to $romdir/atarijaguar"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/virtualjaguar-libretro/master/docs/GPLv3"
+rp_module_repo="git https://github.com/libretro/virtualjaguar-libretro.git master"
 rp_module_section="exp"
 rp_module_flags="!armv6"
 
 function sources_lr-virtualjaguar() {
-    gitPullOrClone "$md_build" https://github.com/libretro/virtualjaguar-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-virtualjaguar() {

--- a/scriptmodules/libretrocores/lr-x1.sh
+++ b/scriptmodules/libretrocores/lr-x1.sh
@@ -12,10 +12,11 @@
 rp_module_id="lr-x1"
 rp_module_desc="Sharp X1 emulator - X Millenium port for libretro"
 rp_module_help="ROM Extensions: .dx1 .zip .2d .2hd .tfd .d88 .88d .hdm .xdf .dup .cmd\n\nCopy your X1 roms to $romdir/x1\n\nCopy the required BIOS files IPLROM.X1 and IPLROM.X1T to $biosdir"
+rp_module_repo="git https://github.com/r-type/xmil-libretro.git master"
 rp_module_section="exp"
 
 function sources_lr-x1() {
-    gitPullOrClone "$md_build" https://github.com/r-type/xmil-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-x1() {

--- a/scriptmodules/libretrocores/lr-xrick.sh
+++ b/scriptmodules/libretrocores/lr-xrick.sh
@@ -13,10 +13,11 @@ rp_module_id="lr-xrick"
 rp_module_desc="Open source implementation of Rich Dangerous - xrick ported for libretro"
 rp_module_help="Install the xrick data.zip to $romdir/ports/xrick/data.zip"
 rp_module_licence="GPL https://raw.githubusercontent.com/libretro/xrick-libretro/master/README"
+rp_module_repo="git https://github.com/libretro/xrick-libretro.git master"
 rp_module_section="opt"
 
 function sources_lr-xrick() {
-    gitPullOrClone "$md_build" https://github.com/libretro/xrick-libretro.git
+    gitPullOrClone
 }
 
 function build_lr-xrick() {

--- a/scriptmodules/libretrocores/lr-yabause.sh
+++ b/scriptmodules/libretrocores/lr-yabause.sh
@@ -13,11 +13,12 @@ rp_module_id="lr-yabause"
 rp_module_desc="Sega Saturn emu - Yabause (optimised) port for libretro"
 rp_module_help="ROM Extensions: .iso .bin .zip\n\nCopy your Sega Saturn roms to $romdir/saturn\n\nCopy the required BIOS file saturn_bios.bin to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/yabause/master/yabause/COPYING"
+rp_module_repo="git https://github.com/libretro/yabause.git master"
 rp_module_section="exp"
 rp_module_flags="!armv6"
 
 function sources_lr-yabause() {
-    gitPullOrClone "$md_build" https://github.com/libretro/yabause.git
+    gitPullOrClone
 }
 
 function build_lr-yabause() {

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -484,9 +484,11 @@ function rp_dateIsNewer() {
     local date_a="$1"
     local date_b="$2"
     [[ -z "$date_a" || -z "$date_b" ]] && return 0
-    date_a="$(date -d "$date_a" +%s)"
-    date_b="$(date -d "$date_b" +%s)"
-    [[ "$date_b" -gt "$date_a" ]] && return 0
+    if date_a="$(date -d "$date_a" +%s 2>/dev/null)" && date_b="$(date -d "$date_b" +%s 2>/dev/null)"; then
+        [[ "$date_b" -gt "$date_a" ]] && return 0
+    else
+        return 0
+    fi
     return 1
 }
 

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -513,6 +513,12 @@ function rp_hasNewerModule() {
                     return 0
                     ;;
             esac
+
+            # check the date of the module code - if it's newer than the install date of the module we force an update
+            local module_date="$(date -Iseconds -r "${__mod_info[$id/path]}")"
+            if rp_dateIsNewer "$pkg_date" "$module_date"; then
+                return 0
+            fi
             ;;
         *)
             # for unknown or in the case of a blank pkg_origin assume there is an update

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -156,12 +156,19 @@ function rp_callModule() {
 
             # if we are in _update_ mode we only update if there is a newer version of the binary or source
             if [[ "$mode" == "_update_" ]]; then
+                printMsgs "heading" "Checking for updates for $md_id"
                 rp_hasNewerModule "$md_id" "$pkg_origin"
                 [[ "$?" -eq 0 || "$?" == 2 ]] && do_update=1
                 # if rp_hasNewerModule returns 3, then there was an error and we should abort
                 [[ "$?" -eq 3 ]] && return 1
             else
                 do_update=1
+            fi
+
+            if [[ "$do_update" -eq 1 ]]; then
+                printMsgs "console" "Update is available - updating ..."
+            else
+                printMsgs "console" "No update was found."
             fi
 
             if [[ "$do_update" -eq 1 ]]; then

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -64,6 +64,32 @@ function rp_printUsageinfo() {
     rp_listFunctions
 }
 
+function rp_moduleVars() {
+    local id="$1"
+
+    # create variables that can be used in modules
+    local code
+    read -d "" -r code <<_EOF_
+        local md_desc="${__mod_info[$id/desc]}"
+        local md_help="${__mod_info[$id/help]}"
+        local md_type="${__mod_info[$id/type]}"
+        local md_flags="${__mod_info[$id/flags]}"
+        local md_path="${__mod_info[$id/path]}"
+
+        local md_repo_type="${__mod_info[$id/repo_type]}"
+        local md_repo_url="${__mod_info[$id/repo_url]}"
+        local md_repo_branch="${__mod_info[$id/repo_branch]}"
+        local md_repo_commit="${__mod_info[$id/repo_commit]}"
+
+        local md_build="$__builddir/$id"
+        local md_inst="$(rp_getInstallPath $id)"
+        # get module path folder + md_id for $md_data
+        local md_data="${__mod_info[$id/path]%/*}/$id"
+_EOF_
+
+    echo "$code"
+}
+
 function rp_callModule() {
     local md_id="$1"
     local mode="$2"
@@ -148,22 +174,9 @@ function rp_callModule() {
             ;;
     esac
 
-    # create variables that can be used in modules
-    local md_desc="${__mod_info[$md_id/desc]}"
-    local md_help="${__mod_info[$md_id/help]}"
-    local md_type="${__mod_info[$md_id/type]}"
-    local md_flags="${__mod_info[$md_id/flags]}"
-    local md_path="${__mod_info[$md_id/path]}"
+    # load our md_* variables
+    eval "$(rp_moduleVars $md_id)"
 
-    local md_repo_type="${__mod_info[$md_id/repo_type]}"
-    local md_repo_url="${__mod_info[$md_id/repo_url]}"
-    local md_repo_branch="${__mod_info[$md_id/repo_branch]}"
-    local md_repo_commit="${__mod_info[$md_id/repo_commit]}"
-
-    local md_build="$__builddir/$md_id"
-    local md_inst="$(rp_getInstallPath $md_id)"
-    # get module path folder + md_id for $md_data
-    local md_data="${md_path%/*}/$md_id"
     local md_mode="install"
 
     # set md_conf_root to $configdir and to $configdir/ports for ports

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -136,6 +136,9 @@ function rp_callModule() {
             local ip="$(getIPAddress)"
             [[ -n "$ip" ]] && has_net=1
 
+            # for modules with nonet flag that don't need to download data, we force has_net to 1
+            hasFlag "${__mod_info[$id/flags]}" "nonet" && has_net=1
+
             if [[ "$has_net" -eq 1 ]]; then
                 rp_hasBinary "$md_id"
                 local ret="$?"

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -527,10 +527,19 @@ function rp_hasNewerModule() {
                     local repo_branch="$(rp_resolveRepoParam "${__mod_info[$id/repo_branch]}")"
                     local repo_commit="$(rp_resolveRepoParam "${__mod_info[$id/repo_commit]}")"
                     [[ -z "$pkg_repo_commit" ]] && return 0
-                    # if we are locked to a single commit, then we compare against current module commit only
-                    if [[ "$pkg_repo_commit" == "$repo_commit" ]]; then
-                        return 1
+                    # if we are locked to a single commit, then we compare against the current module commit only
+                    if [[ -n "$repo_commit" ]]; then
+                        # if we are using git and the module has an 8 character commit hash, then adjust
+                        # the package commit to 8 characters also for the comparison
+                        if [[ "$repo_type" == "git" && "${#repo_commit}" -eq 8 ]]; then
+                            pkg_repo_commit="${pkg_repo_commit::8}"
+                        fi
+
+                        if [[ "$pkg_repo_commit" == "$repo_commit" ]]; then
+                            return 1
+                        fi
                     fi
+
                     local remote_commit="$(rp_getRemoteRepoHash "$repo_type" "$repo_url" "$repo_branch" "$repo_commit")"
                     if [[ "$pkg_repo_commit" != "$remote_commit" ]]; then
                         return 0

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -460,6 +460,19 @@ function rp_dateIsNewer() {
     return 1
 }
 
+# resolve repository parameters - any parameters with a : will get the data from the following function name
+function rp_resolveRepoParam() {
+    local param="$1"
+    if [[ "$param" == :* ]]; then
+        param="${param:1}"
+        if fnExists "$param"; then
+            echo "$($param)"
+            return
+        fi
+    fi
+    echo "$param"
+}
+
 function rp_hasNewerModule() {
     local id="$1"
     local type="$2"
@@ -481,7 +494,7 @@ function rp_hasNewerModule() {
             ;;
         source)
             local repo_type="${__mod_info[$id/repo_type]}"
-            local repo_url="${__mod_info[$id/repo_url]}"
+            local repo_url="$(rp_resolveRepoParam "${__mod_info[$id/repo_url]}")"
             case "$repo_type" in
                 file)
                     [[ -z "$pkg_repo_date" ]] && return 2
@@ -491,8 +504,8 @@ function rp_hasNewerModule() {
                     fi
                     ;;
                 git|svn)
-                    local repo_branch="${__mod_info[$id/repo_branch]}"
-                    local repo_commit="${__mod_info[$id/repo_commit]}"
+                    local repo_branch="$(rp_resolveRepoParam "${__mod_info[$id/repo_branch]}")"
+                    local repo_commit="$(rp_resolveRepoParam "${__mod_info[$id/repo_commit]}")"
                     [[ -z "$pkg_repo_commit" ]] && return 0
                     # if we are locked to a single commit, then we compare against current module commit only
                     if [[ "$pkg_repo_commit" == "$repo_commit" ]]; then
@@ -623,8 +636,8 @@ function rp_setPackageInfo() {
     else
         pkg_date="$(date -Iseconds)"
         pkg_repo_type="${__mod_info[$id/repo_type]}"
-        pkg_repo_url="${__mod_info[$id/repo_url]}"
-        pkg_repo_branch="${__mod_info[$id/repo_branch]}"
+        pkg_repo_url="$(rp_resolveRepoParam "${__mod_info[$id/repo_url]}")"
+        pkg_repo_branch="$(rp_resolveRepoParam "${__mod_info[$id/repo_branch]}")"
         case "$pkg_repo_type" in
             git|svn)
                 if [[ "$pkg_repo_type" == "git" ]]; then

--- a/scriptmodules/ports/alephone.sh
+++ b/scriptmodules/ports/alephone.sh
@@ -13,8 +13,17 @@ rp_module_id="alephone"
 rp_module_desc="AlephOne - Marathon Engine"
 rp_module_help="To get the games running on the Raspberry Pi/Odroid, make sure to set each game to use the software renderer and disable the enhanced HUD from the Plugins menu. For Marathon 1, disable both HUDs from the Plugins menu, start a game, quit back to the title screen and enable Enhanced HUD and it will work and properly."
 rp_module_licence="GPL3 https://raw.githubusercontent.com/Aleph-One-Marathon/alephone/master/COPYING"
+rp_module_repo="git https://github.com/Aleph-One-Marathon/alephone.git :_get_branch_alephone"
 rp_module_section="opt"
 rp_module_flags="!mali"
+
+function _get_branch_alephone() {
+    local branch="release-20150620"
+    if compareVersions "$__os_debian_ver" ge 9 || [[ -n "$__os_ubuntu_ver" ]]; then
+        branch="master"
+    fi
+    echo "$branch"
+}
 
 function depends_alephone() {
     local depends=(libboost-all-dev libspeexdsp-dev libzzip-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev autoconf automake libboost-system-dev libcurl4-openssl-dev)
@@ -27,11 +36,7 @@ function depends_alephone() {
 }
 
 function sources_alephone() {
-    local branch="release-20150620"
-    if compareVersions "$__os_debian_ver" ge 9 || [[ -n "$__os_ubuntu_ver" ]]; then
-        branch="master"
-    fi
-    gitPullOrClone "$md_build" "https://github.com/Aleph-One-Marathon/alephone.git" "$branch"
+    gitPullOrClone
 }
 
 function build_alephone() {

--- a/scriptmodules/ports/bombermaaan.sh
+++ b/scriptmodules/ports/bombermaaan.sh
@@ -12,6 +12,7 @@
 rp_module_id="bombermaaan"
 rp_module_desc="Bombermaaan - Classic bomberman game"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/bjaraujo/Bombermaaan/master/LICENSE.txt"
+rp_module_repo="git https://github.com/bjaraujo/Bombermaaan.git v1.9.7.2126"
 rp_module_section="exp"
 rp_module_flags="dispmanx !mali"
 
@@ -20,7 +21,7 @@ function depends_bombermaaan() {
 }
 
 function sources_bombermaaan() {
-    gitPullOrClone "$md_build" https://github.com/bjaraujo/Bombermaaan.git v1.9.7.2126
+    gitPullOrClone
 }
 
 function build_bombermaaan() {

--- a/scriptmodules/ports/cannonball.sh
+++ b/scriptmodules/ports/cannonball.sh
@@ -13,6 +13,7 @@ rp_module_id="cannonball"
 rp_module_desc="Cannonball - An Enhanced OutRun Engine"
 rp_module_help="You need to unzip your OutRun set B from latest MAME (outrun.zip) to $romdir/ports/cannonball. They should match the file names listed in the roms.txt file found in the roms folder. You will also need to rename the epr-10381a.132 file to epr-10381b.132 before it will work."
 rp_module_licence="NONCOM https://raw.githubusercontent.com/djyt/cannonball/master/docs/license.txt"
+rp_module_repo="git https://github.com/djyt/cannonball.git master 2b3839dd34c1b4263ec5006fdeeb1ae2689cd401"
 rp_module_section="opt"
 
 function depends_cannonball() {
@@ -23,7 +24,7 @@ function depends_cannonball() {
 }
 
 function sources_cannonball() {
-    gitPullOrClone "$md_build" https://github.com/djyt/cannonball.git "master" "2b3839dd34c1b4263ec5006fdeeb1ae2689cd401"
+    gitPullOrClone
     sed -i "s/-march=armv6 -mfpu=vfp -mfloat-abi=hard//" "$md_build/cmake/sdl2_rpi.cmake" "$md_build/cmake/sdl2gles_rpi.cmake"
 }
 

--- a/scriptmodules/ports/cdogs-sdl.sh
+++ b/scriptmodules/ports/cdogs-sdl.sh
@@ -12,6 +12,7 @@
 rp_module_id="cdogs-sdl"
 rp_module_desc="C-Dogs SDL - Classic overhead run-and-gun game"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/cxong/cdogs-sdl/master/COPYING"
+rp_module_repo="git https://github.com/cxong/cdogs-sdl.git 0.7.2"
 rp_module_section="exp"
 rp_module_flags="dispmanx !mali"
 
@@ -20,7 +21,7 @@ function depends_cdogs-sdl() {
 }
 
 function sources_cdogs-sdl() {
-    gitPullOrClone "$md_build" https://github.com/cxong/cdogs-sdl.git 0.7.2
+    gitPullOrClone
 }
 
 function build_cdogs-sdl() {

--- a/scriptmodules/ports/cgenius.sh
+++ b/scriptmodules/ports/cgenius.sh
@@ -12,6 +12,7 @@
 rp_module_id="cgenius"
 rp_module_desc="Commander Genius - Modern Interpreter for the Commander Keen Games (Vorticon and Galaxy Games)"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/gerstrong/Commander-Genius/master/COPYRIGHT"
+rp_module_repo="git https://gitlab.com/Dringgstein/Commander-Genius.git v2.4.4.1"
 rp_module_section="exp"
 
 function depends_cgenius() {
@@ -19,7 +20,7 @@ function depends_cgenius() {
 }
 
 function sources_cgenius() {
-    gitPullOrClone "$md_build" https://gitlab.com/Dringgstein/Commander-Genius.git v2.4.4.1
+    gitPullOrClone
 
     # use -O2 on older GCC due to segmentation fault when compiling with -O3
     if compareVersions $__gcc_version lt 6; then

--- a/scriptmodules/ports/darkplaces-quake.sh
+++ b/scriptmodules/ports/darkplaces-quake.sh
@@ -12,6 +12,7 @@
 rp_module_id="darkplaces-quake"
 rp_module_desc="Quake 1 engine - Darkplaces Quake port with GLES rendering"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/xonotic/darkplaces/master/COPYING"
+rp_module_repo="git https://github.com/xonotic/darkplaces.git div0-stable"
 rp_module_section="opt"
 rp_module_flags="!mali"
 
@@ -23,7 +24,7 @@ function depends_darkplaces-quake() {
 }
 
 function sources_darkplaces-quake() {
-    gitPullOrClone "$md_build" https://github.com/xonotic/darkplaces.git div0-stable
+    gitPullOrClone
     isPlatform "rpi" && applyPatch "$md_data/01_rpi_fixes.diff"
     applyPatch "$md_data/02_makefile_fixes.diff"
     # comment out problematic invariant qualifier which fails to compile with mesa gles on rpi4

--- a/scriptmodules/ports/digger.sh
+++ b/scriptmodules/ports/digger.sh
@@ -12,6 +12,7 @@
 rp_module_id="digger"
 rp_module_desc="Digger Remastered"
 rp_module_licence="GPL https://raw.githubusercontent.com/sobomax/digger/master/README.md"
+rp_module_repo="git https://github.com/proyvind/digger.git joystick"
 rp_module_section="exp"
 
 function depends_digger() {
@@ -19,7 +20,7 @@ function depends_digger() {
 }
 
 function sources_digger() {
-    gitPullOrClone "$md_build" https://github.com/proyvind/digger.git joystick
+    gitPullOrClone
 }
 
 function build_digger() {

--- a/scriptmodules/ports/dxx-rebirth.sh
+++ b/scriptmodules/ports/dxx-rebirth.sh
@@ -12,8 +12,16 @@
 rp_module_id="dxx-rebirth"
 rp_module_desc="DXX-Rebirth (Descent & Descent 2) source port"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/dxx-rebirth/dxx-rebirth/master/COPYING.txt"
+rp_module_repo="git https://github.com/dxx-rebirth/dxx-rebirth master :_get_commit_dxx-rebirth"
 rp_module_section="opt"
 rp_module_flags="!mali"
+
+function _get_commit_dxx-rebirth() {
+    local commit="moooo"
+    # latest code requires gcc 7+
+    compareVersions "$__gcc_version" lt 7 && commit="a1b3a86c"
+    echo "$commit"
+}
 
 function depends_dxx-rebirth() {
     local depends=(libpng-dev libphysfs-dev scons)
@@ -27,10 +35,7 @@ function depends_dxx-rebirth() {
 }
 
 function sources_dxx-rebirth() {
-    local commit=""
-    # latest code requires gcc 7+
-    compareVersions "$__gcc_version" lt 7 && commit="a1b3a86c"
-    gitPullOrClone "$md_build" https://github.com/dxx-rebirth/dxx-rebirth "master" "$commit"
+    gitPullOrClone
 }
 
 function build_dxx-rebirth() {

--- a/scriptmodules/ports/eduke32.sh
+++ b/scriptmodules/ports/eduke32.sh
@@ -12,6 +12,7 @@
 rp_module_id="eduke32"
 rp_module_desc="Duke3D source port"
 rp_module_licence="GPL2 https://voidpoint.io/terminx/eduke32/-/raw/master/package/common/gpl-2.0.txt?inline=false"
+rp_module_repo="git https://voidpoint.io/terminx/eduke32.git master dfc16b08"
 rp_module_section="opt"
 
 function depends_eduke32() {
@@ -27,10 +28,7 @@ function depends_eduke32() {
 }
 
 function sources_eduke32() {
-    # was svn rev -r8090
-    local revision="dfc16b08"
-
-    gitPullOrClone "$md_build" https://voidpoint.io/terminx/eduke32.git "" "$revision"
+    gitPullOrClone
 
     # r6918 causes a 20+ second delay on startup on ARM devices
     isPlatform "arm" && applyPatch "$md_data/0001-revert-r6918.patch"

--- a/scriptmodules/ports/gemrb.sh
+++ b/scriptmodules/ports/gemrb.sh
@@ -12,6 +12,7 @@
 rp_module_id="gemrb"
 rp_module_desc="gemrb - open-source implementation of Infinity Engine"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/gemrb/gemrb/master/COPYING"
+rp_module_repo="git https://github.com/gemrb/gemrb.git v0.8.6"
 rp_module_section="exp"
 rp_module_flags="!mali dispmanx"
 
@@ -20,7 +21,7 @@ function depends_gemrb() {
 }
 
 function sources_gemrb() {
-    gitPullOrClone "$md_build" https://github.com/gemrb/gemrb.git v0.8.6
+    gitPullOrClone
 }
 
 function build_gemrb() {

--- a/scriptmodules/ports/ionfury.sh
+++ b/scriptmodules/ports/ionfury.sh
@@ -12,6 +12,7 @@
 rp_module_id="ionfury"
 rp_module_desc="Ion Fury - commercial FPS game based on eduke32 source port"
 rp_module_licence="GPL2 http://svn.eduke32.com/eduke32/package/common/gpl-2.0.txt"
+rp_module_repo="git https://voidpoint.io/terminx/eduke32.git master dfc16b08"
 rp_module_section="exp"
 
 function depends_ionfury() {

--- a/scriptmodules/ports/ioquake3.sh
+++ b/scriptmodules/ports/ioquake3.sh
@@ -12,6 +12,7 @@
 rp_module_id="ioquake3"
 rp_module_desc="Quake 3 source port"
 rp_module_licence="GPL2 https://github.com/ioquake/ioq3/blob/master/COPYING.txt"
+rp_module_repo="git https://github.com/ioquake/ioq3 main"
 rp_module_section="opt"
 rp_module_flags="!videocore"
 
@@ -20,7 +21,7 @@ function depends_ioquake3() {
 }
 
 function sources_ioquake3() {
-    gitPullOrClone "$md_build" https://github.com/ioquake/ioq3
+    gitPullOrClone
 }
 
 function build_ioquake3() {

--- a/scriptmodules/ports/jumpnbump.sh
+++ b/scriptmodules/ports/jumpnbump.sh
@@ -13,6 +13,7 @@ rp_module_id="jumpnbump"
 rp_module_desc="Jump 'n Bump, play cute bunnies jumping on each other's heads - Modernization fork"
 rp_module_help="Copy custom game levels (.dat) to $romdir/ports/jumpnbump"
 rp_module_licence="GPL2 https://gitlab.com/LibreGames/jumpnbump/raw/master/COPYING"
+rp_module_repo="git https://gitlab.com/LibreGames/jumpnbump.git master"
 rp_module_section="exp"
 rp_module_flags=""
 
@@ -21,7 +22,7 @@ function depends_jumpnbump() {
 }
 
 function sources_jumpnbump() {
-    gitPullOrClone "$md_build" https://gitlab.com/LibreGames/jumpnbump.git
+    gitPullOrClone
 }
 
 function build_jumpnbump() {

--- a/scriptmodules/ports/love-0.10.2.sh
+++ b/scriptmodules/ports/love-0.10.2.sh
@@ -13,6 +13,7 @@ rp_module_id="love-0.10.2"
 rp_module_desc="Love - 2d Game Engine v0.10.2"
 rp_module_help="Copy your Love games to $romdir/love"
 rp_module_licence="ZLIB https://raw.githubusercontent.com/love2d/love/0.10.2/license.txt"
+rp_module_repo="git https://github.com/love2d/love 0.10.2"
 rp_module_section="opt"
 rp_module_flags="!aarch64"
 
@@ -21,7 +22,7 @@ function depends_love-0.10.2() {
 }
 
 function sources_love-0.10.2() {
-    gitPullOrClone "$md_build" https://github.com/love2d/love 0.10.2
+    gitPullOrClone
     # libluajit-5.1-dev in buster (and also on Ubuntu 18.04+) still has
     # LUA_VERSION_NUM defined as 501 but requires the newer luaL_Reg named struct.
     # adjusting the compatibility code #if to check for LUA_VERSION_NUM >= 501 fixes this.

--- a/scriptmodules/ports/love.sh
+++ b/scriptmodules/ports/love.sh
@@ -13,6 +13,7 @@ rp_module_id="love"
 rp_module_desc="Love - 2d Game Engine"
 rp_module_help="Copy your Love games to $romdir/love"
 rp_module_licence="ZLIB https://raw.githubusercontent.com/love2d/love/master/license.txt"
+rp_module_repo="git https://github.com/love2d/love master"
 rp_module_section="opt"
 rp_module_flags="!aarch64"
 
@@ -23,7 +24,7 @@ function depends_love() {
 }
 
 function sources_love() {
-    gitPullOrClone "$md_build" https://github.com/love2d/love
+    gitPullOrClone
 }
 
 function build_love() {

--- a/scriptmodules/ports/lzdoom.sh
+++ b/scriptmodules/ports/lzdoom.sh
@@ -12,6 +12,7 @@
 rp_module_id="lzdoom"
 rp_module_desc="lzdoom - DOOM source port (legacy version of GZDoom)"
 rp_module_licence="GPL3 https://github.com/drfrag666/gzdoom/blob/g3.3mgw/docs/licenses/README.TXT"
+rp_module_repo="git https://github.com/drfrag666/gzdoom 3.86a"
 rp_module_section="opt"
 rp_module_flags=""
 
@@ -25,7 +26,7 @@ function depends_lzdoom() {
 }
 
 function sources_lzdoom() {
-    gitPullOrClone "$md_build" https://github.com/drfrag666/gzdoom "3.86a"
+    gitPullOrClone
 }
 
 function build_lzdoom() {

--- a/scriptmodules/ports/mysticmine.sh
+++ b/scriptmodules/ports/mysticmine.sh
@@ -12,6 +12,7 @@
 rp_module_id="mysticmine"
 rp_module_desc="Mystic Mine - Rail game for up to six players on one keyboard"
 rp_module_licence="MIT https://raw.githubusercontent.com/dewitters/MysticMine/master/LICENSE.txt"
+rp_module_repo="git https://github.com/dewitters/MysticMine.git master"
 rp_module_section="exp"
 
 function depends_mysticmine() {
@@ -19,7 +20,7 @@ function depends_mysticmine() {
 }
 
 function sources_mysticmine() {
-    gitPullOrClone "$md_build" https://github.com/dewitters/MysticMine.git master
+    gitPullOrClone
 }
 
 function build_mysticmine() {

--- a/scriptmodules/ports/openblok.sh
+++ b/scriptmodules/ports/openblok.sh
@@ -12,6 +12,7 @@
 rp_module_id="openblok"
 rp_module_desc="OpenBlok: A Block Dropping Game"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/mmatyas/openblok/master/LICENSE.md"
+rp_module_repo="git https://github.com/mmatyas/openblok.git master"
 rp_module_section="exp"
 rp_module_flags=""
 
@@ -20,7 +21,7 @@ function depends_openblok() {
 }
 
 function sources_openblok() {
-    gitPullOrClone "$md_build" https://github.com/mmatyas/openblok.git
+    gitPullOrClone
 }
 
 function build_openblok() {

--- a/scriptmodules/ports/openbor.sh
+++ b/scriptmodules/ports/openbor.sh
@@ -13,6 +13,7 @@ rp_module_id="openbor"
 rp_module_desc="OpenBOR - Beat 'em Up Game Engine"
 rp_module_help="OpenBOR games need to be extracted to function properly. Place your pak files in $romdir/ports/openbor and then run $rootdir/ports/openbor/extract.sh. When the script is done, your original pak files will be found in $romdir/ports/openbor/originals and can be deleted."
 rp_module_licence="BSD https://raw.githubusercontent.com/rofl0r/openbor/master/LICENSE"
+rp_module_repo="git https://github.com/rofl0r/openbor.git master"
 rp_module_section="exp"
 rp_module_flags="dispmanx !mali !x11"
 
@@ -21,7 +22,7 @@ function depends_openbor() {
 }
 
 function sources_openbor() {
-    gitPullOrClone "$md_build" https://github.com/rofl0r/openbor.git
+    gitPullOrClone
 }
 
 function build_openbor() {

--- a/scriptmodules/ports/opentyrian.sh
+++ b/scriptmodules/ports/opentyrian.sh
@@ -12,6 +12,7 @@
 rp_module_id="opentyrian"
 rp_module_desc="Open Tyrian - port of the DOS shoot-em-up Tyrian"
 rp_module_licence="GPL2 https://bitbucket.org/opentyrian/opentyrian/raw/3e3d6b925342a5891d8b937989dc50b563ff83dd/COPYING"
+rp_module_repo="git https://github.com/opentyrian/opentyrian.git master"
 rp_module_section="opt"
 rp_module_flags=""
 
@@ -20,7 +21,7 @@ function depends_opentyrian() {
 }
 
 function sources_opentyrian() {
-    gitPullOrClone "$md_build" https://github.com/opentyrian/opentyrian.git
+    gitPullOrClone
     # patch to default to fullscreen
     applyPatch "$md_data/01_fullscreen.diff"
 }

--- a/scriptmodules/ports/quake3.sh
+++ b/scriptmodules/ports/quake3.sh
@@ -12,6 +12,7 @@
 rp_module_id="quake3"
 rp_module_desc="Quake 3"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/raspberrypi/quake3/master/COPYING.txt"
+rp_module_repo="git https://github.com/raspberrypi/quake3.git master"
 rp_module_section="opt"
 rp_module_flags="!all videocore"
 
@@ -20,7 +21,7 @@ function depends_quake3() {
 }
 
 function sources_quake3() {
-    gitPullOrClone "$md_build" https://github.com/raspberrypi/quake3.git
+    gitPullOrClone
 }
 
 function build_quake3() {

--- a/scriptmodules/ports/sdlpop.sh
+++ b/scriptmodules/ports/sdlpop.sh
@@ -12,6 +12,7 @@
 rp_module_id="sdlpop"
 rp_module_desc="SDLPoP - Port of Prince of Persia"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/NagyD/SDLPoP/master/doc/gpl-3.0.txt"
+rp_module_repo="git https://github.com/NagyD/SDLPoP.git master"
 rp_module_section="opt"
 
 function depends_sdlpop() {
@@ -19,7 +20,7 @@ function depends_sdlpop() {
 }
 
 function sources_sdlpop() {
-    gitPullOrClone "$md_build" https://github.com/NagyD/SDLPoP.git
+    gitPullOrClone
 }
 
 function build_sdlpop() {

--- a/scriptmodules/ports/smw.sh
+++ b/scriptmodules/ports/smw.sh
@@ -12,6 +12,7 @@
 rp_module_id="smw"
 rp_module_desc="Super Mario War"
 rp_module_licence="GPL http://supermariowar.supersanctuary.net/"
+rp_module_repo="git https://github.com/HerbFargus/Super-Mario-War.git master"
 rp_module_section="opt"
 rp_module_flags="!mali"
 
@@ -20,7 +21,7 @@ function depends_smw() {
 }
 
 function sources_smw() {
-    gitPullOrClone "$md_build" https://github.com/HerbFargus/Super-Mario-War.git
+    gitPullOrClone
 }
 
 function build_smw() {

--- a/scriptmodules/ports/solarus.sh
+++ b/scriptmodules/ports/solarus.sh
@@ -13,6 +13,7 @@ rp_module_id="solarus"
 rp_module_desc="Solarus - A lightweight, free and open-source game engine for Action-RPGs"
 rp_module_help="Copy your Solarus quests (games) to $romdir/solarus"
 rp_module_licence="GPL3 https://gitlab.com/solarus-games/solarus/raw/dev/license.txt"
+rp_module_repo="git https://gitlab.com/solarus-games/solarus.git master"
 rp_module_section="opt"
 rp_module_flags="!aarch64"
 
@@ -34,7 +35,7 @@ function depends_solarus() {
 }
 
 function sources_solarus() {
-    gitPullOrClone "$md_build" https://gitlab.com/solarus-games/solarus.git
+    gitPullOrClone
 }
 
 function build_solarus() {

--- a/scriptmodules/ports/splitwolf.sh
+++ b/scriptmodules/ports/splitwolf.sh
@@ -13,6 +13,7 @@ rp_module_id="splitwolf"
 rp_module_desc="SplitWolf - 2-4 player split-screen Wolfenstein 3D / Spear of Destiny"
 rp_module_help="Game File Extension: .wl6, .sod, .sd2, .sd3\n\nCopy your game files to $romdir/ports/wolf3d/\n\nIf you add new game files, run: sudo ~/RetroPie-Setup/retropie_packages.sh splitwolf configure"
 rp_module_licence="NONCOM https://bitbucket.org/linuxwolf6/splitwolf/raw/scrubbed/license-mame.txt"
+rp_module_repo="git https://bitbucket.org/linuxwolf6/splitwolf.git scrubbed"
 rp_module_section="exp"
 
 function depends_splitwolf() {
@@ -20,7 +21,7 @@ function depends_splitwolf() {
 }
 
 function sources_splitwolf() {
-    gitPullOrClone "$md_build" https://bitbucket.org/linuxwolf6/splitwolf.git scrubbed
+    gitPullOrClone
 }
 
 function _get_opts_splitwolf() {

--- a/scriptmodules/ports/srb2.sh
+++ b/scriptmodules/ports/srb2.sh
@@ -12,6 +12,7 @@
 rp_module_id="srb2"
 rp_module_desc="Sonic Robo Blast 2 - 3D Sonic the Hedgehog fan-game built using a modified version of the Doom Legacy source port of Doom"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/STJr/SRB2/master/LICENSE"
+rp_module_repo="git https://github.com/STJr/SRB2.git SRB2_release_2.2.2"
 rp_module_section="exp"
 
 function depends_srb2() {
@@ -21,7 +22,7 @@ function depends_srb2() {
 }
 
 function sources_srb2() {
-    gitPullOrClone "$md_build" https://github.com/STJr/SRB2.git "SRB2_release_2.2.2"
+    gitPullOrClone
     downloadAndExtract "$__archive_url/srb2-assets.tar.gz" "$md_build"
 }
 

--- a/scriptmodules/ports/tyrquake.sh
+++ b/scriptmodules/ports/tyrquake.sh
@@ -12,6 +12,7 @@
 rp_module_id="tyrquake"
 rp_module_desc="Quake 1 engine - TyrQuake port"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/RetroPie/tyrquake/master/gnu.txt"
+rp_module_repo="git https://github.com/RetroPie/tyrquake.git master"
 rp_module_section="opt"
 
 function depends_tyrquake() {
@@ -24,7 +25,7 @@ function depends_tyrquake() {
 }
 
 function sources_tyrquake() {
-    gitPullOrClone "$md_build" https://github.com/RetroPie/tyrquake.git
+    gitPullOrClone
     isPlatform "kms" && applyPatch "$md_data/0001-force-vsync.patch"
 }
 

--- a/scriptmodules/ports/vvvvvv.sh
+++ b/scriptmodules/ports/vvvvvv.sh
@@ -12,6 +12,7 @@
 rp_module_id="vvvvvv"
 rp_module_desc="VVVVVV - 2D puzzle game by Terry Cavanagh"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/TerryCavanagh/VVVVVV/master/LICENSE.md"
+rp_module_repo="git https://github.com/TerryCavanagh/VVVVVV master"
 rp_module_help="Copy data.zip from a purchased or Make and Play edition of VVVVVV to $romdir/ports/vvvvvv"
 rp_module_section="exp"
 
@@ -20,7 +21,7 @@ function depends_vvvvvv() {
 }
 
 function sources_vvvvvv() {
-    gitPullOrClone "$md_build" https://github.com/TerryCavanagh/VVVVVV
+    gitPullOrClone
     # default to fullscreen
     sed -i "s/fullscreen = false/fullscreen = true/" "$md_build/desktop_version/src/Game.cpp"
 }

--- a/scriptmodules/ports/wolf4sdl.sh
+++ b/scriptmodules/ports/wolf4sdl.sh
@@ -12,6 +12,7 @@
 rp_module_id="wolf4sdl"
 rp_module_desc="Wolf4SDL - port of Wolfenstein 3D / Spear of Destiny engine"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/mozzwald/wolf4sdl/master/license-mame.txt"
+rp_module_repo="git https://github.com/mozzwald/wolf4sdl.git master"
 rp_module_section="opt"
 rp_module_flags="dispmanx !mali"
 
@@ -20,7 +21,7 @@ function depends_wolf4sdl() {
 }
 
 function sources_wolf4sdl() {
-    gitPullOrClone "$md_build" https://github.com/mozzwald/wolf4sdl.git
+    gitPullOrClone
 }
 
 function _get_opts_wolf4sdl() {

--- a/scriptmodules/ports/xrick.sh
+++ b/scriptmodules/ports/xrick.sh
@@ -13,6 +13,7 @@ rp_module_id="xrick"
 rp_module_desc="xrick - Open source implementation of Rick Dangerous"
 rp_module_help="Install the xrick data.zip to $romdir/ports/xrick/data.zip"
 rp_module_licence="GPL https://raw.githubusercontent.com/RetroPie/xrick/master/README"
+rp_module_repo="git https://github.com/RetroPie/xrick.git master"
 rp_module_section="opt"
 rp_module_flags="!mali"
 
@@ -21,7 +22,7 @@ function depends_xrick() {
 }
 
 function sources_xrick() {
-    gitPullOrClone "$md_build" https://github.com/RetroPie/xrick.git
+    gitPullOrClone
 }
 
 function build_xrick() {

--- a/scriptmodules/ports/yquake2.sh
+++ b/scriptmodules/ports/yquake2.sh
@@ -12,6 +12,7 @@
 rp_module_id="yquake2"
 rp_module_desc="yquake2 - The Yamagi Quake II client"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/yquake2/yquake2/master/LICENSE"
+rp_module_repo="git https://github.com/yquake2/yquake2.git QUAKE2_7_41"
 rp_module_section="exp"
 rp_module_flags=""
 
@@ -22,7 +23,7 @@ function depends_yquake2() {
 }
 
 function sources_yquake2() {
-    gitPullOrClone "$md_build" https://github.com/yquake2/yquake2.git "QUAKE2_7_41"
+    gitPullOrClone
 }
 
 function build_yquake2() {

--- a/scriptmodules/supplementary/attractmode.sh
+++ b/scriptmodules/supplementary/attractmode.sh
@@ -12,6 +12,7 @@
 rp_module_id="attractmode"
 rp_module_desc="Attract Mode emulator frontend"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/mickelson/attract/master/License.txt"
+rp_module_repo="git https://github.com/mickelson/attract master"
 rp_module_section="exp"
 rp_module_flags="!mali frontend"
 
@@ -140,7 +141,7 @@ function depends_attractmode() {
 
 function sources_attractmode() {
     isPlatform "rpi" && gitPullOrClone "$md_build/sfml-pi" "https://github.com/mickelson/sfml-pi"
-    gitPullOrClone "$md_build/attract" "https://github.com/mickelson/attract"
+    gitPullOrClone "$md_build/attract"
 }
 
 function build_attractmode() {

--- a/scriptmodules/supplementary/controlblock.sh
+++ b/scriptmodules/supplementary/controlblock.sh
@@ -13,6 +13,7 @@ rp_module_id="controlblock"
 rp_module_desc="ControlBlock Driver"
 rp_module_help="Please note that you need to manually enable or disable the ControlBlock Service in the Configuration section. IMPORTANT: If the service is enabled and the power switch functionality is enabled (which is the default setting) in the config file, you need to have a switch connected to the ControlBlock."
 rp_module_licence="NONCOM https://raw.githubusercontent.com/petrockblog/ControlBlockService2/master/LICENSE.txt"
+rp_module_repo="git https://github.com/petrockblog/ControlBlockService2.git master"
 rp_module_section="driver"
 rp_module_flags="noinstclean !all rpi"
 
@@ -24,7 +25,7 @@ function depends_controlblock() {
 }
 
 function sources_controlblock() {
-    gitPullOrClone "$md_inst" https://github.com/petrockblog/ControlBlockService2.git
+    gitPullOrClone "$md_inst"
 }
 
 function build_controlblock() {

--- a/scriptmodules/supplementary/custombluez.sh
+++ b/scriptmodules/supplementary/custombluez.sh
@@ -12,6 +12,7 @@
 rp_module_id="custombluez"
 rp_module_desc="Updated version of BlueZ Bluetooth stack"
 rp_module_help="Install alongside 'sixaxis' driver if you need to pair third-party (Gasia/Shanwan) DualShock 3 controllers.\nNeeded only if your distribution's BlueZ version is <5.48."
+rp_module_repo="git https://salsa.debian.org/bluetooth-team/bluez.git debian/5.50-1"
 rp_module_licence="GPL2 http://www.bluez.org/faq/common/"
 rp_module_section="driver"
 
@@ -26,7 +27,7 @@ function depends_custombluez() {
 }
 
 function sources_custombluez() {
-    gitPullOrClone "$md_build/custombluez" https://salsa.debian.org/bluetooth-team/bluez "debian/5.50-1"
+    gitPullOrClone "$md_build/custombluez"
     cd "custombluez"
     applyPatch "$md_data/01_raspbian_patches.diff"
 }

--- a/scriptmodules/supplementary/emulationstation-dev.sh
+++ b/scriptmodules/supplementary/emulationstation-dev.sh
@@ -12,6 +12,7 @@
 rp_module_id="emulationstation-dev"
 rp_module_desc="EmulationStation (latest development version) - Frontend used by RetroPie for launching emulators"
 rp_module_licence="MIT https://raw.githubusercontent.com/RetroPie/EmulationStation/master/LICENSE.md"
+rp_module_repo="git https://github.com/RetroPie/EmulationStation master"
 rp_module_section="exp"
 rp_module_flags="frontend"
 
@@ -24,7 +25,7 @@ function depends_emulationstation-dev() {
 }
 
 function sources_emulationstation-dev() {
-    sources_emulationstation "" "master"
+    sources_emulationstation
 }
 
 function build_emulationstation-dev() {

--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -12,7 +12,7 @@
 rp_module_id="emulationstation"
 rp_module_desc="EmulationStation - Frontend used by RetroPie for launching emulators"
 rp_module_licence="MIT https://raw.githubusercontent.com/RetroPie/EmulationStation/master/LICENSE.md"
-rp_module_repo="git https://github.com/RetroPie/EmulationStation stable"
+rp_module_repo="git https://github.com/RetroPie/EmulationStation :_get_branch_emulationstation"
 rp_module_section="core"
 rp_module_flags="frontend"
 
@@ -143,16 +143,19 @@ function depends_emulationstation() {
     getDepends "${depends[@]}"
 }
 
-function sources_emulationstation() {
-    local branch="$1"
+function _get_branch_emulationstation() {
     if [[ -z "$branch" ]]; then
         if compareVersions "$__os_debian_ver" gt 8; then
-            branch="$md_repo_branch"
+            branch="stable"
         else
             branch="v2.7.6"
         fi
     fi
-    gitPullOrClone "$md_build" "$md_repo_url" "$branch"
+    echo "$branch"
+}
+
+function sources_emulationstation() {
+    gitPullOrClone
 }
 
 function build_emulationstation() {

--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -12,6 +12,7 @@
 rp_module_id="emulationstation"
 rp_module_desc="EmulationStation - Frontend used by RetroPie for launching emulators"
 rp_module_licence="MIT https://raw.githubusercontent.com/RetroPie/EmulationStation/master/LICENSE.md"
+rp_module_repo="git https://github.com/RetroPie/EmulationStation stable"
 rp_module_section="core"
 rp_module_flags="frontend"
 
@@ -143,17 +144,15 @@ function depends_emulationstation() {
 }
 
 function sources_emulationstation() {
-    local repo="$1"
-    local branch="$2"
-    [[ -z "$repo" ]] && repo="https://github.com/RetroPie/EmulationStation"
+    local branch="$1"
     if [[ -z "$branch" ]]; then
         if compareVersions "$__os_debian_ver" gt 8; then
-            branch="stable"
+            branch="$md_repo_branch"
         else
             branch="v2.7.6"
         fi
     fi
-    gitPullOrClone "$md_build" "$repo" "$branch"
+    gitPullOrClone "$md_build" "$md_repo_url" "$branch"
 }
 
 function build_emulationstation() {

--- a/scriptmodules/supplementary/launchingimages.sh
+++ b/scriptmodules/supplementary/launchingimages.sh
@@ -12,6 +12,7 @@
 rp_module_id="launchingimages"
 rp_module_desc="Generate runcommand launching images based on emulationstation themes."
 rp_module_help="A runcommand launching image is displayed while loading a game, with this tool you can automatically create some cool images based on a chosen emulationstation theme you have on your system."
+rp_module_repo="git https://github.com/meleu/generate-launching-images.git master"
 rp_module_section="exp"
 rp_module_flags="noinstclean"
 
@@ -26,7 +27,7 @@ function depends_launchingimages() {
 }
 
 function install_bin_launchingimages() {
-    gitPullOrClone "$md_inst" "https://github.com/meleu/generate-launching-images.git"
+    gitPullOrClone "$md_inst"
 }
 
 function _show_images_launchingimages() {

--- a/scriptmodules/supplementary/mehstation.sh
+++ b/scriptmodules/supplementary/mehstation.sh
@@ -12,6 +12,7 @@
 rp_module_id="mehstation"
 rp_module_desc="mehstation emulator frontend"
 rp_module_licence="MIT https://raw.githubusercontent.com/remeh/mehstation/master/LICENSE"
+rp_module_repo="git https://github.com/remeh/mehstation master"
 rp_module_section="exp"
 rp_module_flags="frontend nobin"
 
@@ -74,7 +75,7 @@ function depends_mehstation() {
 }
 
 function sources_mehstation() {
-    gitPullOrClone "$md_build" https://github.com/remeh/mehstation
+    gitPullOrClone
     GOPATH="$md_build/mehtadata" go get github.com/remeh/mehtadata
 }
 

--- a/scriptmodules/supplementary/mesa-drm.sh
+++ b/scriptmodules/supplementary/mesa-drm.sh
@@ -12,6 +12,7 @@
 rp_module_id="mesa-drm"
 rp_module_desc="libdrm - userspace library for drm"
 rp_module_licence="MIT https://www.mesa3d.org/license.html"
+rp_module_repo="git https://github.com/RetroPie/mesa-drm runcommand_debug"
 rp_module_section="depends"
 rp_module_flags=""
 
@@ -22,7 +23,7 @@ function depends_mesa-drm() {
 }
 
 function sources_mesa-drm() {
-    gitPullOrClone "$md_build" https://github.com/RetroPie/mesa-drm "runcommand_debug"
+    gitPullOrClone
 }
 
 function build_mesa-drm() {

--- a/scriptmodules/supplementary/mkarcadejoystick.sh
+++ b/scriptmodules/supplementary/mkarcadejoystick.sh
@@ -13,6 +13,7 @@ rp_module_id="mkarcadejoystick"
 rp_module_desc="Raspberry Pi GPIO Joystick Driver"
 rp_module_help="Installs the GPIO driver from https://github.com/cmitu/mk_arcade_joystick_rpi"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/recalbox/mk_arcade_joystick_rpi/master/LICENSE"
+rp_module_repo="git https://github.com/cmitu/mk_arcade_joystick_rpi retropie"
 rp_module_section="driver"
 rp_module_flags="noinstclean !all rpi"
 
@@ -25,7 +26,7 @@ function depends_mkarcadejoystick() {
 }
 
 function sources_mkarcadejoystick() {
-    gitPullOrClone "$md_inst" https://github.com/cmitu/mk_arcade_joystick_rpi retropie
+    gitPullOrClone "$md_inst"
     pushd "$md_inst"
     sed -i "s/\$MKVERSION/$(_version_mkarcadejoystick)/" "$md_inst/dkms.conf"
     popd

--- a/scriptmodules/supplementary/mobilegamepad.sh
+++ b/scriptmodules/supplementary/mobilegamepad.sh
@@ -12,6 +12,7 @@
 rp_module_id="mobilegamepad"
 rp_module_desc="Mobile Universal Gamepad for RetroPie"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/sbidolach/mobile-gamepad/master/LICENSE"
+rp_module_repo="git https://github.com/sbidolach/mobile-gamepad.git master"
 rp_module_section="exp"
 rp_module_flags="noinstclean nobin"
 
@@ -26,7 +27,7 @@ function remove_mobilegamepad() {
 }
 
 function sources_mobilegamepad() {
-    gitPullOrClone "$md_inst" https://github.com/sbidolach/mobile-gamepad.git
+    gitPullOrClone "$md_inst"
     chown -R $user:$user "$md_inst"
 }
 

--- a/scriptmodules/supplementary/moonlight.sh
+++ b/scriptmodules/supplementary/moonlight.sh
@@ -13,6 +13,7 @@ rp_module_id="moonlight"
 rp_module_desc="Moonlight Embedded - an open source gamestream client for embedded systems"
 rp_module_help="ROM Extensions: .ml\n\nCopy your moonlight launch configurations to $romdir/steam\n\nDon't forget to first pair with your remote host before using moonlight. You can use the configuration menu for pairing/unpairing to/from a remote machine."
 rp_module_licence="GPL3 https://raw.githubusercontent.com/irtimmer/moonlight-embedded/master/LICENSE"
+rp_module_repo="git https://github.com/irtimmer/moonlight-embedded.git master"
 rp_module_section="exp"
 rp_module_flags="!all arm"
 
@@ -79,7 +80,7 @@ function depends_moonlight() {
 }
 
 function sources_moonlight() {
-    gitPullOrClone "$md_build" https://github.com/irtimmer/moonlight-embedded.git
+    gitPullOrClone
 }
 
 function build_moonlight() {

--- a/scriptmodules/supplementary/omxiv.sh
+++ b/scriptmodules/supplementary/omxiv.sh
@@ -12,6 +12,7 @@
 rp_module_id="omxiv"
 rp_module_desc="OpenMAX image viewer for the Raspberry Pi"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/cmitu/omxiv/master/LICENSE"
+rp_module_repo="git https://github.com/retropie/omxiv.git master"
 rp_module_section="depends"
 rp_module_flags="!all rpi"
 
@@ -20,7 +21,7 @@ function depends_omxiv() {
 }
 
 function sources_omxiv() {
-    gitPullOrClone "$md_build" https://github.com/retropie/omxiv.git
+    gitPullOrClone
 }
 
 function build_omxiv() {

--- a/scriptmodules/supplementary/powerblock.sh
+++ b/scriptmodules/supplementary/powerblock.sh
@@ -12,6 +12,7 @@
 rp_module_id="powerblock"
 rp_module_desc="PowerBlock Driver"
 rp_module_help="Please note that you need to manually enable or disable the PowerBlock Service in the Configuration section. IMPORTANT: If the service is enabled and the power switch functionality is enabled (which is the default setting) in the config file, you need to have a switch connected to the PowerBlock."
+rp_module_repo="git https://github.com/petrockblog/PowerBlock.git master"
 rp_module_section="driver"
 rp_module_flags="noinstclean !all rpi"
 
@@ -26,7 +27,7 @@ function sources_powerblock() {
     if [[ -d "$md_inst" ]]; then
         git -C "$md_inst" reset --hard  # ensure that no local changes exist
     fi
-    gitPullOrClone "$md_inst" https://github.com/petrockblog/PowerBlock.git
+    gitPullOrClone "$md_inst"
 }
 
 function install_powerblock() {

--- a/scriptmodules/supplementary/retropie-manager.sh
+++ b/scriptmodules/supplementary/retropie-manager.sh
@@ -13,6 +13,7 @@ rp_module_id="retropie-manager"
 rp_module_desc="Web Based Manager for RetroPie files and configs based on the Recalbox Manager"
 rp_module_help="Open your browser and go to http://your_retropie_ip:8000/"
 rp_module_licence="MIT https://raw.githubusercontent.com/RetroPie/RetroPie-Manager/retropie/ORIGINAL%20LICENCE.txt"
+rp_module_repo="git https://github.com/RetroPie/RetroPie-Manager.git retropie"
 rp_module_section="exp"
 rp_module_flags="noinstclean nobin"
 
@@ -22,7 +23,7 @@ function depends_retropie-manager() {
 }
 
 function sources_retropie-manager() {
-    gitPullOrClone "$md_inst" "https://github.com/RetroPie/RetroPie-Manager.git" retropie
+    gitPullOrClone "$md_inst"
 }
 
 function install_retropie-manager() {

--- a/scriptmodules/supplementary/retropiemenu.sh
+++ b/scriptmodules/supplementary/retropiemenu.sh
@@ -12,6 +12,7 @@
 rp_module_id="retropiemenu"
 rp_module_desc="RetroPie configuration menu for EmulationStation"
 rp_module_section="core"
+rp_module_flags="nonet"
 
 function _update_hook_retropiemenu() {
     # to show as installed when upgrading to retropie-setup 4.x

--- a/scriptmodules/supplementary/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand.sh
@@ -12,6 +12,7 @@
 rp_module_id="runcommand"
 rp_module_desc="The 'runcommand' launch script - needed for launching the emulators from the frontend"
 rp_module_section="core"
+rp_module_flags="nonet"
 
 function _update_hook_runcommand() {
     # make sure runcommand is always updated when updating retropie-setup

--- a/scriptmodules/supplementary/sixaxis.sh
+++ b/scriptmodules/supplementary/sixaxis.sh
@@ -13,6 +13,7 @@ rp_module_id="sixaxis"
 rp_module_desc="Helper service for official and third-party DualShock controllers (ps3controller replacement)"
 rp_module_help="For Shanwan/GASIA third-party controllers, enable third-party support in the configuration options.\n\nTo pair controllers, use the RetroPie Bluetooth menu, choose 'Register and Connect...', then follow the on-screen instructions."
 rp_module_licence="GPL2 https://raw.githubusercontent.com/RetroPie/sixaxis/master/COPYING"
+rp_module_repo="git https://github.com/RetroPie/sixaxis.git master"
 rp_module_section="driver"
 
 function depends_sixaxis() {
@@ -28,14 +29,13 @@ function depends_sixaxis() {
 }
 
 function sources_sixaxis() {
-    gitPullOrClone "$md_build/sixaxis" https://github.com/RetroPie/sixaxis.git
+    gitPullOrClone
 }
 
 function build_sixaxis() {
-    cd sixaxis
     make clean
     make
-    md_ret_require="$md_build/sixaxis/bins/sixaxis-timeout"
+    md_ret_require="$md_build/bins/sixaxis-timeout"
 }
 
 function gui_sixaxis() {
@@ -84,7 +84,6 @@ function gui_sixaxis() {
 }
 
 function install_sixaxis() {
-    cd sixaxis
     checkinstall -y --fstrans=no
 }
 

--- a/scriptmodules/supplementary/skyscraper.sh
+++ b/scriptmodules/supplementary/skyscraper.sh
@@ -12,14 +12,19 @@
 rp_module_id="skyscraper"
 rp_module_desc="Scraper for EmulationStation by Lars Muldjord"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/muldjord/skyscraper/master/LICENSE"
+rp_module_repo="git https://github.com/muldjord/skyscraper :_get_branch_skyscraper"
 rp_module_section="opt"
+
+function _get_branch_skyscraper() {
+    download https://api.github.com/repos/muldjord/skyscraper/releases/latest - | grep -m 1 tag_name | cut -d\" -f4
+}
 
 function depends_skyscraper() {
     getDepends qt5-default p7zip-full
 }
 
 function sources_skyscraper() {
-    gitPullOrClone "$md_build" "https://github.com/muldjord/skyscraper" "$(_latest_ver_skyscraper)"
+    gitPullOrClone
 }
 
 function build_skyscraper() {
@@ -124,10 +129,6 @@ function _get_ver_skyscraper() {
     if [[ -f "$md_inst/Skyscraper" ]]; then
         echo $("$md_inst/Skyscraper" -h | grep 'Running Skyscraper'  | cut -d' '  -f 3 | tr -d v 2>/dev/null)
     fi
-}
-
-function _latest_ver_skyscraper() {
-    download https://api.github.com/repos/muldjord/skyscraper/releases/latest - | grep -m 1 tag_name | cut -d\" -f4
 }
 
 function _check_ver_skyscraper() {
@@ -646,7 +647,7 @@ function gui_skyscraper() {
                     ;;
 
                 U)
-                    local latest_ver="$(_latest_ver_skyscraper)"
+                    local latest_ver="$(_get_branch_skyscraper)"
                     # check for update
                     if compareVersions "$latest_ver" gt "$ver" ; then
                         printMsgs "dialog" "There is a new version available. Latest released version is $latest_ver (You are running $ver).\n\nYou can update the package from RetroPie-Setup -> Manage Packages"

--- a/scriptmodules/supplementary/snesdev.sh
+++ b/scriptmodules/supplementary/snesdev.sh
@@ -12,10 +12,11 @@
 rp_module_id="snesdev"
 rp_module_desc="SNESDev (Driver for the RetroPie GPIO-Adapter)"
 rp_module_section="driver"
+rp_module_repo="git https://github.com/petrockblog/SNESDev-RPi.git master"
 rp_module_flags="noinstclean"
 
 function sources_snesdev() {
-    gitPullOrClone "$md_inst" https://github.com/petrockblog/SNESDev-RPi.git
+    gitPullOrClone "$md_inst"
 }
 
 function build_snesdev() {

--- a/scriptmodules/supplementary/splashscreen.sh
+++ b/scriptmodules/supplementary/splashscreen.sh
@@ -12,6 +12,7 @@
 rp_module_id="splashscreen"
 rp_module_desc="Configure Splashscreen"
 rp_module_section="main"
+rp_module_repo="git https://github.com/RetroPie/retropie-splashscreens.git master"
 rp_module_flags="noinstclean !all rpi !osmc !xbian !aarch64"
 
 function _update_hook_splashscreen() {
@@ -56,7 +57,7 @@ _EOF_
 
     rp_installModule "omxiv" "_autoupdate_"
 
-    gitPullOrClone "$md_inst" https://github.com/RetroPie/retropie-splashscreens.git
+    gitPullOrClone "$md_inst"
 
     cp "$md_data/asplashscreen.sh" "$md_inst"
 

--- a/scriptmodules/supplementary/steamcontroller.sh
+++ b/scriptmodules/supplementary/steamcontroller.sh
@@ -13,6 +13,7 @@ rp_module_id="steamcontroller"
 rp_module_desc="Standalone Steam Controller Driver"
 rp_module_help="Steam Controller Driver from https://github.com/ynsta/steamcontroller"
 rp_module_licence="MIT https://raw.githubusercontent.com/ynsta/steamcontroller/master/LICENSE"
+rp_module_repo="git https://github.com/ynsta/steamcontroller.git master"
 rp_module_section="driver"
 rp_module_flags="noinstclean"
 
@@ -21,7 +22,7 @@ function depends_steamcontroller() {
 }
 
 function sources_steamcontroller() {
-    gitPullOrClone "$md_inst" https://github.com/ynsta/steamcontroller.git
+    gitPullOrClone "$md_inst"
 }
 
 function install_steamcontroller() {

--- a/scriptmodules/supplementary/virtualgamepad.sh
+++ b/scriptmodules/supplementary/virtualgamepad.sh
@@ -12,6 +12,7 @@
 rp_module_id="virtualgamepad"
 rp_module_desc="Virtual Gamepad for Smartphone"
 rp_module_licence="MIT https://raw.githubusercontent.com/miroof/node-virtual-gamepads/master/LICENSE"
+rp_module_repo="git https://github.com/miroof/node-virtual-gamepads.git master"
 rp_module_section="exp"
 rp_module_flags="noinstclean nobin"
 
@@ -26,7 +27,7 @@ function remove_virtualgamepad() {
 }
 
 function sources_virtualgamepad() {
-    gitPullOrClone "$md_inst" https://github.com/miroof/node-virtual-gamepads.git
+    gitPullOrClone "$md_inst"
     chown -R $user:$user "$md_inst"
 }
 

--- a/scriptmodules/supplementary/xarcade2jstick.sh
+++ b/scriptmodules/supplementary/xarcade2jstick.sh
@@ -12,11 +12,12 @@
 rp_module_id="xarcade2jstick"
 rp_module_desc="Xarcade2Jstick"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/petrockblog/Xarcade2Jstick/master/gpl3.txt"
+rp_module_repo="git https://github.com/petrockblog/Xarcade2Joystick.git master"
 rp_module_section="driver"
 rp_module_flags="noinstclean"
 
 function sources_xarcade2jstick() {
-    gitPullOrClone "$md_inst" https://github.com/petrockblog/Xarcade2Joystick.git
+    gitPullOrClone "$md_inst"
 }
 
 function build_xarcade2jstick() {

--- a/scriptmodules/supplementary/xboxdrv.sh
+++ b/scriptmodules/supplementary/xboxdrv.sh
@@ -12,6 +12,7 @@
 rp_module_id="xboxdrv"
 rp_module_desc="Xbox / Xbox 360 gamepad driver"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/zerojay/xboxdrv/stable/COPYING"
+rp_module_repo="git https://github.com/zerojay/xboxdrv.git stable"
 rp_module_section="driver"
 
 function def_controllers_xboxdrv() {
@@ -27,7 +28,7 @@ function depends_xboxdrv() {
 }
 
 function sources_xboxdrv() {
-    gitPullOrClone "$md_build" https://github.com/zerojay/xboxdrv.git stable
+    gitPullOrClone
 }
 
 function build_xboxdrv() {

--- a/scriptmodules/supplementary/xpad.sh
+++ b/scriptmodules/supplementary/xpad.sh
@@ -13,6 +13,7 @@ rp_module_id="xpad"
 rp_module_desc="Updated Xpad Linux Kernel driver"
 rp_module_help="This is the latest Xpad driver from https://github.com/paroj/xpad\n\nThe driver has been patched to allow the triggers to map to buttons for any controller and this has been enabled by default.\n\nThis fixes mapping the triggers in Emulation Station.\n\nIf you want the previous trigger behaviour please edit /etc/modprobe.d/xpad.conf and set triggers_to_buttons=0"
 rp_module_licence="GPL2 https://www.kernel.org/pub/linux/kernel/COPYING"
+rp_module_repo="git https://github.com/paroj/xpad.git master"
 rp_module_section="driver"
 rp_module_flags="noinstclean !mali"
 
@@ -27,7 +28,7 @@ function depends_xpad() {
 
 function sources_xpad() {
     rm -rf "$md_inst"
-    gitPullOrClone "$md_inst" https://github.com/paroj/xpad.git
+    gitPullOrClone "$md_inst"
     cd "$md_inst"
     # LED support (as disabled currently in packaged RPI kernel) and allow forcing MAP_TRIGGERS_TO_BUTTONS
     applyPatch "$md_data/01_enable_leds_and_trigmapping.diff"

--- a/scriptmodules/supplementary/xpadneo.sh
+++ b/scriptmodules/supplementary/xpadneo.sh
@@ -12,6 +12,7 @@
 rp_module_id="xpadneo"
 rp_module_desc="Advanced Linux driver for Xbox One wireless gamepads"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/atar-axis/xpadneo/master/LICENSE"
+rp_module_repo="git https://github.com/atar-axis/xpadneo.git v0.9"
 rp_module_section="driver"
 rp_module_flags="nobin"
 
@@ -25,8 +26,7 @@ function depends_xpadneo() {
 }
 
 function sources_xpadneo() {
-    local tag="v0.9"
-    gitPullOrClone "$md_build" https://github.com/atar-axis/xpadneo.git "$tag"
+    gitPullOrClone
     rsync -a --delete "$md_build/hid-xpadneo/" "$md_inst/"
     cp "$md_build/VERSION" "$md_inst/"
     local version="$(_version_xpadneo)"

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -286,7 +286,7 @@ function get_os_version() {
 }
 
 function get_retropie_depends() {
-    local depends=(git dialog curl gcc g++ build-essential unzip xmlstarlet python3-pyudev ca-certificates dirmngr)
+    local depends=(git subversion dialog curl gcc g++ build-essential unzip xmlstarlet python3-pyudev ca-certificates dirmngr)
 
     [[ -n "$DISTCC_HOSTS" ]] && depends+=(distcc)
 


### PR DESCRIPTION
These changes allow storing of source repo information in retropie.pkg as well as the ability
to check for a new version. To do this, repository information needs to be moved to the variable
md_module_repo in the format

md_module_repo="TYPE URL BRANCH COMMIT"

Currently types of file, git, or svn are suppported.

If using file the BRANCH and COMMIT are not used.
If using svn the BRANCH should be - and the COMMIT is the SVN revision.

This information is split up and provided to the module in the form of

md_repo_type
md_repo_url
md_repo_branch
md_repo_commit

In addition I have added some other related changes including some caching to help with the additional overhead the extra package information adds when navigating menus.
