### PR TITLE
kodi: fix installation on Ubuntu 22.04 and later

### DIFF
--- a/scriptmodules/ports/kodi.sh
+++ b/scriptmodules/ports/kodi.sh
@@ -57,7 +57,8 @@ function install_bin_kodi() {
 
     # not all the kodi packages may be available depending on repository
     # so we will check and install what's available
-    local all_pkgs=(kodi kodi-peripheral-joystick kodi-inputstream-adaptive kodi-inputstream-rtmp kodi-vfs-libarchive kodi-vfs-sftp kodi-vfs-nfs)
+    local all_pkgs=(kodi kodi-peripheral-joystick kodi-inputstream-adaptive kodi-vfs-libarchive kodi-vfs-sftp kodi-vfs-nfs)
+    compareVersions "$__os_ubuntu_ver" lt 22.04 && all_pkgs+=(kodi-inputstream-rtmp)
     local avail_pkgs=()
     local pkg
     for pkg in "${all_pkgs[@]}"; do


### PR DESCRIPTION
The Kodi PPA for Jammy (22.04) and later doesn't include `kodi-inputstream-rtmp` anymore. Trying to install the version from the Ubuntu repositories will produce a conflict due to mismatched dependencies with the versions from the PPA, so  don't try to install the package.

NOTE: the addon can be later installed from inside Kodi, which is also recommended in its installation page: https://kodi.tv/addons/matrix/inputstream.rtmp