### PR TITLE
attractmode: fix build on videocore/kms platforms

### DIFF
--- a/scriptmodules/supplementary/attractmode.sh
+++ b/scriptmodules/supplementary/attractmode.sh
@@ -158,8 +158,8 @@ function build_attractmode() {
     cd attract
     make clean
     local params=(prefix="$md_inst")
-    isPlatform "videocore" && params+=(USE_GLES=1 EXTRA_CFLAGS="$CFLAGS -I$md_build/sfml-pi/include -L$md_build/sfml-pi/lib")
-    isPlatform "kms" && params+=(USE_DRM=1 EXTRA_CFLAGS="$CFLAGS -I$md_build/sfml-pi/include -L$md_build/sfml-pi/lib")
+    isPlatform "videocore" && params+=(USE_GLES=1 EXTRA_CXXFLAGS="$CFLAGS -I$md_build/sfml-pi/include -L$md_build/sfml-pi/lib")
+    isPlatform "kms" && params+=(USE_DRM=1 EXTRA_CXXFLAGS="$CFLAGS -I$md_build/sfml-pi/include -L$md_build/sfml-pi/lib")
     isPlatform "rpi" && params+=(USE_MMAL=1)
     make "${params[@]}"
 


### PR DESCRIPTION
Upstream project changed the `makefile` in [1] and `EXTRA_CFLAGS` was removed.
Use the new `EXTRA_CXXFLAGS` instead, so our compiler flags and directives to find the locally compiled `sfml-pi` are passed on.

[1] https://github.com/mickelson/attract/commit/502f5d71e5f3c97d3d1a6def440e1462c1f6ba0c