### PR TITLE
lzdoom: update to 3.87c

### DIFF
--- a/scriptmodules/ports/lzdoom.sh
+++ b/scriptmodules/ports/lzdoom.sh
@@ -11,8 +11,8 @@
 
 rp_module_id="lzdoom"
 rp_module_desc="lzdoom - DOOM source port (legacy version of GZDoom)"
-rp_module_licence="GPL3 https://github.com/drfrag666/gzdoom/blob/g3.3mgw/docs/licenses/README.TXT"
-rp_module_repo="git https://github.com/drfrag666/gzdoom 3.86a"
+rp_module_licence="GPL3 https://raw.githubusercontent.com/drfrag666/gzdoom/g3.3mgw/docs/licenses/README.TXT"
+rp_module_repo="git https://github.com/drfrag666/gzdoom 3.87c"
 rp_module_section="opt"
 rp_module_flags=""
 
@@ -37,9 +37,8 @@ function build_lzdoom() {
     if isPlatform "armv8"; then
         params+=(-DUSE_ARMV8=On)
     fi
-    # disable unsafe math optimizations to avoid inaccurate hitscan detection, broken doors, omniscient AI, etc.
-    # see: https://forum.zdoom.org/viewtopic.php?f=7&t=57781
-    CFLAGS="${CFLAGS//-funsafe-math-optimizations/}" CXXFLAGS="${CXXFLAGS//-funsafe-math-optimizations/}" cmake "${params[@]}" ..
+    # Note: `-funsafe-math-optimizations` should be avoided, see: https://forum.zdoom.org/viewtopic.php?f=7&t=57781
+    cmake "${params[@]}" ..
     make
     md_ret_require="$md_build/release/$md_id"
 }


### PR DESCRIPTION
Looks like GL2 compatibility has been kept for LZDoom versions post 3.86, so we can update to the latest 3.x release tag.

Other:
* Removed the CFLAGS manipulation, since the math optimizations have been removed in c3751a4f0ee37451991b775e0bea8ba3df424a20, but left the warning for building with `-funsafe-math-optimizations`
* Use the direct link to the license page