### PR TITLE
uqm - rework module to build from source (and update to 0.8.0)

### DIFF
--- a/scriptmodules/ports/uqm.sh
+++ b/scriptmodules/ports/uqm.sh
@@ -11,12 +11,12 @@
 
 rp_module_id="uqm"
 rp_module_desc="The Ur-Quan Masters (Port of DOS game Star Control 2)"
-rp_module_licence="NONCOM https://raw.githubusercontent.com/davidben/uqm/nacl/COPYING"
-rp_module_section="opt"
-rp_module_flags="!mali"
+rp_module_licence="GPL https://sourceforce.net/p/sc2/uqm/ci/master/tree/sc2/COPYING?format=raw"
+rp_module_repo="file :_get_archive_uqm"
+rp_module_section="exp"
 
 function _get_ver_uqm() {
-    echo "0.6.2.dfsg-9.5"
+    echo "0.8.0"
 }
 
 function _update_hook_uqm() {
@@ -24,67 +24,38 @@ function _update_hook_uqm() {
     hasPackage uqm && mkdir -p "$md_inst"
 }
 
-function depends_uqm() {
-    [[ "$__os_id" != "Raspbian" ]] && return 0
-    local depends=(debhelper devscripts libmikmod-dev libsdl1.2-dev libopenal-dev libsdl-image1.2-dev libogg-dev libvorbis-dev)
-    isPlatform "gl" || isPlatform "mesa" && depends+=(libgl1-mesa-dev)
-    isPlatform "kms" && depends+=(xorg)
+function _get_archive_uqm() {
+    echo "$__archive_url/uqm-$(_get_ver_uqm)-src.tgz"
+}
 
-    getDepends "${depends[@]}"
+function depends_uqm() {
+    getDepends libsdl2-dev libogg-dev libvorbis-dev libpng-dev zlib1g-dev
 }
 
 function sources_uqm() {
-    [[ "$__os_id" != "Raspbian" ]] && return 0
+    downloadAndExtract "$(rp_resolveRepoParam "$md_repo_url")" "$md_build" --strip-components 1
+    local packages="$md_build/content/packages"
+    mkdir -p "$packages"
     local ver="$(_get_ver_uqm)"
-    local url="http://http.debian.net/debian/pool/contrib/u/uqm"
-    for file in uqm_$ver.dsc uqm_0.6.2.dfsg.orig.tar.gz uqm_$ver.debian.tar.xz; do
-        download "$url/$file"
-    done
+    download "$__archive_url/uqm-${ver}-content.uqm" "$packages"
+    download "$__archive_url/uqm-${ver}-voice.uqm" "$packages"
+    download "$__archive_url/uqm-${ver}-3domusic.uqm" "$packages"
 }
 
 function build_uqm() {
-    [[ "$__os_id" != "Raspbian" ]] && return 0
-    dpkg-source -x uqm_$(_get_ver_uqm).dsc
-    cd uqm-0.6.2.dfsg
-    dpkg-buildpackage -us -uc
+    ./build.sh uqm clean
+    echo "\n" | CHOICE_debug_VALUE="nodebug" INPUT_install_prefix_VALUE="$md_inst" ./build.sh uqm config
+    ./build.sh uqm
 }
 
 function install_uqm() {
-    # uqm is missing on raspbian
-    if [[ "$__os_id" == "Raspbian" ]]; then
-        cp -v *.deb "$md_inst"
-        dpkg -i *.deb
-        aptInstall uqm-content uqm-music uqm-voice
-    else
-        aptInstall uqm uqm-content uqm-music uqm-voice
-    fi
-}
-
-function install_bin_uqm() {
-    rp_installBin
-    # uqm is missing on raspbian
-    if hasPackage raspberrypi-bootloader; then
-        cd "$md_inst"
-        dpkg -i *.deb
-        aptInstall uqm-content uqm-music uqm-voice
-    else
-        aptInstall uqm uqm-content uqm-music uqm-voice
-    fi
-}
-
-function remove_uqm() {
-    aptRemove uqm uqm-content uqm-music uqm-voice
+    ./build.sh uqm install
 }
 
 function configure_uqm() {
-    local binary="uqm"
-    local params=("-f")
-    if isPlatform "kms"; then
-        # SDL1 needs xinit, and does not have /usr/games in $PATH
-        binary="XINIT:/usr/games/$binary"
-        # OpenGL mode must be also be enabled for high resolution support
-        params+=("-o" "-r %XRES%x%YRES%")
-    fi
+    addPort "$md_id" "uqm" "Ur-quan Masters" "$md_inst/bin/uqm -f"
+
+    [[ "$md_mode" == "remove" ]] && return
+
     moveConfigDir "$home/.uqm" "$md_conf_root/uqm"
-    addPort "$md_id" "uqm" "Ur-quan Masters" "$binary ${params[*]}"
 }


### PR DESCRIPTION
This avoids the messy logic for missing Raspberry Pi Buster packages, and simplifies future updates.