### PR TITLE
Skyscraper - fix critical dependency error (Debian 11+, Ubuntu 21.04+)

### DIFF
--- a/scriptmodules/supplementary/skyscraper.sh
+++ b/scriptmodules/supplementary/skyscraper.sh
@@ -28,7 +28,7 @@ function sources_skyscraper() {
 }
 
 function build_skyscraper() {
-    qmake
+    QT_SELECT=5 qmake
     make
     md_ret_require="$md_build/Skyscraper"
 }

--- a/scriptmodules/supplementary/skyscraper.sh
+++ b/scriptmodules/supplementary/skyscraper.sh
@@ -20,7 +20,7 @@ function _get_branch_skyscraper() {
 }
 
 function depends_skyscraper() {
-    getDepends qt5-default p7zip-full
+    getDepends qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools p7zip-full
 }
 
 function sources_skyscraper() {


### PR DESCRIPTION
qt5 has been removed in all modern versions of Debian and Ubuntu, and the skyscraper script will not work at all without these changes - this dependency change should not break older versions of these operating systems and the package should install fine.
https://askubuntu.com/a/1335187