### PR TITLE
retropiemenu: fix launching RetroArch from the menu

### DIFF
--- a/scriptmodules/supplementary/retropiemenu.sh
+++ b/scriptmodules/supplementary/retropiemenu.sh
@@ -138,7 +138,7 @@ function launch_retropiemenu() {
             joy2keyStop
             cp "$configdir/all/retroarch.cfg" "$configdir/all/retroarch.cfg.bak"
             chown $user:$user "$configdir/all/retroarch.cfg.bak"
-            su $user -c "\"$emudir/retroarch/bin/retroarch\" --menu --config \"$configdir/all/retroarch.cfg\""
+            su $user -c "XDG_RUNTIME_DIR=/run/user/$SUDO_UID \"$emudir/retroarch/bin/retroarch\" --menu --config \"$configdir/all/retroarch.cfg\""
             iniConfig " = " '"' "$configdir/all/retroarch.cfg"
             iniSet "config_save_on_exit" "false"
             ;;


### PR DESCRIPTION
Due to the recent addition of the GameMode support, RetroArch needs access to the user's DBUS session socket.
When starting RetroArch from the RetroPie menu, `su` is used to launch it as the install user, but the DBUS socket path is not preserved (`DBUS_SESSION_BUS_ADDRESS`), leading to a en error and then a crash.

Prevent the crash by setting the XDG_RUNTIME_DIR when RetroArch is started with `su`.

NOTE: this primarily affects X11/PC users, where GameMode is part of the desktop install.