### PR TITLE
lr-quicknes in main packages only for armv6 (pi1/0)

### DIFF
--- a/scriptmodules/libretrocores/lr-quicknes.sh
+++ b/scriptmodules/libretrocores/lr-quicknes.sh
@@ -14,7 +14,7 @@ rp_module_desc="NES emulator - QuickNES Port for libretro"
 rp_module_help="ROM Extensions: .nes .zip\n\nCopy your NES roms to $romdir/nes"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/QuickNES_Core/master/LICENSE"
 rp_module_repo="git https://github.com/libretro/QuickNES_Core.git master"
-rp_module_section="main"
+rp_module_section="opt armv6=main"
 
 function sources_lr-quicknes() {
     gitPullOrClone


### PR DESCRIPTION
As per https://docs.libretro.com/guides/retroachievements/#nes, lr-fceumm (default NES emulator for >armv6) now supports RetroAchievements, so I can't think of a reason to keep lr-quicknes in main packages for anything other than pi1/0 (where it's currently the default as it's the fastest).