### PR TITLE
xpadneo: upgrade to v0.9.2

### DIFF
--- a/scriptmodules/supplementary/xpadneo.sh
+++ b/scriptmodules/supplementary/xpadneo.sh
@@ -12,7 +12,7 @@
 rp_module_id="xpadneo"
 rp_module_desc="Advanced Linux driver for Xbox One wireless gamepads"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/atar-axis/xpadneo/master/LICENSE"
-rp_module_repo="git https://github.com/atar-axis/xpadneo.git v0.9.1"
+rp_module_repo="git https://github.com/atar-axis/xpadneo.git v0.9.2"
 rp_module_section="driver"
 rp_module_flags="nobin"
 


### PR DESCRIPTION
New stable version:

* improved compatibility with the new BLE enabled controller firmware
* better compatibility with kernels 5.12 or later and latest DKMS versions. On kernels 5.12 or later should no longer Bluetooth ERTM is not unconditionally disabled anymore. For better stability, it's generally recommended to upgrade controllers to the new BLE firmware variant (version 5.x and above) for improved connection stability
* fixed rumble throttling for modern (BLE enabled) firmware
* fixed an issue conforming to the Linux input spec better which improves compatibility with jinput
* improved documentation