### PR TITLE
Added PC Engine CD as a seperate system. Fixes Issue #1545.

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -170,6 +170,10 @@ pc98_fullname="NEC PC-9801"
 pc_exts=".bat .com .conf .cue .dosz .exe .ins .ima .img .iso .m3u .m3u8 .sh .vhd .zip"
 pc_fullname="PC"
 
+pce-cd_exts=".ccd .chd .cue .m3u"
+pce-cd_fullname="PC Engine CD"
+pce-cd_theme="pce-cd"
+
 pcengine_exts=".7z .pce .ccd .chd .cue .zip"
 pcengine_fullname="PC Engine"
 pcengine_theme="pcengine"

--- a/scriptmodules/libretrocores/lr-beetle-pce-fast.sh
+++ b/scriptmodules/libretrocores/lr-beetle-pce-fast.sh
@@ -39,9 +39,10 @@ function install_lr-beetle-pce-fast() {
 }
 
 function configure_lr-beetle-pce-fast() {
-    mkRomDir "pcengine"
-    defaultRAConfig "pcengine"
-
-    addEmulator 1 "$md_id" "pcengine" "$md_inst/mednafen_pce_fast_libretro.so"
-    addSystem "pcengine"
+    for system in pcengine pce-cd; do
+	    mkRomDir "$system"
+        defaultRAConfig "$system"
+        addEmulator 1 "$md_id" "$system" "$md_inst/mednafen_pce_fast_libretro.so"
+        addSystem "$system"
+	 done
 }


### PR DESCRIPTION
This is a quick little fix to add PC Engine CD as a separate system. It may not necessarily show the system artwork with some themes, but it does work with the current default theme (Carbon 2021), with both the PC Engine and TurboGrafx logos. This should not cause any problems for people who want to keep CD games in the main PC Engine directory. They will run from there as well as the CD directory.