### PR TITLE
eduke32: (QOL) fix log location

### DIFF
--- a/scriptmodules/ports/eduke32.sh
+++ b/scriptmodules/ports/eduke32.sh
@@ -148,7 +148,7 @@ function add_games_eduke32() {
         game_args="game$game[2]"
 
         if [[ -d "$romdir/ports/$portname/${!game_path}" ]]; then
-           addPort "$md_id" "$portname" "${!game_launcher}" "${binary}.sh %ROM%" "-j$romdir/ports/$portname/${game0[1]} -j$romdir/ports/$portname/${!game_path} ${!game_args}"
+           addPort "$md_id" "$portname" "${!game_launcher}" "pushd $home/.config/eduke32; ${binary}.sh %ROM%; popd" "-j$romdir/ports/$portname/${game0[1]} -j$romdir/ports/$portname/${!game_path} ${!game_args}"
         fi
     done
 


### PR DESCRIPTION
eduke32.log is saved to `.` so it ends up in `~`. If we alter the command to pushd into configdir before launching, it ends up where it should.