### PR TITLE
Update Yamagi Quake 2 to version 8.10

### DIFF
--- a/scriptmodules/ports/yquake2.sh
+++ b/scriptmodules/ports/yquake2.sh
@@ -12,7 +12,7 @@
 rp_module_id="yquake2"
 rp_module_desc="yquake2 - The Yamagi Quake II client"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/yquake2/yquake2/master/LICENSE"
-rp_module_repo="git https://github.com/yquake2/yquake2.git QUAKE2_8_00"
+rp_module_repo="git https://github.com/yquake2/yquake2.git QUAKE2_8_10"
 rp_module_section="exp"
 rp_module_flags=""
 


### PR DESCRIPTION
This version came out in May, and improves controller support, adding better handling of menus and the possibility to use a `gamecontrollerdb.txt` file, instead of setting an environment variable to set up the SDL2 game controller.