### PR TITLE
runcommand: add more parameters for RetroArch

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -701,6 +701,7 @@ function main_menu() {
                 ;;
             L)
                 COMMAND+=" --verbose"
+                VERBOSE=1
                 return 0
                 ;;
             U)
@@ -1100,6 +1101,14 @@ function retroarch_append_config() {
         iniSet "video_fullscreen_x" "${dim[0]}"
         iniSet "video_fullscreen_y" "${dim[1]}"
     fi
+
+    # set `libretro_directory` to the core parent folder
+    local core_dir=$(echo "$COMMAND" | grep -Eo " $ROOTDIR/libretrocores/.*libretro\.so " | head -n 1)
+    core_dir=$(dirname "$core_dir")
+    [[ -n "$core_dir" ]] && iniSet "libretro_directory" "$core_dir"
+
+    # if verbose logging is on, set core logging to INFO
+    [[ "$VERBOSE" -eq 1 ]] && iniSet "libretro_log_level" "1"
 
     # if the ROM has a custom configuration then append that too
     if [[ -f "$ROM.cfg" ]]; then


### PR DESCRIPTION
Added 2 new parameters for the runtime-generated `retroarch.cfg`:

* `libretro_log_level` will add more debug messages from the libretro core, in addition to the frontend debugging messages.
   Cand be useful to diagnose core issues, since `--verbose` activates just the frontend logging.

* `libretro_directory` is set to the core file folder (i.e. `/opt/retropie/libretrocores/lr-<core>`).
   It is used by during netplay, as a client, when RetroArch attempts to re-load the core used during netplay.
   Basically, when connecting to a remote netplay host, RetroArch will try to locate a `core.info` file and then try to re-load the core file. If any of them is missing, the connection fails with "Couldn't find a suitable core or content file".

   The netplay issue was reported and diagnosed in #3161. Rather than symlink each installed libretro core to `$HOME/.config/retroarch/cores` (the default value for `libretro_directory`), we'll just set it at runtime with the above parameter. We still need to add the `.info` files for the installed cores, but that's a separate patch.