### PR TITLE
joy2key: fix a couple of bugs in the SDL version

### DIFF
--- a/scriptmodules/admin/joy2key/joy2key_sdl.py
+++ b/scriptmodules/admin/joy2key/joy2key_sdl.py
@@ -255,7 +255,7 @@ def filter_active_events(event_queue: dict) -> list:
     for e in event_queue:
         if event_queue[e][0] is None:
             continue
-        
+
         last_fire_time = event_queue[e][2]
         repeat_count = event_queue[e][1]
 
@@ -268,7 +268,13 @@ def filter_active_events(event_queue: dict) -> list:
 
     # remove any duplicate events from the list
     return list(set(filtered_events))
-    
+
+"""
+Remove all queued events for a device
+"""
+def remove_events_for_device(event_queue: dict, dev_index: int):
+    return { key:value for (key,value) in event_queue.items() if not key.startswith(f"{dev_index}_")}
+
 def event_loop(configs, joy_map, tty_fd):
     event = SDL_Event()
 
@@ -355,6 +361,8 @@ def event_loop(configs, joy_map, tty_fd):
 
             if event.type == SDL_JOYDEVICEREMOVED:
                 joystick.SDL_JoystickClose(active_devices[event.jdevice.which][1])
+                if event.jdevice.which in active_devices:
+                    event_queue = remove_events_for_device(event_queue, active_devices[event.jdevice.which][0])
                 active_devices.pop(event.jdevice.which, None)
                 axis_prev_values.pop(event.jdevice.which, None)
                 LOG.debug(f'Removed joystick #{event.jdevice.which}')

--- a/scriptmodules/admin/joy2key/joy2key_sdl.py
+++ b/scriptmodules/admin/joy2key/joy2key_sdl.py
@@ -38,7 +38,7 @@ from pwd import getpwnam
 from sdl2 import joystick, events, version, \
     SDL_WasInit, SDL_Init, SDL_QuitSubSystem, SDL_GetError, \
     SDL_INIT_JOYSTICK, SDL_INIT_VIDEO, version_info, \
-    SDL_Event, SDL_PollEvent, SDL_Delay, SDL_Quit, \
+    SDL_Event, SDL_PollEvent, SDL_FlushEvent, SDL_Delay, SDL_Quit, \
     SDL_JOYDEVICEADDED, SDL_JOYDEVICEREMOVED, SDL_QUIT, \
     SDL_JOYBUTTONDOWN, SDL_JOYBUTTONUP, SDL_JOYHATMOTION, SDL_JOYAXISMOTION, \
     SDL_GetTicks
@@ -352,6 +352,8 @@ def event_loop(configs, joy_map, tty_fd):
                 if joystick.SDL_JoystickNumAxes(stick) > 0:
                     axis_prev_values[joystick.SDL_JoystickInstanceID(stick)] = [0 for x in range(joystick.SDL_JoystickNumAxes(stick))]
 
+                # Remove any spurious axis movements reported by SDL during initialization
+                SDL_FlushEvent(SDL_JOYAXISMOTION);
                 continue
 
             if event.jdevice.which not in active_devices:


### PR DESCRIPTION
Added a couple of fixes for issues discovered tracking the errors reported in a forum post [1].

* When a device is disconnected, its events were not cleared. 
   This was problematic for joystick/d-pad movement tracking, which keeps the last move event in the event queue. Disconnecting a device while the movement is active would keep this last move in the event queue forever, so clear all events associated with a device when it disconnects

*  For certain joysticks (axis), SDL will generate spurious axis movement events during initialization.
It seems that for axis where `absmin` and `absmax` are asymmetrical (ex. 0-255 instead of -255 - 255), SDL generates extra events which are not user generated. This can causes issues - i.e. automatically trigger the `runcommand` menu without user interaction, unintended scrolling, etc.

     As a workaround, discard any axis movement events _immediately_ after the device is added.
**NOTE**: this will discard any potential valid axis events from another (already connected) device if they are present, forcing the user to probably re-center/re-position the (other) joystick they were using.

[1] Forum post - https://retropie.org.uk/forum/topic/31569/