### PR TITLE
Add defaultRAConfig to replace ensureSystemretroconfig

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -939,18 +939,39 @@ function setESSystem() {
 
 ## @fn ensureSystemretroconfig()
 ## @param system system to create retroarch.cfg for
-## @param shader set a default shader to use (deprecated)
-## @brief Creates a default retroarch.cfg for specified system in `/opt/retropie/configs/$system/retroarch.cfg`.
+## @brief Deprecated - use defaultRAConfig
+## @details Creates a default retroarch.cfg for specified system in `$configdir/$system/retroarch.cfg`.
 function ensureSystemretroconfig() {
     # don't do any config work on module removal
     [[ "$md_mode" == "remove" ]] && return
 
-    local system="$1"
-    local shader="$2"
+    # reset "$md_conf_root" to "$configdir" as defaultRAConfig handles this whereas ensureSystemretroconfig
+    # expects system to include any subdirectory in the first parameter such as "ports/$system".
+    local save_conf_root="$md_conf_root"
+    md_conf_root="$configdir"
+    defaultRAConfig "$1"
+    md_conf_root="$save_conf_root"
+}
 
-    if [[ ! -d "$configdir/$system" ]]; then
-        mkUserDir "$configdir/$system"
-    fi
+## @fn defaultRAConfig()
+## @param system system to create retroarch.cfg for
+## @param ... optional key then value parameters to be used in the config
+## @brief Creates a default retroarch.cfg for specified system in `$md_root_dir/$system/retroarch.cfg`.
+## @details Additional default configuration values can be provided as parameters to the function - eg. "fps_show" "true"
+## as two parameters would add a default entry of fps_show = "true" to the default configuration.
+## This function uses $md_conf_root as a base, so there is no need to use "ports/$system" for libretro ports as with
+## the older ensureSystemretroconfig
+function defaultRAConfig() {
+    # don't do any config work on module removal
+    [[ "$md_mode" == "remove" ]] && return
+
+    local system="$1"
+    shift
+    local defaults=("$@")
+
+    local config_path="$md_conf_root/$system"
+
+    [[ ! -d "$config_path" ]] && mkUserDir "$config_path"
 
     local config="$(mktemp)"
     # add the initial comment regarding include order
@@ -958,18 +979,19 @@ function ensureSystemretroconfig() {
 
     # add the per system default settings
     iniConfig " = " '"' "$config"
-    iniSet "input_remapping_directory" "$configdir/$system/"
+    iniSet "input_remapping_directory" "$config_path"
 
-    if [[ -n "$shader" ]]; then
-        iniUnset "video_smooth" "false"
-        iniSet "video_shader" "$emudir/retroarch/shader/$shader"
-        iniUnset "video_shader_enable" "true"
-    fi
+    # add any additional config key / values from function parameters
+    local key
+    local value
+    while read key value; do
+        [[ -n "$key" ]] && iniSet "$key" "$value"
+    done <<< "${defaults[@]}"
 
     # include the main retroarch config
     echo -e "\n#include \"$configdir/all/retroarch.cfg\"" >>"$config"
 
-    copyDefaultConfig "$config" "$configdir/$system/retroarch.cfg"
+    copyDefaultConfig "$config" "$config_path/retroarch.cfg"
     rm "$config"
 }
 

--- a/scriptmodules/libretrocores/lr-81.sh
+++ b/scriptmodules/libretrocores/lr-81.sh
@@ -35,7 +35,7 @@ function install_lr-81() {
 
 function configure_lr-81() {
     mkRomDir "zx81"
-    ensureSystemretroconfig "zx81"
+    defaultRAConfig "zx81"
 
     addEmulator 1 "$md_id" "zx81" "$md_inst/81_libretro.so"
     addSystem "zx81"

--- a/scriptmodules/libretrocores/lr-atari800.sh
+++ b/scriptmodules/libretrocores/lr-atari800.sh
@@ -37,8 +37,8 @@ function configure_lr-atari800() {
     mkRomDir "atari800"
     mkRomDir "atari5200"
 
-    ensureSystemretroconfig "atari800"
-    ensureSystemretroconfig "atari5200"
+    defaultRAConfig "atari800"
+    defaultRAConfig "atari5200"
 
     mkUserDir "$md_conf_root/atari800"
     moveConfigFile "$home/.lr-atari800.cfg" "$md_conf_root/atari800/lr-atari800.cfg"

--- a/scriptmodules/libretrocores/lr-beetle-lynx.sh
+++ b/scriptmodules/libretrocores/lr-beetle-lynx.sh
@@ -34,7 +34,7 @@ function install_lr-beetle-lynx() {
 
 function configure_lr-beetle-lynx() {
     mkRomDir "atarilynx"
-    ensureSystemretroconfig "atarilynx"
+    defaultRAConfig "atarilynx"
 
     addEmulator 0 "$md_id" "atarilynx" "$md_inst/mednafen_lynx_libretro.so"
     addSystem "atarilynx"

--- a/scriptmodules/libretrocores/lr-beetle-ngp.sh
+++ b/scriptmodules/libretrocores/lr-beetle-ngp.sh
@@ -41,7 +41,7 @@ function configure_lr-beetle-ngp() {
     local system
     for system in ngp ngpc; do
         mkRomDir "$system"
-        ensureSystemretroconfig "$system"
+        defaultRAConfig "$system"
         addEmulator 1 "$md_id" "$system" "$md_inst/mednafen_ngp_libretro.so"
         addSystem "$system"
     done

--- a/scriptmodules/libretrocores/lr-beetle-pce-fast.sh
+++ b/scriptmodules/libretrocores/lr-beetle-pce-fast.sh
@@ -40,7 +40,7 @@ function install_lr-beetle-pce-fast() {
 
 function configure_lr-beetle-pce-fast() {
     mkRomDir "pcengine"
-    ensureSystemretroconfig "pcengine"
+    defaultRAConfig "pcengine"
 
     addEmulator 1 "$md_id" "pcengine" "$md_inst/mednafen_pce_fast_libretro.so"
     addSystem "pcengine"

--- a/scriptmodules/libretrocores/lr-beetle-pcfx.sh
+++ b/scriptmodules/libretrocores/lr-beetle-pcfx.sh
@@ -34,7 +34,7 @@ function install_lr-beetle-pcfx() {
 
 function configure_lr-beetle-pcfx() {
     mkRomDir "pcfx"
-    ensureSystemretroconfig "pcfx"
+    defaultRAConfig "pcfx"
 
     addEmulator 1 "$md_id" "pcfx" "$md_inst/mednafen_pcfx_libretro.so"
     addSystem "pcfx"

--- a/scriptmodules/libretrocores/lr-beetle-psx.sh
+++ b/scriptmodules/libretrocores/lr-beetle-psx.sh
@@ -42,7 +42,7 @@ function install_lr-beetle-psx() {
 
 function configure_lr-beetle-psx() {
     mkRomDir "psx"
-    ensureSystemretroconfig "psx"
+    defaultRAConfig "psx"
 
     addEmulator 0 "$md_id" "psx" "$md_inst/mednafen_psx_hw_libretro.so"
     addSystem "psx"

--- a/scriptmodules/libretrocores/lr-beetle-saturn.sh
+++ b/scriptmodules/libretrocores/lr-beetle-saturn.sh
@@ -35,7 +35,7 @@ function install_lr-beetle-saturn() {
 
 function configure_lr-beetle-saturn() {
     mkRomDir "saturn"
-    ensureSystemretroconfig "saturn"
+    defaultRAConfig "saturn"
 
     addEmulator 1 "$md_id" "saturn" "$md_inst/mednafen_saturn_libretro.so"
     addSystem "saturn"

--- a/scriptmodules/libretrocores/lr-beetle-supergrafx.sh
+++ b/scriptmodules/libretrocores/lr-beetle-supergrafx.sh
@@ -34,7 +34,7 @@ function install_lr-beetle-supergrafx() {
 
 function configure_lr-beetle-supergrafx() {
     mkRomDir "pcengine"
-    ensureSystemretroconfig "pcengine"
+    defaultRAConfig "pcengine"
 
     addEmulator 0 "$md_id" "pcengine" "$md_inst/mednafen_supergrafx_libretro.so"
     addSystem "pcengine"

--- a/scriptmodules/libretrocores/lr-beetle-vb.sh
+++ b/scriptmodules/libretrocores/lr-beetle-vb.sh
@@ -37,7 +37,7 @@ function install_lr-beetle-vb() {
 
 function configure_lr-beetle-vb() {
     mkRomDir "virtualboy"
-    ensureSystemretroconfig "virtualboy"
+    defaultRAConfig "virtualboy"
 
     addEmulator 1 "$md_id" "virtualboy" "$md_inst/mednafen_vb_libretro.so"
     addSystem "virtualboy"

--- a/scriptmodules/libretrocores/lr-beetle-wswan.sh
+++ b/scriptmodules/libretrocores/lr-beetle-wswan.sh
@@ -40,8 +40,8 @@ function install_lr-beetle-wswan() {
 function configure_lr-beetle-wswan() {
     mkRomDir "wonderswan"
     mkRomDir "wonderswancolor"
-    ensureSystemretroconfig "wonderswan"
-    ensureSystemretroconfig "wonderswancolor"
+    defaultRAConfig "wonderswan"
+    defaultRAConfig "wonderswancolor"
 
     addEmulator 1 "$md_id" "wonderswan" "$md_inst/mednafen_wswan_libretro.so"
     addEmulator 1 "$md_id" "wonderswancolor" "$md_inst/mednafen_wswan_libretro.so"

--- a/scriptmodules/libretrocores/lr-bluemsx.sh
+++ b/scriptmodules/libretrocores/lr-bluemsx.sh
@@ -36,25 +36,27 @@ function install_lr-bluemsx() {
 }
 
 function configure_lr-bluemsx() {
-    mkRomDir "msx"
-    defaultRAConfig "msx"
-
-    mkRomDir "coleco"
-    defaultRAConfig "coleco"
-
-    # force colecovision system
-    local core_config="$md_conf_root/coleco/retroarch-core-options.cfg"
-    iniConfig " = " '"' "$md_conf_root/coleco/retroarch.cfg"
-    iniSet "core_options_path" "$core_config"
-    iniSet "bluemsx_msxtype" "ColecoVision" "$core_config"
-    chown $user:$user "$core_config"
-
-    cp -rv "$md_inst/"{Databases,Machines} "$biosdir/"
-    chown -R $user:$user "$biosdir/"{Databases,Machines}
-
     addEmulator 1 "$md_id" "msx" "$md_inst/bluemsx_libretro.so"
     addSystem "msx"
 
     addEmulator 1 "$md_id" "coleco" "$md_inst/bluemsx_libretro.so"
     addSystem "coleco"
+
+    [[ "$md_mode" == "remove" ]] && return
+
+    mkRomDir "msx"
+    defaultRAConfig "msx"
+
+    # force colecovision system
+    local core_config="$md_conf_root/coleco/retroarch-core-options.cfg"
+    iniConfig " = " '"' "$core_config"
+    iniSet "bluemsx_msxtype" "ColecoVision" "$core_config"
+    chown $user:$user "$core_config"
+
+    mkRomDir "coleco"
+    defaultRAConfig "coleco" "core_options_path" "$core_config"
+
+    cp -rv "$md_inst/"{Databases,Machines} "$biosdir/"
+    chown -R $user:$user "$biosdir/"{Databases,Machines}
+
 }

--- a/scriptmodules/libretrocores/lr-bluemsx.sh
+++ b/scriptmodules/libretrocores/lr-bluemsx.sh
@@ -37,10 +37,10 @@ function install_lr-bluemsx() {
 
 function configure_lr-bluemsx() {
     mkRomDir "msx"
-    ensureSystemretroconfig "msx"
+    defaultRAConfig "msx"
 
     mkRomDir "coleco"
-    ensureSystemretroconfig "coleco"
+    defaultRAConfig "coleco"
 
     # force colecovision system
     local core_config="$md_conf_root/coleco/retroarch-core-options.cfg"

--- a/scriptmodules/libretrocores/lr-bsnes.sh
+++ b/scriptmodules/libretrocores/lr-bsnes.sh
@@ -47,7 +47,7 @@ function install_lr-bsnes() {
 
 function configure_lr-bsnes() {
     mkRomDir "snes"
-    ensureSystemretroconfig "snes"
+    defaultRAConfig "snes"
 
     addEmulator 1 "$md_id" "snes" "$md_inst/bsnes_libretro.so"
     addSystem "snes"

--- a/scriptmodules/libretrocores/lr-caprice32.sh
+++ b/scriptmodules/libretrocores/lr-caprice32.sh
@@ -34,7 +34,7 @@ function install_lr-caprice32() {
 
 function configure_lr-caprice32() {
     mkRomDir "amstradcpc"
-    ensureSystemretroconfig "amstradcpc"
+    defaultRAConfig "amstradcpc"
 
     setRetroArchCoreOption "cap32_autorun" "enabled"
     setRetroArchCoreOption "cap32_Model" "6128"

--- a/scriptmodules/libretrocores/lr-desmume.sh
+++ b/scriptmodules/libretrocores/lr-desmume.sh
@@ -46,7 +46,7 @@ function install_lr-desmume() {
 
 function configure_lr-desmume() {
     mkRomDir "nds"
-    ensureSystemretroconfig "nds"
+    defaultRAConfig "nds"
 
     addEmulator 0 "$md_id" "nds" "$md_inst/desmume_libretro.so"
     addSystem "nds"

--- a/scriptmodules/libretrocores/lr-desmume2015.sh
+++ b/scriptmodules/libretrocores/lr-desmume2015.sh
@@ -39,7 +39,7 @@ function install_lr-desmume2015() {
 
 function configure_lr-desmume2015() {
     mkRomDir "nds"
-    ensureSystemretroconfig "nds"
+    defaultRAConfig "nds"
 
     addEmulator 0 "$md_id" "nds" "$md_inst/desmume2015_libretro.so"
     addSystem "nds"

--- a/scriptmodules/libretrocores/lr-dinothawr.sh
+++ b/scriptmodules/libretrocores/lr-dinothawr.sh
@@ -45,7 +45,7 @@ function configure_lr-dinothawr() {
     addPort "$md_id" "dinothawr" "Dinothawr" "$md_inst/dinothawr_libretro.so" "$romdir/ports/dinothawr/dinothawr.game"
 
     mkRomDir "ports/dinothawr"
-    ensureSystemretroconfig "ports/dinothawr"
+    defaultRAConfig "dinothawr"
 
     cp -Rv "$md_inst/dinothawr" "$romdir/ports"
 

--- a/scriptmodules/libretrocores/lr-dolphin.sh
+++ b/scriptmodules/libretrocores/lr-dolphin.sh
@@ -44,8 +44,8 @@ function configure_lr-dolphin() {
     mkRomDir "gc"
     mkRomDir "wii"
 
-    ensureSystemretroconfig "gc"
-    ensureSystemretroconfig "wii"
+    defaultRAConfig "gc"
+    defaultRAConfig "wii"
 
     addEmulator 1 "$md_id" "gc" "$md_inst/dolphin_libretro.so"
     addEmulator 1 "$md_id" "wii" "$md_inst/dolphin_libretro.so"

--- a/scriptmodules/libretrocores/lr-dosbox-pure.sh
+++ b/scriptmodules/libretrocores/lr-dosbox-pure.sh
@@ -37,7 +37,7 @@ function install_lr-dosbox-pure() {
 
 function configure_lr-dosbox-pure() {
     mkRomDir "pc"
-    ensureSystemretroconfig "pc"
+    defaultRAConfig "pc"
 
     addEmulator 0 "$md_id" "pc" "$md_inst/dosbox_pure_libretro.so"
     addSystem "pc"

--- a/scriptmodules/libretrocores/lr-dosbox.sh
+++ b/scriptmodules/libretrocores/lr-dosbox.sh
@@ -45,7 +45,7 @@ function install_lr-dosbox() {
 
 function configure_lr-dosbox() {
     mkRomDir "pc"
-    ensureSystemretroconfig "pc"
+    defaultRAConfig "pc"
 
     addEmulator 0 "$md_id" "pc" "$md_inst/dosbox_libretro.so"
     addSystem "pc"

--- a/scriptmodules/libretrocores/lr-fbalpha2012.sh
+++ b/scriptmodules/libretrocores/lr-fbalpha2012.sh
@@ -49,7 +49,7 @@ function configure_lr-fbalpha2012() {
     local system
     for system in arcade fba neogeo; do
         mkRomDir "$system"
-        ensureSystemretroconfig "$system"
+        defaultRAConfig "$system"
         addEmulator 0 "$md_id" "$system" "$md_inst/fbalpha2012_libretro.so"
         addSystem "$system"
     done

--- a/scriptmodules/libretrocores/lr-fbneo.sh
+++ b/scriptmodules/libretrocores/lr-fbneo.sh
@@ -102,7 +102,7 @@ function configure_lr-fbneo() {
 
     for system in "${systems[@]}"; do
         mkRomDir "$system"
-        ensureSystemretroconfig "$system"
+        defaultRAConfig "$system"
     done
 
     # Create directories for all support files

--- a/scriptmodules/libretrocores/lr-fceumm.sh
+++ b/scriptmodules/libretrocores/lr-fceumm.sh
@@ -40,8 +40,8 @@ function install_lr-fceumm() {
 function configure_lr-fceumm() {
     mkRomDir "nes"
     mkRomDir "fds"
-    ensureSystemretroconfig "nes"
-    ensureSystemretroconfig "fds"
+    defaultRAConfig "nes"
+    defaultRAConfig "fds"
 
     local def=1
     isPlatform "armv6" && def=0

--- a/scriptmodules/libretrocores/lr-flycast.sh
+++ b/scriptmodules/libretrocores/lr-flycast.sh
@@ -70,7 +70,7 @@ function install_lr-flycast() {
 
 function configure_lr-flycast() {
     mkRomDir "dreamcast"
-    ensureSystemretroconfig "dreamcast"
+    defaultRAConfig "dreamcast"
 
     mkUserDir "$biosdir/dc"
 

--- a/scriptmodules/libretrocores/lr-flycast.sh
+++ b/scriptmodules/libretrocores/lr-flycast.sh
@@ -69,20 +69,23 @@ function install_lr-flycast() {
 }
 
 function configure_lr-flycast() {
-    mkRomDir "dreamcast"
-    defaultRAConfig "dreamcast"
-
-    mkUserDir "$biosdir/dc"
-
-    # system-specific
-    if isPlatform "gl"; then
-        iniConfig " = " "" "$configdir/dreamcast/retroarch.cfg"
-        iniSet "video_shared_context" "true"
-    fi
-
     local def=0
     isPlatform "kms" && def=1
     # segfaults on the rpi without redirecting stdin from </dev/null
     addEmulator $def "$md_id" "dreamcast" "$md_inst/flycast_libretro.so </dev/null"
     addSystem "dreamcast"
+
+    [[ "$md_mode" == "remove" ]] && return
+
+    mkRomDir "dreamcast"
+
+    local params=()
+    # system-specific
+    if isPlatform "gl"; then
+        params+=("video_shared_context" "true")
+    fi
+
+    defaultRAConfig "dreamcast" "${params[@]}"
+
+    mkUserDir "$biosdir/dc"
 }

--- a/scriptmodules/libretrocores/lr-fmsx.sh
+++ b/scriptmodules/libretrocores/lr-fmsx.sh
@@ -36,7 +36,7 @@ function install_lr-fmsx() {
 
 function configure_lr-fmsx() {
     mkRomDir "msx"
-    ensureSystemretroconfig "msx"
+    defaultRAConfig "msx"
 
     # default to MSX2+ core
     setRetroArchCoreOption "fmsx_mode" "MSX2+"

--- a/scriptmodules/libretrocores/lr-freechaf.sh
+++ b/scriptmodules/libretrocores/lr-freechaf.sh
@@ -36,7 +36,7 @@ function install_lr-freechaf() {
 
 function configure_lr-freechaf() {
     mkRomDir "channelf"
-    ensureSystemretroconfig "channelf"
+    defaultRAConfig "channelf"
 
     addEmulator 1 "$md_id" "channelf" "$md_inst/freechaf_libretro.so"
     addSystem "channelf"

--- a/scriptmodules/libretrocores/lr-freeintv.sh
+++ b/scriptmodules/libretrocores/lr-freeintv.sh
@@ -36,7 +36,7 @@ function install_lr-freeintv() {
 
 function configure_lr-freeintv() {
     mkRomDir "intellivision"
-    ensureSystemretroconfig "intellivision"
+    defaultRAConfig "intellivision"
 
     addEmulator 1 "$md_id" "intellivision" "$md_inst/freeintv_libretro.so"
     addSystem "intellivision"

--- a/scriptmodules/libretrocores/lr-fuse.sh
+++ b/scriptmodules/libretrocores/lr-fuse.sh
@@ -36,7 +36,7 @@ function install_lr-fuse() {
 
 function configure_lr-fuse() {
     mkRomDir "zxspectrum"
-    ensureSystemretroconfig "zxspectrum"
+    defaultRAConfig "zxspectrum"
 
     # default to 128k spectrum
     setRetroArchCoreOption "fuse_machine" "Spectrum 128K"

--- a/scriptmodules/libretrocores/lr-gambatte.sh
+++ b/scriptmodules/libretrocores/lr-gambatte.sh
@@ -44,8 +44,8 @@ function configure_lr-gambatte() {
 
     mkRomDir "gbc"
     mkRomDir "gb"
-    ensureSystemretroconfig "gb"
-    ensureSystemretroconfig "gbc"
+    defaultRAConfig "gb"
+    defaultRAConfig "gbc"
     addEmulator 1 "$md_id" "gb" "$md_inst/gambatte_libretro.so"
     addEmulator 1 "$md_id" "gbc" "$md_inst/gambatte_libretro.so"
     addSystem "gb"

--- a/scriptmodules/libretrocores/lr-gearsystem.sh
+++ b/scriptmodules/libretrocores/lr-gearsystem.sh
@@ -39,7 +39,7 @@ function configure_lr-gearsystem() {
     local system
     for system in gamegear mastersystem sg-1000; do
         mkRomDir "$system"
-        ensureSystemretroconfig "$system"
+        defaultRAConfig "$system"
         addEmulator 0 "$md_id" "$system" "$md_inst/gearsystem_libretro.so"
         addSystem "$system"
     done

--- a/scriptmodules/libretrocores/lr-genesis-plus-gx.sh
+++ b/scriptmodules/libretrocores/lr-genesis-plus-gx.sh
@@ -44,7 +44,7 @@ function configure_lr-genesis-plus-gx() {
         # always default emulator for non armv6
         ! isPlatform "armv6" && def=1
         mkRomDir "$system"
-        ensureSystemretroconfig "$system"
+        defaultRAConfig "$system"
         addEmulator "$def" "$md_id" "$system" "$md_inst/genesis_plus_gx_libretro.so"
         addSystem "$system"
     done

--- a/scriptmodules/libretrocores/lr-gpsp.sh
+++ b/scriptmodules/libretrocores/lr-gpsp.sh
@@ -42,7 +42,7 @@ function install_lr-gpsp() {
 
 function configure_lr-gpsp() {
     mkRomDir "gba"
-    ensureSystemretroconfig "gba"
+    defaultRAConfig "gba"
 
     local def=0
     isPlatform "armv6" && def=1

--- a/scriptmodules/libretrocores/lr-gw.sh
+++ b/scriptmodules/libretrocores/lr-gw.sh
@@ -36,7 +36,7 @@ function install_lr-gw() {
 
 function configure_lr-gw() {
     mkRomDir "gameandwatch"
-    ensureSystemretroconfig "gameandwatch"
+    defaultRAConfig "gameandwatch"
 
     addEmulator 1 "$md_id" "gameandwatch" "$md_inst/gw_libretro.so"
     addSystem "gameandwatch"

--- a/scriptmodules/libretrocores/lr-handy.sh
+++ b/scriptmodules/libretrocores/lr-handy.sh
@@ -35,7 +35,7 @@ function install_lr-handy() {
 
 function configure_lr-handy() {
     mkRomDir "atarilynx"
-    ensureSystemretroconfig "atarilynx"
+    defaultRAConfig "atarilynx"
 
     addEmulator 1 "$md_id" "atarilynx" "$md_inst/handy_libretro.so"
     addSystem "atarilynx"

--- a/scriptmodules/libretrocores/lr-hatari.sh
+++ b/scriptmodules/libretrocores/lr-hatari.sh
@@ -45,7 +45,7 @@ function install_lr-hatari() {
 
 function configure_lr-hatari() {
     mkRomDir "atarist"
-    ensureSystemretroconfig "atarist"
+    defaultRAConfig "atarist"
 
     # move any old configs to new location
     moveConfigDir "$home/.hatari" "$md_conf_root/atarist"

--- a/scriptmodules/libretrocores/lr-kronos.sh
+++ b/scriptmodules/libretrocores/lr-kronos.sh
@@ -42,7 +42,7 @@ function install_lr-kronos() {
 
 function configure_lr-kronos() {
     mkRomDir "saturn"
-    ensureSystemretroconfig "saturn"
+    defaultRAConfig "saturn"
 
     addEmulator 1 "$md_id" "saturn" "$md_inst/kronos_libretro.so"
     addSystem "saturn"

--- a/scriptmodules/libretrocores/lr-mame.sh
+++ b/scriptmodules/libretrocores/lr-mame.sh
@@ -59,7 +59,7 @@ function configure_lr-mame() {
     local system
     for system in arcade mame-libretro; do
         mkRomDir "$system"
-        ensureSystemretroconfig "$system"
+        defaultRAConfig "$system"
         addEmulator 0 "$md_id" "$system" "$md_inst/mamearcade_libretro.so"
         addSystem "$system"
     done

--- a/scriptmodules/libretrocores/lr-mame2000.sh
+++ b/scriptmodules/libretrocores/lr-mame2000.sh
@@ -47,7 +47,7 @@ function configure_lr-mame2000() {
     local system
     for system in arcade mame-mame4all mame-libretro; do
         mkRomDir "$system"
-        ensureSystemretroconfig "$system"
+        defaultRAConfig "$system"
         addEmulator 0 "$md_id" "$system" "$md_inst/mame2000_libretro.so"
         addSystem "$system"
     done

--- a/scriptmodules/libretrocores/lr-mame2003.sh
+++ b/scriptmodules/libretrocores/lr-mame2003.sh
@@ -63,7 +63,7 @@ function configure_lr-mame2003() {
     for mame_dir in arcade mame-libretro; do
         mkRomDir "$mame_dir"
         mkRomDir "$mame_dir/$dir_name"
-        ensureSystemretroconfig "$mame_dir"
+        defaultRAConfig "$mame_dir"
 
         for mame_sub_dir in cfg ctrlr diff hi memcard nvram; do
             mkRomDir "$mame_dir/$dir_name/$mame_sub_dir"

--- a/scriptmodules/libretrocores/lr-mame2010.sh
+++ b/scriptmodules/libretrocores/lr-mame2010.sh
@@ -51,7 +51,7 @@ function configure_lr-mame2010() {
     local system
     for system in arcade mame-libretro; do
         mkRomDir "$system"
-        ensureSystemretroconfig "$system"
+        defaultRAConfig "$system"
         addEmulator 0 "$md_id" "$system" "$md_inst/mame2010_libretro.so"
         addSystem "$system"
     done

--- a/scriptmodules/libretrocores/lr-mame2015.sh
+++ b/scriptmodules/libretrocores/lr-mame2015.sh
@@ -45,7 +45,7 @@ function configure_lr-mame2015() {
     local system
     for system in arcade mame-libretro; do
         mkRomDir "$system"
-        ensureSystemretroconfig "$system"
+        defaultRAConfig "$system"
         addEmulator 0 "$md_id" "$system" "$md_inst/mame2015_libretro.so"
         addSystem "$system"
     done

--- a/scriptmodules/libretrocores/lr-mame2016.sh
+++ b/scriptmodules/libretrocores/lr-mame2016.sh
@@ -44,7 +44,7 @@ function configure_lr-mame2016() {
     local system
     for system in arcade mame-libretro; do
         mkRomDir "$system"
-        ensureSystemretroconfig "$system"
+        defaultRAConfig "$system"
         addEmulator 0 "$md_id" "$system" "$md_inst/mamearcade2016_libretro.so"
         addSystem "$system"
     done

--- a/scriptmodules/libretrocores/lr-mesen.sh
+++ b/scriptmodules/libretrocores/lr-mesen.sh
@@ -39,7 +39,7 @@ function configure_lr-mesen() {
     local system
     for system in "nes" "fds"; do
         mkRomDir "$system"
-        ensureSystemretroconfig "$system"
+        defaultRAConfig "$system"
         addEmulator 0 "$md_id" "$system" "$md_inst/mesen_libretro.so"
         addSystem "$system"
     done

--- a/scriptmodules/libretrocores/lr-mess.sh
+++ b/scriptmodules/libretrocores/lr-mess.sh
@@ -50,7 +50,7 @@ function configure_lr-mess() {
     local system
     for system in nes gb coleco arcadia crvision; do
         mkRomDir "$system"
-        ensureSystemretroconfig "$system"
+        defaultRAConfig "$system"
         addEmulator 0 "$md_id" "$system" "$md_inst/$module"
         addSystem "$system"
     done

--- a/scriptmodules/libretrocores/lr-mgba.sh
+++ b/scriptmodules/libretrocores/lr-mgba.sh
@@ -43,7 +43,7 @@ function configure_lr-mgba() {
         def=0
         [[ "$system" == "gba" ]] && ! isPlatform "armv6" && def=1
         mkRomDir "$system"
-        ensureSystemretroconfig "$system"
+        defaultRAConfig "$system"
         addEmulator "$def" "$md_id" "$system" "$md_inst/mgba_libretro.so"
         addSystem "$system"
     done

--- a/scriptmodules/libretrocores/lr-mrboom.sh
+++ b/scriptmodules/libretrocores/lr-mrboom.sh
@@ -46,5 +46,5 @@ function configure_lr-mrboom() {
     addPort "$md_id" "mrboom" "Mr.Boom" "$emudir/retroarch/bin/retroarch -L $md_inst/mrboom_libretro.so --config $md_conf_root/mrboom/retroarch.cfg"
 
     mkRomDir "ports/mrboom"
-    ensureSystemretroconfig "ports/mrboom"
+    defaultRAConfig "mrboom"
 }

--- a/scriptmodules/libretrocores/lr-mupen64plus-next.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus-next.sh
@@ -77,7 +77,7 @@ function install_lr-mupen64plus-next() {
 
 function configure_lr-mupen64plus-next() {
     mkRomDir "n64"
-    ensureSystemretroconfig "n64"
+    defaultRAConfig "n64"
 
     if isPlatform "rpi"; then
         # Disable hybrid upscaling filter (needs better GPU)

--- a/scriptmodules/libretrocores/lr-mupen64plus.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus.sh
@@ -86,7 +86,7 @@ function install_lr-mupen64plus() {
 
 function configure_lr-mupen64plus() {
     mkRomDir "n64"
-    ensureSystemretroconfig "n64"
+    defaultRAConfig "n64"
 
     addEmulator 0 "$md_id" "n64" "$md_inst/mupen64plus_libretro.so"
     addSystem "n64"

--- a/scriptmodules/libretrocores/lr-neocd.sh
+++ b/scriptmodules/libretrocores/lr-neocd.sh
@@ -36,7 +36,7 @@ function install_lr-neocd() {
 
 function configure_lr-neocd() {
     mkRomDir "neogeo"
-    ensureSystemretroconfig "neogeo"
+    defaultRAConfig "neogeo"
 
     addEmulator 0 "$md_id" "neogeo" "$md_inst/neocd_libretro.so"
     addSystem "neogeo"

--- a/scriptmodules/libretrocores/lr-nestopia.sh
+++ b/scriptmodules/libretrocores/lr-nestopia.sh
@@ -39,8 +39,8 @@ function install_lr-nestopia() {
 function configure_lr-nestopia() {
     mkRomDir "nes"
     mkRomDir "fds"
-    ensureSystemretroconfig "nes"
-    ensureSystemretroconfig "fds"
+    defaultRAConfig "nes"
+    defaultRAConfig "fds"
 
     addEmulator 0 "$md_id" "nes" "$md_inst/nestopia_libretro.so"
     addEmulator 1 "$md_id" "fds" "$md_inst/nestopia_libretro.so"

--- a/scriptmodules/libretrocores/lr-np2kai.sh
+++ b/scriptmodules/libretrocores/lr-np2kai.sh
@@ -35,7 +35,7 @@ function install_lr-np2kai() {
 
 function configure_lr-np2kai() {
     mkRomDir "pc98"
-    ensureSystemretroconfig "pc98"
+    defaultRAConfig "pc98"
 
     addEmulator 1 "$md_id" "pc98" "$md_inst/np2kai_libretro.so"
     addSystem "pc98"

--- a/scriptmodules/libretrocores/lr-nxengine.sh
+++ b/scriptmodules/libretrocores/lr-nxengine.sh
@@ -50,5 +50,5 @@ _EOF_
     chown $user:$user "$file"
     chmod +x "$file"
 
-    ensureSystemretroconfig "ports/cavestory"
+    defaultRAConfig "cavestory"
 }

--- a/scriptmodules/libretrocores/lr-o2em.sh
+++ b/scriptmodules/libretrocores/lr-o2em.sh
@@ -35,7 +35,7 @@ function install_lr-o2em() {
 
 function configure_lr-o2em() {
     mkRomDir "videopac"
-    ensureSystemretroconfig "videopac"
+    defaultRAConfig "videopac"
 
     addEmulator 1 "$md_id" "videopac" "$md_inst/o2em_libretro.so"
     addSystem "videopac"

--- a/scriptmodules/libretrocores/lr-opera.sh
+++ b/scriptmodules/libretrocores/lr-opera.sh
@@ -38,7 +38,7 @@ function install_lr-opera() {
 
 function configure_lr-opera() {
     mkRomDir "3do"
-    ensureSystemretroconfig "3do"
+    defaultRAConfig "3do"
 
     addEmulator 1 "$md_id" "3do" "$md_inst/opera_libretro.so"
     addSystem "3do"

--- a/scriptmodules/libretrocores/lr-parallel-n64.sh
+++ b/scriptmodules/libretrocores/lr-parallel-n64.sh
@@ -59,7 +59,7 @@ function install_lr-parallel-n64() {
 
 function configure_lr-parallel-n64() {
     mkRomDir "n64"
-    ensureSystemretroconfig "n64"
+    defaultRAConfig "n64"
 
     # Set core options
     setRetroArchCoreOption "parallel-n64-gfxplugin" "auto"

--- a/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
+++ b/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
@@ -59,7 +59,7 @@ function install_lr-pcsx-rearmed() {
 
 function configure_lr-pcsx-rearmed() {
     mkRomDir "psx"
-    ensureSystemretroconfig "psx"
+    defaultRAConfig "psx"
 
     addEmulator 1 "$md_id" "psx" "$md_inst/pcsx_rearmed_libretro.so"
     addSystem "psx"

--- a/scriptmodules/libretrocores/lr-picodrive.sh
+++ b/scriptmodules/libretrocores/lr-picodrive.sh
@@ -54,7 +54,7 @@ function configure_lr-picodrive() {
         # default on megadrive / mastersystem only on armv6 for performance
         [[ "$system" =~ megadrive|mastersystem ]] && isPlatform "arm6" && def=1
         mkRomDir "$system"
-        ensureSystemretroconfig "$system"
+        defaultRAConfig "$system"
         addEmulator $def "$md_id" "$system" "$md_inst/picodrive_libretro.so"
         addSystem "$system"
     done

--- a/scriptmodules/libretrocores/lr-pokemini.sh
+++ b/scriptmodules/libretrocores/lr-pokemini.sh
@@ -34,7 +34,7 @@ function install_lr-pokemini() {
 
 function configure_lr-pokemini() {
     mkRomDir "pokemini"
-    ensureSystemretroconfig "pokemini"
+    defaultRAConfig "pokemini"
 
     addEmulator 1 "$md_id" "pokemini" "$md_inst/pokemini_libretro.so"
     addSystem "pokemini"

--- a/scriptmodules/libretrocores/lr-ppsspp.sh
+++ b/scriptmodules/libretrocores/lr-ppsspp.sh
@@ -38,7 +38,7 @@ function install_lr-ppsspp() {
 
 function configure_lr-ppsspp() {
     mkRomDir "psp"
-    ensureSystemretroconfig "psp"
+    defaultRAConfig "psp"
 
     if [[ "$md_mode" == "install" ]]; then
         mkUserDir "$biosdir/PPSSPP"

--- a/scriptmodules/libretrocores/lr-prboom.sh
+++ b/scriptmodules/libretrocores/lr-prboom.sh
@@ -99,7 +99,7 @@ function configure_lr-prboom() {
     setConfigRoot "ports"
 
     mkRomDir "ports/doom"
-    ensureSystemretroconfig "ports/doom"
+    defaultRAConfig "doom"
 
     [[ "$md_mode" == "install" ]] && game_data_lr-prboom
 

--- a/scriptmodules/libretrocores/lr-prosystem.sh
+++ b/scriptmodules/libretrocores/lr-prosystem.sh
@@ -36,7 +36,7 @@ function install_lr-prosystem() {
 function configure_lr-prosystem() {
     mkRomDir "atari7800"
 
-    ensureSystemretroconfig "atari7800"
+    defaultRAConfig "atari7800"
 
     addEmulator 1 "$md_id" "atari7800" "$md_inst/prosystem_libretro.so"
     addSystem "atari7800"

--- a/scriptmodules/libretrocores/lr-puae.sh
+++ b/scriptmodules/libretrocores/lr-puae.sh
@@ -34,7 +34,7 @@ function install_lr-puae() {
 
 function configure_lr-puae() {
     mkRomDir "amiga"
-    ensureSystemretroconfig "amiga"
+    defaultRAConfig "amiga"
     addEmulator 1 "$md_id" "amiga" "$md_inst/puae_libretro.so"
     addSystem "amiga"
 }

--- a/scriptmodules/libretrocores/lr-puae2021.sh
+++ b/scriptmodules/libretrocores/lr-puae2021.sh
@@ -34,7 +34,7 @@ function install_lr-puae2021() {
 
 function configure_lr-puae2021() {
     mkRomDir "amiga"
-    ensureSystemretroconfig "amiga"
+    defaultRAConfig "amiga"
     addEmulator 1 "lr-puae2021" "amiga" "$md_inst/puae2021_libretro.so"
     addSystem "amiga"
 }

--- a/scriptmodules/libretrocores/lr-px68k.sh
+++ b/scriptmodules/libretrocores/lr-px68k.sh
@@ -36,7 +36,7 @@ function install_lr-px68k() {
 
 function configure_lr-px68k() {
     mkRomDir "x68000"
-    ensureSystemretroconfig "x68000"
+    defaultRAConfig "x68000"
 
     mkUserDir "$biosdir/keropi"
 

--- a/scriptmodules/libretrocores/lr-quasi88.sh
+++ b/scriptmodules/libretrocores/lr-quasi88.sh
@@ -35,7 +35,7 @@ function install_lr-quasi88() {
 
 function configure_lr-quasi88() {
     mkRomDir "pc88"
-    ensureSystemretroconfig "pc88"
+    defaultRAConfig "pc88"
     addEmulator 1 "$md_id" "pc88" "$md_inst/quasi88_libretro.so"
     addSystem "pc88"
 }

--- a/scriptmodules/libretrocores/lr-quicknes.sh
+++ b/scriptmodules/libretrocores/lr-quicknes.sh
@@ -34,7 +34,7 @@ function install_lr-quicknes() {
 
 function configure_lr-quicknes() {
     mkRomDir "nes"
-    ensureSystemretroconfig "nes"
+    defaultRAConfig "nes"
 
     local def=0
     isPlatform "armv6" && def=1

--- a/scriptmodules/libretrocores/lr-retro8.sh
+++ b/scriptmodules/libretrocores/lr-retro8.sh
@@ -42,9 +42,6 @@ function configure_lr-retro8() {
 
     [[ "$md_mode" == "remove" ]] && return
 
-    ensureSystemretroconfig "pico8"
-
     # disable retroarch built-in imageviewer so we can run .p8.png files
-    iniConfig " = " '"' "$md_conf_root/pico8/retroarch.cfg"
-    iniSet "builtin_imageviewer_enable" "false"
+    defaultRAConfig "pico8" "builtin_imageviewer_enable" "false"
 }

--- a/scriptmodules/libretrocores/lr-scummvm.sh
+++ b/scriptmodules/libretrocores/lr-scummvm.sh
@@ -47,7 +47,7 @@ function configure_lr-scummvm() {
 
     # ensure rom dir and system retroconfig
     mkRomDir "scummvm"
-    ensureSystemretroconfig "scummvm"
+    defaultRAConfig "scummvm"
 
     # download and extract auxiliary data (theme, extra)
     downloadAndExtract "https://github.com/libretro/scummvm/raw/master/backends/platform/libretro/aux-data/scummvm.zip" "$biosdir"

--- a/scriptmodules/libretrocores/lr-smsplus-gx.sh
+++ b/scriptmodules/libretrocores/lr-smsplus-gx.sh
@@ -38,7 +38,7 @@ function configure_lr-smsplus-gx() {
     local system
     for system in gamegear mastersystem; do
         mkRomDir "$system"
-        ensureSystemretroconfig "$system"
+        defaultRAConfig "$system"
         addEmulator 0 "$md_id" "$system" "$md_inst/smsplus_libretro.so"
         addSystem "$system"
     done

--- a/scriptmodules/libretrocores/lr-snes9x.sh
+++ b/scriptmodules/libretrocores/lr-snes9x.sh
@@ -40,7 +40,7 @@ function install_lr-snes9x() {
 
 function configure_lr-snes9x() {
     mkRomDir "snes"
-    ensureSystemretroconfig "snes"
+    defaultRAConfig "snes"
 
     local def=0
     ! isPlatform "armv6" && ! isPlatform "armv7" && def=1

--- a/scriptmodules/libretrocores/lr-snes9x2002.sh
+++ b/scriptmodules/libretrocores/lr-snes9x2002.sh
@@ -41,7 +41,7 @@ function install_lr-snes9x2002() {
 
 function configure_lr-snes9x2002() {
     mkRomDir "snes"
-    ensureSystemretroconfig "snes"
+    defaultRAConfig "snes"
 
     local def=0
     isPlatform "armv6" && def=1

--- a/scriptmodules/libretrocores/lr-snes9x2005.sh
+++ b/scriptmodules/libretrocores/lr-snes9x2005.sh
@@ -39,7 +39,7 @@ function install_lr-snes9x2005() {
 
 function configure_lr-snes9x2005() {
     mkRomDir "snes"
-    ensureSystemretroconfig "snes"
+    defaultRAConfig "snes"
 
     addEmulator 0 "$md_id" "snes" "$md_inst/snes9x2005_libretro.so"
     addSystem "snes"

--- a/scriptmodules/libretrocores/lr-snes9x2010.sh
+++ b/scriptmodules/libretrocores/lr-snes9x2010.sh
@@ -47,7 +47,7 @@ function install_lr-snes9x2010() {
 
 function configure_lr-snes9x2010() {
     mkRomDir "snes"
-    ensureSystemretroconfig "snes"
+    defaultRAConfig "snes"
 
     local def=0
     isPlatform "armv7" && def=1

--- a/scriptmodules/libretrocores/lr-stella.sh
+++ b/scriptmodules/libretrocores/lr-stella.sh
@@ -37,7 +37,7 @@ function install_lr-stella() {
 
 function configure_lr-stella() {
     mkRomDir "atari2600"
-    ensureSystemretroconfig "atari2600"
+    defaultRAConfig "atari2600"
 
     addEmulator 0 "$md_id" "atari2600" "$md_inst/stella_libretro.so"
     addSystem "atari2600"

--- a/scriptmodules/libretrocores/lr-stella2014.sh
+++ b/scriptmodules/libretrocores/lr-stella2014.sh
@@ -36,7 +36,7 @@ function install_lr-stella2014() {
 
 function configure_lr-stella2014() {
     mkRomDir "atari2600"
-    ensureSystemretroconfig "atari2600"
+    defaultRAConfig "atari2600"
 
     addEmulator 1 "$md_id" "atari2600" "$md_inst/stella2014_libretro.so"
     addSystem "atari2600"

--- a/scriptmodules/libretrocores/lr-superflappybirds.sh
+++ b/scriptmodules/libretrocores/lr-superflappybirds.sh
@@ -44,5 +44,5 @@ function configure_lr-superflappybirds() {
 
     addPort "$md_id" "superflappybirds" "Super Flappy Birds" "$md_inst/superflappybirds_libretro.so"
 
-    ensureSystemretroconfig "ports/superflappybirds"
+    defaultRAConfig "superflappybirds"
 }

--- a/scriptmodules/libretrocores/lr-tgbdual.sh
+++ b/scriptmodules/libretrocores/lr-tgbdual.sh
@@ -35,8 +35,8 @@ function install_lr-tgbdual() {
 function configure_lr-tgbdual() {
     mkRomDir "gbc"
     mkRomDir "gb"
-    ensureSystemretroconfig "gb"
-    ensureSystemretroconfig "gbc"
+    defaultRAConfig "gb"
+    defaultRAConfig "gbc"
 
     # enable dual / link by default
     setRetroArchCoreOption "tgbdual_gblink_enable" "enabled"

--- a/scriptmodules/libretrocores/lr-theodore.sh
+++ b/scriptmodules/libretrocores/lr-theodore.sh
@@ -38,7 +38,7 @@ function install_lr-theodore() {
 
 function configure_lr-theodore() {
     mkRomDir "moto"
-    ensureSystemretroconfig "moto"
+    defaultRAConfig "moto"
 
     addEmulator 1 "$md_id" "moto" "$md_inst/theodore_libretro.so"
     addSystem "moto"

--- a/scriptmodules/libretrocores/lr-tic80.sh
+++ b/scriptmodules/libretrocores/lr-tic80.sh
@@ -44,7 +44,7 @@ function install_lr-tic80() {
 
 function configure_lr-tic80() {
     mkRomDir "tic80"
-    ensureSystemretroconfig "tic80"
+    defaultRAConfig "tic80"
     addEmulator 1 "$md_id" "tic80" "$md_inst/tic80_libretro.so"
     addSystem "tic80" "TIC-80"
 }

--- a/scriptmodules/libretrocores/lr-tyrquake.sh
+++ b/scriptmodules/libretrocores/lr-tyrquake.sh
@@ -82,5 +82,5 @@ function configure_lr-tyrquake() {
 
     add_games_lr-tyrquake
 
-    ensureSystemretroconfig "ports/quake"
+    defaultRAConfig "quake"
 }

--- a/scriptmodules/libretrocores/lr-uae4arm.sh
+++ b/scriptmodules/libretrocores/lr-uae4arm.sh
@@ -43,7 +43,7 @@ function install_lr-uae4arm() {
 
 function configure_lr-uae4arm() {
     mkRomDir "amiga"
-    ensureSystemretroconfig "amiga"
+    defaultRAConfig "amiga"
     addEmulator 1 "$md_id" "amiga" "$md_inst/uae4arm_libretro.so"
     addSystem "amiga"
 }

--- a/scriptmodules/libretrocores/lr-vba-next.sh
+++ b/scriptmodules/libretrocores/lr-vba-next.sh
@@ -39,7 +39,7 @@ function install_lr-vba-next() {
 
 function configure_lr-vba-next() {
     mkRomDir "gba"
-    ensureSystemretroconfig "gba"
+    defaultRAConfig "gba"
 
     addEmulator 0 "$md_id" "gba" "$md_inst/vba_next_libretro.so"
     addSystem "gba"

--- a/scriptmodules/libretrocores/lr-vecx.sh
+++ b/scriptmodules/libretrocores/lr-vecx.sh
@@ -48,7 +48,7 @@ function install_lr-vecx() {
 
 function configure_lr-vecx() {
     mkRomDir "vectrex"
-    ensureSystemretroconfig "vectrex"
+    defaultRAConfig "vectrex"
 
     if [[ "$md_mode" == "install" ]]; then
         # Copy bios files

--- a/scriptmodules/libretrocores/lr-vice.sh
+++ b/scriptmodules/libretrocores/lr-vice.sh
@@ -49,7 +49,7 @@ function install_lr-vice() {
 
 function configure_lr-vice() {
     mkRomDir "c64"
-    ensureSystemretroconfig "c64"
+    defaultRAConfig "c64"
 
     local target
     local name

--- a/scriptmodules/libretrocores/lr-virtualjaguar.sh
+++ b/scriptmodules/libretrocores/lr-virtualjaguar.sh
@@ -36,7 +36,7 @@ function install_lr-virtualjaguar() {
 
 function configure_lr-virtualjaguar() {
     mkRomDir "atarijaguar"
-    ensureSystemretroconfig "atarijaguar"
+    defaultRAConfig "atarijaguar"
 
     addEmulator 1 "$md_id" "atarijaguar" "$md_inst/virtualjaguar_libretro.so"
     addSystem "atarijaguar"

--- a/scriptmodules/libretrocores/lr-x1.sh
+++ b/scriptmodules/libretrocores/lr-x1.sh
@@ -34,7 +34,7 @@ function install_lr-x1() {
 
 function configure_lr-x1() {
     mkRomDir "x1"
-    ensureSystemretroconfig "x1"
+    defaultRAConfig "x1"
 
     addEmulator 1 "$md_id" "x1" "$md_inst/x1_libretro.so"
     addSystem "x1"

--- a/scriptmodules/libretrocores/lr-xrick.sh
+++ b/scriptmodules/libretrocores/lr-xrick.sh
@@ -41,5 +41,5 @@ function configure_lr-xrick() {
 
     [[ "$md_mode" == "remove" ]] && return
 
-    ensureSystemretroconfig "ports/xrick"
+    defaultRAConfig "xrick"
 }

--- a/scriptmodules/libretrocores/lr-yabause.sh
+++ b/scriptmodules/libretrocores/lr-yabause.sh
@@ -43,7 +43,7 @@ function install_lr-yabause() {
 
 function configure_lr-yabause() {
     mkRomDir "saturn"
-    ensureSystemretroconfig "saturn"
+    defaultRAConfig "saturn"
 
     addEmulator 1 "$md_id" "saturn" "$md_inst/yabause_libretro.so"
     addSystem "saturn"


### PR DESCRIPTION
Removed deprecated and unused shader parameter support from ensureSystemretroconfig.

defaultRAConfig takes a single parameter for the system name, but also allows additional
parameter pairs to be added to set default ini configuration key/values

eg. defaultRAConfig "dreamcast" "fps_show" "true"

It also uses $md_conf_root as a base, which ensureSystemretroconfig didn't handle, so we save and reset this for backward compatibility for anything still using ensureSystemretroconfig