### PR TITLE
emulationstation: build omxplayer only on dispmanx platforms

### DIFF
--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -137,7 +137,7 @@ function depends_emulationstation() {
 
     compareVersions "$__os_debian_ver" gt 8 && depends+=(rapidjson-dev)
     isPlatform "x11" && depends+=(gnome-terminal)
-    if isPlatform "rpi" && isPlatform "32bit" && ! isPlatform "osmc"; then
+    if isPlatform "dispmanx" && ! isPlatform "osmc"; then
         depends+=(omxplayer)
     fi
     getDepends "${depends[@]}"
@@ -170,6 +170,10 @@ function build_emulationstation() {
         local gl_ver=$(sudo -u $user glxinfo | grep -oP "OpenGL version string: \K(\d+)")
         [[ "$gl_ver" -gt 1 ]] && params+=(-DUSE_OPENGL_21=On)
     fi
+    if isPlatform "dispmanx"; then
+        params+=(-DOMX=On)
+    fi
+
     rpSwap on 1000
     cmake . "${params[@]}"
     make clean


### PR DESCRIPTION
Starting with RaspiOS 'bullseye', the `omxplayer` RPI video player is no longer supported.
Use the new EmulationStation build option (`OMX`) to enable the `omxplayer` bits only for `dispmanx` platforms. The new options is added in https://github.com/RetroPie/EmulationStation/pull/792. The `RPI` build option is used only for pre-setting some program settings on the Raspberry Pi platforms (audio/video memory).

Complements https://github.com/RetroPie/EmulationStation/pull/792.