### PR TITLE
lr-hatari - fix build failing due to CapsLibAll.h include path change

### DIFF
--- a/scriptmodules/emulators/hatari.sh
+++ b/scriptmodules/emulators/hatari.sh
@@ -43,8 +43,6 @@ function _build_libcapsimage_hatari() {
     mkdir -p "$md_build/src/includes/caps"
     cp -R "../LibIPF/"*.h "$md_build/src/includes/caps/"
     cp "../Core/CommonTypes.h" "$md_build/src/includes/caps/"
-    # 'lr-hatari' expects a 'caps5' include path
-    ln -sf "$md_build/src/includes/caps" "$md_build/src/includes/caps5"
 }
 
 function build_hatari() {

--- a/scriptmodules/libretrocores/lr-hatari.sh
+++ b/scriptmodules/libretrocores/lr-hatari.sh
@@ -30,7 +30,7 @@ function build_lr-hatari() {
     _build_libcapsimage_hatari
 
     cd "$md_build"
-    CFLAGS+=" -D__cdecl='' -DHAVE_CAPSIMAGE=1 -DCAPSIMAGE_VERSION=5" CAPSIMG_LDFLAGS="-L./lib -l:libcapsimage.so.5.1" make -f Makefile.libretro
+    CFLAGS+=" -D__cdecl='' -I\"$md_build/src/includes/caps\" -DHAVE_CAPSIMAGE=1 -DCAPSIMAGE_VERSION=5" CAPSIMG_LDFLAGS="-L./lib -l:libcapsimage.so.5.1" make -f Makefile.libretro
     md_ret_require="$md_build/hatari_libretro.so"
 }
 


### PR DESCRIPTION
https://github.com/libretro/hatari/commit/245e1a126f8920cc7f6fbb582fdc9fd110de7a30 changes the include paths for CapsLibAll.h which breaks our build script.

This change adds the include path for the caps headers ($md_build/src/includes/caps) to CFLAGS which resolves it.

Also remove the symlink creation in hatari.sh for the caps5 include path that is no longer used.