### PR TITLE
alephone: (QOL) improve/combine emulator configs

### DIFF
--- a/scriptmodules/ports/alephone.sh
+++ b/scriptmodules/ports/alephone.sh
@@ -72,9 +72,9 @@ function game_data_alephone() {
 }
 
 function configure_alephone() {
-    addPort "$md_id" "marathon" "Aleph One Engine - Marathon" "'$md_inst/bin/alephone' '$romdir/ports/$md_id/Marathon/'"
-    addPort "$md_id" "marathon2" "Aleph One Engine - Marathon 2" "'$md_inst/bin/alephone' '$romdir/ports/$md_id/Marathon 2/'"
-    addPort "$md_id" "marathoninfinity" "Aleph One Engine - Marathon Infinity" "'$md_inst/bin/alephone' '$romdir/ports/$md_id/Marathon Infinity/'"
+    addPort "$md_id" "alephone" "Aleph One Engine - Marathon" "$md_inst/bin/alephone %ROM%" "$romdir/ports/$md_id/Marathon/"
+    addPort "$md_id" "alephone" "Aleph One Engine - Marathon 2" "$md_inst/bin/alephone %ROM%" "$romdir/ports/$md_id/Marathon 2/"
+    addPort "$md_id" "alephone" "Aleph One Engine - Marathon Infinity" "$md_inst/bin/alephone %ROM%" "$romdir/ports/$md_id/Marathon Infinity/"
 
     mkRomDir "ports/$md_id"
 


### PR DESCRIPTION
The different Marathon games are each launched with a unique emulator config, each one configured to launch only that particular game with the executable and game data directory hardcoded into the emulator command.

This change combines them into one "alephone" emulator config, with just the executable in the command, and splits the game data dir out into the "%ROM%" parameter. This allows easy user integration of additional alephone engine games simply by adding their game data and a launch script such as:

    "/opt/retropie/supplementary/runcommand/runcommand.sh" 0 _PORT_ "alephone" "/path/to/game/dir/"

Pros:
- cleaner "configs" folder with only one shared emulator instead of a different one for each game
- easy user integration of additional alephone engine games

Cons:
- none that I can think of off hand?