### PR TITLE
Add input_load_state / input_save_state keyboard hotkeys for RetroArch during input configuration

### DIFF
--- a/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh
@@ -325,10 +325,10 @@ function map_retroarch_keyboard() {
             keys=("input_player1_y")
             ;;
         leftbottom|leftshoulder)
-            keys=("input_player1_l")
+            keys=("input_player1_l" "input_load_state")
             ;;
         rightbottom|rightshoulder)
-            keys=("input_player1_r")
+            keys=("input_player1_r" "input_save_state")
             ;;
         lefttop|lefttrigger)
             keys=("input_player1_l2")


### PR DESCRIPTION
Forum post: https://retropie.org.uk/forum/topic/32790/retroarch-keyboard-hotkeys

Currently, LS / RS buttons enable the `input_load_state` / `input_save_state` hotkeys in RetoArch for joystick inputs: https://github.com/RetroPie/RetroPie-Setup/blob/b2012749de22b1c5c1a55bc9ce8d39191ec928a3/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh#L178-L183

This is not the case for keyboard inputs: https://github.com/RetroPie/RetroPie-Setup/blob/b2012749de22b1c5c1a55bc9ce8d39191ec928a3/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh#L327-L332

All other hotkeys, however, are handled consistently between the two including:
* `input_state_slot_decrease`
* `input_state_slot_increase`
* `input_reset`
* `input_menu_toggle`
* `input_exit_emulator`

This change makes it such that the remaining hotkeys are also configured consistently within RetroArch for joystick and keyboard input configurations.