### PR TITLE
Added upstream / current stella libretro core - lr-stella

### DIFF
--- a/scriptmodules/libretrocores/lr-stella.sh
+++ b/scriptmodules/libretrocores/lr-stella.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-stella"
+rp_module_desc="Atari 2600 emulator - Stella core for libretro"
+rp_module_help="ROM Extensions: .a26 .bin .rom .zip .gz\n\nCopy your Atari 2600 roms to $romdir/atari2600"
+rp_module_licence="GPL2 https://raw.githubusercontent.com/stella-emu/stella/master/License.txt"
+rp_module_repo="git https://github.com/stella-emu/stella.git master"
+rp_module_section="exp"
+
+function sources_lr-stella() {
+    gitPullOrClone
+}
+
+function build_lr-stella() {
+    cd src/libretro
+    make clean
+    make LTO=""
+    md_ret_require="$md_build/src/libretro/stella_libretro.so"
+}
+
+function install_lr-stella() {
+    md_ret_files=(
+        'README.md'
+        'src/libretro/stella_libretro.so'
+        'License.txt'
+    )
+}
+
+function configure_lr-stella() {
+    mkRomDir "atari2600"
+    ensureSystemretroconfig "atari2600"
+
+    addEmulator 0 "$md_id" "atari2600" "$md_inst/stella_libretro.so"
+    addSystem "atari2600"
+}


### PR DESCRIPTION
I put this together rather quickly (and it needs testing), based on the lr-stella2014 script module and referencing the post on https://retropie.org.uk/forum/topic/32067/installing-lr-stella-upstream-on-raspberry-pi-4b/3?_=1643005126251 - which was similar.

If it's useful, it's an easy addition.


