### PR TITLE
scraper: fix building the package

### DIFF
--- a/scriptmodules/supplementary/scraper.sh
+++ b/scriptmodules/supplementary/scraper.sh
@@ -23,6 +23,8 @@ function depends_scraper() {
 function sources_scraper() {
     local goroot="$(_get_goroot_golang)"
     GOPATH="$md_build" GOROOT="$goroot" "$goroot/bin/go" get -u github.com/sselph/scraper
+    # Use an older version of the TGDB go REST bindings, since the new one is not compatible with scraper
+    git -C "$md_build/src/github.com/J-Swift/thegamesdb-swagger-client-go/" checkout 43ed8a0b364ed2d8521d0
     # manually set repo_dir for packaging info / version checking
     __mod_info[$md_id/repo_dir]="$md_build/src/github.com/sselph/scraper"
 }


### PR DESCRIPTION
One of the depedencies updates has broke the `scraper` build [1].
Until the compatibility is restored (could happen) or scraper is updated (unlikely), just use a previous version of the dependent Go library.

[1] https://github.com/J-Swift/thegamesdb-swagger-client-go/commit/06967c20ca1d18e7fbba5929d1b4bf930052956d#commitcomment-75241057