### PR TITLE
Add armhf dependencies for Pegasus

### DIFF
--- a/scriptmodules/supplementary/pegasus-fe.sh
+++ b/scriptmodules/supplementary/pegasus-fe.sh
@@ -25,6 +25,12 @@ function depends_pegasus-fe() {
         libsdl2-dev
         policykit-1
     )
+    isPlatform "aarch64" && depends+=(
+        gstreamer1.0-alsa:armhf
+        gstreamer1.0-libav:armhf
+        gstreamer1.0-plugins-good:armhf
+        libsdl2-dev:armhf
+    )
 
     getDepends "${depends[@]}"
 }


### PR DESCRIPTION
At the moment the Pegasus binaries are built for the traditional 32-bit ARM platform, and as such link to the 32-bit system libraries. On 64-bit distros however these will be missing, so the script should explicitly install the 32-bit `armhf` variant of the dependencies.