### PR TITLE
Add lr-pcsx2 package configuration

### DIFF
--- a/scriptmodules/libretrocores/lr-pcsx2.sh
+++ b/scriptmodules/libretrocores/lr-pcsx2.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-pcsx2"
+rp_module_desc="PlayStation 2 emulator - PCSX2 port for libretro"
+rp_module_help="ROM Extensions: .elf .iso .ciso .chd .cso .bin .mdf .nrg .dump .gz .img .m3u"
+rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/pcsx2/main/COPYING.GPLv3"
+rp_module_repo="git https://github.com/libretro/pcsx2.git main"
+rp_module_section="exp"
+rp_module_flags="!all x86"
+
+function depends_lr-pcsx2() {
+    local depends=(ccache liblzma-dev zlib1g-dev libwxgtk3.0-gtk3-dev libgtk2.0-dev libgtk-3-dev libxml2-dev libpcap-dev libaio-dev)
+    getDepends "${depends[@]}"
+}
+
+function sources_lr-pcsx2() {
+    gitPullOrClone
+}
+
+function build_lr-pcsx2() {
+    mkdir build
+    cd build
+    cmake .. -DLIBRETRO=ON -DCMAKE_BUILD_TYPE=Release
+    make clean
+    make -j$(nproc)
+    md_ret_require="$md_build/build/pcsx2/pcsx2_libretro.so"
+}
+
+function install_lr-pcsx2() {
+    md_ret_files=(
+        'build/pcsx2/pcsx2_libretro.so'
+    )
+}
+
+function configure_lr-pcsx2() {
+    mkRomDir "ps2"
+
+    ensureSystemretroconfig "ps2"
+
+    addEmulator 1 "$md_id" "ps2" "$md_inst/pcsx2_libretro.so"
+
+    addSystem "ps2"
+}

--- a/scriptmodules/libretrocores/lr-pcsx2.sh
+++ b/scriptmodules/libretrocores/lr-pcsx2.sh
@@ -43,10 +43,13 @@ function install_lr-pcsx2() {
 
 function configure_lr-pcsx2() {
     mkRomDir "ps2"
-
     ensureSystemretroconfig "ps2"
 
-    addEmulator 1 "$md_id" "ps2" "$md_inst/pcsx2_libretro.so"
+    if [[ "$md_mode" == "install" ]]; then
+        mkUserDir "$biosdir/pcsx2"
+        mkUserDir "$biosdir/pcsx2/bios"
+    fi
 
+    addEmulator 1 "$md_id" "ps2" "$md_inst/pcsx2_libretro.so"
     addSystem "ps2"
 }


### PR DESCRIPTION
This adds a new experimental package configuration for the in-development [libretro port of the PCSX2 PlayStation2 emulator](https://docs.libretro.com/library/pcsx2/).  This allows much tighter integration with the rest of the RetroPie than is available using the standalone version of PCSX2.

So far I've tested this on Ubuntu 20.04 and 21.10.  Both are able to launch and play the games I tested.