### PR TITLE
Dosbox Staging - move to fixed version instead of master/main

### DIFF
--- a/scriptmodules/emulators/dosbox-staging.sh
+++ b/scriptmodules/emulators/dosbox-staging.sh
@@ -13,9 +13,13 @@ rp_module_id="dosbox-staging"
 rp_module_desc="modern DOS/x86 emulator focusing on ease of use"
 rp_module_help="ROM Extensions: .bat .com .exe .sh .conf\n\nCopy your DOS games to $romdir/pc"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/dosbox-staging/dosbox-staging/master/COPYING"
-rp_module_repo="git https://github.com/dosbox-staging/dosbox-staging.git master"
+rp_module_repo="git https://github.com/dosbox-staging/dosbox-staging.git :_get_branch_dosbox-staging"
 rp_module_section="exp"
 rp_module_flags="sdl2"
+
+function _get_branch_dosbox-staging() {
+    download https://api.github.com/repos/dosbox-staging/dosbox-staging/releases/latest - | grep -m 1 tag_name | cut -d\" -f4
+}
 
 function depends_dosbox-staging() {
     getDepends cmake libasound2-dev libglib2.0-dev libopusfile-dev libpng-dev libsdl2-dev libsdl2-net-dev meson ninja-build


### PR DESCRIPTION
Not sure what I've done here hence I'm sorry for that. The `.git` extension has been restored as I wrongly removed it from previous PR. Should be good this time. _Note to self_: never rush a commit...

### Why move to a fixed version?
The main reason to switch from traditional [master branch](https://github.com/dosbox-staging/dosbox-staging) to a fixed version ([tag](https://github.com/dosbox-staging/dosbox-staging/tags)) is all about stability. Heavy changes are to be worked on shortly on DOSBox Staging (scaling method, better shader integration, input handling, etc just to name a few). Therefore the master branch is likely to break at some point. 

In order to not overwhelm [Github](https://github.com/dosbox-staging/dosbox-staging/issues) with tickets (or Retropie forum) when build is broken, let's stick to a fixed version (starting with **0.77.0**). The fixed/tagged branches are stable and have been heavily tested on various architectures/devices.

### Update the config file
**At the DOSBox `C:\>` prompt, run: `config -wc` to upgrade your config file. Your existing settings will be retained however extraneous comments will be dropped.**

### Significant changes added to 0.77.x ([release notes](https://dosbox-staging.github.io/))

* Migrated Staging from autotools to the Meson build system.
* Added write-xor-execute page support to comply with the latest macOS and SELinux security policies.
* Added variable expansion to the interactive DOS shell.
* Finished FluidSynth integration, which is now included in all release binaries.
* Finished MT-32 integration, which is now included in all release binaries.
* Added IBM PS/1 Audio device support.
* Added Innovation SSI-2001 audio device support.
* Replaced the default `Ctrl+F<keys>` hotkeys on macOS with `Cmd+F<keys>` to reduce conflicts with the OS.
* Added or Improved translations for French, Italian, Polish, Russian, and Spanish.
* Added `splash_only` to the `startup_verbosity` settings. This shows the splash but skips the help banner.
* Three relative window sizes: small, medium, or large are now understood by the `windowresolution` conf setting. These T-shirt sizes correspond to a window that's 25%, 50%, or 80% of your desktop's area, regardless of DPI or type of monitor (be it 720p, 1080p, or 4K).
* Window resizeable using corner-drag is now auto-enabled on all platforms when conditions permit.
* Will no longer lose focus on Raspberry Pi when launched fullscreen in an Xorg session.
* **Release builds now use `dosbox-staging.conf` as the primary conf file instead of `dosbox-staging-git.conf`.**

### Roadmap
Feel free to check the [roadmap for 0.78](https://github.com/dosbox-staging/dosbox-staging/projects/12) as well as the [full project view](https://github.com/dosbox-staging/dosbox-staging/projects).

**As always with DOSBox Staging anyone is very welcome to test, report bugs, ask for feature(s) and also help in developing/maintaining the code.**
