### PR TITLE
xroar: update to 1.0.9 (bugfix release)

### DIFF
--- a/scriptmodules/emulators/xroar.sh
+++ b/scriptmodules/emulators/xroar.sh
@@ -13,7 +13,7 @@ rp_module_id="xroar"
 rp_module_desc="Dragon / CoCo emulator XRoar"
 rp_module_help="ROM Extensions: .cas .wav .bas .asc .dmk .jvc .os9 .dsk .vdk .rom .ccc .sna\n\nCopy your Dragon roms to $romdir/dragon32\n\nCopy your CoCo games to $romdir/coco\n\nCopy the required BIOS files d32.rom (Dragon 32), bas13.rom (CoCo), coco3.rom/coco3p.rom (CoCo3) to $biosdir"
 rp_module_licence="GPL3 http://www.6809.org.uk/xroar/"
-rp_module_repo="git http://www.6809.org.uk/git/xroar.git 1.0.7"
+rp_module_repo="git http://www.6809.org.uk/git/xroar.git 1.0.9"
 rp_module_section="opt"
 rp_module_flags=""
 


### PR DESCRIPTION
Fixes from 1.0.7: 

* Fix WASM audio for non-Firefox [Greg Dionne]
* Fix crash reading zero-length CAS file
* Fix joystick reads for Pacdude Monster Maze
* Close file after serialisation