### PR TITLE
Revert "lr-flycast: update to switch to upstream project"

### DIFF
--- a/scriptmodules/libretrocores/lr-flycast/01_flags_fix.diff
+++ b/scriptmodules/libretrocores/lr-flycast/01_flags_fix.diff
@@ -1,0 +1,30 @@
+diff --git a/Makefile b/Makefile
+index 2c477b4d..92a67b62 100644
+--- a/Makefile
++++ b/Makefile
+@@ -44,8 +44,6 @@ LDFLAGS  :=
+ LDFLAGS_END :=
+ INCFLAGS :=
+ LIBS     :=
+-CFLAGS   := 
+-CXXFLAGS :=
+ 
+ GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ ifneq ($(GIT_VERSION)," unknown")
+@@ -208,6 +206,7 @@ else ifneq (,$(findstring rpi,$(platform)))
+ 		endif
+ 		CORE_DEFINES += -DLOW_END
+ 	endif
++	LDFLAGS += $(CFLAGS)
+ 
+ # Classic Platforms #####################
+ # Platform affix = classic_<ISA>_<µARCH>
+@@ -894,7 +893,7 @@ else
+ 	else ifneq (,$(findstring classic_arm,$(platform)))
+ 		OPTFLAGS       := -O2
+ 	else ifeq (,$(findstring classic_arm,$(platform)))
+-		OPTFLAGS       := -O3
++		OPTFLAGS       := -O2
+ 	endif
+ 
+ 	CORE_DEFINES   += -DNDEBUG


### PR DESCRIPTION
This reverts commit 9b271b2bfd96e703e49f23fce82e4f26ee0f2b9b.

Due to `gcc` seemingly mis-compiling the SH4 interpreter and crashing Naomi games.