### PR TITLE
ppsspp/lr-ppsspp: (QOL) link save file dir for libretro core, and (BUG) resolve conflicts on removal

### DIFF
--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -172,10 +172,19 @@ function configure_ppsspp() {
     fi
 
     mkRomDir "psp"
-    moveConfigDir "$home/.config/ppsspp" "$md_conf_root/psp"
-    mkUserDir "$md_conf_root/psp/PSP"
-    ln -snf "$romdir/psp" "$md_conf_root/psp/PSP/GAME"
+    if [[ "$md_mode" == "install" ]]; then
+        moveConfigDir "$home/.config/ppsspp" "$md_conf_root/psp"
+        mkUserDir "$md_conf_root/psp/PSP"
+        ln -snf "$romdir/psp" "$md_conf_root/psp/PSP/GAME"
+    fi
 
     addEmulator 0 "$md_id" "psp" "pushd $md_inst; $md_inst/PPSSPPSDL ${extra_params[*]} %ROM%; popd"
     addSystem "psp"
+
+    # if we are removing the last remaining psp emu - remove the symlink
+    if [[ "$md_mode" == "remove" ]]; then
+        if [[ -h "$home/.config/ppsspp" && ! -f "$md_conf_root/psp/emulators.cfg" ]]; then
+            rm -f "$home/.config/ppsspp"
+        fi
+    fi
 }

--- a/scriptmodules/libretrocores/lr-ppsspp.sh
+++ b/scriptmodules/libretrocores/lr-ppsspp.sh
@@ -48,9 +48,16 @@ function configure_lr-ppsspp() {
         # the core needs a save file directory, use the same folder as standalone 'ppsspp'
         iniConfig " = " "" "$configdir/psp/retroarch.cfg"
         iniSet "savefile_directory" "$home/.config/ppsspp"
-        mkUserDir "$home/.config/ppsspp"
+        moveConfigDir "$home/.config/ppsspp" "$md_conf_root/psp"
     fi
 
     addEmulator 1 "$md_id" "psp" "$md_inst/ppsspp_libretro.so"
     addSystem "psp"
+
+    # if we are removing the last remaining psp emu - remove the symlink
+    if [[ "$md_mode" == "remove" ]]; then
+        if [[ -h "$home/.config/ppsspp" && ! -f "$md_conf_root/psp/emulators.cfg" ]]; then
+            rm -f "$home/.config/ppsspp"
+        fi
+    fi
 }


### PR DESCRIPTION
Stand-alone already does this with this (shared) dir, but if you only use the lr-core, it doesn't link it.