### PR TITLE
Add advanced wifi module with on screen keyboard

### DIFF
--- a/scriptmodules/supplementary/advanced-wifi.sh
+++ b/scriptmodules/supplementary/advanced-wifi.sh
@@ -18,7 +18,7 @@ rp_module_repo="git https://github.com/OfficialPhilcomm/retropie-wifi-manager.gi
 rp_module_licence="MIT https://raw.githubusercontent.com/OfficialPhilcomm/retropie-wifi-manager/master/LICENSE.md"
 
 function depends_advanced-wifi() {
-  getDepends ruby ruby-dev
+  getDepends ruby ruby-dev libncurses-dev
 }
 
 function sources_advanced-wifi() {


### PR DESCRIPTION
A lot of people (including me) have the problem that you always need a keyboard to connect to a new wifi. Or another device to ssh into the Pi.

This aims to fix this problem.

Built with `ruby` and `curses`, this terminal application allows for connecting to a wifi, without the need of a keyboard.
Since controller buttons are mapped to the arrow keys, enter and space, this app reads them like keyboard inputs for navigation.

This pr just includes the RetroPie-Setup `.sh` file, feel free to `wget -P /home/pi/RetroPie-Setup/scriptmodules/supplementary/ "https://raw.githubusercontent.com/OfficialPhilcomm/retropie-wifi-manager/master/advanced-wifi.sh"
` and try it yourself. I will continue to make improvements on the project's repo, so this can be merged already.

The workflow is as follows:

## Select a WiFi
<img width="437" alt="Screenshot 2021-11-19 at 17 33 44" src="https://user-images.githubusercontent.com/54138860/142658579-93e30d0e-fa57-4d23-95cb-2ffb80f67ff3.png">
The app has a simple wifi selection screen. All networks found with `iwlist scan` are listed here.

White networks are unknown to the device, cyan ones are saved in `wpa_supplicant.conf`, green ones you are connected to right now.

For white networks you only have the option to connect.
Green and Cyan additionally have the functionality to be prioritized (`priority=1` in `wpa_supplicant.conf`) and to be deleted. These options come with a confirmation prompt.

## Enter password
<img width="437" alt="Screenshot 2021-11-19 at 15 52 49" src="https://user-images.githubusercontent.com/54138860/142642739-1b604e16-ee30-40fa-8f23-e0068bb4ed82.png">

On this page you can enter the password. The password must be at least 8 characters long, otherwise it shows an error prompt.

## Saving network config
After clicking on connect, the app writes to the `wpa_supplicant.conf`. It uses `wpa_passphrase` to generate a hashed password, so the one written to the file is not in clear text.