### PR TITLE
Patched pcsx-rearmed installation script to fix lack of sound do to error that should be a warning for PulseAudio

### DIFF
--- a/scriptmodules/emulators/pcsx-rearmed.sh
+++ b/scriptmodules/emulators/pcsx-rearmed.sh
@@ -26,13 +26,12 @@ function sources_pcsx-rearmed() {
 }
 
 function build_pcsx-rearmed() {
-    sed -i '67 s|.|//&|' plugins/dfsound/alsa.c
     if isPlatform "neon"; then
-        ./configure --sound-drivers=alsa --enable-neon
+        ./configure --sound-drivers=libretro --enable-neon
     else
-        ./configure --sound-drivers=alsa --disable-neon
+        ./configure --sound-drivers=libretro --disable-neon
     fi
-    make clean 
+    make clean
     make
     md_ret_require="$md_build/pcsx"
 }

--- a/scriptmodules/emulators/pcsx-rearmed.sh
+++ b/scriptmodules/emulators/pcsx-rearmed.sh
@@ -26,13 +26,15 @@ function sources_pcsx-rearmed() {
 }
 
 function build_pcsx-rearmed() {
+    sed -i '67 s|.|//&|' plugins/dfsound/alsa.c
     if isPlatform "neon"; then
         ./configure --sound-drivers=alsa --enable-neon
     else
         ./configure --sound-drivers=alsa --disable-neon
     fi
     make clean
-    make
+   
+   make
     md_ret_require="$md_build/pcsx"
 }
 

--- a/scriptmodules/emulators/pcsx-rearmed.sh
+++ b/scriptmodules/emulators/pcsx-rearmed.sh
@@ -32,9 +32,8 @@ function build_pcsx-rearmed() {
     else
         ./configure --sound-drivers=alsa --disable-neon
     fi
-    make clean
-   
-   make
+    make clean 
+    make
     md_ret_require="$md_build/pcsx"
 }
 


### PR DESCRIPTION
## Problem
The emulator pcsx_rearmed has no audio on RetroPi 4.7.20 with a Raspberry Pi Zero W resulting in the following error in /dev/shm/runcommand.log:

```bash
alsa: refusing to run under PulseAudio's emulation 
selected sound output driver: none
```

## Impact after merge
The installer  script scriptmodules/emulators/pcsx-rearmed.sh patches the source code of pcsx_rearmed by commenting out an error that should be a warning. The sound works after this pull request.  With line # 67(return -1) commented out in [plugins/dfsound/alsa.c](https://github.com/notaz/pcsx_rearmed/blob/master/plugins/dfsound/alsa.c) the sound card initialized correctly and the emulator produces sound.

## Context
Raspbian GNU/Linux 10 (buster)
RetroPi 4.7.20
Hardware        : BCM2835
Model           : Raspberry Pi Zero W Rev 1.1

## Root cause
The emulator throws an error, which should only be a warning. If  the function alsa/soundlib::snd_ctl_card_info_get_name() returns a sound card identification string containing the words "PulseAudio" . 

## The fix
Patching the file [plugins/dfsound/alsa.c](https://github.com/notaz/pcsx_rearmed/blob/master/plugins/dfsound/alsa.c)  before compile time for all raspberry pies as I have done in this pull request.
The file [plugins/dfsound/alsa.c](https://github.com/notaz/pcsx_rearmed/blob/master/plugins/dfsound/alsa.c) in the project pcsx_rearmed at https://github.com/notaz/pcsx_rearmed throws an error if the function "snd_ctl_card_info_get_name(info)" returns a string with the value "PulseAudio" in it.  This results in the emulator outputting no audio.  This should be a warning only and not an exception at least for this context. I don't know the impact of removing commenting out the line #67  on other systems so sending a pull request to the pcsx_rearmed team may not make sense.

**Update**
Issue can also be resolved by adding a preprocessor directive to select the libretro sound driver
```
    if isPlatform "neon"; then
        ./configure --sound-drivers=libretro --enable-neon
    else
        ./configure --sound-drivers=libretro --disable-neon
    fi
```


## Comments
precompiled binaries need to be patched also.

