### PR TITLE
Fix __curl_opts environment variable being ignored when present

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -1033,7 +1033,7 @@ function applyPatch() {
 function runCurl() {
     local params=("$@")
     # add any user supplied curl opts - timeouts can be overridden as curl uses the last parameters given
-    [[ -z "$__curl_opts" ]] && params+=($__curl_opts)
+    [[ -n "$__curl_opts" ]] && params+=($__curl_opts)
 
     local cmd_err
     local ret


### PR DESCRIPTION
The `__curl_opts` environment variable is currently always ignored due to the inverse logic being used when determining whether the variable is present.  It currently uses the bash `-z` check when it should use `-n`.

## Example of issue

Current logic:
```sh
function runCurl() {
    local params=("$@")
    # add any user supplied curl opts - timeouts can be overridden as curl uses the last parameters given
    [[ -z "$__curl_opts" ]] && params+=($__curl_opts)
    echo "${params[@]}"
}
unset __curl_opts
runCurl --max-time 10 --silent --show-error --fail --head "https://retropie.org.uk/"
__curl_opts='-L'
runCurl --max-time 10 --silent --show-error --fail --head "https://retropie.org.uk/"
```

Output:
```
--max-time 10 --silent --show-error --fail --head https://retropie.org.uk/
--max-time 10 --silent --show-error --fail --head https://retropie.org.uk/
```

## Example after patch is applied

New logic:
```sh
function runCurl() {
    local params=("$@")
    # add any user supplied curl opts - timeouts can be overridden as curl uses the last parameters given
    [[ -n "$__curl_opts" ]] && params+=($__curl_opts)
    echo "${params[@]}"
}
unset __curl_opts
runCurl --max-time 10 --silent --show-error --fail --head "https://retropie.org.uk/"
__curl_opts='-L'
runCurl --max-time 10 --silent --show-error --fail --head "https://retropie.org.uk/"
```

Output:
```
--max-time 10 --silent --show-error --fail --head https://retropie.org.uk/
--max-time 10 --silent --show-error --fail --head https://retropie.org.uk/ -L
```

Visually, I could see an argument for the additional `__curl_opts` being at the front of the command instead of at the end, though it does work either way at least on linux.

## Testing

I confirmed as well that setting the environment variable prior to installing a package caused the options to be successfully interpreted by `curl`.

I suspect this variable likely just isn't used that often, though I had a specific use case where it was exactly what I needed.