### PR TITLE
xroar: update to 1.0.7

### DIFF
--- a/scriptmodules/emulators/xroar.sh
+++ b/scriptmodules/emulators/xroar.sh
@@ -11,14 +11,16 @@
 
 rp_module_id="xroar"
 rp_module_desc="Dragon / CoCo emulator XRoar"
-rp_module_help="ROM Extensions: .cas .wav .bas .asc .dmk .jvc .os9 .dsk .vdk .rom .ccc .sna\n\nCopy your Dragon roms to $romdir/dragon32\n\nCopy your CoCo games to $romdir/coco\n\nCopy the required BIOS files d32.rom (Dragon 32) and bas13.rom (CoCo) to $biosdir"
+rp_module_help="ROM Extensions: .cas .wav .bas .asc .dmk .jvc .os9 .dsk .vdk .rom .ccc .sna\n\nCopy your Dragon roms to $romdir/dragon32\n\nCopy your CoCo games to $romdir/coco\n\nCopy the required BIOS files d32.rom (Dragon 32), bas13.rom (CoCo), coco3.rom/coco3p.rom (CoCo3) to $biosdir"
 rp_module_licence="GPL3 http://www.6809.org.uk/xroar/"
-rp_module_repo="git http://www.6809.org.uk/git/xroar.git 0.36"
+rp_module_repo="git http://www.6809.org.uk/git/xroar.git 1.0.7"
 rp_module_section="opt"
 rp_module_flags=""
 
 function depends_xroar() {
-    getDepends libsdl2-dev automake texinfo
+    local depends=(libsdl2-dev automake libasound-dev texinfo zlib1g-dev)
+    isPlatform "x11" && depends+=(libpulse-dev)
+    getDepends "${depends[@]}"
 }
 
 function sources_xroar() {
@@ -27,7 +29,7 @@ function sources_xroar() {
 }
 
 function build_xroar() {
-    local params=(--without-gtk2 --without-gtkgl)
+    local params=(--without-gtk2 --without-gtkgl --without-oss)
     if ! isPlatform "x11"; then
         params+=(--without-pulse --disable-kbd-translate --without-x)
     fi
@@ -55,6 +57,9 @@ function configure_xroar() {
     addEmulator 1 "$md_id-dragon32" "dragon32" "$md_inst/bin/xroar ${params[*]} -machine dragon32 -run %ROM%"
     addEmulator 1 "$md_id-cocous" "coco" "$md_inst/bin/xroar ${params[*]} -machine cocous -run %ROM%"
     addEmulator 0 "$md_id-coco" "coco" "$md_inst/bin/xroar ${params[*]} -machine coco -run %ROM%"
+    addEmulator 0 "$md_id-coco3us" "coco" "$md_inst/bin/xroar ${params[*]} -machine coco3 -run %ROM%"
+    addEmulator 0 "$md_id-coco3" "coco" "$md_inst/bin/xroar ${params[*]} -machine coco3p -run %ROM%"
+
     addSystem "dragon32"
     addSystem "coco"
 }


### PR DESCRIPTION
Changes:
 * Added support for Tandy Color Computer 3 (NTSC/PAL).
 * Added support for Tandy MC-10
 * Emulator tries multiple SDL video renderers in order
 * Tape play/pause function
 * New snapshot format to support CoCo 3, MC-10
 * Add Control+Shift+D to flush disk images
 * RACE Computer Expansion Cage support (-cart mpi-race)
 * Support leading "~/" in filenames, not just path element
 * IDE, NX32, MOOH now all require user to specify an image

Scriptmodule changes:
 * Added explicit dependencies for ALSA and ZLIB. PulseAudio dependency added for `x11` platforms
 * Added emulator entries for CoCo3 models (PAL/NTSC)
 * Removed OSS support explicitely during build