### PR TITLE
runcommand: remove spurious space from `libretro_directory`

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -1103,7 +1103,7 @@ function retroarch_append_config() {
     fi
 
     # set `libretro_directory` to the core parent folder
-    local core_dir=$(echo "$COMMAND" | grep -Eo " $ROOTDIR/libretrocores/.*libretro\.so " | head -n 1)
+    local core_dir=$(echo "$COMMAND" | grep -Eo "$ROOTDIR/libretrocores/.*libretro\.so" | head -n 1)
     core_dir=$(dirname "$core_dir")
     [[ -n "$core_dir" ]] && iniSet "libretro_directory" "$core_dir"
 


### PR DESCRIPTION
Fix the extra spaces added in the value of `libretro_directory`,caused by the `grep` pattern in 553c4fef.
The extra space at the beginning crashes RetroArch when trying to initiate a netplay connection (as a client), see https://github.com/RetroPie/RetroPie-Setup/issues/3161#issuecomment-1160146932.