### PR TITLE
lr-gpsp: remove the build workaround added in #3456036

### DIFF
--- a/scriptmodules/libretrocores/lr-gpsp.sh
+++ b/scriptmodules/libretrocores/lr-gpsp.sh
@@ -17,10 +17,6 @@ rp_module_repo="git https://github.com/libretro/gpsp.git master"
 rp_module_section="opt arm=main"
 rp_module_flags="!all arm"
 
-function depends_lr-gpsp() {
-    getDepends gcc-6
-}
-
 function sources_lr-gpsp() {
     gitPullOrClone
 }
@@ -30,7 +26,7 @@ function build_lr-gpsp() {
     local params=()
     isPlatform "arm" && params+=(platform=armv)
     make "${params[@]}" clean
-    CC="gcc-6" make "${params[@]}"
+    make "${params[@]}"
     rpSwap off
     md_ret_require="$md_build/gpsp_libretro.so"
 }


### PR DESCRIPTION
The dynarec crash on ARM with GCC7+ have been solved in 6254bbb1d, building with GCC6 is no longer necessary.