### PR TITLE
Do not replace tokens when empty

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -1176,8 +1176,8 @@ function get_sys_command() {
     COMMAND="$(default_emulator get emu_cmd)"
 
     # replace tokens
-    COMMAND="${COMMAND//\%ROM\%/\"$ROM\"}"
-    COMMAND="${COMMAND//\%BASENAME\%/\"$ROM_BN\"}"
+    COMMAND="${COMMAND//\%ROM\%/${ROM:+\"${ROM}\"}}"
+    COMMAND="${COMMAND//\%BASENAME\%/${ROM_BN:+\"${ROM_BN}\"}}"
 
     # special case to get the last 2 folders for quake games for the -game parameter
     # remove everything up to /quake/


### PR DESCRIPTION
Empty %ROM% tokens will cause parameter issues when user elects for them to be empty. 

In some circumstances this makes sense - the binary has a sensible %ROM% default when empty.

Think empty %ROM% = game runs as default, %ROM% provided = user picked a custom level.