### PR TITLE
retroarch: add extra core info files for missing upstream files

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -110,6 +110,8 @@ function update_core_info_retroarch() {
     # remove if not a git repository and do a fresh checkout
     [[ ! -d "$dir/.git" ]] && rm -fr "$dir"
     gitPullOrClone "$configdir/all/retroarch/cores" https://github.com/libretro/libretro-core-info.git
+    # Add the info files for cores/configurations not available upstream
+    cp -f "$md_data/"*.info "$configdir/all/retroarch/cores"
     chown -R $user:$user "$dir"
 }
 

--- a/scriptmodules/emulators/retroarch/mamemess_libretro.info
+++ b/scriptmodules/emulators/retroarch/mamemess_libretro.info
@@ -1,0 +1,32 @@
+# Software Information
+display_name = "MESS (MAME - Current)"
+authors = "MAMEdev"
+supported_extensions = "zip|chd|7z|cmd"
+corename = "MAME (Git)"
+license = "GPLv2+"
+permissions = ""
+display_version = "Git"
+categories = "Emulator"
+
+# Hardware Information
+manufacturer = "Various"
+systemname = "MESS (various)"
+systemid = "mame"
+
+# Libretro Features
+supports_no_game = "false"
+database = "MAME"
+savestate = "false"
+savestate_features = "null"
+cheats = "false"
+input_descriptors = "false"
+memory_descriptors = "false"
+libretro_saves = "false"
+core_options = "true"
+core_options_version = "1.0"
+hw_render = "false"
+disk_control = "false"
+database_match_archive_member = "true"
+notes = "[1] MAME supports MAME save states.|[2] MAME supports extracted MAME cheats.|[3] The BIOS files must be inside the ROM directory.|[4] CHD files and their directories must be inside the ROM directory.|[5] ARTWORK, CHEATS, HASH, INI and SAMPLES directories can be placed|[^] inside the 'SYSTEMDIR\mame' directory. (INI/Source for drivers)|[6] When saving, the following directories will be created in the 'SAVEDIR\mame'|[^] directory: STATES, NVRAM, INPUT, SNAPS, CFG, MEMCARD, and DIFF.|[7] Default combo to call MAME GUI: Retropad Select + X|[^] Retropad Select + Start => CANCEL"
+
+description = "'MAME - Current' is compatible with the latest MAME ROM sets. MAME is the most compatible emulator in the world. This core includes the MESS portion of the emulator. MAME's high compatibility makes it a good option for most users looking to play arcade games. If you cannot run this core full speed, the year-stamped forks are faster at the cost of reduced accuracy"

--- a/scriptmodules/emulators/retroarch/mess2016_libretro.info
+++ b/scriptmodules/emulators/retroarch/mess2016_libretro.info
@@ -1,0 +1,31 @@
+# Software Information
+display_name = "Mess (MAME 2016)"
+authors = "MAMEdev"
+supported_extensions = "zip|chd|7z|cmd"
+corename = "MAME 2016 (0.174)"
+license = "GPLv2+"
+permissions = ""
+display_version = "0.174"
+categories = "Emulator"
+
+# Hardware Information
+manufacturer = "Various"
+systemname = "MESS (various)"
+systemid = "mame"
+
+# Libretro Features
+supports_no_game = "false"
+database = "MAME 2016"
+savestate = "false"
+savestate_features = "null"
+cheats = "false"
+input_descriptors = "false"
+memory_descriptors = "false"
+libretro_saves = "false"
+core_options = "true"
+core_options_version = "1.0"
+hw_render = "false"
+disk_control = "false"
+notes = "[1] MAME 2016 (0.174) supports MAME save states.|[2] MAME 2016 (0.174) supports extracted MAME cheats.|[3] The BIOS files must be inside the ROM directory.|[4] The same directory with CHD files inside must be inside the ROM directory.|[5] If desired, the ARTWORK, CHEATS, and SAMPLES directories can be|[^] inside the 'SYSTEMDIR\mame' directory.|[6] When saving, the following directories will be created in the 'SAVEDIR\mame'|[^] directory: STATES, NVRAM, INPUT, SNAPS, CFG, MEMCARD, and DIFF."
+
+description = "Based on a snapshot of the MAME codebase circa 2016, 'MAME 2016' is compatible with MAME 0.174 ROM sets. MAME is the most compatible emulator in the world, and it can run almost any game from any platform (though running console games through this core requires additional steps). If your device can run the up-to-date MAME - Current core at full speed, most users will have a better experience with that core, while FBNeo is typically a better choice for speed vs accuracy, as long as it supports the game(s) in question. Otherwise, this core is notable as the most recent snapshot core with an unchanging ROM set."

--- a/scriptmodules/emulators/retroarch/mupen64plus_libretro.info
+++ b/scriptmodules/emulators/retroarch/mupen64plus_libretro.info
@@ -1,0 +1,33 @@
+# Software Information
+display_name = "Nintendo - Nintendo 64 (Mupen64Plus-Legacy)"
+authors = "m4xw|Hacktarux|gonetz|GLideN64 Contributors|Mupen64Plus Team"
+supported_extensions = "n64|v64|z64|bin|u1"
+corename = "Mupen64Plus"
+license = "GPLv2"
+permissions = "dynarec_optional"
+display_version = "1.0"
+categories = "Emulator"
+
+# Hardware Information
+manufacturer = "Nintendo"
+systemname = "Nintendo 64"
+systemid = "nintendo_64"
+
+# Libretro Features
+supports_no_game = "false"
+database = "Nintendo - Nintendo 64"
+hw_render = "true"
+required_hw_api = "OpenGL Core >= 3.3 | OpenGL ES >= 2.0"
+savestate = "true"
+savestate_features = "serialized"
+cheats = "true"
+input_descriptors = "true"
+memory_descriptors = "true"
+libretro_saves = "true"
+core_options = "true"
+load_subsystem = "true"
+needs_fullpath = "false"
+disk_control = "false"
+is_experimental = "false"
+
+description = "The legacy version of the Mupen64Plus N64 emulator, ported to libretro. It uses the GLideN64 plugin as its default graphics plug, though the high-accuracy Angrylion and ParaLLEl-RDP plugins are also available. This core is no longer developed, but it's still useful for low power devices - for other platforms use the Mupen64Plus-Next core"


### PR DESCRIPTION
Upstream core info repository doesn't contain core info files for:

 * Mupen64Plus (obsolete upstream, the Plus/Next variant is the only one that has core info). Based on Mupen64Plus-Next core info file
 * Mess (upstream doesn't build/distribute it). Based on the Mame core info file
 * Mess2016 (upstream doesn't build/distribute it). Based on the Mame2016 core info file

This should complement 55aab04a6bb220e001bb0f5cbbafab0a62ecee08, where core info files have been added to RetroPie's RetroArch installation.
In the end, I think the `retroarch` package is the place to add the extra info, since they're only consumed by the front-end, plus it's less files needed to be modified.