### PR TITLE
lr-ppsspp: preset a save directory

### DIFF
--- a/scriptmodules/libretrocores/lr-ppsspp.sh
+++ b/scriptmodules/libretrocores/lr-ppsspp.sh
@@ -44,6 +44,11 @@ function configure_lr-ppsspp() {
         mkUserDir "$biosdir/PPSSPP"
         cp -Rv "$md_inst/assets/"* "$biosdir/PPSSPP/"
         chown -R $user:$user "$biosdir/PPSSPP"
+
+        # the core needs a save file directory, use the same folder as standalone 'ppsspp'
+        iniConfig " = " "" "$configdir/psp/retroarch.cfg"
+        iniSet "savefile_directory" "$home/.config/ppsspp"
+        mkUserDir "$home/.config/ppsspp"
     fi
 
     addEmulator 1 "$md_id" "psp" "$md_inst/ppsspp_libretro.so"


### PR DESCRIPTION
`lr-ppsspp` uses the `savefile_directory` path in order to create its own save structure.
Game saves are not regular `.srm` files, but they're saved in a `PSP/SAVEDATA/<GAME_ID>` folder structure.

Without setting a `savefile_directory`, the core will try to save to `/PSP/SAVEDATA/<GAME_ID>`, which obviously fails.
Setting this to `$HOME/.config/ppsspp` makes it possible to share the savedata with the standalone emulator.