### PR TITLE
Update Amiberry to 5.5.1

### DIFF
--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -13,7 +13,7 @@ rp_module_id="amiberry"
 rp_module_desc="Amiga emulator with JIT support (forked from uae4arm)"
 rp_module_help="ROM Extension: .adf .chd .ipf .lha .zip\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir/amiga"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/BlitterStudio/amiberry/master/LICENSE"
-rp_module_repo="git https://github.com/BlitterStudio/amiberry v5.4"
+rp_module_repo="git https://github.com/BlitterStudio/amiberry v5.5.1"
 rp_module_section="opt"
 rp_module_flags="!all arm rpi3 rpi4"
 
@@ -106,12 +106,14 @@ function configure_amiberry() {
 
     # move config / save folders to $md_conf_root/amiga/amiberry
     local dir
-    for dir in conf savestates screenshots; do
+    for dir in conf nvram savestates screenshots; do
         moveConfigDir "$md_inst/$dir" "$md_conf_root/amiga/amiberry/$dir"
     done
 
-    # symlink cd32.nvr from $md_inst/data to "$md_conf_root/amiga/amiberry
-    moveConfigFile "$md_inst/data/cd32.nvr" "$md_conf_root/amiga/amiberry/cd32.nvr"
+    # check for cd32.nvr and move it to $md_conf_root/amiga/amiberry/nvram
+    if [[ -f "$md_conf_root/amiga/amiberry/cd32.nvr" ]]; then
+        mv "$md_conf_root/amiga/amiberry/cd32.nvr" "$md_conf_root/amiga/amiberry/nvram/"
+    fi
 
     moveConfigDir "$md_inst/kickstarts" "$biosdir/amiga"
     chown -R $user:$user "$biosdir/amiga"


### PR DESCRIPTION
## 5.5 changelog ([link](https://github.com/BlitterStudio/amiberry/releases/tag/v5.5)):

### Bugfixes

- Reverted CD32 autoloader to normal config
- Fixed uaegfx overlay bounds check
- added linefeed in logging errors from CDDA init
- CDDA and AHI wouldn't respect the selected SDL2 audio device
- CDDA audio would fail to init in some cases
- Controller axes inverted status was not respected when reading their input 
- CD32 mode wasn't properly applied when using WHDLoad booter
- fixed passing string to write_log in Panel Paths
- Enumeration of Recording devices would write into sound device ID
- NVRAM path wasn't used in CD32/CDTV configs
- uaegfx blitter was accidentally disabled
- uaegfx masked and overlapping blit fix
- gfx_top_windowed/gfx_left_windowed replacement config entries
- When using Alt-Tab, the keys were not released when returning control
- When selecting a folder/file the contents were not always updated
- Fixed magicmouse without virtual mouse driver.
- Changing HDD controller for Hardfile lost the path to the hardfile
- fixed glitches with File and Folder selectors

### Improvements

- add support for UAE Zorro II RTG boards
- increase Savestate thumb size
- use 2MB Chip also, for A600 configs with Fast RAM
- major refactoring of whdload booter
- add more descriptive text when remapping controller buttons
- updated WHDLoad XML and GameControllers DB to latest versions
- ShowMessage now supports 3 lines. Added timestamp info when updating XML
- Added more configurable paths in GUI: NVRAM, Screenshots, Savestates
- added nvram and inputrecordings directories in repo
- cherry-picked various pieces from x86 branch

## 5.5.1 changelog ([link](https://github.com/BlitterStudio/amiberry/releases/tag/v5.5.1)):

### Bugfix

- Retropie's SDL2 version doesn't have SDL_isupper

## Note
The most important change is the new 'default' for CPU. _Prior_ to **5.5** all games either AGA or non-AGA were defaulting to the **Amiga 1200** configuration. From now on every non-AGA games (majority) will rely on the classic Amiga 600 configuration (68000/7Mhz) whereas anything AGA/CD32 will stick to Amiga 1200 (68020/14Mhz). This simplifies code on Amiberry's side while improving compatibility as well as accuracy. For the few outliers the external 'xml' file will set appropriate defaults whenever needed to ensure a smooth user experience.

As a bonus plenty of 'custom controls' have been added to allow more and more games to play with only a controller (no more keyboard required).

Enjoy!