### PR TITLE
Adding the new Qt version of PCSX2

### DIFF
--- a/scriptmodules/emulators/pcsx2-qt.sh
+++ b/scriptmodules/emulators/pcsx2-qt.sh
@@ -29,7 +29,7 @@ function install_bin_pcsx2-qt() {
 
 function configure_pcsx2-qt() {
     mkRomDir "ps2"
-    addEmulator 0 "$md_id" "ps2" "$md_inst/bin/rpcs2.AppImage %ROM% -fullscreen -batch"
-    addEmulator 1 "$md_id-nogui" "ps2" "$md_inst/bin/rpcs2.AppImage %ROM% -fullscreen -nogui"
+    addEmulator 0 "$md_id" "ps2" "$md_inst/bin/pcsx2.AppImage %ROM% -fullscreen -batch"
+    addEmulator 1 "$md_id-nogui" "ps2" "$md_inst/bin/pcsx2.AppImage %ROM% -fullscreen -nogui"
     addSystem "ps2"
 }

--- a/scriptmodules/emulators/pcsx2-qt.sh
+++ b/scriptmodules/emulators/pcsx2-qt.sh
@@ -17,7 +17,7 @@ rp_module_section="exp"
 rp_module_flags="!all x86"
 
 function depends_pcsx2-qt() {
-    getDepends jq
+    getDepends jq libfuse2
 }
 
 function install_bin_pcsx2-qt() {

--- a/scriptmodules/emulators/pcsx2-qt.sh
+++ b/scriptmodules/emulators/pcsx2-qt.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="pcsx2-qt"
+rp_module_desc="PS2 emulator PCSX2 - New Qt frontend (AVX2)"
+rp_module_help="ROM Extensions: .bin .iso .img .mdf .z .z2 .bz2 .cso .chd .ima .gz\n\nCopy your PS2 roms to $romdir/ps2\n\nCopy the required BIOS file to $biosdir"
+rp_module_licence="GPL3 https://raw.githubusercontent.com/PCSX2/pcsx2/master/COPYING.GPLv3"
+rp_module_section="exp"
+rp_module_flags="!all x86"
+
+function depends_pcsx2-qt() {
+    getDepends jq
+}
+
+function install_bin_pcsx2-qt() {
+    mkdir -p "$md_inst/bin"
+    version=$(curl --silent "https://api.pcsx2.net/v1/latestReleasesAndPullRequests" | jq -r ".nightlyReleases | .data | .[0] | .version")
+    wget --content-disposition https://github.com/PCSX2/pcsx2/releases/download/$version/pcsx2-$version-linux-AppImage-64bit-AVX2-Qt.AppImage -O "$md_inst/bin/pcsx2.AppImage"
+    chmod +x "$md_inst/bin/pcsx2.AppImage"
+}
+
+function configure_pcsx2-qt() {
+    mkRomDir "ps2"
+    addEmulator 0 "$md_id" "ps2" "$md_inst/bin/rpcs2.AppImage %ROM% -fullscreen -batch"
+    addEmulator 1 "$md_id-nogui" "ps2" "$md_inst/bin/rpcs2.AppImage %ROM% -fullscreen -nogui"
+    addSystem "ps2"
+}


### PR DESCRIPTION
This script will install and update the PCSX2 emulator with the new [Qt interface](https://www.reddit.com/r/emulation/comments/uvf7cd/pcsx2_first_public_qt_release_is_now_available/) (AVX2 version).

The new Qt interface has several improvements over Wx, including:
- a fresh and modern user interface with dark mode available
- per-game settings
- new and simplified gamepad configuration panel with an auto-mapping feature
- and much more.

This will add an entry named `pcsx2-qt` under **Experimental**, to not conflict with the Wx version (which still exists, but has no more active development).

This script works querying the api.pcsx2.net site for the latest build.

The latest build is always offered as an [AppImage](https://en.wikipedia.org/wiki/AppImage), which is, in a summary, a portable app (no root required) built in a single compressed file including all libraries the application depends, similar to an OSX `.dmg` file. It works in most distros without additional requirements (usually just add the executable permission). The AppImage has a nice [FAQ for users](https://docs.appimage.org/user-guide/faq.html).

I know we prefer compile emulators from the source, but the binary this script uses is the official from the PCSX2 site, not an external source.

Anyway, feel free to request changes or simply close this PR if you think it doesn't fit here :)
