### PR TITLE
Use Libretro's RetroArch joypad autoconfig presets to generate button labels

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -98,8 +98,13 @@ function update_overlays_retroarch() {
     local dir="$configdir/all/retroarch/overlay"
     # remove if not a git repository for fresh checkout
     [[ ! -d "$dir/.git" ]] && rm -rf "$dir"
-    gitPullOrClone "$configdir/all/retroarch/overlay" https://github.com/libretro/common-overlays.git
+    gitPullOrClone "$dir" https://github.com/libretro/common-overlays.git
     chown -R $user:$user "$dir"
+}
+
+function update_joypad_autoconfigs_retroarch() {
+    gitPullOrClone "$md_build/autoconfigs" https://github.com/libretro/retroarch-joypad-autoconfig.git
+    cp -a "$md_build/autoconfigs/." "$md_inst/autoconfig-presets/"
 }
 
 function update_assets_retroarch() {
@@ -147,6 +152,9 @@ function configure_retroarch() {
 
     # install minimal assets
     install_minimal_assets_retroarch
+
+    # install joypad autoconfig presets
+    update_joypad_autoconfigs_retroarch
 
     local config="$(mktemp)"
 


### PR DESCRIPTION
Whilst using Libretro's [RetroArch joypad autoconfigs](https://github.com/libretro/retroarch-joypad-autoconfig/) has proven problematic, we can still leverage this database in some interesting ways. This PR uses it to apply meaningful button labels across the Retroarch menus, rather than the retropad abstract/button numbers.

Eg, for a DualShock 4:
![IMG_5905](https://user-images.githubusercontent.com/13054748/122678233-cc453f80-d1dd-11eb-8a8e-9b5909d496ec.jpg)

Only tested with UDEV devices - one with labels in the matched preset in the repo (pictured), one with none (but will have after https://github.com/libretro/retroarch-joypad-autoconfig/pull/767). When there's no labels, they appear as previously:
![IMG_5906](https://user-images.githubusercontent.com/13054748/122678878-7de57000-d1e0-11eb-8a64-6279a2bce3a0.jpg)
