### PR TITLE
bluetooth: update python scripts and deps for python3

### DIFF
--- a/scriptmodules/supplementary/bluetooth.sh
+++ b/scriptmodules/supplementary/bluetooth.sh
@@ -38,7 +38,7 @@ function _get_connect_mode() {
 }
 
 function depends_bluetooth() {
-    local depends=(bluetooth python-dbus python-gobject bluez-tools)
+    local depends=(bluetooth python3-dbus python3-gi bluez-tools)
     if [[ "$__os_id" == "Raspbian" ]]; then
         depends+=(pi-bluetooth raspberrypi-sys-mods)
     fi

--- a/scriptmodules/supplementary/bluetooth/bluez-simple-agent
+++ b/scriptmodules/supplementary/bluetooth/bluez-simple-agent
@@ -1,16 +1,12 @@
-#!/usr/bin/python
-
-from __future__ import absolute_import, print_function, unicode_literals
+#!/usr/bin/python3
 
 from optparse import OptionParser
 import sys
 import dbus
 import dbus.service
 import dbus.mainloop.glib
-try:
-  from gi.repository import GObject
-except ImportError:
-  import gobject as GObject
+from gi.repository import GLib
+
 import bluezutils
 
 BUS_NAME = 'org.bluez'
@@ -153,7 +149,7 @@ if __name__ == '__main__':
 	path = "/test/agent"
 	agent = Agent(bus, path)
 
-	mainloop = GObject.MainLoop()
+	mainloop = GLib.MainLoop()
 
 	obj = bus.get_object(BUS_NAME, "/org/bluez");
 	manager = dbus.Interface(obj, "org.bluez.AgentManager1")

--- a/scriptmodules/supplementary/bluetooth/bluez-test-device
+++ b/scriptmodules/supplementary/bluetooth/bluez-test-device
@@ -1,21 +1,17 @@
-#!/usr/bin/python
-
-from __future__ import absolute_import, print_function, unicode_literals
+#!/usr/bin/python3
 
 from optparse import OptionParser, make_option
 import re
 import sys
 import dbus
 import dbus.mainloop.glib
-try:
-  from gi.repository import GObject
-except ImportError:
-  import gobject as GObject
+from gi.repository import GLib
+
 import bluezutils
 
 dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
 bus = dbus.SystemBus()
-mainloop = GObject.MainLoop()
+mainloop = GLib.MainLoop()
 
 option_list = [
 		make_option("-i", "--device", action="store",
@@ -48,7 +44,7 @@ if (args[0] == "list"):
 					"org.freedesktop.DBus.ObjectManager")
 	objects = om.GetManagedObjects()
 
-	for path, interfaces in objects.iteritems():
+	for path, interfaces in objects.items():
 		if "org.bluez.Device1" not in interfaces:
 			continue
 		properties = interfaces["org.bluez.Device1"]

--- a/scriptmodules/supplementary/bluetooth/bluezutils.py
+++ b/scriptmodules/supplementary/bluetooth/bluezutils.py
@@ -15,7 +15,7 @@ def find_adapter(pattern=None):
 
 def find_adapter_in_objects(objects, pattern=None):
 	bus = dbus.SystemBus()
-	for path, ifaces in objects.iteritems():
+	for path, ifaces in objects.items():
 		adapter = ifaces.get(ADAPTER_INTERFACE)
 		if adapter is None:
 			continue
@@ -35,7 +35,7 @@ def find_device_in_objects(objects, device_address, adapter_pattern=None):
 	if adapter_pattern:
 		adapter = find_adapter_in_objects(objects, adapter_pattern)
 		path_prefix = adapter.object_path
-	for path, ifaces in objects.iteritems():
+	for path, ifaces in objects.items():
 		device = ifaces.get(DEVICE_INTERFACE)
 		if device is None:
 			continue


### PR DESCRIPTION
Updated the dependencies and scripts for python3:
    
  * `python-dbus` no longer exists in Debian 11 'bullseye' or Ubuntu > 20.04, installl the `python3` version
  * `python-gobject` has been superseeded by `python(3)-gi`, the current package is just a transitional package that pulls
    `python-gi` and the old `python-gobject-2` (deprecated). Update the dependencies and the scripts to use the new package.
  * set python3 as interpreter for the helper scripts. Fixed the dict syntax for getting items.