### PR TITLE
Bump Amiberry to 5.4

### DIFF
--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -13,7 +13,7 @@ rp_module_id="amiberry"
 rp_module_desc="Amiga emulator with JIT support (forked from uae4arm)"
 rp_module_help="ROM Extension: .adf .chd .ipf .lha .zip\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir/amiga"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/BlitterStudio/amiberry/master/LICENSE"
-rp_module_repo="git https://github.com/BlitterStudio/amiberry v5.3"
+rp_module_repo="git https://github.com/BlitterStudio/amiberry v5.4"
 rp_module_section="opt"
 rp_module_flags="!all arm rpi3 rpi4"
 


### PR DESCRIPTION
Full changelog: 
https://github.com/BlitterStudio/amiberry/releases/tag/v5.4

### Bugfixes
- whdbooter settings were not all parsed correctly
- Fix CD audio not resuming after unminimize.
-  32bit to 64bit clock counter missing update.
- fixed macOS compile errors regarding uaeserial
- always use mouse 0 for mice, until SDL2 supports > 1 system mouse
- settings from XML db were not always parsed correctly
- fixed flickering in native modes when Fast copper was enabled
- copy all prefs when doing a hard reset
- Fixed some memory leaks
- Hard reset CPU startup was not identical to initial power up.
- WHDbooter game paths with commas would not work

### Improvements:
- implemented Screenshot to file custom event ([#1005](https://github.com/BlitterStudio/amiberry/issues/1005))
- Added the possibility to compile with a version of GCC older than 8.0 ([#1008](https://github.com/BlitterStudio/amiberry/pull/1008) by [farox1](https://github.com/farox1))
- P96 - Implement all previously implemented blitter operations.
- Save also MSM6242B RTC model control registers to RTC file.
- added uaeserial implementation from dev
- merged OpenGL experimental version from dev
- Make sure hardware emulated RTG boards don't have barrier at the start of VRAM space to fully support JIT direct.
- merged CIA rewrite from dev
- Optimize compiler code generation for 'strlen()'
- Fix disk read handling when attempting to read from non-selected drive.
- use double fields line mode by default
- brought statusline drawing closer to WinUAE method