### PR TITLE
Macintosh: (BUG) Add missing exts for Basilisk

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -100,7 +100,7 @@ intellivision_fullname="Intellivision"
 love_exts=".love"
 love_fullname="Love"
 
-macintosh_exts=".txt .dsk"
+macintosh_exts=".txt .dsk .img .rom"
 macintosh_fullname="Apple Macintosh"
 
 mame_exts=".zip .7z"


### PR DESCRIPTION
Ref:

https://github.com/RetroPie/RetroPie-Setup/blob/1eedc5ad2c1f344182d425ed8ec04c4664b1db12/scriptmodules/emulators/basilisk.sh#L14

https://www.reddit.com/r/RetroPie/comments/urxlb0/emulating_macintosh_no_roms_shows_up