### PR TITLE
move skyscraper output path to /.media

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -1211,7 +1211,7 @@ function show_launch() {
             "$HOME/RetroPie/roms/$SYSTEM/images/${ROM_BN}-image"
             "$HOME/.emulationstation/downloaded_images/$SYSTEM/${ROM_BN}-image"
             "$HOME/.emulationstation/downloaded_media/$SYSTEM/screenshots/${ROM_BN}"
-            "$HOME/RetroPie/roms/$SYSTEM/media/screenshots/${ROM_BN}"
+            "$HOME/RetroPie/roms/$SYSTEM/.media/screenshots/${ROM_BN}"
         )
     fi
 

--- a/scriptmodules/supplementary/skyscraper.sh
+++ b/scriptmodules/supplementary/skyscraper.sh
@@ -280,7 +280,7 @@ function _scrape_skyscraper() {
 
     if [[ "$use_rom_folder" -eq 1 ]]; then
         params+=(-g "$romdir/$system")
-        params+=(-o "$romdir/$system/media")
+        params+=(-o "$romdir/$system/.media")
         # If we're saving to the ROM folder, then use relative paths in the gamelist
         flags+="relative,"
     else


### PR DESCRIPTION
This will prevent emulation station from entering the directory attempting to parse every file within this directory for games.

In my experimentation, with 10000s of games each with media (screenshots, marquees, etc.) this reduced the startup time for emulation station from 8 minutes to 5 minutes.

Relevant discussions found here: https://github.com/muldjord/skyscraper/issues/307 ; https://github.com/RetroPie/EmulationStation/issues/752