### PR TITLE
xpad: change install folder in the kernel tree

### DIFF
--- a/scriptmodules/supplementary/xpad.sh
+++ b/scriptmodules/supplementary/xpad.sh
@@ -32,6 +32,8 @@ function sources_xpad() {
     cd "$md_inst"
     # LED support (as disabled currently in packaged RPI kernel) and allow forcing MAP_TRIGGERS_TO_BUTTONS
     applyPatch "$md_data/01_enable_leds_and_trigmapping.diff"
+    # Tell 'dkms' to use the 'updates' kernel module folder to store the module
+    applyPatch "$md_data/02_dkms_updates_folder.diff"
 }
 
 function build_xpad() {

--- a/scriptmodules/supplementary/xpad/02_dkms_updates_folder.diff
+++ b/scriptmodules/supplementary/xpad/02_dkms_updates_folder.diff
@@ -1,0 +1,12 @@
+diff --git a/dkms.conf b/dkms.conf
+index 58a1ac2..b56b148 100644
+--- a/dkms.conf
++++ b/dkms.conf
+@@ -2,6 +2,6 @@ PACKAGE_NAME="xpad"
+ PACKAGE_VERSION="0.4"
+ MAKE[0]="make KVERSION=$kernelver"
+ CLEAN="make clean"
+-DEST_MODULE_LOCATION[0]="/extra"
++DEST_MODULE_LOCATION[0]="/updates"
+ BUILT_MODULE_NAME[0]="xpad"
+ AUTOINSTALL="yes"


### PR DESCRIPTION
Changed from `extra` to `updates` to work-around some kernel upgrades (RPI) disabling the RetroPie `xpad` driver.

Upstream `xpad` repo installs the kernel in `/lib/modules/$KERN_VER/extra`, deleting the built-in module:
``` sh
$ modinfo xpad | head -n 5
filename:       /lib/modules/5.10.63-v7l+/extra/xpad.ko
license:        GPL
description:    X-Box pad driver
author:         Marko Friedemann <mfr@bmx-chemnitz.de>
srcversion:     849EA3FE68A31D6FA00FD40
```
During a kernel upgrade, **when** `$KERN_VER` does not change (happened with RPI provided kernels), then `dkms` gets confused about where the module resides:
 * the pre-install hook deletes the module in `extra`, but restores the original module in the same location (!)
 * the post-install hook sees the module in `extra` and assumes is the one shipped by the kernel and replaces it, but doesn't delete the original (which was just installed).

 As a result, during such an upgrade, there are 2 `xpad` modules and `depmod` picks the built-in one, with an ineffective RetroPie `xpad` install:
``` sh
$ find /lib/modules/`uname -r`/ -name xpad.ko -exec ls -l {} \;
-rw-r--r-- 1 root root 39636 Dec  1 16:03 /lib/modules/5.10.63-v7l+/kernel/drivers/input/joystick/xpad.ko
-rw-r--r-- 1 root root 41288 Jan  4 19:23 /lib/modules/5.10.63-v7l+/extra/xpad.ko

$ modinfo xpad | head -n 5
filename:       /lib/modules/5.10.63-v7l+/kernel/drivers/input/joystick/xpad.ko
license:        GPL
description:    X-Box pad driver
author:         Marko Friedemann <mfr@bmx-chemnitz.de>
srcversion:     E1B709DF2EBAA331E53C6D6
```

Now,  `depmod` can be configured to look first in other sub-folders (overriding the built-in module tree), but on RPI OS there is no such configuration (see `man 5 depmod.d`). Ubuntu - for instance - ships with a configuration that adds `updates/ubuntu` before the built-in path.
 Without a configuration file though, `depmod` will look for modules in `updates` first, so moving the install folder to `updates` will result in the the RetroPie's `xpad` being picked first, even without a configuration. 

Note that this may potentially break when there is a configuration for `depmod`, but the work-around is meant for RPI OS, where this config is missing. Upstream Debian/Ubuntu don't usually ship with same `$KERN_VER` on upgrades.