### PR TITLE
Add Bunsen Linux to supported flavours

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -170,7 +170,7 @@ function get_os_version() {
 
     local error=""
     case "$__os_id" in
-        Raspbian|Debian)
+        Raspbian|Debian|Bunsenlabs)
             # get major version (8 instead of 8.0 etc)
             __os_debian_ver="${__os_release%%.*}"
 


### PR DESCRIPTION
This allowed the emulator compilations to work for me using Bunsen Linux on a fairly old PC which is unable to run Ubuntu.