### PR TITLE
Displays launch menu dialog if no image is found

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -1245,7 +1245,7 @@ function show_launch() {
         else
             fbi -1 -t "$IMAGE_DELAY" -noverbose -a "$image" </dev/tty &>/dev/null
         fi
-    elif [[ "$DISABLE_MENU" -ne 1 && "$USE_ART" -ne 1 ]]; then
+    elif [[ "$DISABLE_MENU" -ne 1 ]]; then
         local launch_name
         if [[ -n "$ROM_BN" ]]; then
             launch_name="$ROM_BN ($EMULATOR)"


### PR DESCRIPTION
This change allows the launch menu  dialog to still be shown when launch art is enabled if no image is found. Current behavior is that when art is enabled, the dialog is never shown; therefore if no image is found, nothing is displayed at all.

This line to show the dialog is only called if no image is found in the first place, so checking if art is enabled at this point seems superfluous. We didn't get one, for one reason or another; either because it wasn't there, or because we didn't even look. By eliminating this test, we can fall back to show the dialog whenever an image is not obtained, for WHATEVER reason.