### PR TITLE
eduke32: patch a gameplay bug in E1L4

### DIFF
--- a/scriptmodules/ports/eduke32.sh
+++ b/scriptmodules/ports/eduke32.sh
@@ -39,6 +39,8 @@ function sources_eduke32() {
     isPlatform "gles" && applyPatch "$md_data/0003-replace-gl_red.patch"
     # gcc 6.3.x compiler fix
     applyPatch "$md_data/0004-recast-function.patch"
+    # cherry-picked commit fixing a game bug in E1M4 (shrinker ray stuck)
+    applyPatch "$md_data/0005-e1m4-shrinker-bug.patch"
 }
 
 function build_eduke32() {

--- a/scriptmodules/ports/eduke32/0005-e1m4-shrinker-bug.patch
+++ b/scriptmodules/ports/eduke32/0005-e1m4-shrinker-bug.patch
@@ -1,0 +1,45 @@
+diff --git a/source/duke3d/src/actors.cpp b/source/duke3d/src/actors.cpp
+index 9a4405b2b..21f2570a4 100644
+--- a/source/duke3d/src/actors.cpp
++++ b/source/duke3d/src/actors.cpp
+@@ -507,25 +507,16 @@ int32_t A_MoveSpriteClipdist(int32_t spriteNum, vec3_t const * const change, uin
+ 
+     int returnValue;
+     int32_t diffZ;
+-    spriteheightofs(spriteNum, &diffZ, 0);
+-    int newZ = pSprite->z - diffZ;
++    spriteheightofs(spriteNum, &diffZ, 1);
+ 
+-    pSprite->z -= diffZ >> 1;
+-    switch (pSprite->statnum)
++    if (pSprite->statnum == STAT_PROJECTILE)
++        returnValue = clipmovex(&pSprite->pos, &newSectnum, change->x << 13, change->y << 13, clipDist, diffZ >> 3, diffZ >> 3, clipType, 1);
++    else
+     {
+-        default:
+-        {
+-            returnValue = clipmove(&pSprite->pos, &newSectnum, change->x << 13, change->y << 13, clipDist, ZOFFSET6, ZOFFSET6, clipType);
+-            break;
+-        }
+-
+-        case STAT_PROJECTILE:
+-        {
+-            returnValue = clipmovex(&pSprite->pos, &newSectnum, change->x << 13, change->y << 13, clipDist, diffZ >> 1, diffZ >> 1, clipType, 1);
+-            break;
+-        }
++        pSprite->z -= diffZ >> 1;
++        returnValue = clipmove(&pSprite->pos, &newSectnum, change->x << 13, change->y << 13, clipDist, ZOFFSET6, ZOFFSET6, clipType);
++        pSprite->z += diffZ >> 1;
+     }
+-    pSprite->z += diffZ >> 1;
+ 
+     // Testing: For some reason the assert below this was tripping for clients
+     EDUKE32_UNUSED int16_t   dbg_ClipMoveSectnum = newSectnum;
+@@ -573,6 +564,7 @@ int32_t A_MoveSpriteClipdist(int32_t spriteNum, vec3_t const * const change, uin
+ 
+     Bassert(newSectnum == pSprite->sectnum);
+ 
++    int newZ = pSprite->z;
+     int32_t ceilhit, florhit;
+     int const doZUpdate = change->z ? A_CheckNeedZUpdate(spriteNum, change->z, &newZ, &ceilhit, &florhit) : 0;
+ 


### PR DESCRIPTION
Cherry-picked d8be6964fa81e9 to fix the shrinker ray getting stuck and breaking gameplay.
Reported in https://retropie.org.uk/forum/topic/32180/

Upstream info: https://voidpoint.io/terminx/eduke32/-/commit/d8be6964fa81e98ef370c82a2127d1381373950f