### PR TITLE
advmame: build fixes when using a newer `gcc`

### DIFF
--- a/scriptmodules/emulators/advmame-0.94.sh
+++ b/scriptmodules/emulators/advmame-0.94.sh
@@ -25,6 +25,8 @@ function depends_advmame-0.94() {
 function sources_advmame-0.94() {
     downloadAndExtract "$md_repo_url" "$md_build" --strip-components 1
     _sources_patch_advmame-1.4
+    # Fix the global vars missing the 'external' qualifier, needed for gcc > 10
+    applyPatch "${md_path%/*}/advmame/02_fix_extern_globals_0_94.diff"
 }
 
 function build_advmame-0.94() {

--- a/scriptmodules/emulators/advmame-1.4.sh
+++ b/scriptmodules/emulators/advmame-1.4.sh
@@ -39,13 +39,15 @@ function _sources_patch_advmame-1.4() {
 
         # patch advmame to use a fake generated mode with the exact dimensions for fb - avoids need for configuring monitor / clocks.
         # the pi framebuffer doesn't use any of the framebuffer timing configs - it hardware scales from chosen dimensions to actual size
-        applyPatch "$scriptdir/scriptmodules/$md_type/advmame/01_rpi_framebuffer.diff"
+        applyPatch "${md_path%/*}/advmame/01_rpi_framebuffer.diff"
     fi
 }
 
 function sources_advmame-1.4() {
     downloadAndExtract "$md_repo_url" "$md_build" --strip-components 1
     _sources_patch_advmame-1.4 1.4
+    # Fix the global vars missing the 'external' qualifier, needed for gcc > 10
+    applyPatch "${md_path%/*}/advmame/02_fix_extern_globals_1_4.diff"
 }
 
 function build_advmame-1.4() {

--- a/scriptmodules/emulators/advmame.sh
+++ b/scriptmodules/emulators/advmame.sh
@@ -43,9 +43,9 @@ function sources_advmame() {
 function build_advmame() {
     local params=()
     if isPlatform "videocore"; then
-        params+=(--enable-sdl1 --disable-sdl2 --enable-vc)
+        params+=(--enable-sdl --disable-sdl2 --enable-vc)
     else
-        params+=(--enable-sdl2 --disable-sdl1 --disable-vc)
+        params+=(--enable-sdl2 --disable-sdl --disable-vc)
     fi
     ./autogen.sh
     ./configure CFLAGS="$CFLAGS -fno-stack-protector" --prefix="$md_inst" "${params[@]}"

--- a/scriptmodules/emulators/advmame/02_fix_extern_globals_0_94.diff
+++ b/scriptmodules/emulators/advmame/02_fix_extern_globals_0_94.diff
@@ -1,0 +1,13 @@
+diff --git a/src/drivers/seibuspi.c b/src/drivers/seibuspi.c
+index 143dcc2..91187f8 100644
+--- a/src/drivers/seibuspi.c
++++ b/src/drivers/seibuspi.c
+@@ -602,7 +602,7 @@ WRITE32_HANDLER( video_dma_length_w );
+ WRITE32_HANDLER( video_dma_address_w );
+ WRITE32_HANDLER( sprite_dma_start_w );
+ 
+-UINT32 *scroll_ram;
++extern UINT32 *scroll_ram;
+ extern int old_vidhw;
+ extern int bg_size;
+ data32_t *spimainram;

--- a/scriptmodules/emulators/advmame/02_fix_extern_globals_1_4.diff
+++ b/scriptmodules/emulators/advmame/02_fix_extern_globals_1_4.diff
@@ -1,0 +1,36 @@
+From f8688cae05799a30cd5337e626a07fa9f004c0a3 Mon Sep 17 00:00:00 2001
+From: Andrea Mazzoleni <amadvance@gmail.com>
+Date: Fri, 23 Oct 2020 21:29:41 +0200
+Subject: [PATCH] Fix build errors due new gcc 10 default for -fno-common
+
+---
+ src/drivers/cavepgm.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/drivers/cavepgm.c b/src/drivers/cavepgm.c
+index 38d3dae8..df6e97ab 100644
+--- a/src/drivers/cavepgm.c
++++ b/src/drivers/cavepgm.c
+@@ -287,7 +287,7 @@ Notes:
+ #include "timer.h"
+ 
+ 
+-UINT16 *pgm_mainram, *pgm_bg_videoram, *pgm_tx_videoram, *pgm_videoregs, *pgm_rowscrollram;
++extern UINT16 *pgm_mainram, *pgm_bg_videoram, *pgm_tx_videoram, *pgm_videoregs, *pgm_rowscrollram;
+ static UINT8 *z80_mainram;
+ static UINT32 *arm7_shareram;
+ static UINT32 arm7_latch;
+@@ -852,8 +852,8 @@ static void expand_32x32x5bpp(void)
+ /* This function expands the sprite colour data (in the A Roms) from 3 pixels
+    in each word to a byte per pixel making it easier to use */
+ 
+-UINT8 *pgm_sprite_a_region;
+-size_t	pgm_sprite_a_region_allocate;
++extern UINT8 *pgm_sprite_a_region;
++extern size_t	pgm_sprite_a_region_allocate;
+ 
+ static void expand_colourdata(void)
+ {
+-- 
+2.32.0
+


### PR DESCRIPTION
(Following up on #3440).

1. Build fixes for older `advmame` versions:
   With gcc10 and newer, the `-fno-common` option is the default, causing
issues for global variables with multiple declarations that are missing the `external` initializer.
See https://wiki.gentoo.org/wiki/Project:Toolchain/Gcc_10_porting_notes/fno_common for a summary.

   Added a couple of patches to fix building for older `advmame` versions:
    * for `advmame-1.4`, pick amadvance/advancemame@f8688ca
    * for `advmame-0.94`, created a separate patch

   Added a minor modification to use the scriptmodule's `md_path` variable to calculate the patch folder location.

2. For `advmame`, fixed the SDL1 enable/disable flag, it was incorrect.