### PR TITLE
Atari800 backends

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -648,7 +648,7 @@ function addUdevInputRules() {
 }
 
 ## @fn setBackend()
-## @param module_id name of module to configure backend for
+## @param emulator.cfg key to configure backend for
 ## @param backend name of the backend to set
 ## @param force set to 1 to force the change
 ## @brief Set a backend rendering driver for a module
@@ -656,6 +656,10 @@ function addUdevInputRules() {
 ## This function will only set a backend if
 ##   - It's not already configured, or
 ##   - The 3rd parameter (force) is set to 1
+## The emulator.cfg key is usually the module_id but some modules add multiple emulator.cfg entries
+## which are all handled separately. A module can use a _backend_set_MODULE function hook which is called
+## from the backends module to handle calling setBackend for additional emulator.cfg entries.
+## See "fuse" scriptmodule for an example.
 function setBackend() {
     local config="$configdir/all/backends.cfg"
     local id="$1"
@@ -667,6 +671,25 @@ function setBackend() {
         iniSet "$id" "$mode"
         chown $user:$user "$config"
     fi
+}
+
+## @fn getBackend()
+## @param emulator.cfg key to get backend for
+## @brief Get a backend rendering driver for a module
+## @details Get a backend rendering driver for a module
+## The function echos the result so the value can be captured using var=$(getBackend "$module_id")
+function getBackend() {
+    local config="$configdir/all/backends.cfg"
+    local id="$1"
+    iniConfig " = " '"' "$config"
+    iniGet "$id"
+    if [[ -n "$ini_value" ]]; then
+        # translate old value of 1 as dispmanx for backward compatibility
+        [[ "$ini_value" == "1" ]] && ini_value="dispmanx"
+     else
+        ini_value="default"
+     fi
+     echo "$ini_value"
 }
 
 ## @fn setDispmanx()

--- a/scriptmodules/supplementary/backends.sh
+++ b/scriptmodules/supplementary/backends.sh
@@ -48,19 +48,6 @@ function _list_backends() {
     return 0
 }
 
-function _get_current_backends() {
-    local id="$1"
-    iniConfig " = " '"' "$configdir/all/backends.cfg"
-    iniGet "$id"
-    if [[ -n "$ini_value" ]]; then
-        # translate old value of 1 as dispmanx for backward compatibility
-        [[ "$ini_value" == "1" ]] && ini_value="dispmanx"
-     else
-        ini_value="default"
-     fi
-     echo "$ini_value"
-}
-
 function _update_hook_backends() {
     local dispmanx_cfg="$configdir/all/dispmanx.cfg"
     local backends_cfg="$configdir/all/backends.cfg"
@@ -82,7 +69,7 @@ function gui_backends() {
             valid=0
             if rp_isInstalled "$id"; then
                 if _list_backends "$id" >/dev/null; then
-                    backend="$(_get_current_backends "$id")"
+                    backend="$(getBackend "$id")"
                     options+=("$id" "Using ${backends[$backend]} ($backend)")
                 fi
             fi
@@ -102,7 +89,7 @@ function gui_configure_backends() {
     _list_backends "$id"
 
     while true; do
-        local current="$(_get_current_backends "$id")"
+        local current="$(getBackend "$id")"
         local options=()
         local selected
         local backend


### PR DESCRIPTION
This allows choosing of sdl1 backend for atari800 and changes default to dispmanx for fkms.

More details in the commits.