### PR TITLE
Rework the checks and error messages displayed on network error

### DIFF
--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -185,6 +185,7 @@ function package_setup() {
         hasFlag "${__mod_info[$id/flags]}" "nonet" && has_net=1
 
         if [[ "$has_net" -eq 1 ]]; then
+            dialog --backtitle "$__backtitle" --infobox "Checking for updates for $id ..." 3 60 >/dev/tty
             rp_hasBinary "$id"
             local ret="$?"
             [[ "$ret" -eq 0 ]] && has_binary=1

--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -179,8 +179,7 @@ function package_setup() {
         local has_binary=0
         local has_net=0
 
-        local ip="$(getIPAddress)"
-        [[ -n "$ip" ]] && has_net=1
+        isConnected && has_net=1
 
         # for modules with nonet flag that don't need to download data, we force has_net to 1, so we get install options
         hasFlag "${__mod_info[$id/flags]}" "nonet" && has_net=1
@@ -253,7 +252,7 @@ function package_setup() {
                 options+=(S "${option_msgs[S]}")
            fi
         else
-            status+="\nInstall options disabled (Unable to access internet)"
+            status+="\nInstall options disabled:\n$__NET_ERRMSG"
         fi
 
         if [[ "$is_installed" -eq 1 ]]; then
@@ -372,9 +371,8 @@ function section_gui_setup() {
         local pkgs=()
 
         status="Please choose a package from below"
-        local ip="$(getIPAddress)"
-        if [[ -z "$ip" ]]; then
-            status+="\nInstall options disabled (Unable to access internet)"
+        if ! isConnected; then
+            status+="\nInstall options disabled ($__NET_ERRMSG)"
             has_net=0
         fi
 


### PR DESCRIPTION
Create a new function isConnected in helpers.sh which calls getIPAddress, but also sets a new global __NET_ERRMSG if not connected. This is used in setup.sh and packages.sh so we don't duplicate the same message between files.

Split out a new function runCurl from the download function, to do lower level curl calls, but capture any errors into __NET_ERRMSG for display in setup.sh or via the packaging functions. Use a connect timeout of 10 in the download function rather than 60 which is quite long, but keep the 60 second limit on no data transfer.

Adjust rp_remoteFileExists to use runCurl, so we can capture any error when checking a remote file, and use this value for display in setup and in logs etc. Switch to using long versions of curl options for readability, and add --show-error so we still output errors when being silent.

Also switch rp_getFileDate to use new runCurl function, so that any curl argument overrides are handled, and use long format parameters also. No error handling is done here though.