### PR TITLE
packages - allow custom binary installs when we don't host binaries

### DIFF
--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -412,7 +412,8 @@ function rp_hasBinaries() {
 
 function rp_getBinaryUrl() {
     local id="$1"
-    local url="$__binary_url/${__mod_info[$id/type]}/$id.tar.gz"
+    local url=""
+    rp_hasBinaries && url="$__binary_url/${__mod_info[$id/type]}/$id.tar.gz"
     if fnExists "install_bin_${id}"; then
         if fnExists "__binary_url_${id}"; then
             url="$(__binary_url_${id})"
@@ -458,11 +459,11 @@ function rp_hasBinary() {
     [[ -z "$url" ]] && return 1
 
     [[ -n "${__mod_info[$id/has_binary]}" ]] && return "${__mod_info[$id/has_binary]}"
+
     local ret=1
-    if rp_hasBinaries; then
-        rp_remoteFileExists "$url"
-        ret="$?"
-    fi
+    rp_remoteFileExists "$url"
+    ret="$?"
+
     # if there wasn't an error, cache the result
     [[ "$ret" -ne 2 ]] && __mod_info[$id/has_binary]="$ret"
     return "$ret"


### PR DESCRIPTION
Custom binary URLs provided by __binary_url_* scriptmodule functions were ignored for platforms we don't host general binary builds for. This meant that lr-duckstation wouldn't show binary install options on aarch64 / x86_64.

Moved the rp_hasBinaries check logic to rp_getBinaryUrl, so we only set a URL by default when we have binaries for that system. This is overridden as needed by install_bin_* / __binary_url_* scriptmodule functions. The rp_hasBinary function will check for a binary if the URL is set, so we allow overriding of our own binaries, as well as having the ability to install 3rd party binaries for systems we don't host binaries for.