### PR TITLE
openmsx: fix building on Ubuntu 18.04/GCC 7

### DIFF
--- a/scriptmodules/emulators/openmsx.sh
+++ b/scriptmodules/emulators/openmsx.sh
@@ -19,8 +19,9 @@ rp_module_flags=""
 
 function _get_commit_openmsx() {
     local commit
-    # latest code requires at least GCC 7 as it contains C++17 code
-    # build from earlier commit before C++17 changes for GCC < 7
+    # latest code requires at least GCC 8.3 (Debian Buster) for full C++17 support
+    compareVersions $__gcc_version lt 8 && commit="c8d90e70"
+    # for GCC before 7, build from an earlier commit, before C++17 support was added
     compareVersions $__gcc_version lt 7 && commit="5ee25b62"
     echo "$commit"
 }


### PR DESCRIPTION
Alternatively, we could install `gcc-8` on Ubuntu and compile with it - seems to work.