### PR TITLE
Update Redream to Universal arm (32/64bits)

### DIFF
--- a/scriptmodules/emulators/redream.sh
+++ b/scriptmodules/emulators/redream.sh
@@ -14,10 +14,10 @@ rp_module_desc="Redream Dreamcast emulator"
 rp_module_help="ROM Extensions: .cdi .cue .chd .gdi .iso\n\nCopy your Dreamcast roms to $romdir/dreamcast"
 rp_module_licence="PROP"
 rp_module_section="exp"
-rp_module_flags="noinstclean !all rpi4 !aarch64"
+rp_module_flags="noinstclean !all gles31 aarch64"
 
 function __binary_url_redream() {
-    echo "https://redream.io/download/redream.aarch32-raspberry-linux-latest.tar.gz"
+    echo "https://redream.io/download/redream.universal-raspberry-linux-latest.tar.gz"
 }
 
 function install_bin_redream() {


### PR DESCRIPTION
Hello As you know, a zip  build has been released  about 5 days that  in same link   for arm32-bit and  arm64 64-bit.
It doesn't change much else since the Redream script takes care of loading aarch32.elf or aarch64.elf if you are under 32bits or 64bits. 

Only supported on boards the GPU driver can run context  opengl 3.1 up to 4.5  (some extensions optional) or Opengl es 3.1 context.