### PR TITLE
runcommand: replace hard coded /dev/shm with log_dir, add a runcommand configuration menu item

### DIFF
--- a/scriptmodules/supplementary/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand.sh
@@ -43,6 +43,7 @@ function install_bin_runcommand() {
         iniSet "governor" ""
         iniSet "disable_menu" "0"
         iniSet "image_delay" "2"
+        iniSet "log_dir" ""
         chown $user:$user "$configdir/all/runcommand.cfg"
     fi
     if [[ ! -f "$configdir/all/runcommand-launch-dialog.cfg" ]]; then
@@ -110,6 +111,7 @@ function gui_runcommand() {
             'disable_joystick=0' \
             'image_delay=2' \
             'governor=' \
+            'log_dir=' \
         )"
 
         [[ -z "$governor" ]] && governor="Default: don't change"
@@ -137,6 +139,7 @@ function gui_runcommand() {
 
         options+=(4 "Launch image delay in seconds (currently $image_delay)")
         options+=(5 "CPU governor configuration (currently: $governor)")
+        options+=(6 "Set log/scratch directory (currently: ${log_dir:-/dev/shm})")
 
         local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
         [[ -z "$choice" ]] && break
@@ -158,6 +161,11 @@ function gui_runcommand() {
                 ;;
             5)
                 governor_runcommand
+                ;;
+            6)
+                cmd=(dialog --backtitle "$__backtitle" --inputbox "Please enter the log directory" 10 60 "$log_dir")
+                choice=$("${cmd[@]}" 2>&1 >/dev/tty)
+                iniSet "log_dir" "$choice"
                 ;;
         esac
     done

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -79,11 +79,6 @@
 
 ROOTDIR="/opt/retropie"
 CONFIGDIR="$ROOTDIR/configs"
-OUTPUTDIR="/dev/shm"
-[ -d "${OUTPUTDIR}" ] \
-  && [ -w "${OUTPUTDIR}" ] \
-    || OUTPUTDIR=/tmp
-LOG="${OUTPUTDIR}/runcommand.log"
 
 RUNCOMMAND_CONF="$CONFIGDIR/all/runcommand.cfg"
 VIDEO_CONF="$CONFIGDIR/all/videomodes.cfg"
@@ -123,6 +118,10 @@ function get_config() {
         iniGet "image_delay"
         IMAGE_DELAY="$ini_value"
         [[ -z "$IMAGE_DELAY" ]] && IMAGE_DELAY=2
+        iniGet "log_dir"
+        LOG_DIR="$ini_value"
+        [[ -z "$LOG_DIR" ]] && LOG_DIR="/dev/shm"
+        LOG="$LOG_DIR/runcommand.log"
     fi
 
     if [[ -n "$DISPLAY" ]] && $XRANDR &>/dev/null; then
@@ -933,7 +932,7 @@ function switch_fb_res() {
 
 function build_xinitrc() {
     local mode="$1"
-    local xinitrc="${OUTPUTDIR}/retropie_xinitrc"
+    local xinitrc="$LOG_DIR/retropie_xinitrc"
 
     case "$mode" in
         clear)
@@ -1072,7 +1071,7 @@ function config_backend() {
 }
 
 function retroarch_append_config() {
-    local conf="${OUTPUTDIR}/retroarch.cfg"
+    local conf="$LOG_DIR/retroarch.cfg"
     local dim
 
     # only for retroarch emulators
@@ -1321,7 +1320,7 @@ function launch_command() {
 }
 
 function log_info() {
-    echo -e "$SYSTEM\n$EMULATOR\n$ROM\n$COMMAND" >${OUTPUTDIR}/runcommand.info
+    echo -e "$SYSTEM\n$EMULATOR\n$ROM\n$COMMAND" >"$LOG_DIR/runcommand.info"
 }
 
 function runcommand() {

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -120,7 +120,7 @@ function get_config() {
         [[ -z "$IMAGE_DELAY" ]] && IMAGE_DELAY=2
         iniGet "log_dir"
         LOG_DIR="$ini_value"
-        [[ -z "$LOG_DIR" ]] && LOG_DIR="/dev/shm"
+        [[ -d "$LOG_DIR" ]] && LOG_DIR="/dev/shm"
         LOG="$LOG_DIR/runcommand.log"
     fi
 

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -79,7 +79,11 @@
 
 ROOTDIR="/opt/retropie"
 CONFIGDIR="$ROOTDIR/configs"
-LOG="/dev/shm/runcommand.log"
+OUTPUTDIR="/dev/shm"
+[ -d "${OUTPUTDIR}" ] \
+  && [ -w "${OUTPUTDIR}" ] \
+    || OUTPUTDIR=/tmp
+LOG="${OUTPUTDIR}/runcommand.log"
 
 RUNCOMMAND_CONF="$CONFIGDIR/all/runcommand.cfg"
 VIDEO_CONF="$CONFIGDIR/all/videomodes.cfg"
@@ -929,7 +933,7 @@ function switch_fb_res() {
 
 function build_xinitrc() {
     local mode="$1"
-    local xinitrc="/dev/shm/retropie_xinitrc"
+    local xinitrc="${OUTPUTDIR}/retropie_xinitrc"
 
     case "$mode" in
         clear)
@@ -1068,7 +1072,7 @@ function config_backend() {
 }
 
 function retroarch_append_config() {
-    local conf="/dev/shm/retroarch.cfg"
+    local conf="${OUTPUTDIR}/retroarch.cfg"
     local dim
 
     # only for retroarch emulators
@@ -1317,7 +1321,7 @@ function launch_command() {
 }
 
 function log_info() {
-    echo -e "$SYSTEM\n$EMULATOR\n$ROM\n$COMMAND" >/dev/shm/runcommand.info
+    echo -e "$SYSTEM\n$EMULATOR\n$ROM\n$COMMAND" >${OUTPUTDIR}/runcommand.info
 }
 
 function runcommand() {


### PR DESCRIPTION
This PR extends #3556 with a retropie menu configuration entry for the log/scratch area `log_dir` variable and replaces the remaining hard-coded `/dev/shm` values with the `log_dir` variable.