### PR TITLE
update golang to v1.8.7 and include arm64 version to fix arm64 compatibility

### DIFF
--- a/scriptmodules/supplementary/golang.sh
+++ b/scriptmodules/supplementary/golang.sh
@@ -23,7 +23,7 @@ function install_bin_golang() {
         local version=$(GOROOT="$md_inst" "$md_inst/bin/go" version | sed 's/.*\(go1[^ ]*\).*/\1/')
     fi
     printMsgs "console" "Current Go version: $version"
-    if [[ ! "${version}" < "go1.8" ]]; then
+    if [[ ! "${version}" < "go1.8.7" ]]; then
         return 0
     fi
 
@@ -37,6 +37,9 @@ function install_bin_golang() {
             arch="386"
         fi
     fi
-    printMsgs "console" "Downloading go1.8.linux-$arch.tar.gz"
-    downloadAndExtract "https://storage.googleapis.com/golang/go1.8.linux-$arch.tar.gz" "$md_inst" --strip-components 1
+    if isPlatform "aarch64"; then
+        arch="arm64"
+    fi
+    printMsgs "console" "Downloading go1.8.7.linux-$arch.tar.gz"
+    downloadAndExtract "https://storage.googleapis.com/golang/go1.8.7.linux-$arch.tar.gz" "$md_inst" --strip-components 1
 }


### PR DESCRIPTION
I can change this to https://golang.org/dl/go1.8.linux-$arch.tar.gz if that would be preferable. Comments left in as a reference if anyone ever wants to change it back to Google's servers