### PR TITLE
sdl2 - updated to retropie-2.0.20 branch

### DIFF
--- a/scriptmodules/supplementary/sdl2.sh
+++ b/scriptmodules/supplementary/sdl2.sh
@@ -16,11 +16,11 @@ rp_module_section="depends"
 rp_module_flags=""
 
 function get_ver_sdl2() {
-    echo "2.0.10"
+    echo "2.0.20"
 }
 
 function get_pkg_ver_sdl2() {
-    local ver="$(get_ver_sdl2)+5"
+    local ver="$(get_ver_sdl2)+1"
     isPlatform "rpi" && ver+="rpi"
     isPlatform "mali" && ver+="mali"
     echo "$ver"
@@ -33,7 +33,7 @@ function get_arch_sdl2() {
 function _list_depends_sdl2() {
     # Dependencies from the debian package control + additional dependencies for the pi (some are excluded like dpkg-dev as they are
     # already covered by the build-essential package retropie relies on.
-    local depends=(libasound2-dev libudev-dev libibus-1.0-dev libdbus-1-dev fcitx-libs-dev libsndio-dev)
+    local depends=(libasound2-dev libudev-dev libibus-1.0-dev libdbus-1-dev fcitx-libs-dev libsndio-dev libsamplerate0-dev)
     # these were removed by a PR for vero4k support (cannot test). Needed though at least for for RPI and X11
     ! isPlatform "vero4k" && depends+=(libx11-dev libxcursor-dev libxext-dev libxi-dev libxinerama-dev libxkbcommon-dev libxrandr-dev libxss-dev libxt-dev libxv-dev libxxf86vm-dev libgl1-mesa-dev)
     isPlatform "gles" || isPlatform "gl" && depends+=(libegl1-mesa-dev libgles2-mesa-dev)
@@ -91,6 +91,7 @@ function build_sdl2() {
     if isPlatform "rpi" && [[ -d "/opt/vc/include" ]]; then
         # move proprietary videocore headers
         sed -i -e 's/\"EGL/\"brcmEGL/g' -e 's/\"GLES/\"brcmGLES/g' ./src/video/raspberry/SDL_rpivideo.h
+        sed -i -e 's#<EGL/eglplatform#<brcmEGL/eglplatform#g' configure
         mv /opt/vc/include/EGL /opt/vc/include/brcmEGL
         mv /opt/vc/include/GLES /opt/vc/include/brcmGLES
         mv /opt/vc/include/GLES2 /opt/vc/include/brcmGLES2


### PR DESCRIPTION
Added libsamplerate0-dev dependency to module.

Branch includes reworking the patch for kms modesetting via env variables, some minor changes to our Mali and RPI patches,
and some removal of no longer needed changes. It also includes removal of some debian/control build dependencies which were
added to upstream to align with Debian's packaging. The addition causes dependencies like libwayland-dev and libpulse-dev to
be required for all platforms. As we handle adding dependencies in our sdl module code, these have been removed in our
retropie-2.0.16+ sdl2 branch.