### PR TITLE
Run as root by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ The script is executed with:
 
 ```shell
 cd RetroPie-Setup
-sudo ./retropie_setup.sh
+./retropie_setup.sh
 ```
+Note: the script is running as root by default.
 
 When you first run the script it may install some additional packages that are needed.
 

--- a/retropie_setup.sh
+++ b/retropie_setup.sh
@@ -9,6 +9,11 @@
 # at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
 #
 
+if [ $(id -u) -ne 0 ]; then
+  sudo -E "$0"
+  exit $?
+fi
+
 scriptdir="$(dirname "$0")"
 scriptdir="$(cd "$scriptdir" && pwd)"
 


### PR DESCRIPTION
Requiring users to type sudo is unnecessary. This patch makes running the script a bit easier.