### PR TITLE
inifuncs.sh: using basic RE to allow meta-chars in keys , eg. +()

### DIFF
--- a/scriptmodules/inifuncs.sh
+++ b/scriptmodules/inifuncs.sh
@@ -63,7 +63,7 @@ function iniProcess() {
 
     local match
     if [[ -f "$file" ]]; then
-        match=$(egrep -i "$match_re" "$file" | tail -1)
+        match=$(grep -i "$match_re" "$file" | tail -1)
     else
         touch "$file"
     fi


### PR DESCRIPTION
As tabled here: https://retropie.org.uk/forum/topic/30714/inifuncs-sh-use-basic-regular-expression-match-in-iniset