### PR TITLE
runcommand.sh: refactor output directory into a global variable, use /tmp as fallback

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -79,7 +79,11 @@
 
 ROOTDIR="/opt/retropie"
 CONFIGDIR="$ROOTDIR/configs"
-LOG="/dev/shm/runcommand.log"
+OUTPUTDIR="/dev/shm"
+[ -d "${OUTPUTDIR}" ] \
+  && [ -w "${OUTPUTDIR}" ] \
+    || OUTPUTDIR=/tmp
+LOG="${OUTPUTDIR}/runcommand.log"
 
 RUNCOMMAND_CONF="$CONFIGDIR/all/runcommand.cfg"
 VIDEO_CONF="$CONFIGDIR/all/videomodes.cfg"
@@ -929,7 +933,7 @@ function switch_fb_res() {
 
 function build_xinitrc() {
     local mode="$1"
-    local xinitrc="/dev/shm/retropie_xinitrc"
+    local xinitrc="${OUTPUTDIR}/retropie_xinitrc"
 
     case "$mode" in
         clear)
@@ -1068,7 +1072,7 @@ function config_backend() {
 }
 
 function retroarch_append_config() {
-    local conf="/dev/shm/retroarch.cfg"
+    local conf="${OUTPUTDIR}/retroarch.cfg"
     local dim
 
     # only for retroarch emulators
@@ -1317,7 +1321,7 @@ function launch_command() {
 }
 
 function log_info() {
-    echo -e "$SYSTEM\n$EMULATOR\n$ROM\n$COMMAND" >/dev/shm/runcommand.info
+    echo -e "$SYSTEM\n$EMULATOR\n$ROM\n$COMMAND" >${OUTPUTDIR}/runcommand.info
 }
 
 function runcommand() {


### PR DESCRIPTION
This is to allow another directory for `runcommand.sh` outputs for cases when outputs are worth preserving (i.e. crash). Also, /dev/shm may not be accessible on all environments, for user discretionary reasons. When `/dev/shm` doesn't exist or isn't writable, Fall back to `/tmp`.