### PR TITLE
scummvm: update to fix GL runtime detection

### DIFF
--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -12,8 +12,8 @@
 rp_module_id="scummvm"
 rp_module_desc="ScummVM"
 rp_module_help="Copy your ScummVM games to $romdir/scummvm"
-rp_module_licence="GPL2 https://raw.githubusercontent.com/scummvm/scummvm/master/COPYING"
-rp_module_repo="git https://github.com/scummvm/scummvm.git v2.5.1"
+rp_module_licence="GPL3 https://raw.githubusercontent.com/scummvm/scummvm/master/COPYING"
+rp_module_repo="git https://github.com/scummvm/scummvm.git master a9418f8f"
 rp_module_section="opt"
 rp_module_flags="sdl2"
 


### PR DESCRIPTION
Version 2.5.1 incorporated the OpenGL based scalers by default and this causes a runtime error on GLES platforms.
Update to a post-2.5.1 commit which changes the OpenGL loader from GLEW to GLAD and fixes this problem.

Minor - upstream license changed to GPL3+.