### PR TITLE
retroarch: update to v1.12.0

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -12,7 +12,7 @@
 rp_module_id="retroarch"
 rp_module_desc="RetroArch - frontend to the libretro emulator cores - required by all lr-* emulators"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/RetroArch/master/COPYING"
-rp_module_repo="git https://github.com/RetroPie/RetroArch.git retropie-v1.10.0"
+rp_module_repo="git https://github.com/retropie/RetroArch.git retropie-v1.12.0"
 rp_module_section="core"
 
 function depends_retroarch() {
@@ -173,7 +173,6 @@ function configure_retroarch() {
     iniSet "system_directory" "$biosdir"
     iniSet "config_save_on_exit" "false"
     iniSet "video_aspect_ratio_auto" "true"
-    iniSet "rgui_show_start_screen" "false"
     iniSet "rgui_browser_directory" "$romdir"
     iniSet "rgui_switch_icons" "false"
 
@@ -229,6 +228,7 @@ function configure_retroarch() {
     iniSet "auto_remaps_enable" "true"
     iniSet "input_joypad_driver" "udev"
     iniSet "all_users_control_menu" "true"
+    iniSet "remap_save_on_exit" "false"
 
     # rgui by default
     iniSet "menu_driver" "rgui"
@@ -238,6 +238,14 @@ function configure_retroarch() {
     iniSet "menu_show_core_updater" "false"
     iniSet "menu_show_online_updater" "false"
     iniSet "menu_show_restart_retroarch" "false"
+    # disable the search action
+    iniSet "menu_disable_search_button" "true"
+
+    # remove some options from quick menu
+    iniSet "quick_menu_show_close_content" "false"
+    iniSet "quick_menu_show_add_to_favorites" "false"
+    iniSet "menu_show_overlays" "false"
+
     # disable the load notification message with core and game info
     iniSet "menu_show_load_content_animation" "false"
 
@@ -286,6 +294,12 @@ function configure_retroarch() {
 
     # disable the content load info popup with core and game info
     _set_config_option_retroarch "menu_show_load_content_animation" "false"
+
+    # disable search action
+    _set_config_option_retroarch "menu_disable_search_button" "true"
+
+    # don't save input remaps by default
+    _set_config_option_retroarch "remap_save_on_exit" "false"
 
     # remapping hack for old 8bitdo firmware
     addAutoConf "8bitdo_hack" 0


### PR DESCRIPTION
Current patched tree is at https://github.com/cmitu/retroarch/tree/retropie-v1.12.0

**NOTE**: it includes one post-v1.12.0 change (https://github.com/libretro/RetroArch/pull/14537) which solves an issue with shader presents affecting configurations using the `glcore` video driver.
 
Scriptmodule changes:
1. Added a few more default options to the main config:
   - `remap_save_on_exit` set to false (new option), since by default any changes will be auto-saved on exit. Prevents users accidentally messing their controls and keeps the behavior similar to the previous versions.
   - `menu_disable_search_button`  set to `true` (new option) instead of using our patch for disabling the Search action.
   - (cosmetic) disabled some Quick Menu items (Overlay and Favorites).

2. Removed `rgui_show_start_screen`, since it's now `false` by default.

---------------------------------------------
RetroArch changes between v1.10.0 and v1.12.0, cherry-picked for user-facing changes.

  * RetroAchievements:
    - Upgrade to rcheevos 10.4 (1.11.0)
    - Allow creating auto savestate in hardcore (1.11.0)
    - Release achievement badge textures when video driver is deinitialized (1.11.0)
    - Re-enforce hardcore limitations once achievements are loaded (1.11.0)
    - Support for Arduboy (1.10.2)
    - Add mastery placard  (1.10.1)
    - More description message for missing RetroAchievements credentials (1.10.1)
    - Support for identifying Dreamcast CHDs (1.10.1)

  * Menu improvements and additions
    - XMB: Remember selection per main tabs. Addresses the following : collection playlists can contain hundreds or thousands of items. When scrolling through one, pressing left or right by accident can be common. This resets the playlist to the top (1.12.0)
    - Add View feature – Add saving of a filter set in the Explore menu into a so called “View” file which then gets listed alongside playlists. This also adds the ability to filter a category by range in the Explore menu and not just filter on exact matches. (1.12.0)
    - Better Disc Control append focus (1.11.0)
    - Menu paging navigation adjustments (1.11.0)
    - New Menu Items for disabling Info & Search buttons in the menu (1.11.0)
    - Allow the user to use volume up/down/mute hotkeys from within the menu (1.11.0)
    - Add missing sublabels for non-running Quick Menu (1.11.0)
    - Reorganize Quick Menu Information (1.11.0)
    - Savestate thumbnails – Savestate slot reset action (1.11.0)
    - Allow changing savestate slots with left/right on save/load (1.11.0)
    - Add proper icons for shader items (1.11.0)
    - Show core version (1.10.1)
    - XMB: Add options for hiding header and horizontal title margin (1.11.0)
    - XMB: Dynamic wallpaper fixes (1.11.0)
    - XMB: Add Daite XMB Icon Theme (1.11.0)
    - XMB: Add title margin adjustment (1.10.2)
    - XMB: Vertical fade corrections (1.10.2)
    - OZONE: Fix playlist thumbnail mouse hover after returning from Quick -  (1.11.0)
    - OZONE: Thumbnail visibility corrections (1.11.0)
    - OZONE: Playlist metadata reformat (1.11.0)
    - OZONE: Savestate thumbnail fixes (1.11.0)
    - OZONE: Add savestate thumbnails (1.11.0)
    - OZONE: Header icon spacing adjustment (1.11.0)
    - OZONE: The size of the thumbnail bar can now be changed though a new option (Settings->User interface->Appearance) up to double its normal size. (1.10.2)
    - OZONE: Add ‘Gray Dark + Light’ themes (1.10.2)
    - OZONE: Add thumbnail scale option (1.10.2)
    - XMB/OZONE: Savestate thumbnail aspect ratio (1.11.0)
    - XMB/OZONE: Core option category icon refinements (1.11.0)
    - XMB/OZONE: Fullscreen thumbnail browsing (1.11.0)
    - XMB/OZONE: Add playlist icons under ‘Load Content’ (1.11.0)
    - XMB/OZONE: Thumbnail improvements (1.11.0)
    - XMB/OZONE: Savestate thumbnail fullscreen + dropdown (1.11.0)
    - XMB/OZONE: Prevent unnecessary thumbnail requests when scrolling through playlists (1.11.0)
    - WIDGETS: Widget color + position adjustments (1.11.0)
    - SETTINGS: Add sublabels for ‘Subsystems’ and ‘Input Deadzone/Sensitivity’ (1.10.3)
    - SETTINGS: Move ‘On-Screen Notifications’ to top (1.10.3)
    - SETTINGS: Remove ‘Advanced Settings’ flag from ‘Settings > Core’ -  (1.10.2)
    - SETTINGS: Turn Advanced Settings on by default, this entire filtering of settings will need a complete rethink anyways (1.11.0)
    - RGUI: Savestate thumbnails (1.11.0)
    - RGUI: Add 6×10 extended ASCII and Latin Extended A and B fonts. These will enable most Latin alphabets to be displayed in RGUI. (1.10.2)
    - RGUI: Add ‘Gray Dark + Light’ themes (1.10.2)
    - RGUI: Add dynamic theme (1.10.1)

  * Netplay has been given a lot of attentions and received quite a few gameplay and interface improvements
    - Disable and hide stateless mode (1.11.0)
    - Change default for input sharing to “no sharing” (1.11.0)
    - Enforce a timeout during connection (1.11.0)
    - Disallow clients from loading states and resetting (1.11.0)
    - Ensure current content is reloaded before joining a host (1.11.0)
    - Fix client info devices index (1.11.0)
    - Fix input for some cores when hosting (1.11.0)
    - Force a core update when starting netplay (1.11.0)
    - Support for customizing chat colors (1.11.0)
    - Support for banning clients (1.11.0)
    - Support for gathering client info and kicking (1.11.0)
    -  Netplay/LAN Discovery Task refactor – aims to prevent blocking the main thread while awaiting for the LAN discovery timeout; This is accomplished by moving the whole discovery functionality into its task and using a non-blocking timer to finish the task. Also fixes discovery sockets not being made non-blocking, which could cause the main thread to hang for very long periods of time every pre-frame. (1.11.0)
    - LOBBY: Add setting for filtering out rooms with non-installed cores (1.11.0)
    - LOBBY: Hide older (incompatible) rooms (1.11.0)
    - LOBBY: Add a toggleable filter for passworded rooms. In addition, move lobby filters into its own submenu for better organization. (1.11.0)
    - Chat supported info for the host kick submenu (1.11.0)
    - Host Ban Submenu (1.11.0)
    - Add client devices info to the kick sub-menu (1.11.0)
    - Support for banning clients. (1.11.0)
    - Disable savestates on stateless mode (1.10.1)

  * Input system additions and changes
    - Fix off by one error for input_block_timeout setting. Also default to 0 for this setting (performance gain) (1.11.0)
    - Analog button mapping fixes (1.11.0)
    - Fix analog stick not working with ‘Unified Menu Controls’ (1.10.2)
    - Added hotkey for toggling sync to exact content framerate (1.10.2)
    - Prevent log spam when using rewind hotkey with cores that don’t support rewind, if rewind functionality itself is disabled (1.10.2)
    - HID/LINUX: (qb) Disable HAVE_HID by default for now for Linux as long as there are no working backends for both (1.11.0)
    - LINUX/UDEV: Fix lightgun scaling on Y axis (1.11.0)
    - LINUX/X11/LED: Add LED keyboard driver (1.11.0)
    - REMAPPING: Add option to disable automatic saving of input remap files (1.11.0)
    - MAPPING: Fix offset + crash when clearing input port binds (1.10.3)
    - MAPPING: Fix saving of ‘Analog to Digital Type’ when configuration overrides are used (1.10.3)
    - MAPPING: Add ‘Manage Remap Files’ submenu + automatically save input remaps when closing content (1.10.2)
    - MAPPING: Add ‘Reset Input Mapping’ option to ‘Manage Remap Files’ menu (1.10.2)
    - MAPPING: Fix keyboard device remap nulling (1.10.2)
    - WAYLAND: Allow toggling mouse grabs (1.10.1)
    - WAYLAND: Release keys and mouse buttons on lost focus (1.10.1)

  * Database scanner additions:
    - Fix Redump bin/cue scan for some DC games (1.11.0)
    - Add RVZ/WIA scan support for GC/Wii (1.11.0)
    - Improved success rate of Serial scanning on PS1 by adding support for the xx.xxx format (1.11.0)
    - Serial scanning for Wii now includes WBFS (1.10.3)

  * Video/Graphics improvements and changes:
    * Add conditional support for OpenGL ES 3.x (1.12.0)
    * Fix screenshot widget crash with Vulkan driver when ticker animating (1.12.0)
    * Avoid ‘video_gpu_screenshot’ with savestates (1.11.1)
    * Fast-Forward Frameskip improvement (1.10.3)
    * Stability fixes for threaded video (1.10.3)
    * Fix readability and precision issues in aspectratio_lut (1.11.0)
    * Add option to manually enable/disable automatic refresh rate switching (1.11.0)
    * Enable automatic configuration of ‘VSync Swap Interval’ (1.11.0)
    * Thumbnail aspect ratio fix (1.11.0)
	* Optimizations, fixes and cleanups for threaded video (1.11.0, 1.10.3)
    * Fast-Forward Frameskip improvement (1.10.3)

  * Other changes and fixes:
    * Allow use of –appendconfig with override cfgs instead of getting ignored (1.12.0)
    * Disable save states based on save state support level defined in core info files (1.10.1)
    * Allow setting the default libretro_directory via environment variable (1.10.1)
    * Add optional frame skipping when fast-forwarding (1.10.1)
    * Fix building against FFmpeg 5.0 (1.10.1)

Official changelog posts:
  * v1.10.1: https://www.libretro.com/index.php/retroarch-1-10-1-release/
  * v1.10.2: https://www.libretro.com/index.php/retroarch-1-10-2-release/
  * v1.10.3: https://www.libretro.com/index.php/retroarch-1-10-3-release/
  * v1.11.0: https://www.libretro.com/index.php/retroarch-1-11.0-release/
  * v1.11.1: https://www.libretro.com/index.php/retroarch-1-11-0-release/
  * v1.12.0: https://www.libretro.com/index.php/retroarch-1-12-0-release/
