### PR TITLE
helpers: teach `aptUpdate` to hop releases

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -175,7 +175,7 @@ function hasPackage() {
 ## @brief Calls apt-get update (if it has not been called before).
 function aptUpdate() {
     if [[ "$__apt_update" != "1" ]]; then
-        apt-get update
+        apt-get update --allow-releaseinfo-change
         __apt_update="1"
     fi
 }


### PR DESCRIPTION
When the release of the remote repository is changed, `apt-get` will not update its packages without
`--allow-releaseinfo-change`, so fix that.

This has become problematic due to last week's Debian Bullseye release, which changed the <raspbian.raspberrypi.org> suite from 'stable' to 'oldstable' and prevents `apt` to refresh its index. Upgrading from 4.7.1 (image) to the current version is no longer possible because of this, since `subversion` is not installed on 4.7.1, but it's required now and due to it being updated in the repo, it's not installable.

In the future, we might switch to just using `apt update` (which doesn't have this problem), but there are several other places where `apt-get` is still used, so this change is meant just as a quick fix for the recent suite changes.