### PR TITLE
Checkinstall replaced by make install

### DIFF
--- a/scriptmodules/supplementary/ps3controller.sh
+++ b/scriptmodules/supplementary/ps3controller.sh
@@ -74,9 +74,9 @@ function remove_ps3controller() {
     )
     for paths in ${remove_paths[@]}; do
         if [[ -d ${paths} ]]; then
-            sudo rm -rfv ${paths}
-        elif [[ condition ]]; then
-            sudo rm -fv ${paths}
+            rm -rfv ${paths}
+        elif [[ -f ${paths} ]]; then
+            rm -fv ${paths}
         fi
     done
     [[ -f /usr/sbin/bluetoothd ]] && chmod 755 /usr/sbin/bluetoothd

--- a/scriptmodules/supplementary/ps3controller.sh
+++ b/scriptmodules/supplementary/ps3controller.sh
@@ -56,7 +56,29 @@ function install_ps3controller() {
 }
 
 function remove_ps3controller() {
-    dpkg --purge sixad
+    declare -a remove_paths=("
+                /etc/default/sixad"
+                "/etc/systemd/system/sixad.service"
+                "/etc/logrotate.d/sixad"
+                "/usr/bin/sixad"
+                "/usr/sbin/sixad-bin"
+                "/usr/sbin/sixad-sixaxis"
+                "/usr/sbin/sixad-remote"
+                "/usr/sbin/sixad-3in1"
+                "/usr/sbin/sixad-raw"
+                "/usr/sbin/sixpair"
+                "/usr/sbin/sixad-helper"
+                "/etc/udev/rules.d/99-sixad.rules"
+                "/etc/udev/rules.d/10-hci.rules"
+                "/var/lib/sixad/"
+    )
+    for paths in ${remove_paths[@]}; do
+        if [[ -d ${paths} ]]; then
+            sudo rm -rfv ${paths}
+        elif [[ condition ]]; then
+            sudo rm -fv ${paths}
+        fi
+    done
     [[ -f /usr/sbin/bluetoothd ]] && chmod 755 /usr/sbin/bluetoothd
 }
 

--- a/scriptmodules/supplementary/ps3controller.sh
+++ b/scriptmodules/supplementary/ps3controller.sh
@@ -16,7 +16,7 @@ rp_module_section="driver"
 
 function depends_ps3controller() {
     depends_bluetooth
-    local depends=(checkinstall libusb-dev libbluetooth-dev joystick)
+    local depends=(libusb-dev libbluetooth-dev joystick)
     getDepends "${depends[@]}"
 }
 
@@ -46,8 +46,7 @@ function install_ps3controller() {
     [[ -z "$branch" ]] && branch="ps3"
 
     cd sixad
-    checkinstall -y --fstrans=no
-
+    make install
     echo "$branch" >"$md_inst/type.txt"
 
     # Disable timeouts


### PR DESCRIPTION
This change allows installations on Debian, tested on: Debian 10

Linux HP 5.10.0-0.bpo.3-amd64  SMP Debian 5.10.13-1~bpo10+1 (2021-02-11) x86_64 GNU/Linux