### PR TITLE
ppsspp: add a workaround for assets folder detection issues

### DIFF
--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -176,6 +176,6 @@ function configure_ppsspp() {
     mkUserDir "$md_conf_root/psp/PSP"
     ln -snf "$romdir/psp" "$md_conf_root/psp/PSP/GAME"
 
-    addEmulator 0 "$md_id" "psp" "$md_inst/PPSSPPSDL ${extra_params[*]} %ROM%"
+    addEmulator 0 "$md_id" "psp" "pushd $md_inst; $md_inst/PPSSPPSDL ${extra_params[*]} %ROM%; popd"
     addSystem "psp"
 }


### PR DESCRIPTION
Reported initially in https://retropie.org.uk/forum/topic/30620/, it looks like recent versions don't detect correctly the binary folder at runtime and they're unable to find the `assets` folder correctly.
Running from the emulator's folder fixes it, since `cwd` is added to the search path by the emulator.
Needs further investigation to find the cause and - possibly - a proper fix. 