### PR TITLE
emulationstation: fix OpenGL 2.1 for x11

### DIFF
--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -168,7 +168,7 @@ function build_emulationstation() {
         isPlatform "videocore" && params+=(-DUSE_GLES1=On)
     elif isPlatform "x11"; then
         local gl_ver=$(sudo -u $user glxinfo | grep -oP "OpenGL version string: \K(\d+)")
-        [[ "$gl_ver" -gt 1 ]] && params+=(-DUSE_OPENGL_21=On)
+        [[ "$gl_ver" -gt 1 ]] && params+=(-DUSE_GL21=On)
     fi
     if isPlatform "dispmanx"; then
         params+=(-DOMX=On)


### PR DESCRIPTION
Add new build option for OpenGL 2.1 renderer on x11 platforms.
https://github.com/RetroPie/EmulationStation/pull/795/files