### PR TITLE
Fix gles2rice plugin entry.

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -266,7 +266,7 @@ function configure_mupen64plus() {
             addEmulator 0 "${md_id}-GLideN64-highres" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-GLideN64 %ROM% $res 0 --set Video-GLideN64[UseNativeResolutionFactor]\=2"
             addEmulator 0 "${md_id}-gles2n64" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-n64 %ROM%"
             if isPlatform "32bit"; then
-                addEmulator 0 "${md_id}-gles2rice$name" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-rice %ROM% $res"
+                addEmulator 0 "${md_id}-gles2rice" "n64" "$md_inst/bin/mupen64plus.sh mupen64plus-video-rice %ROM% $res"
             fi
         else
             for res in "${resolutions[@]}"; do


### PR DESCRIPTION
This var is not set locally, it is inheriting wrong value "main packages" from ../admin/setup.sh#L380, resulting in:

    mupen64plus-gles2ricemain packages = "...