### PR TITLE
amiberry: upgrade to version 5.3

### DIFF
--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -12,8 +12,8 @@
 rp_module_id="amiberry"
 rp_module_desc="Amiga emulator with JIT support (forked from uae4arm)"
 rp_module_help="ROM Extension: .adf .chd .ipf .lha .zip\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir/amiga"
-rp_module_licence="GPL3 https://raw.githubusercontent.com/midwan/amiberry/master/COPYING"
-rp_module_repo="git https://github.com/midwan/amiberry v5.2"
+rp_module_licence="GPL3 https://raw.githubusercontent.com/BlitterStudio/amiberry/master/LICENSE"
+rp_module_repo="git https://github.com/BlitterStudio/amiberry v5.3"
 rp_module_section="opt"
 rp_module_flags="!all arm rpi3 rpi4"
 


### PR DESCRIPTION
Changed the license file link and updated the upstream project location.
Changelog (taken from upstream https://github.com/BlitterStudio/amiberry/releases/tag/v5.3):

New:
 * statusline resync indicator, merged from latest WinUAE

Fixes:

 * AmiQuit was missing from boot-data.zip file
 * Fixed P96 not working anymore in some environments
 * Navigation in Custom controls when using SDL2 versions older than 2.0.14 wasn't correct
 * input options were not properly parsed when using default.uae on startup, until the GUI was opened once
 * don't overwrite all of changed_prefs when enabling autoheight in DMX
 * Reverted CIA changes until upstream bug is fixed (fixes Mega Typhoon,Cruise for a corpse, probably more, see https://github.com/BlitterStudio/amiberry/issues/985)

Improvements:

 * updated WHDLoad binary to 18.8
 * updated WHDBooter XML to latest version
 * added logging when parsing Custom Controls from XML
 * CD32 C2P/NVRAM only config fixes, C2P init fix
 * add Brightness/Contrast controls on the GUI
 * upgraded floppybridge to latest version (v1.3), fixes some issues with GreaseWeazle
 * newcpu emulation minor fixes