### PR TITLE
lr-pcsx-rearmed: fix fatal build error on aarch64

### DIFF
--- a/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
+++ b/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
@@ -31,11 +31,13 @@ function build_lr-pcsx-rearmed() {
 
     if isPlatform "arm"; then
         params+=(ARCH=arm DYNAREC=ari64)
-        if isPlatform "neon"; then
-            params+=(HAVE_NEON=1 BUILTIN_GPU=neon)
-        else
-            params+=(HAVE_NEON=0 BUILTIN_GPU=peops)
-        fi
+    elif isPlatform "aarch64"; then
+        params+=(ARCH=aarch64 DYNAREC=ari64)
+    fi
+    if isPlatform "neon"; then
+        params+=(HAVE_NEON=1 BUILTIN_GPU=neon)
+    else
+        params+=(HAVE_NEON=0 BUILTIN_GPU=peops)
     fi
 
     make -f Makefile.libretro "${params[@]}" clean


### PR DESCRIPTION
should be safe to run on armhf systems as well, though having someone test that for me would be nice