### PR TITLE
amiberry: update to version 5.2

### DIFF
--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -13,7 +13,7 @@ rp_module_id="amiberry"
 rp_module_desc="Amiga emulator with JIT support (forked from uae4arm)"
 rp_module_help="ROM Extension: .adf .chd .ipf .lha .zip\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir/amiga"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/midwan/amiberry/master/COPYING"
-rp_module_repo="git https://github.com/midwan/amiberry v5.1"
+rp_module_repo="git https://github.com/midwan/amiberry v5.2"
 rp_module_section="opt"
 rp_module_flags="!all arm rpi3 rpi4"
 


### PR DESCRIPTION
* New:
  - Added new CD32 config with 8MB Fast, use that with --autoload option
  - Enable RTC automatically if enabled expansions have RTC
  - Support for Cycle-Exact mode from XML options (#959)
  - Ability to set default soundcard (#963)

* Bugs fixed
  - Hotkey mappings didn't work with controller buttons (#949)
  - Only check for hotkey buttons if they have been mapped (#949)
  - When using Auto-crop and virtual mouse driver, the pointer would not reach the edges of the screen (#962)
  - Launch Amiberry binary directly in macOS app bundle (#970)

* Improvements
  - Updated bundled AROS ROMs to latest version
  - Updated WHDBooter XML and WHDLoad to latest versions
  - Picasso96 new features are now optional. DACSWITCH fix.