### PR TITLE
lzdoom: fix the build for RPI1/ARMv6 platforms

### DIFF
--- a/scriptmodules/ports/lzdoom/01_remove_cmake_arm_options.diff
+++ b/scriptmodules/ports/lzdoom/01_remove_cmake_arm_options.diff
@@ -1,0 +1,21 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 5b3e777..0bce388 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -334,16 +334,6 @@ if( ZD_CMAKE_COMPILER_IS_GNUCXX_COMPATIBLE )
+ 	set( CMAKE_C_FLAGS "-Wall -Wextra -Wno-unused -Wno-unused-parameter -Wno-missing-field-initializers -ffp-contract=off ${CMAKE_C_FLAGS}" )
+ 	set( CMAKE_CXX_FLAGS "-Wall -Wextra -Wno-unused -Wno-unused-parameter -Wno-missing-field-initializers -ffp-contract=off ${CMAKE_CXX_FLAGS}" )
+ 
+-	# ARM processors (Raspberry Pi, et al) - enable ARM NEON support.
+-	if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+-		set (USE_ARMV8 0 CACHE BOOL "Use ARMv8 instructions - Raspberry Pi 3")
+-		if (USE_ARMV8)
+-			set( CMAKE_CXX_FLAGS "-mcpu=cortex-a53 -mfpu=neon-fp-armv8 -mtune=cortex-a53 -mhard-float -DNO_SSE ${CMAKE_CXX_FLAGS}" )
+-		else ()
+-			set( CMAKE_CXX_FLAGS "-mcpu=cortex-a7 -mfpu=neon-vfpv4 -mtune=cortex-a7 -mhard-float -DNO_SSE ${CMAKE_CXX_FLAGS}" )
+-		endif ()
+-	endif ()
+-
+ 	if( NOT X64 AND NOT CAN_DO_MFPMATH )
+ 		set( CMAKE_C_FLAGS "-DNO_SSE ${CMAKE_C_FLAGS}" )
+ 		set( CMAKE_CXX_FLAGS "-DNO_SSE ${CMAKE_CXX_FLAGS}" )

--- a/scriptmodules/ports/lzdoom/02_lzma_sdk_dont_force_arm_crc32.diff
+++ b/scriptmodules/ports/lzdoom/02_lzma_sdk_dont_force_arm_crc32.diff
@@ -1,0 +1,17 @@
+diff --git a/libraries/lzma/C/7zCrc.c b/libraries/lzma/C/7zCrc.c
+index f186324..f3ae7be 100644
+--- a/libraries/lzma/C/7zCrc.c
++++ b/libraries/lzma/C/7zCrc.c
+@@ -83,12 +83,6 @@ UInt32 MY_FAST_CALL CrcUpdateT1(UInt32 v, const void *data, size_t size, const U
+     #endif
+   #elif (defined(__clang__) && (__clang_major__ >= 3)) \
+      || (defined(__GNUC__) && (__GNUC__ > 4))
+-      #if !defined(__ARM_FEATURE_CRC32)
+-        #define __ARM_FEATURE_CRC32 1
+-          #if (!defined(__clang__) || (__clang_major__ > 3)) // fix these numbers
+-            #define ATTRIB_CRC __attribute__((__target__("arch=armv8-a+crc")))
+-          #endif
+-      #endif
+       #if defined(__ARM_FEATURE_CRC32)
+         #define USE_ARM64_CRC
+         #include <arm_acle.h>


### PR DESCRIPTION
The changes added enable `lzdoom` to build (and run) on RPI1/RPI0:

  - remove the `ARMV8` build option, since it used upstream as a toggle between RPI2 or RPI3 CPU parameters. Since we're passing the platform CPU flags to `gcc` ourselves, they're not really needed and they'll add the wrong options for other ARM platforms
  - patch the included LZMA SDK CRC calculation to not assume every ARM platform supports hardware-assistet CRC (i.e. ARMv8). This will fix the build for RPI1/ARMv6 platforms