### PR TITLE
Add cloud sync utility for RetroArch and Ports saves

### DIFF
--- a/scriptmodules/supplementary/arklone.sh
+++ b/scriptmodules/supplementary/arklone.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="arklone"
+rp_module_desc="arklone cloud sync utility by ridgek"
+rp_module_licence="GPL3 https://raw.githubusercontent.com/ridgekuhn/arklone-retropie/master/LICENSE.md"
+rp_module_repo="git https://github.com/ridgekuhn/arklone-retropie master"
+rp_module_section="opt"
+
+function sources_arklone() {
+    gitPullOrClone
+}
+
+function install_arklone() {
+    md_ret_files=(
+        'src'
+        'LICENSE.md'
+        'README.md'
+        'install.sh'
+        'uninstall.sh'
+    )
+}
+
+function configure_arklone() {
+    if [[ "${md_mode}" = "install" ]]; then
+        # Run install script
+        "${md_inst}/install.sh"
+
+        # Link to EmulationStation RetroPie menu
+        touch "${home}/RetroPie/retropiemenu/arklone.rp"
+    fi
+}
+
+function gui_arklone() {
+    # Run arklone settings manager script
+    "${md_inst}/src/dialogs/settings.sh"
+}
+
+function remove_arklone() {
+    # Run uninstall script
+    "${md_inst}/uninstall.sh" true
+
+    # Remove EmulationStation RetroPie menu link
+    rm -fv "${home}/RetroPie/retropiemenu/arklone.rp"
+}
+


### PR DESCRIPTION
Hello,

I've written a cloud sync utility using [rclone](https://rclone.org/), systemd, `inotifywait`, and bash. It registers save directories for RetroArch (based on the user's `retroarch.cfg`) and allows the user to sync their saves with an rclone remote either manually or automatically in the background. It also includes support for a few ports, the standalone ppsspp emulator, and multiple builds of RetroArch (ie, if the user is on a 64-bit distro and has both 64-bit and 32-bit builds of RetroArch). I've tried to make it easy to extend, so more ports and standalones should be supported in the future. There is also a version for [ArkOS](https://github.com/ridgekuhn/arklone-arkos).

Video here: https://youtu.be/-jmoS1xwVcI

I couldn't find any documentation on writing a RetroPie module, so I've taken my best guess and would appreciate feedback on this if it seems like a good candidate to be merged in. Any issues with the app itself should go to [the project repo](https://github.com/ridgekuhn/arklone-retropie/).

The only issue I've encountered so far is that the RetroArch build included with the 4.7.1 Raspberry Pi 2/3 image does not respect the `sort_savefiles_by_content_enable` and `sort_savestates_by_content_enable` settings in `retroarch.cfg`. (Building from source or downloading the updated binary works as expected.) Is there any way to get the packages script to update RetroArch while installing this module?

Thanks!
