### PR TITLE
lr-vice: preset a couple of SID options on ARMv6

### DIFF
--- a/scriptmodules/libretrocores/lr-vice.sh
+++ b/scriptmodules/libretrocores/lr-vice.sh
@@ -66,6 +66,11 @@ function configure_lr-vice() {
 
     [[ "$md_mode" == "remove" ]] && return
 
+    if isPlatform "arm"; then
+        setRetroArchCoreOption "vice_sid_engine" "FastSID"
+        isPlatform "armv6" && setRetroArchCoreOption "vice_sound_sample_rate" "22050"
+    fi
+
     cp -R "$md_inst/data" "$biosdir"
     chown -R $user:$user "$biosdir/data"
 }


### PR DESCRIPTION
The options changed are similar to the configuration used for the standalone VICE:

* Set the SID implementation to FastSID
* Decrease the sound sample rate to 22050