### PR TITLE
lr-pcsx-rearmed: trust the project's makefile to detect defaults

### DIFF
--- a/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
+++ b/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
@@ -36,8 +36,6 @@ function build_lr-pcsx-rearmed() {
     fi
     if isPlatform "neon"; then
         params+=(HAVE_NEON=1 HAVE_NEON_ASM=1 BUILTIN_GPU=neon)
-    else
-        params+=(HAVE_NEON=0 BUILTIN_GPU=peops)
     fi
 
     make -f Makefile.libretro "${params[@]}" clean


### PR DESCRIPTION
The libretro/pcsx_rearmed NEON gpu plugin now can also run on arm64 and x86, and it's makefile should be able to detect when to enable those things. Remove the 'else' case and let it do the detection.

libretro/pcsx_rearmed#690