### PR TITLE
Update amiberry version to v5.1

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -4,7 +4,7 @@
 ags_exts=".exe"
 ags_fullname="Adventure Game Studio"
 
-amiga_exts=".adf .adz .cue .dms .ipf .lha .m3u .sh .uae .zip"
+amiga_exts=".adf .adz .chd .cue .dms .ipf .lha .m3u .sh .uae .zip"
 amiga_fullname="Commodore Amiga"
 
 amstradcpc_exts=".cdt .cpc .dsk .zip"

--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -15,7 +15,7 @@ rp_module_help="ROM Extension: .adf .chd .ipf .lha .zip\n\nCopy your Amiga games
 rp_module_licence="GPL3 https://raw.githubusercontent.com/midwan/amiberry/master/COPYING"
 rp_module_repo="git https://github.com/midwan/amiberry v5.1"
 rp_module_section="opt"
-rp_module_flags="!all arm"
+rp_module_flags="!all arm rpi3 rpi4"
 
 function _update_hook_amiberry() {
     local rom
@@ -29,7 +29,9 @@ function _update_hook_amiberry() {
 
 function _get_platform_amiberry() {
     local platform="$__platform-sdl2"
-    if isPlatform "dispmanx"; then
+    if isPlatform "aarch64" && isPlatform "rpi"; then
+        platform="$__platform-64-sdl2"
+    elif isPlatform "dispmanx"; then
         platform="$__platform"
     elif isPlatform "odroid-xu"; then
         platform="xu4"

--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -11,11 +11,21 @@
 
 rp_module_id="amiberry"
 rp_module_desc="Amiga emulator with JIT support (forked from uae4arm)"
-rp_module_help="ROM Extension: .adf .ipf .zip\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir"
+rp_module_help="ROM Extension: .adf .chd .ipf .lha .zip\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir/amiga"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/midwan/amiberry/master/COPYING"
-rp_module_repo="git https://github.com/midwan/amiberry v3.3"
+rp_module_repo="git https://github.com/midwan/amiberry v5.1"
 rp_module_section="opt"
 rp_module_flags="!all arm"
+
+function _update_hook_amiberry() {
+    local rom
+    for rom in kick13.rom kick20.rom kick31.rom; do
+        # if we have a kickstart rom in $biosdir, move it to $biosdir/amiga and symlink the old location
+        if [[ -f "$biosdir/$rom" && ! -h "$biosdir/$rom" ]]; then
+            moveConfigFile "$biosdir/$rom" "$biosdir/amiga/$rom"
+        fi
+    done
+}
 
 function _get_platform_amiberry() {
     local platform="$__platform-sdl2"
@@ -34,7 +44,7 @@ function _get_platform_amiberry() {
 }
 
 function depends_amiberry() {
-    local depends=(autoconf libpng-dev libmpeg2-4-dev zlib1g-dev libmpg123-dev libflac-dev libxml2-dev libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev)
+    local depends=(autoconf libpng-dev libmpeg2-4-dev zlib1g-dev libmpg123-dev libflac-dev libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev)
 
     isPlatform "dispmanx" && depends+=(libraspberrypi-dev)
     isPlatform "vero4k" && depends+=(vero3-userland-dev-osmc)
@@ -44,43 +54,70 @@ function depends_amiberry() {
 
 function sources_amiberry() {
     gitPullOrClone
+    applyPatch "$md_data/01_preserve_env.diff"
     # use our default optimisation level
-    sed -i "s/-Ofast//" "$md_build/Makefile"
+    sed -i "/CFLAGS += -O3/d" "$md_build/Makefile"
 }
 
 function build_amiberry() {
     local platform=$(_get_platform_amiberry)
     cd external/capsimg
-    ./bootstrap.fs
-    ./configure.fs
-    make -f Makefile.fs clean
-    make -f Makefile.fs
+    ./bootstrap
+    ./configure
+    make clean
+    make
     cd "$md_build"
     make clean
-    make PLATFORM="$platform"
+    make PLATFORM="$platform" CPUFLAGS="$__cpu_flags"
     md_ret_require="$md_build/amiberry"
 }
 
 function install_amiberry() {
     md_ret_files=(
+        'abr'
         'amiberry'
         'data'
         'external/capsimg/capsimg.so'
+        'kickstarts'
     )
 
     cp -R "$md_build/whdboot" "$md_inst/whdboot-dist"
 }
 
 function configure_amiberry() {
-    configure_uae4arm
+    addEmulator 1 "amiberry" "amiga" "$md_inst/amiberry.sh %ROM%"
+    addEmulator 0 "amiberry-a500" "amiga" "$md_inst/amiberry.sh %ROM% --model A500"
+    addEmulator 0 "amiberry-a500plus" "amiga" "$md_inst/amiberry.sh %ROM% --model A500P"
+    addEmulator 0 "amiberry-a1200" "amiga" "$md_inst/amiberry.sh %ROM% --model A1200"
+    addEmulator 0 "amiberry-a4000" "amiga" "$md_inst/amiberry.sh %ROM% --model A4000"
+    addEmulator 0 "amiberry-cdtv" "amiga" "$md_inst/amiberry.sh %ROM% --model CDTV"
+    addEmulator 0 "amiberry-cd32" "amiga" "$md_inst/amiberry.sh %ROM% --model CD32"
+    addSystem "amiga"
 
     [[ "$md_mode" == "remove" ]] && return
+
+    mkRomDir "amiga"
+
+    mkUserDir "$md_conf_root/amiga"
+    mkUserDir "$md_conf_root/amiga/amiberry"
+
+    # move config / save folders to $md_conf_root/amiga/amiberry
+    local dir
+    for dir in conf savestates screenshots; do
+        moveConfigDir "$md_inst/$dir" "$md_conf_root/amiga/amiberry/$dir"
+    done
+
+    # symlink cd32.nvr from $md_inst/data to "$md_conf_root/amiga/amiberry
+    moveConfigFile "$md_inst/data/cd32.nvr" "$md_conf_root/amiga/amiberry/cd32.nvr"
+
+    moveConfigDir "$md_inst/kickstarts" "$biosdir/amiga"
+    chown -R $user:$user "$biosdir/amiga"
 
     # symlink the retroarch config / autoconfigs for amiberry to use
     ln -sf "$configdir/all/retroarch/autoconfig" "$md_inst/controllers"
     ln -sf "$configdir/all/retroarch.cfg" "$md_inst/conf/retroarch.cfg"
 
-    local config_dir="$md_conf_root/amiga/$md_id"
+    local config_dir="$md_conf_root/amiga/amiberry"
 
     # create whdboot config area
     moveConfigDir "$md_inst/whdboot" "$config_dir/whdboot"
@@ -89,4 +126,16 @@ function configure_amiberry() {
     cp -R "$md_inst/whdboot-dist/"{game-data,save-data,boot-data.zip,WHDLoad} "$config_dir/whdboot/"
 
     chown -R $user:$user "$config_dir/whdboot"
+
+    # copy shared uae4arm/amiberry launch script while setting is_amiberry=1
+    sed "s/is_amiberry=0/is_amiberry=1/" "$md_data/../uae4arm/uae4arm.sh" >"$md_inst/amiberry.sh"
+    chmod a+x "$md_inst/amiberry.sh"
+
+    local script="+Start Amiberry.sh"
+    cat > "$romdir/amiga/$script" << _EOF_
+#!/bin/bash
+"$md_inst/amiberry.sh"
+_EOF_
+    chmod a+x "$romdir/amiga/$script"
+    chown $user:$user "$romdir/amiga/$script"
 }

--- a/scriptmodules/emulators/amiberry/01_preserve_env.diff
+++ b/scriptmodules/emulators/amiberry/01_preserve_env.diff
@@ -1,0 +1,18 @@
+diff --git a/Makefile b/Makefile
+index 29969690..dc798edf 100644
+--- a/Makefile
++++ b/Makefile
+@@ -17,10 +17,10 @@ SDL_CONFIG ?= sdl2-config
+ export SDL_CFLAGS := $(shell $(SDL_CONFIG) --cflags)
+ export SDL_LDFLAGS := $(shell $(SDL_CONFIG) --libs)
+ 
+-CPPFLAGS = -MD -MT $@ -MF $(@:%.o=%.d) $(SDL_CFLAGS) -Iexternal/libguisan/include -Isrc -Isrc/osdep -Isrc/threaddep -Isrc/include -Isrc/archivers -Isrc/floppybridge -DAMIBERRY -D_FILE_OFFSET_BITS=64
+-CFLAGS=-pipe -Wno-shift-overflow -Wno-narrowing
++CPPFLAGS += -MD -MT $@ -MF $(@:%.o=%.d) $(SDL_CFLAGS) -Iexternal/libguisan/include -Isrc -Isrc/osdep -Isrc/threaddep -Isrc/include -Isrc/archivers -Isrc/floppybridge -DAMIBERRY -D_FILE_OFFSET_BITS=64
++CFLAGS += -pipe -Wno-shift-overflow -Wno-narrowing
+ USE_LD ?= gold
+-LDFLAGS = $(SDL_LDFLAGS) -lSDL2_image -lSDL2_ttf -lguisan -Lexternal/libguisan/lib
++LDFLAGS += $(SDL_LDFLAGS) -lSDL2_image -lSDL2_ttf -lguisan -Lexternal/libguisan/lib
+ ifneq ($(strip $(USE_LD)),)
+ 	LDFLAGS += -fuse-ld=$(USE_LD)
+ endif

--- a/scriptmodules/emulators/uae4all.sh
+++ b/scriptmodules/emulators/uae4all.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="uae4all"
 rp_module_desc="Amiga emulator UAE4All"
-rp_module_help="ROM Extension: .adf\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir"
+rp_module_help="ROM Extension: .adf\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir/amiga"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/RetroPie/uae4all2/retropie/copying"
 rp_module_repo="git https://github.com/RetroPie/uae4all2.git retropie"
 rp_module_section="opt"
@@ -76,13 +76,13 @@ function configure_uae4all() {
     if [[ ! -h "$md_inst/kickstarts" ]]; then
         rm -f "$md_inst/kickstarts/"{kick12.rom,kick13.rom,kick20.rom,kick31.rom}
     fi
-    moveConfigDir "$md_inst/kickstarts" "$biosdir"
+    moveConfigDir "$md_inst/kickstarts" "$biosdir/amiga"
 
     rm -f "$romdir/amiga/+Start UAE4All.sh"
     if [[ "$md_mode" == "install" ]]; then
         if [[ ! -f "$biosdir/aros-amiga-m68k-ext.bin" ]]; then
             # unpack aros kickstart
-            unzip -j "aros20140110.zip" -d "$biosdir"
+            unzip -j "aros20140110.zip" -d "$biosdir/amiga"
         fi
 
         cat > "$romdir/amiga/+Start UAE4All.sh" << _EOF_

--- a/scriptmodules/emulators/uae4arm.sh
+++ b/scriptmodules/emulators/uae4arm.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="uae4arm"
 rp_module_desc="Amiga emulator with JIT support"
-rp_module_help="ROM Extension: .adf\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir/amiga"
+rp_module_help="ROM Extension: .adf .ipf\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir/amiga"
 rp_module_licence="GPL2"
 rp_module_repo="git https://github.com/Chips-fr/uae4arm-rpi.git master"
 rp_module_section="opt"

--- a/scriptmodules/emulators/uae4arm.sh
+++ b/scriptmodules/emulators/uae4arm.sh
@@ -15,7 +15,7 @@ rp_module_help="ROM Extension: .adf\n\nCopy your Amiga games to $romdir/amiga\n\
 rp_module_licence="GPL2"
 rp_module_repo="git https://github.com/Chips-fr/uae4arm-rpi.git master"
 rp_module_section="opt"
-rp_module_flags="!all videocore"
+rp_module_flags="!all dispmanx"
 
 function depends_uae4arm() {
     getDepends libsdl1.2-dev libsdl-gfx1.2-dev libsdl-ttf2.0-dev libguichan-dev libmpg123-dev libxml2-dev libflac-dev libmpeg2-4-dev

--- a/scriptmodules/emulators/uae4arm/uae4arm.sh
+++ b/scriptmodules/emulators/uae4arm/uae4arm.sh
@@ -1,33 +1,30 @@
 #!/bin/bash
-
-emulator="./EMULATOR"
-config="$1"
-rom="$2"
-rom_path="${rom%/*}"
-rom_name="${rom##*/}"
-rom_bn="${rom_name%.*}"
-
-config_param="-config="
 is_amiberry=0
-if [[ "$emulator" == *amiberry* ]]; then
-    is_amiberry=1
-    config_param="--config "
-fi
+
+emulator="./uae4arm"
+[[ "$is_amiberry" -eq 1 ]] && emulator="./amiberry"
 
 pushd "${0%/*}" >/dev/null
-if [[ -z "$rom" ]]; then
-    "$emulator"
-elif [[ "$rom" == *.uae ]]; then
-    "$emulator" ${config_param}"$rom" -G
-elif [[ "$is_amiberry" -eq 1 ]] && [[ "$rom" == *.lha || "$rom" == *.cue ]]; then
-    "$emulator" --autoload "$rom" -G
+source "../../lib/archivefuncs.sh"
+
+params=()
+
+arg="$1"
+
+if [[ "$arg" == *.uae ]]; then
+    config="$arg"
 else
-    source "../../lib/archivefuncs.sh"
+    rom="$arg"
+fi
+shift
 
-    archiveExtract "$rom" ".adf .adz .dms .ipf"
+images=()
 
+if [[ "$is_amiberry" -eq 1 ]] && [[ "$rom" == *.lha || "$rom" == *.cue || "$rom" == *.chd ]]; then
+    params+=(--autoload "$rom")
+elif [[ -n "$rom" ]]; then
     # check successful extraction and if we have at least one file
-    if [[ $? == 0 ]]; then
+    if archiveExtract "$rom" ".adf .adz .dms .ipf"; then
         for i in {0..3}; do
             [[ -n "${arch_files[$i]}" ]] && images+=(-$i "${arch_files[$i]}")
         done
@@ -46,27 +43,68 @@ else
         [[ "${#images[@]}" -eq 0 ]] && images=(-0 "$rom")
     fi
 
-    # if no config or auto provided, then look for rom config or choose automatically 
-    if [[ -z "$config" || "$config" == "auto" ]]; then
-        # check for .uae files with the base name as the adf/zip
-        if [[ -f "$rom_path/$rom_bn.uae" ]]; then
-            config="$rom_path/$rom_bn.uae"
-        elif [[ -f "conf/$rom_bn.uae" ]]; then
-            config="conf/$rom_bn.uae"
+    rom_path="${rom%/*}"
+    rom_name="${rom##*/}"
+    rom_bn="${rom_name%.*}"
+
+    # check for .uae files with the same base name as the adf/zip in the rom directory and conf
+    if [[ -f "$rom_path/$rom_bn.uae" ]]; then
+        config="$rom_path/$rom_bn.uae"
+    elif [[ -f "conf/$rom_bn.uae" ]]; then
+        config="conf/$rom_bn.uae"
+    # if no config / model parameters are included in the arguments choose a config/model automatically
+    elif [[ "$*" != *-config* && "$*" != *--model* ]]; then
+        # if amiberry choose a model for amiberry based on the rom filename
+        if [[ "$is_amiberry" -eq 1 ]]; then
+            model="A500"
+            case "$name" in
+                *ECS*)
+                    model="A500P"
+                    ;;
+                *AGA*)
+                    model="A1200"
+                    ;;
+                *CD32*)
+                    model="CD32"
+                    ;;
+                *CDTV*)
+                    model="CDTV"
+                    ;;
+            esac
+            params+=(--model "$model")
         else
+            # or for uae4arm choose an Amiga config based on the rom filename
             if [[ "$name" =~ AGA|CD32 ]]; then
                 config="conf/rp-a1200.uae"
             else
                 config="conf/rp-a500.uae"
             fi
         fi
-    else
-        # add conf directory
-        config="conf/$config"
     fi
-
-    "$emulator" ${config_param}"$config" "${images[@]}" -G
-    archiveCleanup
 fi
+
+# if there is a config set then use it
+if [[ -n "$config" ]]; then
+    if [[ "$is_amiberry" -eq 1 ]]; then
+        params+=(--config "$config")
+    else
+        params+=(-config="$config")
+    fi
+fi
+
+# add any other provided arguments
+params+=("$@")
+
+# add images to parameters (needs to be after any config arguments)
+params+=("${images[@]}")
+
+# start directly into emulation if the first argument is set
+[[ -n "$arg" ]] && params+=(-G)
+
+echo "Launching ..."
+echo "$emulator" "${params[@]}"
+
+"$emulator" "${params[@]}"
+archiveCleanup
 
 popd


### PR DESCRIPTION
[](https://github.com/RetroPie/RetroPie-Setup/commits?author=joolswills)Update amiberry version to v5.1 tag

Remove no longer needed libxml2-dev dependency

Add patch for amiberry Makefile so it doesn't override our CFLAGS/CPPFLAGS/LDFLAGS

Remove -O3 from Makefile so it uses our default optimisation level. Previously this was -Ofast but from my own testing -O2 with our compiler flags works best.

Modify build_amiberry with updated paths for caps bootstrap/configure. Override CPUFLAGS for amiberry, so our flags are used, rather than the ones hard-coded into the Makefile.

Include abr and kickstarts folder in install_amiberry. The kickstarts folder includes a freely distributable AROS rom, so let's include it.

Symlink cd32.nvr from "$md_inst/data" to "$md_conf_root/amiga/amiberry" so it's writable by amiberry.

Split uae4arm's shared configure function out so uae4arm and amiberry now only share the launcher code. There is a small amount of duplication with some folder creation in configure_amiberry but it makes sense to split them due to the new amiberry changes.

Rework uae4arm/amiberry configure functions to simplify logic and remove nesting by changing order of calls.

Change the addEmulator calls in uae4arm and amiberry due to parameter ordering changes in the shared launcher script.

Move rom location for amiberry/uae4arm/uae4all to $biosdir/amiga

Create update hook to move / symlink kickstart ROMs from $biosdir to $biosdir/amiga

Add .lha to module description extensions
    
Added .chd extension to platforms.cfg

Rework the logic in the shared launcher script:

 * Instead of setting EMULATOR variable via sed in uae4arm/amiberry we just change "use_amiberry=0" to "use_amiberry=1" in configure_amiberry.
 * Argument ordering is changed to simplify the logic. Previously the launch script expected [CONFIG] [ROM/GAME], and setting [CONFIG] to auto or "" would handle it automatically. Now it uses [ROM/GAME] [ARGS]. As passing in a configuration was optional, it made it simpler just to have the ROM first, and then allow additional arguments to be sent to the emulator.
 * We now build up an parameters array which avoids duplication and simplifies the code - There is only a single call to launch uae4arm/amiberry with the processed parameters.
 * Switched to using the amiberry --model parameter over our previous rp-a500.uae/rp-a1200.uae configs. Users who have set a particular rom to use amiberry-a500/amiberry-a1200 will still get the same functionality but it will instead use --model A500/A1200. A per rom .uae config can still be saved with customised settings for an adf etc.

How uae4arm.sh handles launching:

 * If the first argument (ROM/GAME) is a .cue or .lha file, and we are launching amiberry, use amiberry's --autoload function.
 * Otherwise if a rom argument is present, see if it's an archive (only zip supported currently). If it is, unpack all known disk image extensions from the archive attach each one as floppy drive arguments (-0 / -1 / -2 etc)
 * If it's not an archive, treat it as a disk image itself, and try and find additional files starting with the same name (eg Game_Disk1/Game_Disk2) and attach them as floppy drive arguments.
 * We then check if there is a .uae config file with the same name as the ROM argument in the ROM's folder or in amiberry's conf folder.
 * If there isn't we will try and use a config based on the filename. For uae4arm it will use the pre-installed rp-a500.uae config by default and rp-a1200.uae for any files containing AGA or CD32. For amiberry we use the --model parameter which chooses a default config based on argument. By default we use A500, but switch to A500P if a file contains ECS and A1200 if a file contains AGA, and CD32/CDTV if those strings are included also (Although cd images are handled separately so this may not be too useful).
 * We always set -G to not show the GUI when the first argument is present - to override this the first argument can be blank and manual parameters can be used (or the amiberry executable can just be used directly)

--

amiberry - add support for building with 64bit on rpi 

uae4arm - enable for dispmanx (works ok on rpi4 + fkms)

uae4arm - added missing .ipf extension