### PR TITLE
ppsspp - Fix linking on rpi1 / armv6

### DIFF
--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -128,7 +128,7 @@ function build_ppsspp() {
     local params=()
     if isPlatform "videocore"; then
         if isPlatform "armv6"; then
-            params+=(-DCMAKE_TOOLCHAIN_FILE=cmake/Toolchains/raspberry.armv6.cmake -DFORCED_CPU=armv6)
+            params+=(-DCMAKE_TOOLCHAIN_FILE=cmake/Toolchains/raspberry.armv6.cmake -DFORCED_CPU=armv6 -DATOMIC_LIB=atomic)
         else
             params+=(-DCMAKE_TOOLCHAIN_FILE=cmake/Toolchains/raspberry.armv7.cmake)
         fi


### PR DESCRIPTION
PPSSPP CMakeLists.txt adds -latomic for android targets, but this is also needed on armv6 on RaspberryPi OS Buster.

This commit sets the variable ATOMIC_LIB to "atomic" for videocore / armv6 so that -latomic is added.