### PR TITLE
lr-scummvm.sh: Recognize *.svm files in libretro.cpp

### DIFF
--- a/scriptmodules/libretrocores/lr-scummvm.sh
+++ b/scriptmodules/libretrocores/lr-scummvm.sh
@@ -11,13 +11,14 @@
 
 rp_module_id="lr-scummvm"
 rp_module_desc="ScummVM port for libretro"
-rp_module_help="Copy your ScummVM games to $romdir/scummvm\n\nThe name of your game directories must be suffixed with '.svm' for direct launch in EmulationStation."
+rp_module_help="Copy your ScummVM games to $romdir/scummvm\n\nSee https://retropie.org.uk/docs/ScummVM/#example\nfor expected folders and files."
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/scummvm/master/COPYING"
 rp_module_repo="git https://github.com/libretro/scummvm.git master"
 rp_module_section="exp"
 
 function sources_lr-scummvm() {
     gitPullOrClone
+    applyPatch "$md_data/01-libretro-svm-file-extension.patch"
 }
 
 function build_lr-scummvm() {

--- a/scriptmodules/libretrocores/lr-scummvm/01-libretro-svm-file-extension.patch
+++ b/scriptmodules/libretrocores/lr-scummvm/01-libretro-svm-file-extension.patch
@@ -1,0 +1,22 @@
+--- upstream/backends/platform/libretro/libretro.cpp	2021-06-03 20:25:28.752752783 +0200
++++ backends/platform/libretro/libretro.cpp	2021-06-03 22:26:03.824621401 +0200
+@@ -116,7 +120,7 @@
+ #define GIT_VERSION ""
+ #endif
+    info->library_version = SCUMMVM_VERSION GIT_VERSION;
+-   info->valid_extensions = "scummvm";
++   info->valid_extensions = "svm";
+    info->need_fullpath = true;
+    info->block_extract = false;
+ }
+@@ -298,8 +302,8 @@
+       char* gamedir = dirname(path);
+       char buffer[400];
+ 
+-      // See if we are loading a .scummvm file.
+-      if (strstr(game->path, ".scummvm") != NULL) {
++      // See if we are loading a .svm file.
++      if (strstr(game->path, ".svm") != NULL) {
+          // Open the file.
+          FILE * gamefile = fopen(game->path, "r");
+          if (gamefile == NULL)


### PR DESCRIPTION
Making it full compliant to the documentation:
https://retropie.org.uk/docs/ScummVM/#example

Note: It was working before but only used the `%ROM%` file contents (=game short title/id) iff the extension was `.scummvm` in other cases it fell back to auto detection within that game subfolder.