### PR TITLE
Update Yamagi Quake 2 (yquake2) from 7.41 to 7.45

### DIFF
--- a/scriptmodules/ports/yquake2.sh
+++ b/scriptmodules/ports/yquake2.sh
@@ -12,7 +12,7 @@
 rp_module_id="yquake2"
 rp_module_desc="yquake2 - The Yamagi Quake II client"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/yquake2/yquake2/master/LICENSE"
-rp_module_repo="git https://github.com/yquake2/yquake2.git QUAKE2_7_41"
+rp_module_repo="git https://github.com/yquake2/yquake2.git QUAKE2_7_45"
 rp_module_section="exp"
 rp_module_flags=""
 


### PR DESCRIPTION
There have been a lot of performance changes among others since 7.41
[I figured it was better to use the latest release (vs master branch source build) for multiplayer compatibility, I gave a LAN match a quick try between my PC and RPI and it worked fine.]

Tested on:
    Device: Raspberry Pi 4 - 4GB
    OS: Raspbian 10 (buster) on kernel 5.10.17-v7l+
    RetroPie Version: 4.7.11

Here is the changelog:

Oct 17, 2020 - Quake II 7.44 to 7.45:
- Fix a crash under windows when opening the games menu with mods
  installed.

Oct 16, 2020 - Quake II 7.43 to 7.44:
- Fix some input option not getting saved.
- Limit busywaits to the full client. This lowers the cpu consumption
  of q2ded considerably.
- Rework the build system to be more distribution friendly. The base
  CFLAGS and LDFLAGS can now be overridden by the environment and by
  options passed to make. (by Simon McVittie)
- Fix some corner cases of broken IPv6 connectivity.
- Fix qport colliding between several Yamagi Quake II clients.
- Keyboard keys unknown to Yamagi Quake II can now be bound.
- Adaptive vsync is now supported by setting 'r_vsync' to '1'.
- Implement 'coop_pickup_weapons'. When set to '1', a weapon may be
  picked up by coop players if the player doesn't have the weapon in
  their inventory or no other player has already picked it up.
- In coop elevators wait for 'coop_elevator_delay' seconds.
- If 'cl_anglekick' is set '1' angle kicks are ignored. This breaks
  the gameplay a little bit, but helps against motion sickness. This
  cvar is cheat protected.
- Add 'listmaps' command and autocompletion for maps. (by JBerg)
- Make 'wait' in scripts wait for 17 ms. This fixes some movement
  makros.
- Support for Haiku. (by David Carlier)
- Add a 'mods' submenu. (by earth-metal)
- Add the 'vstr' command and 'nextdemo' cvar. Ported from ioquake3.
  (by Denis Pauk)

Feb 24, 2020 - Quake II 7.42 to 7.43:
- Recover from a lost sound device, do not crash of no sound device is
  available. This fixes several problem with DisplayPort and HDMI audio,
  especially with the Intel Windows GPU drivers.
- Several small game logic fixes. This includes a fix for a potential
  progress blocker in 'The Torture Chambers' introduced in the last
  release. (by BjossiAlfreds)
- Add the 'gl1_particle_square' cvar, it forces square particles in
  the GL1 renderer. (by Mason UnixBeard)
- The software renderer is no longer experimental.
- Add an option to configure the gun Z offset in the software renderer.

Nov 29, 2019 Quake II 7.41 to 7.42:
- The console can now be scrolled with the mouse wheel. (by maxcrofts)
- Fix entities on non-horizontal surfaces rendered in full black.
- Add an option to choose the display Quake II runs on. (by Spirrwell)
- Add an option to specify the display refresh rate used in fullscreen.
- Allow mouse 'sensitivity' to be set to non-integral values.
- Port cvar operations from q2pro. These allow the manipulation of cvar
  values, supported are: dec, inc, reset, resetall and toggle
- Put the client into pause mode during savegame load. This prevents the
  world getting forwarded about 100 frames during load, time in which
  the player might be hurt by monsters or the environment.
- New commands: 'listentities' allows listing of entities. 'teleport'
  teleports the player to the given coordinates.
- Fix loading of config files not ending in newlines.
- A lot of fixes for subtle, long standing AI and game play bugs. (by
  BjossiAlfreds)
- Quicksaves can now be loaded and saved throught the savegame menus.
- The software renderer now skips frames with no changes. This improves
  performance quite a bit, especially on slow CPUs. (by Denis Pauk)