### PR TITLE
redream: not available on aarch64 yet

### DIFF
--- a/scriptmodules/emulators/redream.sh
+++ b/scriptmodules/emulators/redream.sh
@@ -14,7 +14,7 @@ rp_module_desc="Redream Dreamcast emulator"
 rp_module_help="ROM Extensions: .cdi .cue .chd .gdi .iso\n\nCopy your Dreamcast roms to $romdir/dreamcast"
 rp_module_licence="PROP"
 rp_module_section="exp"
-rp_module_flags="noinstclean !all rpi4"
+rp_module_flags="noinstclean !all rpi4 !aarch64"
 
 function __binary_url_redream() {
     echo "https://redream.io/download/redream.aarch32-raspberry-linux-latest.tar.gz"


### PR DESCRIPTION
Fix `redream` being installable on `aarch64`, now that #3357 fixed the issue of packages with custom binary url set.