### PR TITLE
emulationstation: fix an input mapping corner case bug

### DIFF
--- a/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh
@@ -238,11 +238,14 @@ function map_retroarch_joystick() {
     local key
     local value
     local type
+    declare -A hat_map=([1]="up" [2]="right" [4]="down" [8]="left")
     for key in "${keys[@]}"; do
         case "$input_type" in
             hat)
+                # check if hat input value is correct
+                [[ -z ${hat_map[$input_value]} ]] && return
                 type="btn"
-                value="h$input_id$input_name"
+                value="h$input_id${hat_map[$input_value]}"
                 ;;
             axis)
                 type="axis"


### PR DESCRIPTION
When a hat is mapped to another set of inputs other than D-Pad's up/down/left/right in EmulationStation, the resulting RetroArch mapping can be incorrect.
As an example, the following ES input mapping (obtained by probably mapping the physical D-Pad to the left analog stick inputs in EmulationStation):

    <input name="leftanalogdown" type="hat" id="0" value="4"/>
    <input name="leftanalogright" type="hat" id="0" value="2"/>
    <input name="leftanalogleft" type="hat" id="0" value="8"/>
    <input name="leftanalogup" type="hat" id="0" value="1"/>

results in the following incorrect RetroArch input configuration:

    input_l_y_plus_btn = "h0leftanalogdown"
    input_l_x_plus_btn = "h0leftanalogright"
    input_l_x_minus_btn = "h0leftanalogleft"
    input_l_y_minus_btn = "h0leftanalogup"

Rather than use `input_name`, map the `input_value` to the hat's cardinal directions (up/right/down/left) in the joypad's configuration profile.