### PR TITLE
fix for uqm optional 3DO music and speech

### DIFF
--- a/scriptmodules/ports/uqm.sh
+++ b/scriptmodules/ports/uqm.sh
@@ -36,10 +36,12 @@ function sources_uqm() {
     downloadAndExtract "$(rp_resolveRepoParam "$md_repo_url")" "$md_build" --strip-components 1
     local packages="$md_build/content/packages"
     mkdir -p "$packages"
+    local addons="$md_build/content/addons"
+    mkdir -p "$addons"
     local ver="$(_get_ver_uqm)"
     download "$__archive_url/uqm-${ver}-content.uqm" "$packages"
-    download "$__archive_url/uqm-${ver}-voice.uqm" "$packages"
-    download "$__archive_url/uqm-${ver}-3domusic.uqm" "$packages"
+    download "$__archive_url/uqm-${ver}-voice.uqm" "$addons"
+    download "$__archive_url/uqm-${ver}-3domusic.uqm" "$addons"
 }
 
 function build_uqm() {


### PR DESCRIPTION
As reported in #3483, the `uqm.sh` install script currently puts all content archives in the installed `.../content/packages/` directory, which seems eminently reasonable. However, despite the upstream project website and INSTALL guide having no obvious documentation to this effect, it is not correct: in fact only the `uqm-*-content.uqm` file goes here; `uqm-*-voice.uqm` and `uqm-*-3domusic.uqm` have to go in the `.../content/addons/` directory or the game won't find them.

This patch corrects the path when installing uqm from source, but the pre-compiled binary archive still contains all three files in the `packages/` directory and will have to be similarly updated.

I might also suggest adding the "remix" music packs to the installation, which are found at http://sc2.sourceforge.net/downloads.php under "The official Ur-Quan Masters remix packs"; they also have to go under `.../content/addons/`. I haven't added that to this PR since those files would also have to be mirrored in the RetroPie archives first.