### PR TITLE
enable crypto extensions for TX1 and TX2

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -551,12 +551,12 @@ function platform_odroid-xu() {
 }
 
 function platform_tegra-x1() {
-    cpu_armv8 "cortex-a57"
+    cpu_armv8 "cortex-a57+crypto"
     __platform_flags+=(x11 gl)
 }
 
 function platform_tegra-x2() {
-    cpu_armv8 "native"
+    cpu_armv8 "cortex-a57+crypto"
     __platform_flags+=(x11 gl)
 }
 


### PR DESCRIPTION
crc and simd and enable by default in all versions of gcc so would be redundant to add here.

Cortex-A57 armv8.0 has optional crypto extensions so they are not enabled by default. TX1 and TX2 have these extensions available in hardware.