### PR TITLE
setup - change colours around to work with other terminals

### DIFF
--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -335,15 +335,15 @@ function section_gui_setup() {
             # do a heading for each origin and module type
             if [[ "$last_type" != "$type" ]]; then
                 info="$type"
-                pkgs+=("----" "\Z4$info ----\Zn" "Packages from $info")
+                pkgs+=("----" "\Z4$info ----" "Packages from $info")
                 last_type="$type"
             fi
             if ! rp_isEnabled "$id"; then
-                info="\Zb*$id - Not available for your system\Zn"
+                info="\Z1$id\Zn - Not available for your system"
             else
                 if rp_isInstalled "$id"; then
                     eval $(rp_getPackageInfo "$id")
-                    info="\Zb\Z7$id\Zn \Zb(Installed - via $pkg_origin)"
+                    info="$id (Installed - via $pkg_origin)"
                     ((num_pkgs++))
                 else
                     info="$id"


### PR DESCRIPTION
On the Raspberry Pi console, bold text results in a lighter colour, rather than actually being bold.

One user (it may not be a common issue) reported on their terminal that they couldn't see installed packages. This was due to our "bold white" for installed applications which ended up being bold grey on a grey background - so they couldn't see what was installed without hovering over it.

I have switched the colours around here, so the section heading is just "bold" which will be a light
grey on the Raspberry Pi, and blue for installed apps, and red for unavailable packages.

I'm not completely happy with this, as it's more colourful than before, and perhaps too busy. However, this should work on terminals that decode it as 7 colours + bold rather than 15 colours etc.

--

Thoughts welcome. I was hoping to primarily highlight installed packages, and didn't want it to get busy with colour. However if this is not to people's liking it may be easiest to just switch back to plain text in the menus.