### PR TITLE
On 64-bit OSs compiling Mupen64bit requires more swap

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -152,7 +152,11 @@ function sources_mupen64plus() {
 }
 
 function build_mupen64plus() {
-    rpSwap on 750
+    if isPlatform "64bit"; then
+        rpSwap on 2048
+    else
+        rpSwap on 750
+    fi
 
     local dir
     local params=()

--- a/scriptmodules/libretrocores/lr-mupen64plus.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus.sh
@@ -52,7 +52,11 @@ function sources_lr-mupen64plus() {
 }
 
 function build_lr-mupen64plus() {
-    rpSwap on 750
+    if isPlatform "64bit"; then
+        rpSwap on 2048
+    else
+        rpSwap on 750
+    fi
     local params=()
     if isPlatform "videocore"; then
         params+=(platform="$__platform")


### PR DESCRIPTION
Hello,

A little while ago, I had created a pull request (https://github.com/RetroPie/RetroPie-Setup/pull/3522), but then I had lost track of the status. Relevant info is as follows:

In my testing on 64bit OSes, I found that mupen64bit would throw errors while compiling. After further investigation, I found that just increasing swap when on a 64-bit system would alleviate the issue. This is similar to how more swap is needed when compiling MAME on a 64-bit platform.

On my original pull request, I recently discovered that it was suggested I squash commits. It had been quite some time though since my original commits so my attempts at squashing them grew messier and messier. So I reset my branch and recommitted the changes. Unfortunately, in doing so, my original pull request was closed (since there were no changes after my branch was reset). So I've created a new pull request.

Apologies for the confusion and for letting my original pull request languish for so long.