### PR TITLE
ps2: add support for CHD disc images

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -187,7 +187,7 @@ ports_exts=".sh"
 ports_fullname="Ports"
 ports_platform="pc"
 
-ps2_exts=".iso .img .bin .mdf .z .z2 .bz2 .dump .cso .ima .gz"
+ps2_exts=".iso .img .bin .mdf .z .z2 .bz2 .dump .cso .chd .ima .gz"
 ps2_fullname="PlayStation 2"
 
 psp_exts=".iso .pbp .cso"

--- a/scriptmodules/emulators/pcsx2.sh
+++ b/scriptmodules/emulators/pcsx2.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="pcsx2"
 rp_module_desc="PS2 emulator PCSX2"
-rp_module_help="ROM Extensions: .bin .iso .img .mdf .z .z2 .bz2 .cso .ima .gz\n\nCopy your PS2 roms to $romdir/ps2\n\nCopy the required BIOS file to $biosdir"
+rp_module_help="ROM Extensions: .bin .iso .img .mdf .z .z2 .bz2 .cso .chd .ima .gz\n\nCopy your PS2 roms to $romdir/ps2\n\nCopy the required BIOS file to $biosdir"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/PCSX2/pcsx2/master/COPYING.GPLv3"
 rp_module_section="exp"
 rp_module_flags="!all x86"


### PR DESCRIPTION
Supported by `pcsx2` since https://github.com/PCSX2/pcsx2/pull/4314.