### PR TITLE
add * to catch icosa_emmc and icosa both

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -397,7 +397,7 @@ function get_platform() {
                         "NVIDIA Jetson Nano Developer Kit")
                             __platform="jetson-nano"
                             ;;
-                        icosa)
+                        icosa*)
                             __platform="tegra-x1"
                             ;;
                     esac


### PR DESCRIPTION
Nintendo Switch users who launch from emmc instead of SD storage get the model name icosa_emmc

I wasn't aware of this myself until and switch user notified me of this