### PR TITLE
Use bash operators instead of compareVersions for __os_debian_ver

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -25,7 +25,7 @@ function depends_retroarch() {
     isPlatform "vero4k" && depends+=(vero3-userland-dev-osmc zlib1g-dev libfreetype6-dev)
     isPlatform "kms" && depends+=(libgbm-dev)
 
-    if compareVersions "$__os_debian_ver" ge 9; then
+    if [[ "$__os_debian_ver" -ge 9 ]]; then
         depends+=(libavcodec-dev libavformat-dev libavdevice-dev)
     fi
 
@@ -42,7 +42,7 @@ function build_retroarch() {
         params+=(--disable-pulse)
         ! isPlatform "mesa" && params+=(--disable-x11)
     fi
-    if compareVersions "$__os_debian_ver" lt 9; then
+    if [[ "$__os_debian_ver" -lt 9 ]]; then
         params+=(--disable-ffmpeg)
     fi
     isPlatform "gles" && params+=(--enable-opengles)

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -224,7 +224,7 @@ function _mapPackage() {
             ;;
         # map libpng-dev to libpng12-dev for Jessie
         libpng-dev)
-            compareVersions "$__os_debian_ver" lt 9 && pkg="libpng12-dev"
+            [[ "$__os_debian_ver" -lt 9 ]] && pkg="libpng12-dev"
             ;;
         libsdl1.2-dev)
             rp_isEnabled "sdl1" && pkg="RP sdl1 $pkg"
@@ -1545,7 +1545,7 @@ function patchVendorGraphics() {
     local filename="$1"
 
     # patchelf is not available on Raspbian Jessie
-    compareVersions "$__os_debian_ver" lt 9 && return
+    [[ "$__os_debian_ver" -lt 9 ]] && return
 
     getDepends patchelf
     printMsgs "console" "Applying vendor graphics patch: $filename"

--- a/scriptmodules/ports/alephone.sh
+++ b/scriptmodules/ports/alephone.sh
@@ -19,7 +19,7 @@ rp_module_flags="!mali"
 
 function _get_branch_alephone() {
     local branch="release-20150620"
-    if compareVersions "$__os_debian_ver" ge 9 || [[ -n "$__os_ubuntu_ver" ]]; then
+    if [[ "$__os_debian_ver" -ge 9 ]] || [[ -n "$__os_ubuntu_ver" ]]; then
         branch="master"
     fi
     echo "$branch"
@@ -27,7 +27,7 @@ function _get_branch_alephone() {
 
 function depends_alephone() {
     local depends=(libboost-all-dev libspeexdsp-dev libzzip-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev autoconf automake libboost-system-dev libcurl4-openssl-dev autoconf-archive)
-    if compareVersions "$__os_debian_ver" ge 9 || [[ -n "$__os_ubuntu_ver" ]]; then
+    if [[ "$__os_debian_ver" -ge 9 ]] || [[ -n "$__os_ubuntu_ver" ]]; then
         depends+=(libsdl2-dev libsdl2-net-dev libsdl2-image-dev libsdl2-ttf-dev libglu1-mesa-dev libgl1-mesa-dev)
     else
         depends+=(libsdl1.2-dev libsdl-net1.2-dev libsdl-image1.2-dev libsdl-ttf2.0-dev)
@@ -62,7 +62,7 @@ function install_alephone() {
 
 function game_data_alephone() {
     local version="20150620"
-    if compareVersions "$__os_debian_ver" ge 9 || [[ -n "$__os_ubuntu_ver" ]]; then
+    if [[ "$__os_debian_ver" -ge 9 ]] || [[ -n "$__os_ubuntu_ver" ]]; then
         version="20220115"
     fi
     local release_url="https://github.com/Aleph-One-Marathon/alephone/releases/download/release-$version"

--- a/scriptmodules/ports/srb2.sh
+++ b/scriptmodules/ports/srb2.sh
@@ -17,7 +17,7 @@ rp_module_section="exp"
 
 function depends_srb2() {
     local depends=(cmake libsdl2-dev libsdl2-mixer-dev libgme-dev libpng-dev libcurl4-openssl-dev)
-    compareVersions "$__os_debian_ver" gt 9 && depends+=(libopenmpt-dev)
+    [[ "$__os_debian_ver" -gt 9 ]] && depends+=(libopenmpt-dev)
     getDepends "${depends[@]}"
 }
 
@@ -32,7 +32,7 @@ function build_srb2() {
 
     # Disable OpenMPT on Debian Stretch and old, its version is too old
     local extra
-    compareVersions "$__os_debian_ver" lt 10 && extra="-DSRB2_CONFIG_HAVE_OPENMPT=Off"
+    [[ "$__os_debian_ver" -lt 10 ]] && extra="-DSRB2_CONFIG_HAVE_OPENMPT=Off"
     cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$md_inst" $extra
     make
     md_ret_require="$md_build/build/bin/lsdlsrb2"

--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -135,7 +135,7 @@ function depends_emulationstation() {
         libvlc-dev libvlccore-dev vlc
     )
 
-    compareVersions "$__os_debian_ver" gt 8 && depends+=(rapidjson-dev)
+    [[ "$__os_debian_ver" -gt 8 ]] && depends+=(rapidjson-dev)
     isPlatform "x11" && depends+=(gnome-terminal mesa-utils)
     if isPlatform "dispmanx" && ! isPlatform "osmc"; then
         depends+=(omxplayer)
@@ -145,7 +145,7 @@ function depends_emulationstation() {
 
 function _get_branch_emulationstation() {
     if [[ -z "$branch" ]]; then
-        if compareVersions "$__os_debian_ver" gt 8; then
+        if [[ "$__os_debian_ver" -gt 8 ]]; then
             branch="stable"
         else
             branch="v2.7.6"
@@ -193,7 +193,7 @@ function install_emulationstation() {
     )
 
     # This folder is present only from 2.8.x, don't include it for older releases
-    if compareVersions "$__os_debian_ver" gt 8; then
+    if [[ "$__os_debian_ver" -gt 8 ]]; then
         md_ret_files+=('resources')
     fi
 }

--- a/scriptmodules/supplementary/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand.sh
@@ -51,7 +51,7 @@ function install_bin_runcommand() {
     fi
 
     # needed for KMS modesetting (debian buster or later only)
-    if compareVersions "$__os_debian_ver" ge 10; then
+    if [[ "$__os_debian_ver" -ge 10 ]]; then
         rp_installModule "mesa-drm" "_autoupdate_"
     fi
 

--- a/scriptmodules/supplementary/sdl1.sh
+++ b/scriptmodules/supplementary/sdl1.sh
@@ -19,10 +19,10 @@ function get_pkg_ver_sdl1() {
     local basever
     local revision
 
-    if compareVersions "$__os_debian_ver" eq 9; then
+    if [[ "$__os_debian_ver" -eq 9 ]]; then
         basever="1.2.15+dfsg1"
         revision="4"
-    elif compareVersions "$__os_debian_ver" eq 10; then
+    elif [[ "$__os_debian_ver" -eq 10 ]]; then
         basever="1.2.15+dfsg2"
         revision="6"
     else
@@ -50,7 +50,7 @@ function depends_sdl1() {
 
 function sources_sdl1() {
     local files=()
-    if compareVersions "$__os_debian_ver" eq 9; then
+    if [[ "$__os_debian_ver" -eq 9 ]]; then
         files+=(libsdl1.2_$(get_pkg_ver_sdl1 base).orig.tar.xz)
     else
         files+=(libsdl1.2_$(get_pkg_ver_sdl1 base).orig.tar.gz)

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -180,7 +180,7 @@ function get_os_version() {
             fi
 
             # we still allow Raspbian 8 (jessie) to work (We show an popup in the setup module)
-            if compareVersions "$__os_debian_ver" lt 8; then
+            if [[ "$__os_debian_ver" -lt 8 ]]; then
                 error="You need Raspbian/Debian Stretch or newer"
             fi
 
@@ -203,7 +203,7 @@ function get_os_version() {
             # we provide binaries for RPI on Raspbian 9/10
             if isPlatform "rpi" && \
                isPlatform "32bit" && \
-               compareVersions "$__os_debian_ver" gt 9 && compareVersions "$__os_debian_ver" lt 11; then
+               [[ "$__os_debian_ver" -gt 9 && "$__os_debian_ver" -lt 11 ]]; then
                # only set __has_binaries if not already set
                [[ -z "$__has_binaries" ]] && __has_binaries=1
             fi


### PR DESCRIPTION
There was a mix of compareVersions "$__os_debian_ver" OP $arg and [[ "$__os_debian_ver OP $arg ]] around the code.

As $__os_debian_ver is always an integer, use the bash built in operators for performance.

The compareVersions call is significantly slower as it uses an external command (dpkg).