### PR TITLE
attractmode: dependency update

### DIFF
--- a/scriptmodules/supplementary/attractmode.sh
+++ b/scriptmodules/supplementary/attractmode.sh
@@ -128,9 +128,9 @@ function _add_rom_attractmode() {
 
 function depends_attractmode() {
     local depends=(
-        cmake libflac-dev libogg-dev libvorbis-dev libopenal-dev libfreetype6-dev
+        cmake libflac-dev libcurl4-openssl-dev libogg-dev libvorbis-dev libopenal-dev libfreetype6-dev
         libudev-dev libjpeg-dev libudev-dev libavutil-dev libavcodec-dev
-        libavformat-dev libavfilter-dev libswscale-dev libavresample-dev
+        libavformat-dev libavfilter-dev libswscale-dev libswresample-dev
         libfontconfig1-dev
     )
     isPlatform "videocore" && depends+=(libraspberrypi-dev)


### PR DESCRIPTION
`libavresample-dev` has been obsoleted by `libswresample-dev` on recent (21.10 and later) Ubuntu versions and Debian Testing.
Also explicitely add the dependency on curl's libs.