### PR TITLE
dosbox-staging - fix building for armv6

### DIFF
--- a/scriptmodules/admin/image.sh
+++ b/scriptmodules/admin/image.sh
@@ -174,7 +174,7 @@ function _init_chroot_image() {
     trap "_trap_chroot_image '$chroot'" INT
 
     # mount special filesystems to chroot
-    mkdir -p "$chroot"/dev/pts
+    mkdir -p "$chroot"{/dev/pts,/proc}
     mount none -t devpts "$chroot/dev/pts"
     mount -t proc /proc "$chroot/proc"
 

--- a/scriptmodules/emulators/dosbox-staging.sh
+++ b/scriptmodules/emulators/dosbox-staging.sh
@@ -27,6 +27,10 @@ function depends_dosbox-staging() {
 
 function sources_dosbox-staging() {
     gitPullOrClone
+    # patch the dosbox-staging meson.build script to disable neon instructions for older arm
+    if ! isPlatform "neon"; then
+        applyPatch "$md_data/speexdsp_simd_disable.diff"
+    fi
 }
 
 function build_dosbox-staging() {

--- a/scriptmodules/emulators/dosbox-staging/speexdsp_simd_disable.diff
+++ b/scriptmodules/emulators/dosbox-staging/speexdsp_simd_disable.diff
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index 8db4dd4..e5e7549 100644
+--- a/meson.build
++++ b/meson.build
+@@ -396,7 +396,7 @@ endif
+ if not speexdsp_dep.found() or not is_system_speexdsp_reliable
+     speexdsp_dep = subproject(
+         'speexdsp',
+-        default_options: default_wrap_options,
++        default_options: default_wrap_options + ['simd=false']
+     ).get_variable('speexdsp_dep')
+     speexdsp_summary_msg = 'built-in'
+ endif


### PR DESCRIPTION
The speexdsp meson wrap enables armv7/neon instructions when building for armv6 (Raspberry Pi 1). This causes compilation to fail.

Patch meson.build to disable the simd option for older arm platforms (that don't have the neon platform flag).