### PR TITLE
Update Yamagi Quake 2 to version 8.20

### DIFF
--- a/scriptmodules/ports/yquake2.sh
+++ b/scriptmodules/ports/yquake2.sh
@@ -12,7 +12,7 @@
 rp_module_id="yquake2"
 rp_module_desc="yquake2 - The Yamagi Quake II client"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/yquake2/yquake2/master/LICENSE"
-rp_module_repo="git https://github.com/yquake2/yquake2.git QUAKE2_8_10"
+rp_module_repo="git https://github.com/yquake2/yquake2.git QUAKE2_8_20"
 rp_module_section="exp"
 rp_module_flags=""
 
@@ -25,10 +25,8 @@ function depends_yquake2() {
 function sources_yquake2() {
     gitPullOrClone
     # get the add-ons sources
-    local repo
-    for repo in 'xatrix' 'rogue'; do
-        gitPullOrClone "$md_build/$repo" "https://github.com/yquake2/$repo"
-    done
+    gitPullOrClone "$md_build/xatrix" "https://github.com/yquake2/xatrix" "XATRIX_2_11"
+    gitPullOrClone "$md_build/rogue" "https://github.com/yquake2/rogue" "ROGUE_2_10"
 }
 
 function build_yquake2() {


### PR DESCRIPTION
I know you've just updated to the 8.10 version, but today is Quake II's 25th anniversary, and Yamagi released 8.20, which adds even more improvements to controllers. Now, you can even change sticks layout and deadzone sizes from the menu. Playing on a RPi 3 B+, no performance lost from previous versions.

To make this PR have a little more value, I've also let the expansions' source clone from a certain tag, instead of doing it from "master". This let the expansion take into account a certain version, just like the main repository.