### PR TITLE
eduke32: (QOL) ignore case when check for user game data

### DIFF
--- a/scriptmodules/ports/eduke32.sh
+++ b/scriptmodules/ports/eduke32.sh
@@ -79,8 +79,8 @@ function install_eduke32() {
 function game_data_eduke32() {
     local dest="$romdir/ports/duke3d"
     if [[ "$md_id" == "eduke32" ]]; then
-        if [[ ! -f "$dest/duke3d.grp" ]]; then
-            mkUserDir "$dest"
+        mkUserDir "$dest"
+        if [[ -z "$(find "$dest" -maxdepth 1 -iname duke3d.grp)" ]]; then
             local temp="$(mktemp -d)"
             download "$__archive_url/3dduke13.zip" "$temp"
             unzip -L -o "$temp/3dduke13.zip" -d "$temp" dn3dsw13.shr


### PR DESCRIPTION
...so shareware version is not downloaded unnecessarily, in case user has old DOS files in ALL CAPS. Add `rename` dependency. Modeled after **wolf4sdl**.