### PR TITLE
Runcommand tweaks

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -1319,6 +1319,10 @@ function launch_command() {
     return $ret
 }
 
+function log_info() {
+    echo -e "$SYSTEM\n$EMULATOR\n$ROM\n$COMMAND" >/dev/shm/runcommand.info
+}
+
 function runcommand() {
     get_config
 
@@ -1333,7 +1337,7 @@ function runcommand() {
     clear
 
     rm -f "$LOG"
-    echo -e "$SYSTEM\n$EMULATOR\n$ROM\n$COMMAND" >/dev/shm/runcommand.info
+    log_info
     user_script "runcommand-onstart.sh"
 
     set_save_vars
@@ -1359,6 +1363,9 @@ function runcommand() {
     COMMAND="${COMMAND//\%XRES\%/${MODE_CUR[2]}}"
     COMMAND="${COMMAND//\%YRES\%/${MODE_CUR[3]}}"
     COMMAND="${COMMAND//\%REFRESH\%/${MODE_CUR[5]}}"
+
+    # resave info after menu and resolution replacements so runcommand.info is up to date
+    log_info
 
     [[ -n "$FB_NEW" ]] && switch_fb_res $FB_NEW
 

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -1381,6 +1381,8 @@ function runcommand() {
         build_xinitrc build
     fi
 
+    user_script "runcommand-onlaunch.sh"
+
     local ret
     launch_command
     ret=$?


### PR DESCRIPTION
Split out runcommand.info creation to a function and call it again after menu is used in case any emulator settings are changed

Added additional runcommand-onlaunch.sh user script support which is run just before launching. This was requested in #2779 and #2810 

