### PR TITLE
add forced modes to analog_dpad_mode

### DIFF
--- a/scriptmodules/supplementary/configedit.sh
+++ b/scriptmodules/supplementary/configedit.sh
@@ -176,10 +176,10 @@ function basic_configedit() {
         'input_overlay_enable true false'
         "input_overlay _file_ *.cfg $rootdir/emulators/retroarch/overlays"
         '_function_ _joypad_index_configedit'
-        'input_player1_analog_dpad_mode _id_ disabled left-stick right-stick'
-        'input_player2_analog_dpad_mode _id_ disabled left-stick right-stick'
-        'input_player3_analog_dpad_mode _id_ disabled left-stick right-stick'
-        'input_player4_analog_dpad_mode _id_ disabled left-stick right-stick'
+        'input_player1_analog_dpad_mode _id_ disabled left-stick right-stick left-stick-forced right-stick-forced'
+        'input_player2_analog_dpad_mode _id_ disabled left-stick right-stick left-stick-forced right-stick-forced'
+        'input_player3_analog_dpad_mode _id_ disabled left-stick right-stick left-stick-forced right-stick-forced'
+        'input_player4_analog_dpad_mode _id_ disabled left-stick right-stick left-stick-forced right-stick-forced'
     )
 
     local ini_titles=(
@@ -206,10 +206,10 @@ function basic_configedit() {
         'Load input overlay on startup. Other overlays can still be loaded later in runtime.'
         'Input overlay to use (default none)'
         'Manual selection of joypad order'
-        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick'
-        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick'
-        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick'
-        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick'
+        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick, 3 = left stick forced, 4 = right stick forced'
+        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick, 3 = left stick forced, 4 = right stick forced'
+        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick, 3 = left stick forced, 4 = right stick forced'
+        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick, 3 = left stick forced, 4 = right stick forced'
     )
 
     iniFileEditor " = " '"' "$config"
@@ -261,14 +261,14 @@ function advanced_configedit() {
         'input_player6_joypad_index _string_'
         'input_player7_joypad_index _string_'
         'input_player8_joypad_index _string_'
-        'input_player1_analog_dpad_mode _id_ disabled left-stick right-stick'
-        'input_player2_analog_dpad_mode _id_ disabled left-stick right-stick'
-        'input_player3_analog_dpad_mode _id_ disabled left-stick right-stick'
-        'input_player4_analog_dpad_mode _id_ disabled left-stick right-stick'
-        'input_player5_analog_dpad_mode _id_ disabled left-stick right-stick'
-        'input_player6_analog_dpad_mode _id_ disabled left-stick right-stick'
-        'input_player7_analog_dpad_mode _id_ disabled left-stick right-stick'
-        'input_player8_analog_dpad_mode _id_ disabled left-stick right-stick'
+        'input_player1_analog_dpad_mode _id_ disabled left-stick right-stick left-stick-forced right-stick-forced'
+        'input_player2_analog_dpad_mode _id_ disabled left-stick right-stick left-stick-forced right-stick-forced'
+        'input_player3_analog_dpad_mode _id_ disabled left-stick right-stick left-stick-forced right-stick-forced'
+        'input_player4_analog_dpad_mode _id_ disabled left-stick right-stick left-stick-forced right-stick-forced'
+        'input_player5_analog_dpad_mode _id_ disabled left-stick right-stick left-stick-forced right-stick-forced'
+        'input_player6_analog_dpad_mode _id_ disabled left-stick right-stick left-stick-forced right-stick-forced'
+        'input_player7_analog_dpad_mode _id_ disabled left-stick right-stick left-stick-forced right-stick-forced'
+        'input_player8_analog_dpad_mode _id_ disabled left-stick right-stick left-stick-forced right-stick-forced'
 
     )
 
@@ -310,14 +310,14 @@ function advanced_configedit() {
         'Manual selection of joypad order'
         'Manual selection of joypad order'
         'Manual selection of joypad order'
-        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick'
-        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick'
-        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick'
-        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick'
-        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick'
-        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick'
-        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick'
-        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick'
+        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick, 3 = left stick forced, 4 = right stick forced'
+        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick, 3 = left stick forced, 4 = right stick forced'
+        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick, 3 = left stick forced, 4 = right stick forced'
+        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick, 3 = left stick forced, 4 = right stick forced'
+        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick, 3 = left stick forced, 4 = right stick forced'
+        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick, 3 = left stick forced, 4 = right stick forced'
+        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick, 3 = left stick forced, 4 = right stick forced'
+        'Allow analogue sticks to be used as a d-pad - 0 = disabled, 1 = left stick, 2 = right stick, 3 = left stick forced, 4 = right stick forced'
 
     )
 


### PR DESCRIPTION
Since v1.9.6 RetroArch changes the way the "analog to digital" works and since then the "forced mode" is need for some cores (eg. lr-vice, lr-puae).

#https://github.com/libretro/RetroArch/pull/12562