### PR TITLE
lr-fbneo - add ensureSystemretroconfig calls for all fbneo subsystems

### DIFF
--- a/scriptmodules/libretrocores/lr-fbneo.sh
+++ b/scriptmodules/libretrocores/lr-fbneo.sh
@@ -74,30 +74,35 @@ function configure_lr-fbneo() {
     addEmulator 0 "$md_id-ngpc" "ngpc" "$md_inst/fbneo_libretro.so --subsystem ngp"
     addEmulator 0 "$md_id-chf" "channelf" "$md_inst/fbneo_libretro.so --subsystem chf"
 
-    addSystem "arcade"
-    addSystem "neogeo"
-    addSystem "fba"
+    local systems=(
+        "arcade"
+        "neogeo"
+        "fba"
+        "pcengine"
+        "gamegear"
+        "mastersystem"
+        "megadrive"
+        "sg-1000"
+        "coleco"
+        "msx"
+        "zxspectrum"
+        "fds"
+        "nes"
+        "ngp"
+        "ngpc"
+        "channelf"
+    )
 
-    addSystem "pcengine"
-    addSystem "gamegear"
-    addSystem "mastersystem"
-    addSystem "megadrive"
-    addSystem "sg-1000"
-    addSystem "coleco"
-    addSystem "msx"
-    addSystem "zxspectrum"
-    addSystem "fds"
-    addSystem "nes"
-    addSystem "ngp"
-    addSystem "ngpc"
-    addSystem "channelf"
+    local system
+    for system in "${systems[@]}"; do
+        addSystem "$system"
+    done
 
     [[ "$md_mode" == "remove" ]] && return
 
-    local dir
-    for dir in arcade fba neogeo; do
-        mkRomDir "$dir"
-        ensureSystemretroconfig "$dir"
+    for system in "${systems[@]}"; do
+        mkRomDir "$system"
+        ensureSystemretroconfig "$system"
     done
 
     # Create directories for all support files


### PR DESCRIPTION
We were missing ensureSystemretroconfig calls for FBNeo's console subsystems that are needed to populate a default retroarch.cfg

Move the systems into an array to avoid listing them twice.