### PR TITLE
scummvm: updated to version 2.5

### DIFF
--- a/scriptmodules/emulators/scummvm-sdl1.sh
+++ b/scriptmodules/emulators/scummvm-sdl1.sh
@@ -13,7 +13,7 @@ rp_module_id="scummvm-sdl1"
 rp_module_desc="ScummVM - built with legacy SDL1 support."
 rp_module_help="Copy your ScummVM games to $romdir/scummvm"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/scummvm/scummvm/master/COPYING"
-rp_module_repo="git https://github.com/scummvm/scummvm.git v2.2.0"
+rp_module_repo="git https://github.com/scummvm/scummvm.git v2.5.0"
 rp_module_section="opt"
 rp_module_flags="sdl1 !mali !x11"
 
@@ -44,6 +44,6 @@ function install_scummvm-sdl1() {
 
 function configure_scummvm-sdl1() {
     # use dispmanx by default on rpi with fkms
-    isPlatform "dispmanx" && ! isPlatform "videocore" && setBackend "$md_id" "dispmmanx"
+    isPlatform "dispmanx" && ! isPlatform "videocore" && setBackend "$md_id" "dispmanx"
     configure_scummvm
 }

--- a/scriptmodules/emulators/scummvm-sdl1/01_rpi_kms_sdl1.diff
+++ b/scriptmodules/emulators/scummvm-sdl1/01_rpi_kms_sdl1.diff
@@ -1,8 +1,8 @@
 diff --git a/configure b/configure
-index b7654c4..13799c5 100755
+index 0951e9ab..b9577ddc 100755
 --- a/configure
 +++ b/configure
-@@ -3274,12 +3274,12 @@ if test -n "$_host"; then
+@@ -3306,13 +3306,13 @@ if test -n "$_host"; then
  			# We prefer SDL2 on the Raspberry Pi: acceleration now depends on it
  			# since SDL2 manages dispmanx/GLES2 very well internally.
  			# SDL1 is bit-rotten on this platform.
@@ -13,7 +13,9 @@ index b7654c4..13799c5 100755
  			# The Raspberry Pi always supports OpenGL ES 2.0 contexts, thus we
  			# take advantage of those.
 -			_opengl_mode=gles2
+-			_opengl_game_es2=yes
 +			_opengl_mode=none
++			_opengl_game_es2=no
  			;;
  		dreamcast)
  			append_var DEFINES "-DDISABLE_DEFAULT_SAVEFILEMANAGER"

--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -13,13 +13,13 @@ rp_module_id="scummvm"
 rp_module_desc="ScummVM"
 rp_module_help="Copy your ScummVM games to $romdir/scummvm"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/scummvm/scummvm/master/COPYING"
-rp_module_repo="git https://github.com/scummvm/scummvm.git v2.2.0"
+rp_module_repo="git https://github.com/scummvm/scummvm.git v2.5.0"
 rp_module_section="opt"
 rp_module_flags="sdl2"
 
 function depends_scummvm() {
     local depends=(
-        libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng-dev
+        liba52-0.7.4-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libgif-dev libmad0-dev libpng-dev
         libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev
         libjpeg-dev libasound2-dev libcurl4-openssl-dev
     )
@@ -80,7 +80,7 @@ function configure_scummvm() {
 #!/bin/bash
 game="\$1"
 pushd "$romdir/scummvm" >/dev/null
-$md_inst/bin/scummvm --fullscreen --joystick=0 --extrapath="$md_inst/extra" \$game
+$md_inst/bin/scummvm --fullscreen --joystick=0 --extrapath="$md_inst/extra" "\$game"
 while read id desc; do
     echo "\$desc" > "$romdir/scummvm/\$id.svm"
 done < <($md_inst/bin/scummvm --list-targets | tail -n +3)


### PR DESCRIPTION
Notable changes in ScummVM 2.5:

 - ResidualVM project merged with ScummVM, adding support for Grim Fandango, The Longest Journey and Myst 3: Exile.
 - 10 more new engines and subengines that add compatibility with the following games:
   * Little Big Adventure
   * Red Comrades 1: Save the Galaxy
   * Red Comrades 2: For the Great Justice
   * Transylvania
   * Crimson Crown
   * OO-Topos
   * Glulx interactive fiction games
   * Private Eye
   * AGS Games versions 2.5+
   * Nightlong: Union City Conspiracy
   * The Journeyman Project 2: Buried in Time
   * Crusader: No Remorse
   * L-ZONE
   * Spaceship Warlock
 - added new localization and multiple platform versions existing games.
 - major rework of the GUI: support for Unicode everywhere, support for high resolutions and HiDPI screens.
 - support for GOG/Steam achievements to a large number of Wintermute games.
 - support for Keymapper in more games.

Module changes:
 - corrected the backend spelling for the SDL1 version and quoted the game name in the start script.
 - minor adjustment to the SDL1 version patches.
 - added 2 new dependencies (libgif,liba52)