### PR TITLE
Add Hypseus Singe (Daphne) SDL2 Laserdisc emulator.

### DIFF
--- a/scriptmodules/emulators/hypseus.sh
+++ b/scriptmodules/emulators/hypseus.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="hypseus"
+rp_module_desc="Hypseus Singe - Laserdisc Emulator"
+rp_module_help="ROM Extension: .daphne\n\nCopy your Daphne roms to $romdir/daphne"
+rp_module_licence="GPL3 https://raw.githubusercontent.com/DirtBagXon/hypseus-singe/master/LICENSE"
+rp_module_repo="git https://github.com/DirtBagXon/hypseus-singe.git RetroPie"
+rp_module_section="exp"
+rp_module_flags="sdl2"
+
+function depends_hypseus() {
+    getDepends libvorbis-dev libogg-dev zlib1g-dev libmpeg2-4-dev libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev cmake
+}
+
+function sources_hypseus() {
+    gitPullOrClone
+}
+
+function build_hypseus() {
+    rm -rf build
+    mkdir build
+    cd build
+    rpSwap on 1024
+    cmake ../src
+    make
+    rpSwap off
+    cp hypseus ../hypseus.bin
+    md_ret_require="hypseus"
+}
+
+function install_hypseus() {
+    md_ret_files=(
+        'sound'
+        'pics'
+        'fonts'
+        'hypseus.bin'
+        'LICENSE'
+    )
+}
+
+function configure_hypseus() {
+    mkRomDir "daphne"
+    mkRomDir "daphne/roms"
+
+    addEmulator 0 "$md_id" "daphne" "$md_inst/hypseus.sh %ROM%"
+    addSystem "daphne"
+
+    [[ "$md_mode" == "remove" ]] && return
+
+    mkUserDir "$md_conf_root/daphne"
+
+    local dir
+    for dir in ram logs screenshots; do
+        mkUserDir "$md_conf_root/daphne/$dir"
+        ln -snf "$md_conf_root/daphne/$dir" "$md_inst/$dir"
+    done
+
+    copyDefaultConfig "$md_data/hypinput.ini" "$md_conf_root/daphne/hypinput.ini"
+
+    ln -snf "$romdir/daphne/roms" "$md_inst/roms"
+    ln -snf "$romdir/daphne/roms" "$md_inst/singe"
+
+    ln -sf "$md_conf_root/daphne/hypinput.ini" "$md_inst/hypinput.ini"
+
+    local common_args="-framefile \"\$dir/\$name.txt\" -homedir \"$md_inst\" -fullscreen \$params"
+
+    cat >"$md_inst/hypseus.sh" <<_EOF_
+#!/bin/bash
+dir="\$1"
+name="\${dir##*/}"
+name="\${name%.*}"
+
+if [[ -f "\$dir/\$name.commands" ]]; then
+    params=\$(<"\$dir/\$name.commands")
+fi
+
+if [[ -f "\$dir/\$name.singe" ]]; then
+    "$md_inst/hypseus.bin" singe vldp -retropath -manymouse -script "\$dir/\$name.singe" $common_args
+else
+    "$md_inst/hypseus.bin" "\$name" vldp $common_args
+fi
+_EOF_
+    chmod +x "$md_inst/hypseus.sh"
+    mkdir -p "$md_inst/framefile"
+}

--- a/scriptmodules/emulators/hypseus/hypinput.ini
+++ b/scriptmodules/emulators/hypseus/hypinput.ini
@@ -1,0 +1,58 @@
+# Sample hypinput.ini
+# All key options listed
+# Hypseus uses SDL2 Keycodes
+#
+# The first two entries are SDL2 keyboard codes or names (0 for "none")
+#
+# Find SDL2 keyboard code information here:
+# https://github.com/DirtBagXon/hypseus-singe/blob/master/doc/keylist.txt
+#
+# Hypseus Singe supports configuration on multiple joysticks
+# First joystick is defined as 0, second joystick as 1 etc.
+#
+# IMPORTANT: Find the joystick button and axis by running:
+# jstest /dev/input/js0 || jstest /dev/input/js1
+#
+# The third number in config is a joystick button code (or 0 for "none")
+# Since 0 is reserved for special meaning, joystick button 0 is
+# identified as 1. Button 1 is identified as 2, and so on.
+#
+# Defining 001 (or 1) identifies first joystick(0) button 0
+# Defining 111 identifies second joystick(1) button 10
+#
+# The fourth number in config (if specified) is the joystick axis
+# configuration (or 0 for "none"). Since 0 is reserved for
+# special meaning, joystick axis 0 is identified as 1.
+# Axis 1 is identified as 2, and so on.
+#
+# Only the first four switches are defined (SWITCH_UP->SWITCH_RIGHT) for axis
+#
+# Defining -001 (or -1) identifies first joystick(0) axis 0 in negative direction
+# Defining +102 identifies second joystick(1) axis 1 in positive direction
+
+# KEY_BUTTON3 Turns scoreboard on/off in lair/ace
+
+[KEYBOARD]
+KEY_UP = SDLK_UP SDLK_r 5 -002
+KEY_DOWN = SDLK_DOWN SDLK_f 7 +002
+KEY_LEFT = SDLK_LEFT SDLK_d 8 -001
+KEY_RIGHT = SDLK_RIGHT SDLK_g 6 +001
+KEY_COIN1 = SDLK_5 0 1
+KEY_COIN2 = SDLK_6 0 0
+KEY_START1 = SDLK_1 0 4
+KEY_START2 = SDLK_2 0 0
+KEY_BUTTON1 = SDLK_LCTRL SDLK_a 14
+KEY_BUTTON2 = SDLK_LALT SDLK_s 15
+KEY_BUTTON3 = SDLK_SPACE SDLK_d 16
+KEY_SKILL1 = SDLK_LSHIFT SDLK_w 0
+KEY_SKILL2 = SDLK_z SDLK_i 0
+KEY_SKILL3 = SDLK_x SDLK_k 0
+KEY_SERVICE = SDLK_9 0 0
+KEY_TEST = SDLK_F2 0 0
+KEY_RESET = SDLK_0 0 0
+KEY_SCREENSHOT = SDLK_F12 0 0
+KEY_QUIT = SDLK_ESCAPE SDLK_q 17
+KEY_PAUSE = SDLK_p 0 0
+KEY_CONSOLE = SDLK_BACKSLASH 0 0
+KEY_TILT = SDLK_t 0 0
+END


### PR DESCRIPTION
This is to automate: https://github.com/DirtBagXon/hypseus-singe/blob/master/src/3rdparty/retropie/RETROPIE.md

This plugin is not restricted in arcitecture like the previous SDL1 version.
Supports Pi (inc. aarch64), ODroid & PC (i386/AMD64).

Standing Forum discussions:
https://retropie.org.uk/forum/topic/18505/new-hypseus-and-lr-daphne-to-add-on-retropie-setup
https://retropie.org.uk/forum/topic/27426/request-add-daphne-singe-emulator
https://retropie.org.uk/forum/topic/31155/integrate-daphne-emulator-back-into-the-retropie-script-for-ubuntu

This setup follows the existing Daphne plugin installation as closely as possible.
I have mirrored the included config file to the existing plugin where appropriate.

This is my first pull request for RetroPie, please let me know if anything else is required.

I have tagged as an experimental package, application should be stable.

~Would like to shift 'RetroPie' branch from:~

~https://github.com/DirtBagXon/hypseus-singe~
~to~
~https://github.com/RetroPie/hypseus-singe~

~If someone could provide details on how to submit on a new repo.~