### PR TITLE
runcommand: suppress framebuffer garbage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ The script is executed with:
 
 ```shell
 cd RetroPie-Setup
-sudo ./retropie_setup.sh
+./retropie_setup.sh
 ```
+Note: the script is running as root by default.
 
 When you first run the script it may install some additional packages that are needed.
 

--- a/retropie_setup.sh
+++ b/retropie_setup.sh
@@ -9,6 +9,11 @@
 # at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
 #
 
+if [ $(id -u) -ne 0 ]; then
+  sudo -E "$0"
+  exit $?
+fi
+
 scriptdir="$(dirname "$0")"
 scriptdir="$(cd "$scriptdir" && pwd)"
 

--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -127,7 +127,7 @@ function updatescript_setup()
     fi
     popd >/dev/null
 
-    printMsgs "dialog" "Fetched the latest version of the RetroPie Setup script."
+    [ -n "$IAMSURE" ] || printMsgs "dialog" "Fetched the latest version of the RetroPie Setup script."
     return 0
 }
 
@@ -150,7 +150,7 @@ function post_update_setup() {
     } &> >(_setup_gzip_log "$logfilename")
     rps_printInfo "$logfilename"
 
-    printMsgs "dialog" "NOTICE: The RetroPie-Setup script and pre-made RetroPie SD card images are available to download for free from https://retropie.org.uk.\n\nThe pre-built RetroPie image includes software that has non commercial licences. Selling RetroPie images or including RetroPie with your commercial product is not allowed.\n\nNo copyrighted games are included with RetroPie.\n\nIf you have been sold this software, you can let us know about it by emailing retropieproject@gmail.com."
+    [ -n "$IAMSURE" ] || printMsgs "dialog" "NOTICE: The RetroPie-Setup script and pre-made RetroPie SD card images are available to download for free from https://retropie.org.uk.\n\nThe pre-built RetroPie image includes software that has non commercial licences. Selling RetroPie images or including RetroPie with your commercial product is not allowed.\n\nNo copyrighted games are included with RetroPie.\n\nIf you have been sold this software, you can let us know about it by emailing retropieproject@gmail.com."
 
     # return to set return function
     "${return_func[@]}"
@@ -284,7 +284,7 @@ function package_setup() {
 
         case "$choice" in
             U|B|S)
-                dialog --defaultno --yesno "Are you sure you want to ${option_msgs[$choice]}?" 22 76 2>&1 >/dev/tty || continue
+                [ -n "$IAMSURE" ] || dialog --defaultno --yesno "Are you sure you want to ${option_msgs[$choice]}?" 22 76 2>&1 >/dev/tty || continue
                 local mode
                 case "$choice" in
                     U) mode="_auto_" ;;
@@ -463,7 +463,7 @@ function section_gui_setup() {
             U|I)
                 local mode="update"
                 [[ "$choice" == "I" ]] && mode="install"
