### PR TITLE
lr-freeintv: synchronise license with upstream

### DIFF
--- a/scriptmodules/libretrocores/lr-freeintv.sh
+++ b/scriptmodules/libretrocores/lr-freeintv.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-freeintv"
 rp_module_desc="Intellivision emulator for libretro"
 rp_module_help="ROM Extensions: .int .bin\n\nCopy your Intellivision roms to $romdir/intellivision\n\nCopy the required BIOS files exec.bin and grom.bin to $biosdir"
-rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/FreeIntv/master/LICENSE"
+rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/FreeIntv/master/LICENSE"
 rp_module_repo="git https://github.com/libretro/FreeIntv.git master"
 rp_module_section="opt"
 


### PR DESCRIPTION
License changed upstream with commit [e8d7ff7ae0d048055e7b0da0de78ed92eb0173a0](https://github.com/libretro/FreeIntv/commit/e8d7ff7ae0d048055e7b0da0de78ed92eb0173a0).