### PR TITLE
added missing gettext dependency

### DIFF
--- a/scriptmodules/ports/openblok.sh
+++ b/scriptmodules/ports/openblok.sh
@@ -17,7 +17,7 @@ rp_module_section="exp"
 rp_module_flags=""
 
 function depends_openblok() {
-    getDepends cmake libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev
+    getDepends cmake libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev gettext
 }
 
 function sources_openblok() {


### PR DESCRIPTION
Tried to install RetroPie on a clean minimal Kubuntu installation.
Had to add gettext to the list of dependencies.