### PR TITLE
scriptmodule: jzIntv release 2020-07-12, SDL2 build

### DIFF
--- a/scriptmodules/emulators/jzintv.sh
+++ b/scriptmodules/emulators/jzintv.sh
@@ -11,44 +11,67 @@
 
 rp_module_id="jzintv"
 rp_module_desc="Intellivision emulator"
-rp_module_help="ROM Extensions: .int .bin\n\nCopy your Intellivision roms to $romdir/intellivision\n\nCopy the required BIOS files exec.bin and grom.bin to $biosdir"
+rp_module_help="ROM Extensions: .int .bin .rom\n\nCopy your Intellivision roms to $romdir/intellivision\n\nCopy the required BIOS files exec.bin and grom.bin to $biosdir"
 rp_module_licence="GPL2 http://spatula-city.org/%7Eim14u2c/intv/"
-rp_module_repo="file $__archive_url/jzintv-20181225.zip"
+rp_module_repo="file $__archive_url/jzintv-20200712-src.zip"
 rp_module_section="opt"
-rp_module_flags="sdl1 !mali"
+rp_module_flags="sdl2"
 
 function depends_jzintv() {
-    getDepends libsdl1.2-dev
+    getDepends libsdl2-dev libreadline-dev
 }
 
 function sources_jzintv() {
+    rm -rf "$md_build/jzintv"
     downloadAndExtract "$md_repo_url" "$md_build"
+    # jzintv-YYYYMMDD/ --> jzintv/
+    mv jzintv-[0-9]* jzintv
     cd jzintv/src
-    # aarch64 doesn't include sys/io.h - we can just remove it in this case
-    isPlatform "aarch64" && grep -rl "include.*sys/io.h" | xargs sed -i "/include.*sys\/io.h/d"
+
+    # Add source release date information to build
+    mv buildcfg/90-svn.mak buildcfg/90-svn.mak.txt
+    echo "SVN_REV := $(echo $md_repo_url | grep -o -P '[\d]{8}')" > buildcfg/90-src_releasedate.mak
+    sed -i.zip-dist "s/SVN Revision/Releasedate/" svn_revision.c
+
+    # aarch64 doesn't include sys/io.h - but it's not needed so we can remove
+    grep -rl "include.*sys/io.h" | xargs sed -i "/include.*sys\/io.h/d"
+
+    # remove shipped binaries / libraries
+    rm -rf ../bin
 }
 
 function build_jzintv() {
     mkdir -p jzintv/bin
     cd jzintv/src
+
     make clean
-    make CC="gcc" CXX="g++" WARN="" WARNXX="" OPT_FLAGS="$CFLAGS"
+    make
+
     md_ret_require="$md_build/jzintv/bin/jzintv"
 }
 
 function install_jzintv() {
     md_ret_files=(
         'jzintv/bin'
+        'jzintv/doc'
         'jzintv/src/COPYING.txt'
         'jzintv/src/COPYRIGHT.txt'
+        $(find jzintv/Release*)
     )
 }
 
 function configure_jzintv() {
     mkRomDir "intellivision"
 
-    ! isPlatform "x11" && setBackend "$md_id" "dispmanx"
+    local options=(
+        --displaysize="%XRES%x%YRES%"
+        --quiet
+        --rom-path="$biosdir"
+        --voice=1
+    )
 
-    addEmulator 1 "$md_id" "intellivision" "$md_inst/bin/jzintv -p $biosdir -q %ROM%"
+    addEmulator 1 "$md_id" "intellivision" "$md_inst/bin/jzintv ${options[*]} %ROM%"
+    options+=(--ecs=1)
+    addEmulator 0 "${md_id}-ecs" "intellivision" "$md_inst/bin/jzintv ${options[*]} %ROM%"
     addSystem "intellivision"
 }


### PR DESCRIPTION
As initially sketched here: https://retropie.org.uk/forum/topic/30662/intellivision-jzintv-for-sdl2-proposed-scriptmodule

Note for early adapters trying this before it is merged upstream: If the download fails replace `$__archive_url/jzintv-20200712-src.zip` with `file http://spatula-city.org/%7Eim14u2c/intv/dl/jzintv-20200712-src.zip`