-                dialog --defaultno --yesno "Are you sure you want to $mode all installed $name?" 22 76 2>&1 >/dev/tty || continue
+                [ -n "$IAMSURE" ] || dialog --defaultno --yesno "Are you sure you want to $mode all installed $name?" 22 76 2>&1 >/dev/tty || continue
                 rps_logInit
                 {
                     rps_logStart
@@ -574,7 +574,7 @@ function update_packages_gui_setup() {
     local update="$1"
     if [[ "$update" != "update" ]]; then
         ! check_connection_gui_setup && return 1
-        dialog --defaultno --yesno "Are you sure you want to update installed packages?" 22 76 2>&1 >/dev/tty || return 1
+        [ -n "$IAMSURE" ] || dialog --defaultno --yesno "Are you sure you want to update installed packages?" 22 76 2>&1 >/dev/tty || return 1
         updatescript_setup || return 1
         # restart at post_update and then call "update_packages_gui_setup update" afterwards
         joy2keyStop
@@ -582,7 +582,7 @@ function update_packages_gui_setup() {
     fi
 
     local update_os=0
-    dialog --yesno "Would you like to update the underlying OS packages (eg kernel etc) ?" 22 76 2>&1 >/dev/tty && update_os=1
+    [ -n "$IAMSURE" ] || dialog --yesno "Would you like to update the underlying OS packages (eg kernel etc) ?" 22 76 2>&1 >/dev/tty && update_os=1
 
     clear
 
@@ -741,7 +741,7 @@ function gui_setup() {
                 ;;
             S)
                 ! check_connection_gui_setup && continue
-                dialog --defaultno --yesno "Are you sure you want to update the RetroPie-Setup script ?" 22 76 2>&1 >/dev/tty || continue
+                [ -n "$IAMSURE" ] || dialog --defaultno --yesno "Are you sure you want to update the RetroPie-Setup script ?" 22 76 2>&1 >/dev/tty || continue
                 if updatescript_setup; then
                     joy2keyStop
                     exec "$scriptdir/retropie_packages.sh" setup post_update gui_setup

--- a/scriptmodules/supplementary/bashwelcometweak.sh
+++ b/scriptmodules/supplementary/bashwelcometweak.sh
@@ -20,9 +20,21 @@ function install_bashwelcometweak() {
 
 function getIPAddress() {
     local ip_route
-    ip_route=$(ip -4 route get 8.8.8.8 2>/dev/null)
+    declare -a roots_ipv4=(198.41.0.4 199.9.14.201 192.33.4.12 199.7.91.13 192.203.230.10
+                           192.5.5.241 192.112.36.4 198.97.190.53 192.36.148.17 192.58.128.30
+                           193.0.14.129 199.7.83.42 202.12.27.33)
+    declare -a roots_ipv6=(2001:503:ba3e::2:30 2001:500:200::b 2001:500:2::c 2001:500:2d::d
+                           2001:500:a8::e 2001:500:2f::f 2001:500:12::d0d 2001:500:1::53
+                           2001:7fe::53 2001:503:c27::2:30 2001:7fd::1 2001:500:9f::42 2001:dc3::35)
+    for ((i=0;i<13;i++)) {
+        ip_route=$(ip -4 route get ${roots_ipv4[RANDOM%13]} ${dev:+dev $dev} 2>/dev/null) \
+            && break
+    }
     if [[ -z "$ip_route" ]]; then
-        ip_route=$(ip -6 route get 2001:4860:4860::8888 2>/dev/null)
+        for ((i=0;i<13;i++)) {
+            ip_route=$(ip -6 route get ${roots_ipv6[RANDOM%13]} ${dev:+dev $dev} 2>/dev/null) \
+                && break
+        }
     fi
     [[ -n "$ip_route" ]] && grep -oP "src \K[^\s]+" <<< "$ip_route"
 }

--- a/scriptmodules/supplementary/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand.sh
@@ -43,6 +43,7 @@ function install_bin_runcommand() {
         iniSet "governor" ""
         iniSet "disable_menu" "0"
         iniSet "image_delay" "2"
+        iniSet "log_dir" ""
         chown $user:$user "$configdir/all/runcommand.cfg"
     fi
     if [[ ! -f "$configdir/all/runcommand-launch-dialog.cfg" ]]; then
@@ -110,6 +111,7 @@ function gui_runcommand() {
             'disable_joystick=0' \
             'image_delay=2' \
             'governor=' \
+            'log_dir=' \
         )"
 
         [[ -z "$governor" ]] && governor="Default: don't change"
@@ -137,6 +139,7 @@ function gui_runcommand() {
 
         options+=(4 "Launch image delay in seconds (currently $image_delay)")
         options+=(5 "CPU governor configuration (currently: $governor)")
+        options+=(6 "Set log/scratch directory (currently: ${log_dir:-/dev/shm})")
 
         local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
         [[ -z "$choice" ]] && break
@@ -158,6 +161,11 @@ function gui_runcommand() {
                 ;;
             5)
                 governor_runcommand
+                ;;
+            6)
+                cmd=(dialog --backtitle "$__backtitle" --inputbox "Please enter the log directory" 10 60 "$log_dir")
+                choice=$("${cmd[@]}" 2>&1 >/dev/tty)
+                iniSet "log_dir" "$choice"
                 ;;
         esac
     done

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -1028,6 +1028,7 @@ function mode_switch() {
         # if we have switched mode, switch the framebuffer resolution also
         if [[ "$?" -eq 0 ]]; then
             sleep 1
+            clear
             MODE_CUR=($(get_${HAS_MODESET}_mode_info))
             [[ -z "$FB_NEW" ]] && FB_NEW="${MODE_CUR[2]}x${MODE_CUR[3]}"
             return 0

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -1176,8 +1176,8 @@ function get_sys_command() {
     COMMAND="$(default_emulator get emu_cmd)"
 
     # replace tokens
-    COMMAND="${COMMAND//\%ROM\%/\"$ROM\"}"
-    COMMAND="${COMMAND//\%BASENAME\%/\"$ROM_BN\"}"
+    COMMAND="${COMMAND//\%ROM\%/${ROM:+\"${ROM}\"}}"
+    COMMAND="${COMMAND//\%BASENAME\%/${ROM_BN:+\"${ROM_BN}\"}}"
 
     # special case to get the last 2 folders for quake games for the -game parameter
     # remove everything up to /quake/

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -701,6 +701,7 @@ function main_menu() {
                 ;;
             L)
                 COMMAND+=" --verbose"
+                VERBOSE=1
                 return 0
                 ;;
             U)
@@ -1100,6 +1101,14 @@ function retroarch_append_config() {
         iniSet "video_fullscreen_x" "${dim[0]}"
         iniSet "video_fullscreen_y" "${dim[1]}"
     fi
+
+    # set `libretro_directory` to the core parent folder
+    local core_dir=$(echo "$COMMAND" | grep -Eo " $ROOTDIR/libretrocores/.*libretro\.so " | head -n 1)
+    core_dir=$(dirname "$core_dir")
+    [[ -n "$core_dir" ]] && iniSet "libretro_directory" "$core_dir"
+
+    # if verbose logging is on, set core logging to INFO
+    [[ "$VERBOSE" -eq 1 ]] && iniSet "libretro_log_level" "1"
 
     # if the ROM has a custom configuration then append that too
     if [[ -f "$ROM.cfg" ]]; then

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -79,11 +79,6 @@
 
 ROOTDIR="/opt/retropie"
 CONFIGDIR="$ROOTDIR/configs"
-OUTPUTDIR="/dev/shm"
-[ -d "${OUTPUTDIR}" ] \
-  && [ -w "${OUTPUTDIR}" ] \
-    || OUTPUTDIR=/tmp
-LOG="${OUTPUTDIR}/runcommand.log"
 
 RUNCOMMAND_CONF="$CONFIGDIR/all/runcommand.cfg"
 VIDEO_CONF="$CONFIGDIR/all/videomodes.cfg"
@@ -123,6 +118,10 @@ function get_config() {
         iniGet "image_delay"
         IMAGE_DELAY="$ini_value"
         [[ -z "$IMAGE_DELAY" ]] && IMAGE_DELAY=2
+        iniGet "log_dir"
+        LOG_DIR="$ini_value"
+        [[ -z "$LOG_DIR" ]] && LOG_DIR="/dev/shm"
+        LOG="$LOG_DIR/runcommand.log"
     fi
 
     if [[ -n "$DISPLAY" ]] && $XRANDR &>/dev/null; then
@@ -933,7 +932,7 @@ function switch_fb_res() {
 
 function build_xinitrc() {
     local mode="$1"
-    local xinitrc="${OUTPUTDIR}/retropie_xinitrc"
+    local xinitrc="$LOG_DIR/retropie_xinitrc"
 
     case "$mode" in
         clear)
@@ -1072,7 +1071,7 @@ function config_backend() {
 }
 
 function retroarch_append_config() {
-    local conf="${OUTPUTDIR}/retroarch.cfg"
+    local conf="$LOG_DIR/retroarch.cfg"
     local dim
 
     # only for retroarch emulators
@@ -1321,7 +1320,7 @@ function launch_command() {
 }
 
 function log_info() {
-    echo -e "$SYSTEM\n$EMULATOR\n$ROM\n$COMMAND" >${OUTPUTDIR}/runcommand.info
+    echo -e "$SYSTEM\n$EMULATOR\n$ROM\n$COMMAND" >"$LOG_DIR/runcommand.info"
 }
 
 function runcommand() {

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -120,7 +120,7 @@ function get_config() {
         [[ -z "$IMAGE_DELAY" ]] && IMAGE_DELAY=2
         iniGet "log_dir"
         LOG_DIR="$ini_value"
-        [[ -z "$LOG_DIR" ]] && LOG_DIR="/dev/shm"
+        [[ -d "$LOG_DIR" ]] && LOG_DIR="/dev/shm"
         LOG="$LOG_DIR/runcommand.log"
     fi
 

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -79,7 +79,11 @@
 
 ROOTDIR="/opt/retropie"
 CONFIGDIR="$ROOTDIR/configs"
-LOG="/dev/shm/runcommand.log"
+OUTPUTDIR="/dev/shm"
+[ -d "${OUTPUTDIR}" ] \
+  && [ -w "${OUTPUTDIR}" ] \
+    || OUTPUTDIR=/tmp
+LOG="${OUTPUTDIR}/runcommand.log"
 
 RUNCOMMAND_CONF="$CONFIGDIR/all/runcommand.cfg"
 VIDEO_CONF="$CONFIGDIR/all/videomodes.cfg"
@@ -929,7 +933,7 @@ function switch_fb_res() {
 
 function build_xinitrc() {
     local mode="$1"
-    local xinitrc="/dev/shm/retropie_xinitrc"
+    local xinitrc="${OUTPUTDIR}/retropie_xinitrc"
 
     case "$mode" in
         clear)
@@ -1068,7 +1072,7 @@ function config_backend() {
 }
 
 function retroarch_append_config() {
-    local conf="/dev/shm/retroarch.cfg"
+    local conf="${OUTPUTDIR}/retroarch.cfg"
     local dim
 
     # only for retroarch emulators
@@ -1317,7 +1321,7 @@ function launch_command() {
 }
 
 function log_info() {
-    echo -e "$SYSTEM\n$EMULATOR\n$ROM\n$COMMAND" >/dev/shm/runcommand.info
+    echo -e "$SYSTEM\n$EMULATOR\n$ROM\n$COMMAND" >${OUTPUTDIR}/runcommand.info
 }
 
 function runcommand() {


### PR DESCRIPTION
The launch banner from runcommand.sh is displayed as screen garbage while running after quitting amiberry (and possibly other emulators). This PR removes the garbage that hasn't been cleared properly.