### PR TITLE
mupen64plus: (QOL) Link config dir for network access to saves, etc.

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -299,6 +299,7 @@ function configure_mupen64plus() {
     addSystem "n64"
 
     mkRomDir "n64"
+    moveConfigDir "$home/.local/share/mupen64plus" "$md_conf_root/n64/mupen64plus"
 
     [[ "$md_mode" == "remove" ]] && return
 


### PR DESCRIPTION
For backup over network.