### PR TITLE
controlblock: update dependencies

### DIFF
--- a/scriptmodules/supplementary/controlblock.sh
+++ b/scriptmodules/supplementary/controlblock.sh
@@ -18,7 +18,7 @@ rp_module_section="driver"
 rp_module_flags="noinstclean !all rpi"
 
 function depends_controlblock() {
-    local depends=(cmake doxygen)
+    local depends=(cmake doxygen gpiod libgpiod-dev)
     isPlatform "rpi" && depends+=(libraspberrypi-dev)
 
     getDepends "${depends[@]}"


### PR DESCRIPTION
Added `libgpiod` dependency, introduced in https://github.com/petrockblog/ControlBlockService2/commit/1d3492c545ea4db99d7e9425e3b2d0f58d51487c.