### PR TITLE
emulationstation: remove non existent branch v2.7.6

### DIFF
--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -145,11 +145,7 @@ function depends_emulationstation() {
 
 function _get_branch_emulationstation() {
     if [[ -z "$branch" ]]; then
-        if compareVersions "$__os_debian_ver" gt 8; then
-            branch="stable"
-        else
-            branch="v2.7.6"
-        fi
+        branch="stable"
     fi
     echo "$branch"
 }


### PR DESCRIPTION
Remove deprecated debian version check. Our emulationstation repo has no v2.7.6 branch anymore. If branch is not existent default branch "master" is used. Fix this and always use branch "stable".