### PR TITLE
Retroarch: Add libretro glsl and slang shaders if platform is not rpi

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -101,6 +101,10 @@ function update_shaders_retroarch() {
             gitPullOrClone "$dir/$shadersystem" "https://github.com/libretro/$shadersystem-shaders.git" "$branch"
             chown -R $user:$user "$dir/$shadersystem"
         done
+        # remove if not git repository for fresh checkout
+        [[ ! -d "$dir/retropie/.git" ]] && rm -rf "$dir/retropie"
+        gitPullOrClone "$dir/retropie" https://github.com/RetroPie/common-shaders.git "rpi"
+        chown -R $user:$user "$dir/retropie"
     fi
 }
 

--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -87,11 +87,21 @@ function install_retroarch() {
 function update_shaders_retroarch() {
     local dir="$configdir/all/retroarch/shaders"
     local branch=""
-    isPlatform "rpi" && branch="rpi"
     # remove if not git repository for fresh checkout
     [[ ! -d "$dir/.git" ]] && rm -rf "$dir"
-    gitPullOrClone "$dir" https://github.com/RetroPie/common-shaders.git "$branch"
-    chown -R $user:$user "$dir"
+    if isPlatform "rpi"; then
+        branch="rpi"
+        gitPullOrClone "$dir" https://github.com/RetroPie/common-shaders.git "$branch"
+        chown -R $user:$user "$dir"
+    else
+        local shadersystem
+        for shadersystem in "glsl" "slang"; do
+            # remove if not git repository for fresh checkout
+            [[ ! -d "$dir/$shadersystem/.git" ]] && rm -rf "$dir/$shadersystem"
+            gitPullOrClone "$dir/$shadersystem" "https://github.com/libretro/$shadersystem-shaders.git" "$branch"
+            chown -R $user:$user "$dir/$shadersystem"
+        done
+    fi
 }
 
 function update_overlays_retroarch() {


### PR DESCRIPTION
The current RetroPie/common-shaders master branch is outdated (last update 2016). Libretro has an own glsl repo with glsl now. Common-shaders has no slang shaders for video drivers glcore and vulkan.

This PR adds three folders in the shader directory if platform is not rpi.
shaders/slang: Contains libretro  slang shaders for drivers glcore/vulkan
shaders/glsl: Contains libretro glsl shaders for driver gl
shaders/retropie: Contains common-shaders branch rpi shaders for driver gl