### PR TITLE
remove tegra 2 and change tegra 3/4 to gles

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -412,9 +412,6 @@ function get_platform() {
                     esac
                 elif [[ -e "/sys/devices/soc0/family" ]]; then
                     case "$(tr -d '\0' < /sys/devices/soc0/family)" in
-                        *tegra20*)
-                            __platform="tegra-2"
-                            ;;
                         *tegra30*)
                             __platform="tegra-3"
                             ;;
@@ -561,19 +558,14 @@ function platform_xavier() {
     __platform_flags+=(x11 gl)
 }
 
-function platform_tegra-2() {
-    cpu_armv7 "cortex-a9"
-    __platform_flags+=(x11 gl)
-}
-
 function platform_tegra-3() {
     cpu_armv7 "cortex-a9"
-    __platform_flags+=(x11 gl)
+    __platform_flags+=(x11 gles)
 }
 
 function platform_tegra-4() {
     cpu_armv7 "cortex-a15"
-    __platform_flags+=(x11 gl)
+    __platform_flags+=(x11 gles)
 }
 
 function platform_tegra-k1-32() {


### PR DESCRIPTION
tegra 2 is armv7 and doesn't support NEON and is unlikely to ever be used
tegra 3 (and maybe 4?) only support gles (up to 2.0) not gl (in L4T linux at least)