### PR TITLE
lr-desmume - fix building on arm

### DIFF
--- a/scriptmodules/libretrocores/lr-desmume.sh
+++ b/scriptmodules/libretrocores/lr-desmume.sh
@@ -18,7 +18,7 @@ rp_module_section="exp"
 
 function _params_lr-desmume() {
     local params=()
-    isPlatform "arm" && params+=("platform=armvhardfloat")
+    isPlatform "arm" && params+=("platform=unixarmvhardfloat")
     isPlatform "aarch64" && params+=("DESMUME_JIT=0")
     echo "${params[@]}"
 }


### PR DESCRIPTION
platform var needs the additional 'unix' keyword since the changes in https://github.com/libretro/desmume/commit/3af49d8d5d851a512d1be34a4ff369b813f57313 or else the wrong target platform is used (it tries to include x86 specific code)