### PR TITLE
mupen64plus: enable GLideN64 plugin option EnableInaccurateTextureCoordinates for rpi.

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -358,6 +358,8 @@ function configure_mupen64plus() {
         iniSet "BufferSwapMode" "2"
         # Disable hybrid upscaling filter (needs better GPU)
         iniSet "EnableHybridFilter" "False"
+        # Use fast but less accurate shaders. Can help with low-end GPUs.
+        iniSet "EnableInaccurateTextureCoordinates" "True"
 
         if isPlatform "videocore"; then
             # Disable gles2n64 autores feature and use dispmanx upscaling


### PR DESCRIPTION
 Massively improves framerate at cost of accuracy.

Tested on Pi 4, GoldenEye menu:
True = 47 FPS
False = 33 FPS

The accuracy cost is essentially the last few months of texture handling improvements. These do fix some long standing display/accuracy bugs, but the framerate cost is so prohibitive on Pi that I doubt there would be cause to use them. Certainly not by default.