### PR TITLE
lr-fbneo.sh: be less specific about version

### DIFF
--- a/scriptmodules/libretrocores/lr-fbneo.sh
+++ b/scriptmodules/libretrocores/lr-fbneo.sh
@@ -10,7 +10,7 @@
 #
 
 rp_module_id="lr-fbneo"
-rp_module_desc="Arcade emu - FinalBurn Neo v1.0.0.01 (Upstream) port for libretro"
+rp_module_desc="Arcade emu - FinalBurn Neo (latest version) port for libretro"
 rp_module_help="Previously called lr-fba-next and fbalpha\n\ROM Extension: .zip\n\nCopy your FBA roms to\n$romdir/fba or\n$romdir/neogeo or\n$romdir/arcade\n\nFor NeoGeo games the neogeo.zip BIOS is required and must be placed in the same directory as your FBA roms."
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/FBNeo/master/src/license.txt"
 rp_module_repo="git https://github.com/libretro/FBNeo.git master"


### PR DESCRIPTION
remove version from description, i think the previous 0.2.97.44 description is still causing misunderstandings for ppl who didn't update their retropie-setup script yet, and we'll probably change version more regularily from now on.