### PR TITLE
ags - switch to to release-3.5.1 branch

### DIFF
--- a/scriptmodules/emulators/ags.sh
+++ b/scriptmodules/emulators/ags.sh
@@ -13,7 +13,7 @@ rp_module_id="ags"
 rp_module_desc="Adventure Game Studio - Adventure game engine"
 rp_module_help="ROM Extension: .exe\n\nCopy your Adventure Game Studio roms to $romdir/ags"
 rp_module_licence="OTHER https://raw.githubusercontent.com/adventuregamestudio/ags/master/License.txt"
-rp_module_repo="git https://github.com/adventuregamestudio/ags.git ags3"
+rp_module_repo="git https://github.com/adventuregamestudio/ags.git release-3.5.1"
 rp_module_section="opt"
 rp_module_flags="!mali"
 


### PR DESCRIPTION
ags3 development branch has switched to an SDL2 backend, but also has build issues on my Ubuntu 21.10 system.

The module will need updating to support this, but it's better to wait until the next version is released and tested working.