### PR TITLE
Remove npm dependency for Mobile Gamepad

### DIFF
--- a/scriptmodules/supplementary/mobilegamepad.sh
+++ b/scriptmodules/supplementary/mobilegamepad.sh
@@ -17,7 +17,7 @@ rp_module_section="exp"
 rp_module_flags="noinstclean nobin"
 
 function depends_mobilegamepad() {
-    depends_virtualgamepad "$@"
+    getDepends nodejs
 }
 
 function remove_mobilegamepad() {


### PR DESCRIPTION
I've removed npm from the list of dependencies. The `npm` is part of `nodejs` and is not required to be installed independently.