### PR TITLE
gitPullOrClone improvements

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -435,7 +435,7 @@ function gitPullOrClone() {
     else
         local git="git clone --recursive"
         if [[ "$depth" -gt 0 ]]; then
-            git+=" --depth $depth"
+            git+=" --depth $depth --shallow-submodules"
         fi
         git+=" --branch $branch"
         printMsgs "console" "$git \"$repo\" \"$dir\""

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -402,9 +402,11 @@ function gitPullOrClone() {
     fi
     [[ -z "$repo" ]] && return 1
     [[ -z "$branch" ]] && branch="master"
-    if [[ -z "$depth" && "$__persistent_repos" -ne 1 && -z "$commit" ]]; then
-        depth=1
-    else
+
+    # if no depth is provided default to shallow clone (depth 1)
+    [[ -z "$depth" ]] && depth=1
+    # if we are using persistent repos or checking out a specific commit, don't shallow clone
+    if [[ "$__persistent_repos" -eq 1 || -n "$commit" ]]; then
         depth=0
     fi
 
@@ -416,9 +418,19 @@ function gitPullOrClone() {
 
     if [[ -d "$dir/.git" ]]; then
         pushd "$dir" > /dev/null
+        # if we are using persistent repos, fetch the latest remote changes and clean the source so
+        # any patches can be re-applied as needed.
+        if [[ "$__persistent_repos" -eq 1 ]]; then
+            runCmd git fetch
+            runCmd git reset --hard
+            runCmd git clean -f -d
+        fi
         runCmd git checkout "$branch"
-        runCmd git pull --ff-only
-        runCmd git submodule update --init --recursive
+        # only try to pull if we are on a tracking branch
+        if [[ -n "$(git config --get branch.$branch.merge)" ]]; then
+            runCmd git pull --ff-only
+            runCmd git submodule update --init --recursive
+        fi
         popd > /dev/null
     else
         local git="git clone --recursive"


### PR DESCRIPTION
Couple of changes:

When env __persistent_repos is 1, we do full checkouts of repositories. This allows users with diskspace to spare to speed up source updates, by avoiding doing a shallow clone everytime.

However, it was not working for cases where a module switched to a newer tag/branch as remote changes were not fetched first. This is now fixed.

Also fixed errors thrown when calling gitPullOrClone on an existing repository when doing git pull, when HEAD is detached (for tags) or there is no tracking branch.

And

When doing a shallow clone, also add --shallow-submodules which will do a shallow clone of submodules with depth 1.

This significantly speeds up checkouts of repositories with a lot of submodules (eg lr-tic80).