### PR TITLE
lr-pcsx-rearmed: fix build for NEON platforms

### DIFF
--- a/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
+++ b/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
@@ -35,7 +35,7 @@ function build_lr-pcsx-rearmed() {
         params+=(ARCH=aarch64 DYNAREC=ari64)
     fi
     if isPlatform "neon"; then
-        params+=(HAVE_NEON=1 BUILTIN_GPU=neon)
+        params+=(HAVE_NEON=1 HAVE_NEON_ASM=1 BUILTIN_GPU=neon)
     else
         params+=(HAVE_NEON=0 BUILTIN_GPU=peops)
     fi


### PR DESCRIPTION
Upstream introduced recently an ASM optimized path for NEON platforms, enabled with a new `define`.
Added the new define for NEON platforms, otherwise the build fails because it picks the wrong ASM path.

Introduced in https://github.com/libretro/pcsx_rearmed/commit/047899a4f30d4a11e467e6b5aa0ba4cbf94c3f6b

NB: standalone doesn't seem affected, since the `makefile` is created properly by `configure`.