### PR TITLE
joy2key: simplify debug message; fix python warning

### DIFF
--- a/scriptmodules/supplementary/runcommand/joy2key_sdl.py
+++ b/scriptmodules/supplementary/runcommand/joy2key_sdl.py
@@ -510,7 +510,7 @@ def main():
     if LOG.isEnabledFor(logging.DEBUG):
         sdl_ver = version.SDL_version()
         version.SDL_GetVersion(byref(sdl_ver))
-        wrapper_version = '.'.join(str(i) for i in version_info if i is not '')
+        wrapper_version = '.'.join(str(i) for i in version_info)
         LOG.debug(f'Using SDL Version {sdl_ver.major}.{sdl_ver.minor}.{sdl_ver.patch}, PySDL2 version {wrapper_version}')
 
     if joystick.SDL_NumJoysticks() < 1:


### PR DESCRIPTION
`python3.8(+)` throws a warning for using 'is/is not' with with certain literal types [1].
Simplifying the debug message that shows the `python3-sdl2` wrapper version gets rid of this warning, the end result is the same.

[1] https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior

Reported in https://retropie.org.uk/forum/topic/30876.