### PR TITLE
lower-case required for recent ubuntu package

### DIFF
--- a/scriptmodules/emulators/pcsx2.sh
+++ b/scriptmodules/emulators/pcsx2.sh
@@ -62,8 +62,8 @@ function remove_pcsx2() {
 function configure_pcsx2() {
     mkRomDir "ps2"
     # Windowed option
-    addEmulator 0 "$md_id" "ps2" "/usr/games/PCSX2 %ROM% --windowed"
+    addEmulator 0 "$md_id" "ps2" "/usr/games/pcsx2 %ROM% --windowed"
     # Fullscreen option with no gui (default, because we can close with `Esc` key, easy to map for gamepads)
-    addEmulator 1 "$md_id-nogui" "ps2" "/usr/games/PCSX2 %ROM% --fullscreen --nogui"
+    addEmulator 1 "$md_id-nogui" "ps2" "/usr/games/pcsx2 %ROM% --fullscreen --nogui"
     addSystem "ps2"
 }


### PR DESCRIPTION
seems like the binary was changed to lower-case in the recent package:
pcsx2-unstable 3:1.7.0~git202112312251+202201010334~ubuntu21.10.1