### PR TITLE
Branch / Tag 9.1 no longer available.

### DIFF
--- a/scriptmodules/emulators/zesarux.sh
+++ b/scriptmodules/emulators/zesarux.sh
@@ -13,7 +13,7 @@ rp_module_id="zesarux"
 rp_module_desc="ZX Spectrum emulator ZEsarUX"
 rp_module_help="ROM Extensions: .sna .szx .z80 .tap .tzx .gz .udi .mgt .img .trd .scl .dsk .zip\n\nCopy your ZX Spectrum games to $romdir/zxspectrum"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/chernandezba/zesarux/master/src/LICENSE"
-rp_module_repo="git https://github.com/chernandezba/zesarux.git 9.1"
+rp_module_repo="git https://github.com/chernandezba/zesarux.git ZEsarUX-10.0"
 rp_module_section="opt"
 rp_module_flags="sdl2 sdl1-videocore"
 


### PR DESCRIPTION
See: https://github.com/chernandezba/zesarux/tags
Latest Tag is: ZEsarUX-10.0
Deprecated Unavailable Tag is: 9.1