### PR TITLE
Fix chown to use primary group of user for group name by using group as variable

### DIFF
--- a/retropie_packages.sh
+++ b/retropie_packages.sh
@@ -28,6 +28,7 @@ else
     [[ -z "$user" ]] && user="$(id -un)"
 fi
 
+group=$(id -ng $user)
 home="$(eval echo ~$user)"
 datadir="$home/RetroPie"
 biosdir="$datadir/BIOS"

--- a/scriptmodules/admin/apidocs.sh
+++ b/scriptmodules/admin/apidocs.sh
@@ -47,7 +47,7 @@ function build_apidocs() {
 
 function install_apidocs() {
     rsync -a --delete "$md_build/html/" "$__tmpdir/apidocs/"
-    chown -R $user: "$__tmpdir/apidocs"
+    chown -R $user:$group "$__tmpdir/apidocs"
 }
 
 function upload_apidocs() {

--- a/scriptmodules/admin/apidocs.sh
+++ b/scriptmodules/admin/apidocs.sh
@@ -47,7 +47,7 @@ function build_apidocs() {
 
 function install_apidocs() {
     rsync -a --delete "$md_build/html/" "$__tmpdir/apidocs/"
-    chown -R $user:$user "$__tmpdir/apidocs"
+    chown -R $user: "$__tmpdir/apidocs"
 }
 
 function upload_apidocs() {

--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -20,7 +20,7 @@ function _setup_gzip_log() {
 function rps_logInit() {
     if [[ ! -d "$__logdir" ]]; then
         if mkdir -p "$__logdir"; then
-            chown $user:$user "$__logdir"
+            chown $user: "$__logdir"
         else
             fatalError "Couldn't make directory $__logdir"
         fi
@@ -32,7 +32,7 @@ function rps_logInit() {
     local now=$(date +'%Y-%m-%d_%H%M%S')
     logfilename="$__logdir/rps_$now.log.gz"
     touch "$logfilename"
-    chown $user:$user "$logfilename"
+    chown $user: "$logfilename"
     time_start=$(date +"%s")
 }
 
@@ -111,7 +111,7 @@ function depends_setup() {
 function updatescript_setup()
 {
     clear
-    chown -R $user:$user "$scriptdir"
+    chown -R $user: "$scriptdir"
     printHeading "Fetching latest version of the RetroPie Setup Script."
     pushd "$scriptdir" >/dev/null
     if [[ ! -d ".git" ]]; then

--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -111,7 +111,7 @@ function depends_setup() {
 function updatescript_setup()
 {
     clear
-    chown -R $user: "$scriptdir"
+    chown -R $user:$group "$scriptdir"
     printHeading "Fetching latest version of the RetroPie Setup Script."
     pushd "$scriptdir" >/dev/null
     if [[ ! -d ".git" ]]; then

--- a/scriptmodules/admin/setup.sh
+++ b/scriptmodules/admin/setup.sh
@@ -20,7 +20,7 @@ function _setup_gzip_log() {
 function rps_logInit() {
     if [[ ! -d "$__logdir" ]]; then
         if mkdir -p "$__logdir"; then
-            chown $user: "$__logdir"
+            chown $user:$group "$__logdir"
         else
             fatalError "Couldn't make directory $__logdir"
         fi
@@ -32,7 +32,7 @@ function rps_logInit() {
     local now=$(date +'%Y-%m-%d_%H%M%S')
     logfilename="$__logdir/rps_$now.log.gz"
     touch "$logfilename"
-    chown $user: "$logfilename"
+    chown $user:$group "$logfilename"
     time_start=$(date +"%s")
 }
 

--- a/scriptmodules/admin/stats.sh
+++ b/scriptmodules/admin/stats.sh
@@ -42,7 +42,7 @@ function build_stats() {
 
     cp -rv "$md_data/licences" "$dest/"
     cp -rv "$md_data/pkgflags" "$dest/"
-    chown -R $user: "$dest"
+    chown -R $user:$group "$dest"
 }
 
 function upload_stats() {

--- a/scriptmodules/admin/stats.sh
+++ b/scriptmodules/admin/stats.sh
@@ -42,7 +42,7 @@ function build_stats() {
 
     cp -rv "$md_data/licences" "$dest/"
     cp -rv "$md_data/pkgflags" "$dest/"
-    chown -R $user:$user "$dest"
+    chown -R $user: "$dest"
 }
 
 function upload_stats() {

--- a/scriptmodules/admin/wikidocs.sh
+++ b/scriptmodules/admin/wikidocs.sh
@@ -28,7 +28,7 @@ function build_wikidocs() {
 
 function install_wikidocs() {
     rsync -a --delete "$md_build/site/" "$__tmpdir/wikidocs/"
-    chown -R $user: "$__tmpdir/wikidocs"
+    chown -R $user:$group "$__tmpdir/wikidocs"
 }
 
 function upload_wikidocs() {

--- a/scriptmodules/admin/wikidocs.sh
+++ b/scriptmodules/admin/wikidocs.sh
@@ -28,7 +28,7 @@ function build_wikidocs() {
 
 function install_wikidocs() {
     rsync -a --delete "$md_build/site/" "$__tmpdir/wikidocs/"
-    chown -R $user:$user "$__tmpdir/wikidocs"
+    chown -R $user: "$__tmpdir/wikidocs"
 }
 
 function upload_wikidocs() {

--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -114,7 +114,7 @@ function configure_amiberry() {
     moveConfigFile "$md_inst/data/cd32.nvr" "$md_conf_root/amiga/amiberry/cd32.nvr"
 
     moveConfigDir "$md_inst/kickstarts" "$biosdir/amiga"
-    chown -R $user: "$biosdir/amiga"
+    chown -R $user:$group "$biosdir/amiga"
 
     # symlink the retroarch config / autoconfigs for amiberry to use
     ln -sf "$configdir/all/retroarch/autoconfig" "$md_inst/controllers"
@@ -128,7 +128,7 @@ function configure_amiberry() {
     # copy game-data, save-data folders, boot-data.zip and WHDLoad
     cp -R "$md_inst/whdboot-dist/"{game-data,save-data,boot-data.zip,WHDLoad} "$config_dir/whdboot/"
 
-    chown -R $user: "$config_dir/whdboot"
+    chown -R $user:$group "$config_dir/whdboot"
 
     # copy shared uae4arm/amiberry launch script while setting is_amiberry=1
     sed "s/is_amiberry=0/is_amiberry=1/" "$md_data/../uae4arm/uae4arm.sh" >"$md_inst/amiberry.sh"

--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -114,7 +114,7 @@ function configure_amiberry() {
     moveConfigFile "$md_inst/data/cd32.nvr" "$md_conf_root/amiga/amiberry/cd32.nvr"
 
     moveConfigDir "$md_inst/kickstarts" "$biosdir/amiga"
-    chown -R $user:$user "$biosdir/amiga"
+    chown -R $user: "$biosdir/amiga"
 
     # symlink the retroarch config / autoconfigs for amiberry to use
     ln -sf "$configdir/all/retroarch/autoconfig" "$md_inst/controllers"
@@ -128,7 +128,7 @@ function configure_amiberry() {
     # copy game-data, save-data folders, boot-data.zip and WHDLoad
     cp -R "$md_inst/whdboot-dist/"{game-data,save-data,boot-data.zip,WHDLoad} "$config_dir/whdboot/"
 
-    chown -R $user:$user "$config_dir/whdboot"
+    chown -R $user: "$config_dir/whdboot"
 
     # copy shared uae4arm/amiberry launch script while setting is_amiberry=1
     sed "s/is_amiberry=0/is_amiberry=1/" "$md_data/../uae4arm/uae4arm.sh" >"$md_inst/amiberry.sh"
@@ -140,5 +140,5 @@ function configure_amiberry() {
 "$md_inst/amiberry.sh"
 _EOF_
     chmod a+x "$romdir/amiga/$script"
-    chown $user:$user "$romdir/amiga/$script"
+    chown $user: "$romdir/amiga/$script"
 }

--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -140,5 +140,5 @@ function configure_amiberry() {
 "$md_inst/amiberry.sh"
 _EOF_
     chmod a+x "$romdir/amiga/$script"
-    chown $user: "$romdir/amiga/$script"
+    chown $user:$group "$romdir/amiga/$script"
 }

--- a/scriptmodules/emulators/daphne.sh
+++ b/scriptmodules/emulators/daphne.sh
@@ -79,7 +79,7 @@ fi
 _EOF_
     chmod +x "$md_inst/daphne.sh"
 
-    chown -R $user:$user "$md_inst"
-    chown -R $user:$user "$md_conf_root/daphne/dapinput.ini"
+    chown -R $user: "$md_inst"
+    chown -R $user: "$md_conf_root/daphne/dapinput.ini"
 
 }

--- a/scriptmodules/emulators/daphne.sh
+++ b/scriptmodules/emulators/daphne.sh
@@ -79,7 +79,7 @@ fi
 _EOF_
     chmod +x "$md_inst/daphne.sh"
 
-    chown -R $user: "$md_inst"
-    chown -R $user: "$md_conf_root/daphne/dapinput.ini"
+    chown -R $user:$group "$md_inst"
+    chown -R $user:$group "$md_conf_root/daphne/dapinput.ini"
 
 }

--- a/scriptmodules/emulators/dgen.sh
+++ b/scriptmodules/emulators/dgen.sh
@@ -64,7 +64,7 @@ function configure_dgen() {
 
     if [[ ! -f "$md_conf_root/megadrive/dgenrc" ]]; then
         cp "sample.dgenrc" "$md_conf_root/megadrive/dgenrc"
-        chown $user:$user "$md_conf_root/megadrive/dgenrc"
+        chown $user: "$md_conf_root/megadrive/dgenrc"
     fi
 
     iniConfig " = " "" "$md_conf_root/megadrive/dgenrc"

--- a/scriptmodules/emulators/dgen.sh
+++ b/scriptmodules/emulators/dgen.sh
@@ -64,7 +64,7 @@ function configure_dgen() {
 
     if [[ ! -f "$md_conf_root/megadrive/dgenrc" ]]; then
         cp "sample.dgenrc" "$md_conf_root/megadrive/dgenrc"
-        chown $user: "$md_conf_root/megadrive/dgenrc"
+        chown $user:$group "$md_conf_root/megadrive/dgenrc"
     fi
 
     iniConfig " = " "" "$md_conf_root/megadrive/dgenrc"

--- a/scriptmodules/emulators/dolphin.sh
+++ b/scriptmodules/emulators/dolphin.sh
@@ -62,7 +62,7 @@ function configure_dolphin() {
 FullscreenResolution = Auto
 Fullscreen = True
 _EOF_
-        chown -R $user:$user "$md_conf_root/gc/Config"
+        chown -R $user: "$md_conf_root/gc/Config"
     fi
 
     addEmulator 1 "$md_id" "gc" "$md_inst/bin/dolphin-emu-nogui -e %ROM%"

--- a/scriptmodules/emulators/dolphin.sh
+++ b/scriptmodules/emulators/dolphin.sh
@@ -62,7 +62,7 @@ function configure_dolphin() {
 FullscreenResolution = Auto
 Fullscreen = True
 _EOF_
-        chown -R $user: "$md_conf_root/gc/Config"
+        chown -R $user:$group "$md_conf_root/gc/Config"
     fi
 
     addEmulator 1 "$md_id" "gc" "$md_inst/bin/dolphin-emu-nogui -e %ROM%"

--- a/scriptmodules/emulators/dosbox-staging.sh
+++ b/scriptmodules/emulators/dosbox-staging.sh
@@ -55,7 +55,7 @@ function configure_dosbox-staging() {
     [[ "$md_id" == "remove" ]] && return
 
     local config_dir="$md_conf_root/pc"
-    chown -R $user: "$config_dir"
+    chown -R $user:$group "$config_dir"
 
     local staging_output="texturenb"
     if isPlatform "kms"; then

--- a/scriptmodules/emulators/dosbox.sh
+++ b/scriptmodules/emulators/dosbox.sh
@@ -143,7 +143,7 @@ midi_synth start
 midi_synth stop
 _EOF_
     chmod +x "$romdir/pc/$launcher_name"
-    chown $user:$user "$romdir/pc/$launcher_name"
+    chown $user: "$romdir/pc/$launcher_name"
 
     if [[ "$md_id" == "dosbox" || "$md_id" == "dosbox-sdl2" ]]; then
         local config_path=$(su "$user" -c "\"$md_inst/bin/dosbox\" -printconf")

--- a/scriptmodules/emulators/dosbox.sh
+++ b/scriptmodules/emulators/dosbox.sh
@@ -143,7 +143,7 @@ midi_synth start
 midi_synth stop
 _EOF_
     chmod +x "$romdir/pc/$launcher_name"
-    chown $user: "$romdir/pc/$launcher_name"
+    chown $user:$group "$romdir/pc/$launcher_name"
 
     if [[ "$md_id" == "dosbox" || "$md_id" == "dosbox-sdl2" ]]; then
         local config_path=$(su "$user" -c "\"$md_inst/bin/dosbox\" -printconf")

--- a/scriptmodules/emulators/frotz.sh
+++ b/scriptmodules/emulators/frotz.sh
@@ -41,7 +41,7 @@ function game_data_frotz() {
             rm -rf "$temp"
         done
         rm -rf "$temp"
-        chown -R $user:$user "$romdir/zmachine"
+        chown -R $user: "$romdir/zmachine"
     fi
 }
 

--- a/scriptmodules/emulators/frotz.sh
+++ b/scriptmodules/emulators/frotz.sh
@@ -41,7 +41,7 @@ function game_data_frotz() {
             rm -rf "$temp"
         done
         rm -rf "$temp"
-        chown -R $user: "$romdir/zmachine"
+        chown -R $user:$group "$romdir/zmachine"
     fi
 }
 

--- a/scriptmodules/emulators/fuse.sh
+++ b/scriptmodules/emulators/fuse.sh
@@ -68,7 +68,7 @@ function configure_fuse() {
 #!/bin/bash
 $md_inst/bin/fuse --machine 128 --full-screen
 _EOF_
-    chown $user:$user "$script"
+    chown $user: "$script"
     chmod +x "$script"
 }
 

--- a/scriptmodules/emulators/fuse.sh
+++ b/scriptmodules/emulators/fuse.sh
@@ -68,7 +68,7 @@ function configure_fuse() {
 #!/bin/bash
 $md_inst/bin/fuse --machine 128 --full-screen
 _EOF_
-    chown $user: "$script"
+    chown $user:$group "$script"
     chmod +x "$script"
 }
 

--- a/scriptmodules/emulators/gngeopi.sh
+++ b/scriptmodules/emulators/gngeopi.sh
@@ -54,7 +54,7 @@ function configure_gngeopi() {
 p1control A=K122,B=K120,C=K97,D=K115,START=K49,COIN=K51,UP=K273,DOWN=K274,LEFT=K276,RIGHT=K275,MENU=K27
 p2control A=K108,B=K59,C=K111,D=K112,START=K50,COIN=K52,UP=K264,DOWN=K261,LEFT=K260,RIGHT=K262,MENU=K27
 _EOF_
-        chown -R $user: "$md_conf_root/neogeo/gngeorc"
+        chown -R $user:$group "$md_conf_root/neogeo/gngeorc"
     fi
 
     addEmulator 0 "$md_id" "arcade" "$md_inst/bin/gngeo -i $romdir/neogeo -B $md_inst/neogeobios %ROM%"

--- a/scriptmodules/emulators/gngeopi.sh
+++ b/scriptmodules/emulators/gngeopi.sh
@@ -54,7 +54,7 @@ function configure_gngeopi() {
 p1control A=K122,B=K120,C=K97,D=K115,START=K49,COIN=K51,UP=K273,DOWN=K274,LEFT=K276,RIGHT=K275,MENU=K27
 p2control A=K108,B=K59,C=K111,D=K112,START=K50,COIN=K52,UP=K264,DOWN=K261,LEFT=K260,RIGHT=K262,MENU=K27
 _EOF_
-        chown -R $user:$user "$md_conf_root/neogeo/gngeorc"
+        chown -R $user: "$md_conf_root/neogeo/gngeorc"
     fi
 
     addEmulator 0 "$md_id" "arcade" "$md_inst/bin/gngeo -i $romdir/neogeo -B $md_inst/neogeobios %ROM%"

--- a/scriptmodules/emulators/gpsp.sh
+++ b/scriptmodules/emulators/gpsp.sh
@@ -45,7 +45,7 @@ function install_gpsp() {
 
 function configure_gpsp() {
     mkRomDir "gba"
-    chown $user:$user -R "$md_inst"
+    chown $user: -R "$md_inst"
 
     mkUserDir "$md_conf_root/gba"
 

--- a/scriptmodules/emulators/gpsp.sh
+++ b/scriptmodules/emulators/gpsp.sh
@@ -45,7 +45,7 @@ function install_gpsp() {
 
 function configure_gpsp() {
     mkRomDir "gba"
-    chown $user: -R "$md_inst"
+    chown $user:$group -R "$md_inst"
 
     mkUserDir "$md_conf_root/gba"
 

--- a/scriptmodules/emulators/mame4all.sh
+++ b/scriptmodules/emulators/mame4all.sh
@@ -83,7 +83,7 @@ function configure_mame4all() {
         copyDefaultConfig "$config" "$md_conf_root/$system/mame.cfg"
         rm "$config"
 
-        chown -R $user:$user "$md_conf_root/$system"
+        chown -R $user: "$md_conf_root/$system"
     fi
 
     addEmulator 0 "$md_id" "arcade" "$md_inst/mame %BASENAME%"

--- a/scriptmodules/emulators/mame4all.sh
+++ b/scriptmodules/emulators/mame4all.sh
@@ -83,7 +83,7 @@ function configure_mame4all() {
         copyDefaultConfig "$config" "$md_conf_root/$system/mame.cfg"
         rm "$config"
 
-        chown -R $user: "$md_conf_root/$system"
+        chown -R $user:$group "$md_conf_root/$system"
     fi
 
     addEmulator 0 "$md_id" "arcade" "$md_inst/mame %BASENAME%"

--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -381,5 +381,5 @@ function configure_mupen64plus() {
     addAutoConf mupen64plus_hotkeys 1
     addAutoConf mupen64plus_texture_packs 1
 
-    chown -R $user: "$md_conf_root/n64"
+    chown -R $user:$group "$md_conf_root/n64"
 }

--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -381,5 +381,5 @@ function configure_mupen64plus() {
     addAutoConf mupen64plus_hotkeys 1
     addAutoConf mupen64plus_texture_packs 1
 
-    chown -R $user:$user "$md_conf_root/n64"
+    chown -R $user: "$md_conf_root/n64"
 }

--- a/scriptmodules/emulators/openmsx.sh
+++ b/scriptmodules/emulators/openmsx.sh
@@ -79,7 +79,7 @@ function configure_openmsx() {
 
     # Add an autostart script, used for joypad configuration
     cp "$md_data/retropie-init.tcl" "$home/.openMSX/share/scripts"
-    chown -R "$user:" "$home/.openMSX/share/scripts"
+    chown -R $user:$group "$home/.openMSX/share/scripts"
 }
 
 function _default_settings_openmsx() {

--- a/scriptmodules/emulators/openmsx.sh
+++ b/scriptmodules/emulators/openmsx.sh
@@ -79,7 +79,7 @@ function configure_openmsx() {
 
     # Add an autostart script, used for joypad configuration
     cp "$md_data/retropie-init.tcl" "$home/.openMSX/share/scripts"
-    chown -R "$user:$user" "$home/.openMSX/share/scripts"
+    chown -R "$user:" "$home/.openMSX/share/scripts"
 }
 
 function _default_settings_openmsx() {

--- a/scriptmodules/emulators/oricutron.sh
+++ b/scriptmodules/emulators/oricutron.sh
@@ -50,7 +50,7 @@ function game_data_oricutron() {
     if [[ -d "$md_inst/disks" && ! -f "$romdir/oric/barbitoric.dsk" ]]; then
         # copy demo disks
         cp -v "$md_inst/disks/"* "$romdir/oric/"
-        chown -R $user:$user "$romdir/oric"
+        chown -R $user: "$romdir/oric"
     fi
 }
 

--- a/scriptmodules/emulators/oricutron.sh
+++ b/scriptmodules/emulators/oricutron.sh
@@ -50,7 +50,7 @@ function game_data_oricutron() {
     if [[ -d "$md_inst/disks" && ! -f "$romdir/oric/barbitoric.dsk" ]]; then
         # copy demo disks
         cp -v "$md_inst/disks/"* "$romdir/oric/"
-        chown -R $user: "$romdir/oric"
+        chown -R $user:$group "$romdir/oric"
     fi
 }
 

--- a/scriptmodules/emulators/pcsx2.sh
+++ b/scriptmodules/emulators/pcsx2.sh
@@ -22,7 +22,7 @@ function depends_pcsx2() {
         iniGet "own_sdl2"
         if [[ "$ini_value" != "0" ]]; then
             if dialog --yesno "PCSX2 cannot be installed on a 64bit system with the RetroPie custom version of SDL2 installed due to version conflicts with the multiarch i386 version of SDL2.\n\nDo you want to downgrade to your OS version of SDL2 and continue to install PCSX2?" 22 76 2>&1 >/dev/tty; then
-                chown $user: "$configdir/all/retropie.cfg"
+                chown $user:$group "$configdir/all/retropie.cfg"
                 if rp_callModule sdl2 revert; then
                     iniSet "own_sdl2" "0"
                 else

--- a/scriptmodules/emulators/pcsx2.sh
+++ b/scriptmodules/emulators/pcsx2.sh
@@ -22,7 +22,7 @@ function depends_pcsx2() {
         iniGet "own_sdl2"
         if [[ "$ini_value" != "0" ]]; then
             if dialog --yesno "PCSX2 cannot be installed on a 64bit system with the RetroPie custom version of SDL2 installed due to version conflicts with the multiarch i386 version of SDL2.\n\nDo you want to downgrade to your OS version of SDL2 and continue to install PCSX2?" 22 76 2>&1 >/dev/tty; then
-                chown $user:$user "$configdir/all/retropie.cfg"
+                chown $user: "$configdir/all/retropie.cfg"
                 if rp_callModule sdl2 revert; then
                     iniSet "own_sdl2" "0"
                 else

--- a/scriptmodules/emulators/redream.sh
+++ b/scriptmodules/emulators/redream.sh
@@ -36,7 +36,7 @@ function configure_redream() {
 
     [[ "$md_mode" == "remove" ]] && return
 
-    chown -R $user:$user "$md_inst"
+    chown -R $user: "$md_inst"
 
     local dest="$md_conf_root/dreamcast/redream"
     mkUserDir "$dest"

--- a/scriptmodules/emulators/redream.sh
+++ b/scriptmodules/emulators/redream.sh
@@ -36,7 +36,7 @@ function configure_redream() {
 
     [[ "$md_mode" == "remove" ]] && return
 
-    chown -R $user: "$md_inst"
+    chown -R $user:$group "$md_inst"
 
     local dest="$md_conf_root/dreamcast/redream"
     mkUserDir "$dest"

--- a/scriptmodules/emulators/reicast.sh
+++ b/scriptmodules/emulators/reicast.sh
@@ -116,7 +116,7 @@ function configure_reicast() {
     # copy default mappings
     cp "$md_inst/share/reicast/mappings/"*.cfg "$md_conf_root/dreamcast/mappings/"
 
-    chown -R $user:$user "$md_conf_root/dreamcast"
+    chown -R $user: "$md_conf_root/dreamcast"
 
     if [[ "$md_mode" == "install" ]]; then
         cat > "$romdir/dreamcast/+Start Reicast.sh" << _EOF_
@@ -124,7 +124,7 @@ function configure_reicast() {
 $md_inst/bin/reicast.sh
 _EOF_
         chmod a+x "$romdir/dreamcast/+Start Reicast.sh"
-        chown $user:$user "$romdir/dreamcast/+Start Reicast.sh"
+        chown $user: "$romdir/dreamcast/+Start Reicast.sh"
     else
         rm "$romdir/dreamcast/+Start Reicast.sh"
     fi
@@ -155,7 +155,7 @@ function input_reicast() {
     iniGet "mapping_name"
     local mapping_file="$configdir/dreamcast/mappings/evdev_${ini_value//[:><?\"]/-}.cfg"
     mv "$temp_file" "$mapping_file"
-    chown $user:$user "$mapping_file"
+    chown $user: "$mapping_file"
 }
 
 function gui_reicast() {

--- a/scriptmodules/emulators/reicast.sh
+++ b/scriptmodules/emulators/reicast.sh
@@ -124,7 +124,7 @@ function configure_reicast() {
 $md_inst/bin/reicast.sh
 _EOF_
         chmod a+x "$romdir/dreamcast/+Start Reicast.sh"
-        chown $user: "$romdir/dreamcast/+Start Reicast.sh"
+        chown $user:$group "$romdir/dreamcast/+Start Reicast.sh"
     else
         rm "$romdir/dreamcast/+Start Reicast.sh"
     fi
@@ -155,7 +155,7 @@ function input_reicast() {
     iniGet "mapping_name"
     local mapping_file="$configdir/dreamcast/mappings/evdev_${ini_value//[:><?\"]/-}.cfg"
     mv "$temp_file" "$mapping_file"
-    chown $user: "$mapping_file"
+    chown $user:$group "$mapping_file"
 }
 
 function gui_reicast() {

--- a/scriptmodules/emulators/reicast.sh
+++ b/scriptmodules/emulators/reicast.sh
@@ -116,7 +116,7 @@ function configure_reicast() {
     # copy default mappings
     cp "$md_inst/share/reicast/mappings/"*.cfg "$md_conf_root/dreamcast/mappings/"
 
-    chown -R $user: "$md_conf_root/dreamcast"
+    chown -R $user:$group "$md_conf_root/dreamcast"
 
     if [[ "$md_mode" == "install" ]]; then
         cat > "$romdir/dreamcast/+Start Reicast.sh" << _EOF_

--- a/scriptmodules/emulators/residualvm.sh
+++ b/scriptmodules/emulators/residualvm.sh
@@ -82,7 +82,7 @@ while read id desc; do
 done < <($md_inst/bin/residualvm --list-targets | tail -n +3)
 popd >/dev/null
 _EOF_
-    chown $user:$user "$romdir/residualvm/+Start ResidualVM.sh"
+    chown $user: "$romdir/residualvm/+Start ResidualVM.sh"
     chmod u+x "$romdir/residualvm/+Start ResidualVM.sh"
 
     addEmulator 0 "$md_id" "residualvm" "bash $romdir/residualvm/+Start\ ResidualVM.sh opengl_shaders %BASENAME%"

--- a/scriptmodules/emulators/residualvm.sh
+++ b/scriptmodules/emulators/residualvm.sh
@@ -82,7 +82,7 @@ while read id desc; do
 done < <($md_inst/bin/residualvm --list-targets | tail -n +3)
 popd >/dev/null
 _EOF_
-    chown $user: "$romdir/residualvm/+Start ResidualVM.sh"
+    chown $user:$group "$romdir/residualvm/+Start ResidualVM.sh"
     chmod u+x "$romdir/residualvm/+Start ResidualVM.sh"
 
     addEmulator 0 "$md_id" "residualvm" "bash $romdir/residualvm/+Start\ ResidualVM.sh opengl_shaders %BASENAME%"

--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -81,7 +81,7 @@ function update_shaders_retroarch() {
     # remove if not git repository for fresh checkout
     [[ ! -d "$dir/.git" ]] && rm -rf "$dir"
     gitPullOrClone "$dir" https://github.com/RetroPie/common-shaders.git "$branch"
-    chown -R $user: "$dir"
+    chown -R $user:$group "$dir"
 }
 
 function update_overlays_retroarch() {
@@ -89,7 +89,7 @@ function update_overlays_retroarch() {
     # remove if not a git repository for fresh checkout
     [[ ! -d "$dir/.git" ]] && rm -rf "$dir"
     gitPullOrClone "$dir" https://github.com/libretro/common-overlays.git
-    chown -R $user: "$dir"
+    chown -R $user:$group "$dir"
 }
 
 function update_joypad_autoconfigs_retroarch() {
@@ -102,7 +102,7 @@ function update_assets_retroarch() {
     # remove if not a git repository for fresh checkout
     [[ ! -d "$dir/.git" ]] && rm -rf "$dir"
     gitPullOrClone "$dir" https://github.com/libretro/retroarch-assets.git
-    chown -R $user: "$dir"
+    chown -R $user:$group "$dir"
 }
 
 function update_core_info_retroarch() {
@@ -112,7 +112,7 @@ function update_core_info_retroarch() {
     gitPullOrClone "$configdir/all/retroarch/cores" https://github.com/libretro/libretro-core-info.git
     # Add the info files for cores/configurations not available upstream
     cp -f "$md_data/"*.info "$configdir/all/retroarch/cores"
-    chown -R $user: "$dir"
+    chown -R $user:$group "$dir"
 }
 
 function install_minimal_assets_retroarch() {
@@ -120,7 +120,7 @@ function install_minimal_assets_retroarch() {
     [[ -d "$dir/.git" ]] && return
     [[ ! -d "$dir" ]] && mkUserDir "$dir"
     downloadAndExtract "$__binary_base_url/retroarch-minimal-assets.tar.gz" "$dir"
-    chown -R $user: "$dir"
+    chown -R $user:$group "$dir"
 }
 
 function _package_minimal_assets_retroarch() {

--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -81,7 +81,7 @@ function update_shaders_retroarch() {
     # remove if not git repository for fresh checkout
     [[ ! -d "$dir/.git" ]] && rm -rf "$dir"
     gitPullOrClone "$dir" https://github.com/RetroPie/common-shaders.git "$branch"
-    chown -R $user:$user "$dir"
+    chown -R $user: "$dir"
 }
 
 function update_overlays_retroarch() {
@@ -89,7 +89,7 @@ function update_overlays_retroarch() {
     # remove if not a git repository for fresh checkout
     [[ ! -d "$dir/.git" ]] && rm -rf "$dir"
     gitPullOrClone "$dir" https://github.com/libretro/common-overlays.git
-    chown -R $user:$user "$dir"
+    chown -R $user: "$dir"
 }
 
 function update_joypad_autoconfigs_retroarch() {
@@ -102,7 +102,7 @@ function update_assets_retroarch() {
     # remove if not a git repository for fresh checkout
     [[ ! -d "$dir/.git" ]] && rm -rf "$dir"
     gitPullOrClone "$dir" https://github.com/libretro/retroarch-assets.git
-    chown -R $user:$user "$dir"
+    chown -R $user: "$dir"
 }
 
 function update_core_info_retroarch() {
@@ -112,7 +112,7 @@ function update_core_info_retroarch() {
     gitPullOrClone "$configdir/all/retroarch/cores" https://github.com/libretro/libretro-core-info.git
     # Add the info files for cores/configurations not available upstream
     cp -f "$md_data/"*.info "$configdir/all/retroarch/cores"
-    chown -R $user:$user "$dir"
+    chown -R $user: "$dir"
 }
 
 function install_minimal_assets_retroarch() {
@@ -120,7 +120,7 @@ function install_minimal_assets_retroarch() {
     [[ -d "$dir/.git" ]] && return
     [[ ! -d "$dir" ]] && mkUserDir "$dir"
     downloadAndExtract "$__binary_base_url/retroarch-minimal-assets.tar.gz" "$dir"
-    chown -R $user:$user "$dir"
+    chown -R $user: "$dir"
 }
 
 function _package_minimal_assets_retroarch() {

--- a/scriptmodules/emulators/rpix86.sh
+++ b/scriptmodules/emulators/rpix86.sh
@@ -39,7 +39,7 @@ fi
 popd
 _EOF_
     chmod +x "$romdir/pc/+Start rpix86.sh"
-    chown $user:$user "$romdir/pc/+Start rpix86.sh"
+    chown $user: "$romdir/pc/+Start rpix86.sh"
     ln -sfn "$romdir/pc" games
 
     addEmulator 0 "$md_id" "pc" "bash $romdir/pc/+Start\ rpix86.sh %ROM%"

--- a/scriptmodules/emulators/rpix86.sh
+++ b/scriptmodules/emulators/rpix86.sh
@@ -39,7 +39,7 @@ fi
 popd
 _EOF_
     chmod +x "$romdir/pc/+Start rpix86.sh"
-    chown $user: "$romdir/pc/+Start rpix86.sh"
+    chown $user:$group "$romdir/pc/+Start rpix86.sh"
     ln -sfn "$romdir/pc" games
 
     addEmulator 0 "$md_id" "pc" "bash $romdir/pc/+Start\ rpix86.sh %ROM%"

--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -86,7 +86,7 @@ while read id desc; do
 done < <($md_inst/bin/scummvm --list-targets | tail -n +3)
 popd >/dev/null
 _EOF_
-    chown $user: "$romdir/scummvm/+Start $name.sh"
+    chown $user:$group "$romdir/scummvm/+Start $name.sh"
     chmod u+x "$romdir/scummvm/+Start $name.sh"
 
     addEmulator 1 "$md_id" "scummvm" "bash $romdir/scummvm/+Start\ $name.sh %BASENAME%"

--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -86,7 +86,7 @@ while read id desc; do
 done < <($md_inst/bin/scummvm --list-targets | tail -n +3)
 popd >/dev/null
 _EOF_
-    chown $user:$user "$romdir/scummvm/+Start $name.sh"
+    chown $user: "$romdir/scummvm/+Start $name.sh"
     chmod u+x "$romdir/scummvm/+Start $name.sh"
 
     addEmulator 1 "$md_id" "scummvm" "bash $romdir/scummvm/+Start\ $name.sh %BASENAME%"

--- a/scriptmodules/emulators/uae4all.sh
+++ b/scriptmodules/emulators/uae4all.sh
@@ -92,7 +92,7 @@ pushd "$md_inst"
 popd
 _EOF_
         chmod a+x "$romdir/amiga/+Start UAE4All.sh"
-        chown $user:$user "$romdir/amiga/+Start UAE4All.sh"
+        chown $user: "$romdir/amiga/+Start UAE4All.sh"
 
         isPlatform "dispmanx" && setBackend "$md_id" "dispmanx"
     else

--- a/scriptmodules/emulators/uae4all.sh
+++ b/scriptmodules/emulators/uae4all.sh
@@ -92,7 +92,7 @@ pushd "$md_inst"
 popd
 _EOF_
         chmod a+x "$romdir/amiga/+Start UAE4All.sh"
-        chown $user: "$romdir/amiga/+Start UAE4All.sh"
+        chown $user:$group "$romdir/amiga/+Start UAE4All.sh"
 
         isPlatform "dispmanx" && setBackend "$md_id" "dispmanx"
     else

--- a/scriptmodules/emulators/uae4arm.sh
+++ b/scriptmodules/emulators/uae4arm.sh
@@ -62,7 +62,7 @@ function configure_uae4arm() {
     done
 
     moveConfigDir "$md_inst/kickstarts" "$biosdir/amiga"
-    chown -R $user: "$biosdir/amiga"
+    chown -R $user:$group "$biosdir/amiga"
 
     local conf="$(mktemp)"
     iniConfig "=" "" "$conf"

--- a/scriptmodules/emulators/uae4arm.sh
+++ b/scriptmodules/emulators/uae4arm.sh
@@ -98,5 +98,5 @@ function configure_uae4arm() {
 "$md_inst/uae4arm.sh"
 _EOF_
     chmod a+x "$romdir/amiga/$script"
-    chown $user: "$romdir/amiga/$script"
+    chown $user:$group "$romdir/amiga/$script"
 }

--- a/scriptmodules/emulators/uae4arm.sh
+++ b/scriptmodules/emulators/uae4arm.sh
@@ -62,7 +62,7 @@ function configure_uae4arm() {
     done
 
     moveConfigDir "$md_inst/kickstarts" "$biosdir/amiga"
-    chown -R $user:$user "$biosdir/amiga"
+    chown -R $user: "$biosdir/amiga"
 
     local conf="$(mktemp)"
     iniConfig "=" "" "$conf"
@@ -98,5 +98,5 @@ function configure_uae4arm() {
 "$md_inst/uae4arm.sh"
 _EOF_
     chmod a+x "$romdir/amiga/$script"
-    chown $user:$user "$romdir/amiga/$script"
+    chown $user: "$romdir/amiga/$script"
 }

--- a/scriptmodules/emulators/zesarux.sh
+++ b/scriptmodules/emulators/zesarux.sh
@@ -65,7 +65,7 @@ function configure_zesarux() {
 "$md_inst/bin/zesarux" "\$@"
 _EOF_
     chmod +x "$romdir/zxspectrum/+Start ZEsarUX.sh"
-    chown $user: "$romdir/zxspectrum/+Start ZEsarUX.sh"
+    chown $user:$group "$romdir/zxspectrum/+Start ZEsarUX.sh"
 
     moveConfigFile "$home/.zesaruxrc" "$md_conf_root/zxspectrum/.zesaruxrc"
 

--- a/scriptmodules/emulators/zesarux.sh
+++ b/scriptmodules/emulators/zesarux.sh
@@ -65,7 +65,7 @@ function configure_zesarux() {
 "$md_inst/bin/zesarux" "\$@"
 _EOF_
     chmod +x "$romdir/zxspectrum/+Start ZEsarUX.sh"
-    chown $user:$user "$romdir/zxspectrum/+Start ZEsarUX.sh"
+    chown $user: "$romdir/zxspectrum/+Start ZEsarUX.sh"
 
     moveConfigFile "$home/.zesaruxrc" "$md_conf_root/zxspectrum/.zesaruxrc"
 

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -537,7 +537,7 @@ function moveConfigDir() {
     fi
     ln -snf "$to" "$from"
     # set ownership of the actual link to $user
-    chown -h $user: "$from"
+    chown -h $user:$group "$from"
 }
 
 ## @fn moveConfigFile()
@@ -560,7 +560,7 @@ function moveConfigFile() {
     fi
     ln -sf "$to" "$from"
     # set ownership of the actual link to $user
-    chown -h $user: "$from"
+    chown -h $user:$group "$from"
 }
 
 ## @fn diffFiles()

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -483,7 +483,7 @@ function setupDirectories() {
     if [[ ! -f "$config" ]]; then
         echo "# this file can be used to enable/disable retropie autoconfiguration features" >"$config"
     fi
-    chown $user: "$config"
+    chown $user:$group "$config"
 }
 
 ## @fn rmDirExists()
@@ -500,7 +500,7 @@ function rmDirExists() {
 ## @brief Creates a directory owned by the current user.
 function mkUserDir() {
     mkdir -p "$1"
-    chown $user: "$1"
+    chown $user:$group "$1"
 }
 
 ## @fn mkRomDir()
@@ -622,7 +622,7 @@ function copyDefaultConfig() {
         cp "$from" "$to"
     fi
 
-    chown $user: "$to"
+    chown $user:$group "$to"
 }
 
 ## @fn renameModule()
@@ -681,7 +681,7 @@ function setBackend() {
     iniGet "$id"
     if [[ "$force" -eq 1 || -z "$ini_value" ]]; then
         iniSet "$id" "$mode"
-        chown $user: "$config"
+        chown $user:$group "$config"
     fi
 }
 
@@ -1007,7 +1007,7 @@ function setRetroArchCoreOption() {
     if [[ -z "$ini_value" ]]; then
         iniSet "$option" "$value"
     fi
-    chown $user: "$configdir/all/retroarch-core-options.cfg"
+    chown $user:$group "$configdir/all/retroarch-core-options.cfg"
 }
 
 ## @fn setConfigRoot()
@@ -1446,7 +1446,7 @@ function addPort() {
 "$rootdir/supplementary/runcommand/runcommand.sh" 0 _PORT_ "$port" "$game"
 _EOF_
 
-    chown $user: "$file"
+    chown $user:$group "$file"
     chmod +x "$file"
 
     [[ -n "$cmd" ]] && addEmulator 1 "$id" "$port" "$cmd"
@@ -1507,7 +1507,7 @@ function addEmulator() {
         if [[ -z "$ini_value" && "$default" -eq 1 ]]; then
             iniSet "default" "$id"
         fi
-        chown $user: "$md_conf_root/$system/emulators.cfg"
+        chown $user:$group "$md_conf_root/$system/emulators.cfg"
     fi
 }
 

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -483,7 +483,7 @@ function setupDirectories() {
     if [[ ! -f "$config" ]]; then
         echo "# this file can be used to enable/disable retropie autoconfiguration features" >"$config"
     fi
-    chown $user:$user "$config"
+    chown $user: "$config"
 }
 
 ## @fn rmDirExists()
@@ -500,7 +500,7 @@ function rmDirExists() {
 ## @brief Creates a directory owned by the current user.
 function mkUserDir() {
     mkdir -p "$1"
-    chown $user:$user "$1"
+    chown $user: "$1"
 }
 
 ## @fn mkRomDir()
@@ -537,7 +537,7 @@ function moveConfigDir() {
     fi
     ln -snf "$to" "$from"
     # set ownership of the actual link to $user
-    chown -h $user:$user "$from"
+    chown -h $user: "$from"
 }
 
 ## @fn moveConfigFile()
@@ -560,7 +560,7 @@ function moveConfigFile() {
     fi
     ln -sf "$to" "$from"
     # set ownership of the actual link to $user
-    chown -h $user:$user "$from"
+    chown -h $user: "$from"
 }
 
 ## @fn diffFiles()
@@ -622,7 +622,7 @@ function copyDefaultConfig() {
         cp "$from" "$to"
     fi
 
-    chown $user:$user "$to"
+    chown $user: "$to"
 }
 
 ## @fn renameModule()
@@ -681,7 +681,7 @@ function setBackend() {
     iniGet "$id"
     if [[ "$force" -eq 1 || -z "$ini_value" ]]; then
         iniSet "$id" "$mode"
-        chown $user:$user "$config"
+        chown $user: "$config"
     fi
 }
 
@@ -1007,7 +1007,7 @@ function setRetroArchCoreOption() {
     if [[ -z "$ini_value" ]]; then
         iniSet "$option" "$value"
     fi
-    chown $user:$user "$configdir/all/retroarch-core-options.cfg"
+    chown $user: "$configdir/all/retroarch-core-options.cfg"
 }
 
 ## @fn setConfigRoot()
@@ -1446,7 +1446,7 @@ function addPort() {
 "$rootdir/supplementary/runcommand/runcommand.sh" 0 _PORT_ "$port" "$game"
 _EOF_
 
-    chown $user:$user "$file"
+    chown $user: "$file"
     chmod +x "$file"
 
     [[ -n "$cmd" ]] && addEmulator 1 "$id" "$port" "$cmd"
@@ -1507,7 +1507,7 @@ function addEmulator() {
         if [[ -z "$ini_value" && "$default" -eq 1 ]]; then
             iniSet "default" "$id"
         fi
-        chown $user:$user "$md_conf_root/$system/emulators.cfg"
+        chown $user: "$md_conf_root/$system/emulators.cfg"
     fi
 }
 

--- a/scriptmodules/inifuncs.sh
+++ b/scriptmodules/inifuncs.sh
@@ -198,7 +198,7 @@ function addAutoConf() {
     ini_value="${ini_value// /}"
     if [[ -z "$ini_value" ]]; then
         iniSet "$key" "$default"
-        chown $user: "$file"
+        chown $user:$group "$file"
     fi
 }
 
@@ -210,7 +210,7 @@ function setAutoConf() {
 
     iniConfig " = " '"' "$file"
     iniSet "$key" "$value"
-    chown $user: "$file"
+    chown $user:$group "$file"
 }
 
 # arg 1: key

--- a/scriptmodules/inifuncs.sh
+++ b/scriptmodules/inifuncs.sh
@@ -198,7 +198,7 @@ function addAutoConf() {
     ini_value="${ini_value// /}"
     if [[ -z "$ini_value" ]]; then
         iniSet "$key" "$default"
-        chown $user:$user "$file"
+        chown $user: "$file"
     fi
 }
 
@@ -210,7 +210,7 @@ function setAutoConf() {
 
     iniConfig " = " '"' "$file"
     iniSet "$key" "$value"
-    chown $user:$user "$file"
+    chown $user: "$file"
 }
 
 # arg 1: key

--- a/scriptmodules/libretrocores/lr-bluemsx.sh
+++ b/scriptmodules/libretrocores/lr-bluemsx.sh
@@ -51,12 +51,12 @@ function configure_lr-bluemsx() {
     local core_config="$md_conf_root/coleco/retroarch-core-options.cfg"
     iniConfig " = " '"' "$core_config"
     iniSet "bluemsx_msxtype" "ColecoVision" "$core_config"
-    chown $user:$user "$core_config"
+    chown $user: "$core_config"
 
     mkRomDir "coleco"
     defaultRAConfig "coleco" "core_options_path" "$core_config"
 
     cp -rv "$md_inst/"{Databases,Machines} "$biosdir/"
-    chown -R $user:$user "$biosdir/"{Databases,Machines}
+    chown -R $user: "$biosdir/"{Databases,Machines}
 
 }

--- a/scriptmodules/libretrocores/lr-bluemsx.sh
+++ b/scriptmodules/libretrocores/lr-bluemsx.sh
@@ -51,7 +51,7 @@ function configure_lr-bluemsx() {
     local core_config="$md_conf_root/coleco/retroarch-core-options.cfg"
     iniConfig " = " '"' "$core_config"
     iniSet "bluemsx_msxtype" "ColecoVision" "$core_config"
-    chown $user: "$core_config"
+    chown $user:$group "$core_config"
 
     mkRomDir "coleco"
     defaultRAConfig "coleco" "core_options_path" "$core_config"

--- a/scriptmodules/libretrocores/lr-bluemsx.sh
+++ b/scriptmodules/libretrocores/lr-bluemsx.sh
@@ -57,6 +57,6 @@ function configure_lr-bluemsx() {
     defaultRAConfig "coleco" "core_options_path" "$core_config"
 
     cp -rv "$md_inst/"{Databases,Machines} "$biosdir/"
-    chown -R $user: "$biosdir/"{Databases,Machines}
+    chown -R $user:$group "$biosdir/"{Databases,Machines}
 
 }

--- a/scriptmodules/libretrocores/lr-dinothawr.sh
+++ b/scriptmodules/libretrocores/lr-dinothawr.sh
@@ -49,5 +49,5 @@ function configure_lr-dinothawr() {
 
     cp -Rv "$md_inst/dinothawr" "$romdir/ports"
 
-    chown $user: -R "$romdir/ports/dinothawr"
+    chown $user:$group -R "$romdir/ports/dinothawr"
 }

--- a/scriptmodules/libretrocores/lr-dinothawr.sh
+++ b/scriptmodules/libretrocores/lr-dinothawr.sh
@@ -49,5 +49,5 @@ function configure_lr-dinothawr() {
 
     cp -Rv "$md_inst/dinothawr" "$romdir/ports"
 
-    chown $user:$user -R "$romdir/ports/dinothawr"
+    chown $user: -R "$romdir/ports/dinothawr"
 }

--- a/scriptmodules/libretrocores/lr-fbneo.sh
+++ b/scriptmodules/libretrocores/lr-fbneo.sh
@@ -114,7 +114,7 @@ function configure_lr-fbneo() {
 
     # copy hiscore.dat
     cp "$md_inst/metadata/hiscore.dat" "$biosdir/fbneo/"
-    chown $user:$user "$biosdir/fbneo/hiscore.dat"
+    chown $user: "$biosdir/fbneo/hiscore.dat"
 
     # Set core options
     setRetroArchCoreOption "fbneo-diagnostic-input" "Hold Start"

--- a/scriptmodules/libretrocores/lr-fbneo.sh
+++ b/scriptmodules/libretrocores/lr-fbneo.sh
@@ -114,7 +114,7 @@ function configure_lr-fbneo() {
 
     # copy hiscore.dat
     cp "$md_inst/metadata/hiscore.dat" "$biosdir/fbneo/"
-    chown $user: "$biosdir/fbneo/hiscore.dat"
+    chown $user:$group "$biosdir/fbneo/hiscore.dat"
 
     # Set core options
     setRetroArchCoreOption "fbneo-diagnostic-input" "Hold Start"

--- a/scriptmodules/libretrocores/lr-fmsx.sh
+++ b/scriptmodules/libretrocores/lr-fmsx.sh
@@ -48,5 +48,5 @@ function configure_lr-fmsx() {
 
     # Copy CARTS.SHA to $biosdir
     cp "$md_inst/CARTS.SHA" "$biosdir/"
-    chown $user: "$biosdir/CARTS.SHA"
+    chown $user:$group "$biosdir/CARTS.SHA"
 }

--- a/scriptmodules/libretrocores/lr-fmsx.sh
+++ b/scriptmodules/libretrocores/lr-fmsx.sh
@@ -48,5 +48,5 @@ function configure_lr-fmsx() {
 
     # Copy CARTS.SHA to $biosdir
     cp "$md_inst/CARTS.SHA" "$biosdir/"
-    chown $user:$user "$biosdir/CARTS.SHA"
+    chown $user: "$biosdir/CARTS.SHA"
 }

--- a/scriptmodules/libretrocores/lr-gambatte.sh
+++ b/scriptmodules/libretrocores/lr-gambatte.sh
@@ -39,7 +39,7 @@ function configure_lr-gambatte() {
     # add default green yellow palette for gameboy classic
     mkUserDir "$biosdir/palettes"
     cp "$md_data/default.pal" "$biosdir/palettes/"
-    chown $user:$user "$biosdir/palettes/default.pal"
+    chown $user: "$biosdir/palettes/default.pal"
     setRetroArchCoreOption "gambatte_gb_colorization" "custom"
 
     mkRomDir "gbc"

--- a/scriptmodules/libretrocores/lr-gambatte.sh
+++ b/scriptmodules/libretrocores/lr-gambatte.sh
@@ -39,7 +39,7 @@ function configure_lr-gambatte() {
     # add default green yellow palette for gameboy classic
     mkUserDir "$biosdir/palettes"
     cp "$md_data/default.pal" "$biosdir/palettes/"
-    chown $user: "$biosdir/palettes/default.pal"
+    chown $user:$group "$biosdir/palettes/default.pal"
     setRetroArchCoreOption "gambatte_gb_colorization" "custom"
 
     mkRomDir "gbc"

--- a/scriptmodules/libretrocores/lr-mame2003.sh
+++ b/scriptmodules/libretrocores/lr-mame2003.sh
@@ -81,7 +81,7 @@ function configure_lr-mame2003() {
     if [[ "$md_id" == "lr-mame2003-plus" ]]; then
         mkUserDir "$biosdir/$dir_name/artwork"
         cp "$md_inst/metadata/artwork/"* "$biosdir/$dir_name/artwork/"
-        chown -R $user: "$biosdir/$dir_name/artwork"
+        chown -R $user:$group "$biosdir/$dir_name/artwork"
     fi
 
     # Set core options

--- a/scriptmodules/libretrocores/lr-mame2003.sh
+++ b/scriptmodules/libretrocores/lr-mame2003.sh
@@ -75,7 +75,7 @@ function configure_lr-mame2003() {
 
     # copy hiscore.dat and cheat.dat
     cp "$md_inst/metadata/"{hiscore.dat,cheat.dat} "$biosdir/$dir_name/"
-    chown $user: "$biosdir/$dir_name/"{hiscore.dat,cheat.dat}
+    chown $user:$group "$biosdir/$dir_name/"{hiscore.dat,cheat.dat}
 
     # lr-mame2003-plus also has an artwork folder
     if [[ "$md_id" == "lr-mame2003-plus" ]]; then

--- a/scriptmodules/libretrocores/lr-mame2003.sh
+++ b/scriptmodules/libretrocores/lr-mame2003.sh
@@ -75,13 +75,13 @@ function configure_lr-mame2003() {
 
     # copy hiscore.dat and cheat.dat
     cp "$md_inst/metadata/"{hiscore.dat,cheat.dat} "$biosdir/$dir_name/"
-    chown $user:$user "$biosdir/$dir_name/"{hiscore.dat,cheat.dat}
+    chown $user: "$biosdir/$dir_name/"{hiscore.dat,cheat.dat}
 
     # lr-mame2003-plus also has an artwork folder
     if [[ "$md_id" == "lr-mame2003-plus" ]]; then
         mkUserDir "$biosdir/$dir_name/artwork"
         cp "$md_inst/metadata/artwork/"* "$biosdir/$dir_name/artwork/"
-        chown -R $user:$user "$biosdir/$dir_name/artwork"
+        chown -R $user: "$biosdir/$dir_name/artwork"
     fi
 
     # Set core options

--- a/scriptmodules/libretrocores/lr-mess.sh
+++ b/scriptmodules/libretrocores/lr-mess.sh
@@ -63,5 +63,5 @@ function configure_lr-mess() {
 
     mkUserDir "$biosdir/mame"
     cp -rv "$md_inst/hash" "$biosdir/mame/"
-    chown -R $user: "$biosdir/mame"
+    chown -R $user:$group "$biosdir/mame"
 }

--- a/scriptmodules/libretrocores/lr-mess.sh
+++ b/scriptmodules/libretrocores/lr-mess.sh
@@ -63,5 +63,5 @@ function configure_lr-mess() {
 
     mkUserDir "$biosdir/mame"
     cp -rv "$md_inst/hash" "$biosdir/mame/"
-    chown -R $user:$user "$biosdir/mame"
+    chown -R $user: "$biosdir/mame"
 }

--- a/scriptmodules/libretrocores/lr-nxengine.sh
+++ b/scriptmodules/libretrocores/lr-nxengine.sh
@@ -47,7 +47,7 @@ else
     "$rootdir/supplementary/runcommand/runcommand.sh" 0 _PORT_ cavestory "$romdir/ports/CaveStory/Doukutsu.exe"
 fi
 _EOF_
-    chown $user:$user "$file"
+    chown $user: "$file"
     chmod +x "$file"
 
     defaultRAConfig "cavestory"

--- a/scriptmodules/libretrocores/lr-nxengine.sh
+++ b/scriptmodules/libretrocores/lr-nxengine.sh
@@ -47,7 +47,7 @@ else
     "$rootdir/supplementary/runcommand/runcommand.sh" 0 _PORT_ cavestory "$romdir/ports/CaveStory/Doukutsu.exe"
 fi
 _EOF_
-    chown $user: "$file"
+    chown $user:$group "$file"
     chmod +x "$file"
 
     defaultRAConfig "cavestory"

--- a/scriptmodules/libretrocores/lr-parallel-n64.sh
+++ b/scriptmodules/libretrocores/lr-parallel-n64.sh
@@ -169,7 +169,7 @@ rom name=Mega Man 64
 framebuffer enable=1
 target FPS=25
 _EOF_
-    chown $user: "$biosdir/gles2n64rom.conf"
+    chown $user:$group "$biosdir/gles2n64rom.conf"
 
     addEmulator 0 "$md_id" "n64" "$md_inst/parallel_n64_libretro.so"
     addSystem "n64"

--- a/scriptmodules/libretrocores/lr-parallel-n64.sh
+++ b/scriptmodules/libretrocores/lr-parallel-n64.sh
@@ -169,7 +169,7 @@ rom name=Mega Man 64
 framebuffer enable=1
 target FPS=25
 _EOF_
-    chown $user:$user "$biosdir/gles2n64rom.conf"
+    chown $user: "$biosdir/gles2n64rom.conf"
 
     addEmulator 0 "$md_id" "n64" "$md_inst/parallel_n64_libretro.so"
     addSystem "n64"

--- a/scriptmodules/libretrocores/lr-ppsspp.sh
+++ b/scriptmodules/libretrocores/lr-ppsspp.sh
@@ -43,7 +43,7 @@ function configure_lr-ppsspp() {
     if [[ "$md_mode" == "install" ]]; then
         mkUserDir "$biosdir/PPSSPP"
         cp -Rv "$md_inst/assets/"* "$biosdir/PPSSPP/"
-        chown -R $user:$user "$biosdir/PPSSPP"
+        chown -R $user: "$biosdir/PPSSPP"
 
         # the core needs a save file directory, use the same folder as standalone 'ppsspp'
         iniConfig " = " "" "$configdir/psp/retroarch.cfg"

--- a/scriptmodules/libretrocores/lr-ppsspp.sh
+++ b/scriptmodules/libretrocores/lr-ppsspp.sh
@@ -43,7 +43,7 @@ function configure_lr-ppsspp() {
     if [[ "$md_mode" == "install" ]]; then
         mkUserDir "$biosdir/PPSSPP"
         cp -Rv "$md_inst/assets/"* "$biosdir/PPSSPP/"
-        chown -R $user: "$biosdir/PPSSPP"
+        chown -R $user:$group "$biosdir/PPSSPP"
 
         # the core needs a save file directory, use the same folder as standalone 'ppsspp'
         iniConfig " = " "" "$configdir/psp/retroarch.cfg"

--- a/scriptmodules/libretrocores/lr-prboom.sh
+++ b/scriptmodules/libretrocores/lr-prboom.sh
@@ -46,7 +46,7 @@ function game_data_lr-prboom() {
     fi
 
     mkUserDir "$dest/addon"
-    chown -R $user:$user "$dest"
+    chown -R $user: "$dest"
 }
 
 function _add_games_lr-prboom() {
@@ -106,5 +106,5 @@ function configure_lr-prboom() {
     add_games_lr-prboom
 
     cp prboom.wad "$romdir/ports/doom/"
-    chown $user:$user "$romdir/ports/doom/prboom.wad"
+    chown $user: "$romdir/ports/doom/prboom.wad"
 }

--- a/scriptmodules/libretrocores/lr-prboom.sh
+++ b/scriptmodules/libretrocores/lr-prboom.sh
@@ -46,7 +46,7 @@ function game_data_lr-prboom() {
     fi
 
     mkUserDir "$dest/addon"
-    chown -R $user: "$dest"
+    chown -R $user:$group "$dest"
 }
 
 function _add_games_lr-prboom() {

--- a/scriptmodules/libretrocores/lr-prboom.sh
+++ b/scriptmodules/libretrocores/lr-prboom.sh
@@ -106,5 +106,5 @@ function configure_lr-prboom() {
     add_games_lr-prboom
 
     cp prboom.wad "$romdir/ports/doom/"
-    chown $user: "$romdir/ports/doom/prboom.wad"
+    chown $user:$group "$romdir/ports/doom/prboom.wad"
 }

--- a/scriptmodules/libretrocores/lr-scummvm.sh
+++ b/scriptmodules/libretrocores/lr-scummvm.sh
@@ -51,7 +51,7 @@ function configure_lr-scummvm() {
 
     # download and extract auxiliary data (theme, extra)
     downloadAndExtract "https://github.com/libretro/scummvm/raw/master/backends/platform/libretro/aux-data/scummvm.zip" "$biosdir"
-    chown -R $user: "$biosdir/scummvm"
+    chown -R $user:$group "$biosdir/scummvm"
 
     # basic initial configuration (if config file not found)
     if [[ ! -f "$biosdir/scummvm.ini" ]]; then

--- a/scriptmodules/libretrocores/lr-scummvm.sh
+++ b/scriptmodules/libretrocores/lr-scummvm.sh
@@ -64,7 +64,7 @@ function configure_lr-scummvm() {
         iniSet "subtitles" "true"
         iniSet "multi_midi" "true"
         iniSet "gm_device" "fluidsynth"
-        chown $user: "$biosdir/scummvm.ini"
+        chown $user:$group "$biosdir/scummvm.ini"
     fi
 
     # enable speed hack core option if running in arm platform

--- a/scriptmodules/libretrocores/lr-scummvm.sh
+++ b/scriptmodules/libretrocores/lr-scummvm.sh
@@ -51,7 +51,7 @@ function configure_lr-scummvm() {
 
     # download and extract auxiliary data (theme, extra)
     downloadAndExtract "https://github.com/libretro/scummvm/raw/master/backends/platform/libretro/aux-data/scummvm.zip" "$biosdir"
-    chown -R $user:$user "$biosdir/scummvm"
+    chown -R $user: "$biosdir/scummvm"
 
     # basic initial configuration (if config file not found)
     if [[ ! -f "$biosdir/scummvm.ini" ]]; then
@@ -64,7 +64,7 @@ function configure_lr-scummvm() {
         iniSet "subtitles" "true"
         iniSet "multi_midi" "true"
         iniSet "gm_device" "fluidsynth"
-        chown $user:$user "$biosdir/scummvm.ini"
+        chown $user: "$biosdir/scummvm.ini"
     fi
 
     # enable speed hack core option if running in arm platform

--- a/scriptmodules/libretrocores/lr-tyrquake.sh
+++ b/scriptmodules/libretrocores/lr-tyrquake.sh
@@ -47,7 +47,7 @@ function game_data_lr-tyrquake() {
         cp -rf id1 "$romdir/ports/quake/"
         popd
         rm -rf "$temp"
-        chown -R $user: "$romdir/ports/quake"
+        chown -R $user:$group "$romdir/ports/quake"
         chmod 644 "$romdir/ports/quake/id1/"*
     fi
 }

--- a/scriptmodules/libretrocores/lr-tyrquake.sh
+++ b/scriptmodules/libretrocores/lr-tyrquake.sh
@@ -47,7 +47,7 @@ function game_data_lr-tyrquake() {
         cp -rf id1 "$romdir/ports/quake/"
         popd
         rm -rf "$temp"
-        chown -R $user:$user "$romdir/ports/quake"
+        chown -R $user: "$romdir/ports/quake"
         chmod 644 "$romdir/ports/quake/id1/"*
     fi
 }

--- a/scriptmodules/libretrocores/lr-vecx.sh
+++ b/scriptmodules/libretrocores/lr-vecx.sh
@@ -53,7 +53,7 @@ function configure_lr-vecx() {
     if [[ "$md_mode" == "install" ]]; then
         # Copy bios files
         cp -v "$md_inst/"{fast.bin,skip.bin,system.bin} "$biosdir/"
-        chown $user:$user "$biosdir/"{fast.bin,skip.bin,system.bin}
+        chown $user: "$biosdir/"{fast.bin,skip.bin,system.bin}
     else
         rm -f "$biosdir/"{fast.bin,skip.bin,system.bin}
     fi

--- a/scriptmodules/libretrocores/lr-vecx.sh
+++ b/scriptmodules/libretrocores/lr-vecx.sh
@@ -53,7 +53,7 @@ function configure_lr-vecx() {
     if [[ "$md_mode" == "install" ]]; then
         # Copy bios files
         cp -v "$md_inst/"{fast.bin,skip.bin,system.bin} "$biosdir/"
-        chown $user: "$biosdir/"{fast.bin,skip.bin,system.bin}
+        chown $user:$group "$biosdir/"{fast.bin,skip.bin,system.bin}
     else
         rm -f "$biosdir/"{fast.bin,skip.bin,system.bin}
     fi

--- a/scriptmodules/libretrocores/lr-vice.sh
+++ b/scriptmodules/libretrocores/lr-vice.sh
@@ -74,5 +74,5 @@ function configure_lr-vice() {
     fi
 
     cp -R "$md_inst/data" "$biosdir"
-    chown -R $user:$user "$biosdir/data"
+    chown -R $user: "$biosdir/data"
 }

--- a/scriptmodules/libretrocores/lr-vice.sh
+++ b/scriptmodules/libretrocores/lr-vice.sh
@@ -74,5 +74,5 @@ function configure_lr-vice() {
     fi
 
     cp -R "$md_inst/data" "$biosdir"
-    chown -R $user: "$biosdir/data"
+    chown -R $user:$group "$biosdir/data"
 }

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -712,7 +712,7 @@ function rp_createBin() {
     if tar cvzf "$dest/$archive" -C "$rootdir/$md_type" "$md_id"; then
         if [[ -n "$__gpg_signing_key" ]]; then
             if signFile "$dest/$archive"; then
-                chown $user:$user "$dest/$archive" "$dest/$archive.asc"
+                chown $user: "$dest/$archive" "$dest/$archive.asc"
                 ret=0
             fi
         else

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -712,7 +712,7 @@ function rp_createBin() {
     if tar cvzf "$dest/$archive" -C "$rootdir/$md_type" "$md_id"; then
         if [[ -n "$__gpg_signing_key" ]]; then
             if signFile "$dest/$archive"; then
-                chown $user: "$dest/$archive" "$dest/$archive.asc"
+                chown $user:$group "$dest/$archive" "$dest/$archive.asc"
                 ret=0
             fi
         else

--- a/scriptmodules/ports/alephone.sh
+++ b/scriptmodules/ports/alephone.sh
@@ -79,7 +79,7 @@ function game_data_alephone() {
         downloadAndExtract "$release_url/MarathonInfinity-$version-Data.zip" "$romdir/ports/$md_id"
     fi
 
-    chown -R $user:$user "$romdir/ports/$md_id"
+    chown -R $user: "$romdir/ports/$md_id"
 }
 
 function configure_alephone() {
@@ -94,7 +94,7 @@ function configure_alephone() {
     if [[ -d "/alephone" ]]; then
         cp -R /alephone "$md_conf_root/"
         rm -rf /alephone
-        chown $user:$user "$md_conf_root/alephone"
+        chown $user: "$md_conf_root/alephone"
     fi
 
     [[ "$md_mode" == "install" ]] && game_data_alephone

--- a/scriptmodules/ports/alephone.sh
+++ b/scriptmodules/ports/alephone.sh
@@ -79,7 +79,7 @@ function game_data_alephone() {
         downloadAndExtract "$release_url/MarathonInfinity-$version-Data.zip" "$romdir/ports/$md_id"
     fi
 
-    chown -R $user: "$romdir/ports/$md_id"
+    chown -R $user:$group "$romdir/ports/$md_id"
 }
 
 function configure_alephone() {

--- a/scriptmodules/ports/alephone.sh
+++ b/scriptmodules/ports/alephone.sh
@@ -94,7 +94,7 @@ function configure_alephone() {
     if [[ -d "/alephone" ]]; then
         cp -R /alephone "$md_conf_root/"
         rm -rf /alephone
-        chown $user: "$md_conf_root/alephone"
+        chown $user:$group "$md_conf_root/alephone"
     fi
 
     [[ "$md_mode" == "install" ]] && game_data_alephone

--- a/scriptmodules/ports/bombermaaan.sh
+++ b/scriptmodules/ports/bombermaaan.sh
@@ -53,6 +53,6 @@ pushd "$md_inst"
 "$rootdir/supplementary/runcommand/runcommand.sh" 0 _PORT_ bombermaaan ""
 popd
 _EOF_
-    chown $user: "$file"
+    chown $user:$group "$file"
     chmod +x "$file"
 }

--- a/scriptmodules/ports/bombermaaan.sh
+++ b/scriptmodules/ports/bombermaaan.sh
@@ -53,6 +53,6 @@ pushd "$md_inst"
 "$rootdir/supplementary/runcommand/runcommand.sh" 0 _PORT_ bombermaaan ""
 popd
 _EOF_
-    chown $user:$user "$file"
+    chown $user: "$file"
     chmod +x "$file"
 }

--- a/scriptmodules/ports/cannonball.sh
+++ b/scriptmodules/ports/cannonball.sh
@@ -70,7 +70,7 @@ function configure_cannonball() {
 
     cp -v roms.txt "$romdir/ports/$md_id/"
 
-    chown -R $user:$user "$romdir/ports/$md_id" "$md_conf_root/$md_id"
+    chown -R $user: "$romdir/ports/$md_id" "$md_conf_root/$md_id"
 
     ln -snf "$romdir/ports/$md_id" "$md_inst/roms"
 }

--- a/scriptmodules/ports/cannonball.sh
+++ b/scriptmodules/ports/cannonball.sh
@@ -70,7 +70,7 @@ function configure_cannonball() {
 
     cp -v roms.txt "$romdir/ports/$md_id/"
 
-    chown -R $user: "$romdir/ports/$md_id" "$md_conf_root/$md_id"
+    chown -R $user:$group "$romdir/ports/$md_id" "$md_conf_root/$md_id"
 
     ln -snf "$romdir/ports/$md_id" "$md_inst/roms"
 }

--- a/scriptmodules/ports/dxx-rebirth.sh
+++ b/scriptmodules/ports/dxx-rebirth.sh
@@ -118,7 +118,7 @@ function game_data_dxx-rebirth() {
         download "$D2X_OGG_URL" "$dest_d2"
     fi
 
-    chown -R $user:$user "$dest_d1" "$dest_d2"
+    chown -R $user: "$dest_d1" "$dest_d2"
 }
 
 function configure_dxx-rebirth() {
@@ -139,7 +139,7 @@ function configure_dxx-rebirth() {
             config="$md_conf_root/descent${ver}/descent.cfg"
             iniConfig "=" '' "$config"
             iniSet "VSync" "1"
-            chown $user:$user "$config"
+            chown $user: "$config"
         fi
     done
 

--- a/scriptmodules/ports/dxx-rebirth.sh
+++ b/scriptmodules/ports/dxx-rebirth.sh
@@ -139,7 +139,7 @@ function configure_dxx-rebirth() {
             config="$md_conf_root/descent${ver}/descent.cfg"
             iniConfig "=" '' "$config"
             iniSet "VSync" "1"
-            chown $user: "$config"
+            chown $user:$group "$config"
         fi
     done
 

--- a/scriptmodules/ports/dxx-rebirth.sh
+++ b/scriptmodules/ports/dxx-rebirth.sh
@@ -118,7 +118,7 @@ function game_data_dxx-rebirth() {
         download "$D2X_OGG_URL" "$dest_d2"
     fi
 
-    chown -R $user: "$dest_d1" "$dest_d2"
+    chown -R $user:$group "$dest_d1" "$dest_d2"
 }
 
 function configure_dxx-rebirth() {

--- a/scriptmodules/ports/eduke32.sh
+++ b/scriptmodules/ports/eduke32.sh
@@ -84,7 +84,7 @@ function game_data_eduke32() {
             unzip -L -o "$temp/3dduke13.zip" -d "$temp" dn3dsw13.shr
             unzip -L -o "$temp/dn3dsw13.shr" -d "$dest" duke3d.grp duke.rts
             rm -rf "$temp"
-            chown -R $user: "$dest"
+            chown -R $user:$group "$dest"
         fi
     fi
 }
@@ -118,7 +118,7 @@ function configure_eduke32() {
         # the VC4 & V3D drivers render menu splash colours incorrectly without this
         isPlatform "mesa" && iniSet "r_useindexedcolortextures" "0"
 
-        chown -R $user: "$config"
+        chown -R $user:$group "$config"
     fi
 }
 

--- a/scriptmodules/ports/eduke32.sh
+++ b/scriptmodules/ports/eduke32.sh
@@ -84,7 +84,7 @@ function game_data_eduke32() {
             unzip -L -o "$temp/3dduke13.zip" -d "$temp" dn3dsw13.shr
             unzip -L -o "$temp/dn3dsw13.shr" -d "$dest" duke3d.grp duke.rts
             rm -rf "$temp"
-            chown -R $user:$user "$dest"
+            chown -R $user: "$dest"
         fi
     fi
 }
@@ -118,7 +118,7 @@ function configure_eduke32() {
         # the VC4 & V3D drivers render menu splash colours incorrectly without this
         isPlatform "mesa" && iniSet "r_useindexedcolortextures" "0"
 
-        chown -R $user:$user "$config"
+        chown -R $user: "$config"
     fi
 }
 

--- a/scriptmodules/ports/gemrb.sh
+++ b/scriptmodules/ports/gemrb.sh
@@ -144,9 +144,9 @@ CD1=$romdir/ports/planescape/data/
 CachePath=$romdir/ports/cache/
 _EOF_
 
-    chown $user: "$md_conf_root/baldursgate1/GemRB.cfg"
-    chown $user: "$md_conf_root/baldursgate2/GemRB.cfg"
-    chown $user: "$md_conf_root/icewind1/GemRB.cfg"
-    chown $user: "$md_conf_root/icewind2/GemRB.cfg"
-    chown $user: "$md_conf_root/planescape/GemRB.cfg"
+    chown $user:$group "$md_conf_root/baldursgate1/GemRB.cfg"
+    chown $user:$group "$md_conf_root/baldursgate2/GemRB.cfg"
+    chown $user:$group "$md_conf_root/icewind1/GemRB.cfg"
+    chown $user:$group "$md_conf_root/icewind2/GemRB.cfg"
+    chown $user:$group "$md_conf_root/planescape/GemRB.cfg"
 }

--- a/scriptmodules/ports/gemrb.sh
+++ b/scriptmodules/ports/gemrb.sh
@@ -144,9 +144,9 @@ CD1=$romdir/ports/planescape/data/
 CachePath=$romdir/ports/cache/
 _EOF_
 
-    chown $user:$user "$md_conf_root/baldursgate1/GemRB.cfg"
-    chown $user:$user "$md_conf_root/baldursgate2/GemRB.cfg"
-    chown $user:$user "$md_conf_root/icewind1/GemRB.cfg"
-    chown $user:$user "$md_conf_root/icewind2/GemRB.cfg"
-    chown $user:$user "$md_conf_root/planescape/GemRB.cfg"
+    chown $user: "$md_conf_root/baldursgate1/GemRB.cfg"
+    chown $user: "$md_conf_root/baldursgate2/GemRB.cfg"
+    chown $user: "$md_conf_root/icewind1/GemRB.cfg"
+    chown $user: "$md_conf_root/icewind2/GemRB.cfg"
+    chown $user: "$md_conf_root/planescape/GemRB.cfg"
 }

--- a/scriptmodules/ports/jumpnbump.sh
+++ b/scriptmodules/ports/jumpnbump.sh
@@ -48,7 +48,7 @@ function game_data_jumpnbump() {
         uncompressed="${uncompressed%.bz2}"
         if [[ ! -f "$romdir/ports/jumpnbump/$uncompressed" ]]; then
             bzcat "$compressed" > "$romdir/ports/jumpnbump/$uncompressed"
-            chown -R $user:$user "$romdir/ports/jumpnbump/$uncompressed"
+            chown -R $user: "$romdir/ports/jumpnbump/$uncompressed"
         fi
     done
     rm -rf "$tmpdir"

--- a/scriptmodules/ports/jumpnbump.sh
+++ b/scriptmodules/ports/jumpnbump.sh
@@ -48,7 +48,7 @@ function game_data_jumpnbump() {
         uncompressed="${uncompressed%.bz2}"
         if [[ ! -f "$romdir/ports/jumpnbump/$uncompressed" ]]; then
             bzcat "$compressed" > "$romdir/ports/jumpnbump/$uncompressed"
-            chown -R $user: "$romdir/ports/jumpnbump/$uncompressed"
+            chown -R $user:$group "$romdir/ports/jumpnbump/$uncompressed"
         fi
     done
     rm -rf "$tmpdir"

--- a/scriptmodules/ports/lincity-ng.sh
+++ b/scriptmodules/ports/lincity-ng.sh
@@ -42,6 +42,6 @@ function configure_lincity-ng() {
     if [[ -d "/lincity-ng" ]]; then
         cp -R /lincity-ng "$md_conf_root/"
         rm -rf /lincity-ng
-        chown $user:$user "$md_conf_root/lincity-ng"
+        chown $user: "$md_conf_root/lincity-ng"
     fi
 }

--- a/scriptmodules/ports/lincity-ng.sh
+++ b/scriptmodules/ports/lincity-ng.sh
@@ -42,6 +42,6 @@ function configure_lincity-ng() {
     if [[ -d "/lincity-ng" ]]; then
         cp -R /lincity-ng "$md_conf_root/"
         rm -rf /lincity-ng
-        chown $user: "$md_conf_root/lincity-ng"
+        chown $user:$group "$md_conf_root/lincity-ng"
     fi
 }

--- a/scriptmodules/ports/love.sh
+++ b/scriptmodules/ports/love.sh
@@ -55,7 +55,7 @@ function game_data_love() {
         zip -qr "$romdir/love/mari0.love" .
         popd
         rm -fr "$__tmpdir/mari0"
-        chown $user: "$romdir/love/mari0.love"
+        chown $user:$group "$romdir/love/mari0.love"
     fi
 }
 

--- a/scriptmodules/ports/love.sh
+++ b/scriptmodules/ports/love.sh
@@ -55,7 +55,7 @@ function game_data_love() {
         zip -qr "$romdir/love/mari0.love" .
         popd
         rm -fr "$__tmpdir/mari0"
-        chown $user:$user "$romdir/love/mari0.love"
+        chown $user: "$romdir/love/mari0.love"
     fi
 }
 

--- a/scriptmodules/ports/opentyrian.sh
+++ b/scriptmodules/ports/opentyrian.sh
@@ -43,7 +43,7 @@ function game_data_opentyrian() {
         cd "$__tmpdir"
         # get Tyrian 2.1 (freeware game data)
         downloadAndExtract "$__archive_url/tyrian21.zip" "$romdir/ports/opentyrian/data" -j
-        chown -R $user: "$romdir/ports/opentyrian"
+        chown -R $user:$group "$romdir/ports/opentyrian"
     fi
 }
 

--- a/scriptmodules/ports/opentyrian.sh
+++ b/scriptmodules/ports/opentyrian.sh
@@ -43,7 +43,7 @@ function game_data_opentyrian() {
         cd "$__tmpdir"
         # get Tyrian 2.1 (freeware game data)
         downloadAndExtract "$__archive_url/tyrian21.zip" "$romdir/ports/opentyrian/data" -j
-        chown -R $user:$user "$romdir/ports/opentyrian"
+        chown -R $user: "$romdir/ports/opentyrian"
     fi
 }
 

--- a/scriptmodules/ports/quake3.sh
+++ b/scriptmodules/ports/quake3.sh
@@ -41,7 +41,7 @@ function game_data_quake3() {
         downloadAndExtract "$__archive_url/Q3DemoPaks.zip" "$romdir/ports/quake3" -j
     fi
     # always chown as moveConfigDir in the configure_ script would move the root owned demo files
-    chown -R $user: "$romdir/ports/quake3"
+    chown -R $user:$group "$romdir/ports/quake3"
 }
 
 function configure_quake3() {

--- a/scriptmodules/ports/quake3.sh
+++ b/scriptmodules/ports/quake3.sh
@@ -41,7 +41,7 @@ function game_data_quake3() {
         downloadAndExtract "$__archive_url/Q3DemoPaks.zip" "$romdir/ports/quake3" -j
     fi
     # always chown as moveConfigDir in the configure_ script would move the root owned demo files
-    chown -R $user:$user "$romdir/ports/quake3"
+    chown -R $user: "$romdir/ports/quake3"
 }
 
 function configure_quake3() {

--- a/scriptmodules/ports/sdlpop.sh
+++ b/scriptmodules/ports/sdlpop.sh
@@ -52,5 +52,5 @@ function configure_sdlpop() {
     moveConfigFile "$md_inst/QUICKSAVE.SAV" "$md_conf_root/$md_id/QUICKSAVE.SAV"
     moveConfigFile "$md_inst/SDLPoP.cfg" "$md_conf_root/$md_id/SDLPoP.cfg"
 
-    chown -R $user: "$md_conf_root/$md_id"
+    chown -R $user:$group "$md_conf_root/$md_id"
 }

--- a/scriptmodules/ports/sdlpop.sh
+++ b/scriptmodules/ports/sdlpop.sh
@@ -52,5 +52,5 @@ function configure_sdlpop() {
     moveConfigFile "$md_inst/QUICKSAVE.SAV" "$md_conf_root/$md_id/QUICKSAVE.SAV"
     moveConfigFile "$md_inst/SDLPoP.cfg" "$md_conf_root/$md_id/SDLPoP.cfg"
 
-    chown -R $user:$user "$md_conf_root/$md_id"
+    chown -R $user: "$md_conf_root/$md_id"
 }

--- a/scriptmodules/ports/solarus.sh
+++ b/scriptmodules/ports/solarus.sh
@@ -132,7 +132,7 @@ function gui_solarus() {
                     else
                         iniDel "JOYPAD_DEADZONE"
                     fi
-                    chown $user: "$(_options_cfg_file_solarus)"
+                    chown $user:$group "$(_options_cfg_file_solarus)"
                 fi
                 ;;
             Q)
@@ -144,7 +144,7 @@ function gui_solarus() {
                     else
                         iniDel "QUIT_COMBO"
                     fi
-                    chown $user: "$(_options_cfg_file_solarus)"
+                    chown $user:$group "$(_options_cfg_file_solarus)"
                 fi
                 ;;
             *)

--- a/scriptmodules/ports/solarus.sh
+++ b/scriptmodules/ports/solarus.sh
@@ -132,7 +132,7 @@ function gui_solarus() {
                     else
                         iniDel "JOYPAD_DEADZONE"
                     fi
-                    chown $user:$user "$(_options_cfg_file_solarus)"
+                    chown $user: "$(_options_cfg_file_solarus)"
                 fi
                 ;;
             Q)
@@ -144,7 +144,7 @@ function gui_solarus() {
                     else
                         iniDel "QUIT_COMBO"
                     fi
-                    chown $user:$user "$(_options_cfg_file_solarus)"
+                    chown $user: "$(_options_cfg_file_solarus)"
                 fi
                 ;;
             *)

--- a/scriptmodules/ports/steamlink.sh
+++ b/scriptmodules/ports/steamlink.sh
@@ -41,7 +41,7 @@ function configure_steamlink() {
 
         # create optional streaming_args.txt for user modification
         touch "$valve_dir/SteamLink/streaming_args.txt"
-        chown $user: "$valve_dir/SteamLink/streaming_args.txt"
+        chown $user:$group "$valve_dir/SteamLink/streaming_args.txt"
         moveConfigFile "$valve_dir/SteamLink/streaming_args.txt" "$md_conf_root/$md_id/streaming_args.txt"
 
         cat > "$sl_script" << _EOF_

--- a/scriptmodules/ports/steamlink.sh
+++ b/scriptmodules/ports/steamlink.sh
@@ -41,7 +41,7 @@ function configure_steamlink() {
 
         # create optional streaming_args.txt for user modification
         touch "$valve_dir/SteamLink/streaming_args.txt"
-        chown $user:$user "$valve_dir/SteamLink/streaming_args.txt"
+        chown $user: "$valve_dir/SteamLink/streaming_args.txt"
         moveConfigFile "$valve_dir/SteamLink/streaming_args.txt" "$md_conf_root/$md_id/streaming_args.txt"
 
         cat > "$sl_script" << _EOF_

--- a/scriptmodules/ports/wolf4sdl.sh
+++ b/scriptmodules/ports/wolf4sdl.sh
@@ -93,7 +93,7 @@ function game_data_wolf4sdl() {
         downloadAndExtract "http://maniacsvault.net/ecwolf/files/shareware/soddemo.zip" "$romdir/ports/wolf3d" -j -LL
     fi
 
-    chown -R $user: "$romdir/ports/wolf3d"
+    chown -R $user:$group "$romdir/ports/wolf3d"
 }
 
 function configure_wolf4sdl() {

--- a/scriptmodules/ports/wolf4sdl.sh
+++ b/scriptmodules/ports/wolf4sdl.sh
@@ -93,7 +93,7 @@ function game_data_wolf4sdl() {
         downloadAndExtract "http://maniacsvault.net/ecwolf/files/shareware/soddemo.zip" "$romdir/ports/wolf3d" -j -LL
     fi
 
-    chown -R $user:$user "$romdir/ports/wolf3d"
+    chown -R $user: "$romdir/ports/wolf3d"
 }
 
 function configure_wolf4sdl() {

--- a/scriptmodules/ports/yquake2.sh
+++ b/scriptmodules/ports/yquake2.sh
@@ -87,7 +87,7 @@ function game_data_yquake2() {
         done
     fi
 
-    chown -R $user:$user "$romdir/ports/quake2"
+    chown -R $user: "$romdir/ports/quake2"
 }
 
 

--- a/scriptmodules/ports/yquake2.sh
+++ b/scriptmodules/ports/yquake2.sh
@@ -87,7 +87,7 @@ function game_data_yquake2() {
         done
     fi
 
-    chown -R $user: "$romdir/ports/quake2"
+    chown -R $user:$group "$romdir/ports/quake2"
 }
 
 

--- a/scriptmodules/supplementary/attractmode.sh
+++ b/scriptmodules/supplementary/attractmode.sh
@@ -57,7 +57,7 @@ function _add_system_attractmode() {
     iniSet "artwork snap" "$path/$snap"
     iniSet "artwork wheel" "$path/wheel"
 
-    chown $user: "$config"
+    chown $user:$group "$config"
 
     # if no gameslist, generate one
     if [[ ! -f "$attract_dir/romlists/$fullname.txt" ]]; then
@@ -73,7 +73,7 @@ display${tab}$fullname
 ${tab}layout               Basic
 ${tab}romlist              $fullname
 _EOF_
-        chown $user: "$config"
+        chown $user:$group "$config"
     fi
 }
 
@@ -123,7 +123,7 @@ function _add_rom_attractmode() {
     fi
 
     echo "$path;$name;$system_fullname;;;;;;;;;;;;;;" >>"$config"
-    chown $user: "$config"
+    chown $user:$group "$config"
 }
 
 function depends_attractmode() {

--- a/scriptmodules/supplementary/attractmode.sh
+++ b/scriptmodules/supplementary/attractmode.sh
@@ -57,7 +57,7 @@ function _add_system_attractmode() {
     iniSet "artwork snap" "$path/$snap"
     iniSet "artwork wheel" "$path/wheel"
 
-    chown $user:$user "$config"
+    chown $user: "$config"
 
     # if no gameslist, generate one
     if [[ ! -f "$attract_dir/romlists/$fullname.txt" ]]; then
@@ -73,7 +73,7 @@ display${tab}$fullname
 ${tab}layout               Basic
 ${tab}romlist              $fullname
 _EOF_
-        chown $user:$user "$config"
+        chown $user: "$config"
     fi
 }
 
@@ -123,7 +123,7 @@ function _add_rom_attractmode() {
     fi
 
     echo "$path;$name;$system_fullname;;;;;;;;;;;;;;" >>"$config"
-    chown $user:$user "$config"
+    chown $user: "$config"
 }
 
 function depends_attractmode() {

--- a/scriptmodules/supplementary/audiosettings.sh
+++ b/scriptmodules/supplementary/audiosettings.sh
@@ -176,7 +176,7 @@ ctl.!default {
 EOF
 
     mv "$tmpfile" "$home/.asoundrc"
-    chown "$user:$user" "$home/.asoundrc"
+    chown "$user:" "$home/.asoundrc"
 }
 
 function _pulseaudio_audiosettings() {

--- a/scriptmodules/supplementary/audiosettings.sh
+++ b/scriptmodules/supplementary/audiosettings.sh
@@ -176,7 +176,7 @@ ctl.!default {
 EOF
 
     mv "$tmpfile" "$home/.asoundrc"
-    chown "$user:" "$home/.asoundrc"
+    chown $user:$group "$home/.asoundrc"
 }
 
 function _pulseaudio_audiosettings() {

--- a/scriptmodules/supplementary/autostart.sh
+++ b/scriptmodules/supplementary/autostart.sh
@@ -46,7 +46,7 @@ _EOF_
             echo "emulationstation #auto" >>"$script"
             ;;
     esac
-    chown $user:$user "$script"
+    chown $user: "$script"
 }
 
 function enable_autostart() {

--- a/scriptmodules/supplementary/autostart.sh
+++ b/scriptmodules/supplementary/autostart.sh
@@ -46,7 +46,7 @@ _EOF_
             echo "emulationstation #auto" >>"$script"
             ;;
     esac
-    chown $user: "$script"
+    chown $user:$group "$script"
 }
 
 function enable_autostart() {

--- a/scriptmodules/supplementary/bluetooth.sh
+++ b/scriptmodules/supplementary/bluetooth.sh
@@ -416,7 +416,7 @@ _EOF_
     esac
     iniConfig "=" '"' "$configdir/all/bluetooth.cfg"
     iniSet "connect_mode" "$mode"
-    chown $user:$user "$configdir/all/bluetooth.cfg"
+    chown $user: "$configdir/all/bluetooth.cfg"
 }
 
 function gui_bluetooth() {

--- a/scriptmodules/supplementary/bluetooth.sh
+++ b/scriptmodules/supplementary/bluetooth.sh
@@ -416,7 +416,7 @@ _EOF_
     esac
     iniConfig "=" '"' "$configdir/all/bluetooth.cfg"
     iniSet "connect_mode" "$mode"
-    chown $user: "$configdir/all/bluetooth.cfg"
+    chown $user:$group "$configdir/all/bluetooth.cfg"
 }
 
 function gui_bluetooth() {

--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -125,7 +125,7 @@ function _add_rom_emulationstation() {
             -u "/gameList/game[name='$name']/image" -v "$image" \
             "$config"
     fi
-    chown $user:$user "$config"
+    chown $user: "$config"
 }
 
 function depends_emulationstation() {
@@ -219,7 +219,7 @@ function init_input_emulationstation() {
             "$es_config"
     fi
 
-    chown $user:$user "$es_config"
+    chown $user: "$es_config"
 }
 
 function copy_inputscripts_emulationstation() {

--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -125,7 +125,7 @@ function _add_rom_emulationstation() {
             -u "/gameList/game[name='$name']/image" -v "$image" \
             "$config"
     fi
-    chown $user: "$config"
+    chown $user:$group "$config"
 }
 
 function depends_emulationstation() {
@@ -219,7 +219,7 @@ function init_input_emulationstation() {
             "$es_config"
     fi
 
-    chown $user: "$es_config"
+    chown $user:$group "$es_config"
 }
 
 function copy_inputscripts_emulationstation() {

--- a/scriptmodules/supplementary/launchingimages.sh
+++ b/scriptmodules/supplementary/launchingimages.sh
@@ -366,7 +366,7 @@ function _generate_launchingimages() {
     fi
 
     for file in $(_get_all_launchingimages); do
-        chown $user: "$file"
+        chown $user:$group "$file"
     done
 }
 

--- a/scriptmodules/supplementary/launchingimages.sh
+++ b/scriptmodules/supplementary/launchingimages.sh
@@ -366,7 +366,7 @@ function _generate_launchingimages() {
     fi
 
     for file in $(_get_all_launchingimages); do
-        chown $user:$user "$file"
+        chown $user: "$file"
     done
 }
 

--- a/scriptmodules/supplementary/mobilegamepad.sh
+++ b/scriptmodules/supplementary/mobilegamepad.sh
@@ -28,7 +28,7 @@ function remove_mobilegamepad() {
 
 function sources_mobilegamepad() {
     gitPullOrClone "$md_inst"
-    chown -R $user:$user "$md_inst"
+    chown -R $user: "$md_inst"
 }
 
 function install_mobilegamepad() {

--- a/scriptmodules/supplementary/mobilegamepad.sh
+++ b/scriptmodules/supplementary/mobilegamepad.sh
@@ -28,7 +28,7 @@ function remove_mobilegamepad() {
 
 function sources_mobilegamepad() {
     gitPullOrClone "$md_inst"
-    chown -R $user: "$md_inst"
+    chown -R $user:$group "$md_inst"
 }
 
 function install_mobilegamepad() {

--- a/scriptmodules/supplementary/moonlight.sh
+++ b/scriptmodules/supplementary/moonlight.sh
@@ -118,7 +118,7 @@ function configure_moonlight() {
 # global config file for moonlight
 quitappafter = true
 _EOF_
-        chown $user:$user "$(_global_cfg_file_moonlight)"
+        chown $user: "$(_global_cfg_file_moonlight)"
     fi
 
     # create wrapper for moonlight with appropriate directories set
@@ -166,7 +166,7 @@ function set_scriptmodule_cfg_moonlight() {
     iniSet "wipe" "$wipe"
     iniSet "mangle" "$mangle"
 
-    chown $user:$user "$(_scriptmodule_cfg_file_moonlight)"
+    chown $user: "$(_scriptmodule_cfg_file_moonlight)"
 }
 
 function get_resolution_moonlight() {
@@ -211,7 +211,7 @@ function set_host_moonlight() {
     iniSet "sops" "$sops"
     iniSet "unsupported" "$unsupported"
 
-    chown $user:$user "$(_global_cfg_file_moonlight)"
+    chown $user: "$(_global_cfg_file_moonlight)"
 }
 
 
@@ -233,7 +233,7 @@ function set_resolution_moonlight() {
         iniDel "fps"
     fi
 
-    chown $user:$user "$(_global_cfg_file_moonlight)"
+    chown $user: "$(_global_cfg_file_moonlight)"
 }
 
 function get_bitrate_moonlight() {
@@ -261,7 +261,7 @@ function set_bitrate_moonlight() {
         iniDel "bitrate"
     fi
 
-    chown $user:$user "$(_global_cfg_file_moonlight)"
+    chown $user: "$(_global_cfg_file_moonlight)"
 }
 
 function exec_moonlight() {
@@ -317,7 +317,7 @@ function gen_configs_moonlight() {
         iniSet "config" "$(_global_cfg_file_moonlight)"
         [[ -n "${config[0]}" ]] && iniSet "address" "${config[0]}"
         iniSet "app" "$app"
-        chown $user:$user "$romdir/steam/$fname.ml" 2>/dev/null
+        chown $user: "$romdir/steam/$fname.ml" 2>/dev/null
     done
 }
 

--- a/scriptmodules/supplementary/moonlight.sh
+++ b/scriptmodules/supplementary/moonlight.sh
@@ -118,7 +118,7 @@ function configure_moonlight() {
 # global config file for moonlight
 quitappafter = true
 _EOF_
-        chown $user: "$(_global_cfg_file_moonlight)"
+        chown $user:$group "$(_global_cfg_file_moonlight)"
     fi
 
     # create wrapper for moonlight with appropriate directories set
@@ -166,7 +166,7 @@ function set_scriptmodule_cfg_moonlight() {
     iniSet "wipe" "$wipe"
     iniSet "mangle" "$mangle"
 
-    chown $user: "$(_scriptmodule_cfg_file_moonlight)"
+    chown $user:$group "$(_scriptmodule_cfg_file_moonlight)"
 }
 
 function get_resolution_moonlight() {
@@ -211,7 +211,7 @@ function set_host_moonlight() {
     iniSet "sops" "$sops"
     iniSet "unsupported" "$unsupported"
 
-    chown $user: "$(_global_cfg_file_moonlight)"
+    chown $user:$group "$(_global_cfg_file_moonlight)"
 }
 
 
@@ -233,7 +233,7 @@ function set_resolution_moonlight() {
         iniDel "fps"
     fi
 
-    chown $user: "$(_global_cfg_file_moonlight)"
+    chown $user:$group "$(_global_cfg_file_moonlight)"
 }
 
 function get_bitrate_moonlight() {
@@ -261,7 +261,7 @@ function set_bitrate_moonlight() {
         iniDel "bitrate"
     fi
 
-    chown $user: "$(_global_cfg_file_moonlight)"
+    chown $user:$group "$(_global_cfg_file_moonlight)"
 }
 
 function exec_moonlight() {
@@ -317,7 +317,7 @@ function gen_configs_moonlight() {
         iniSet "config" "$(_global_cfg_file_moonlight)"
         [[ -n "${config[0]}" ]] && iniSet "address" "${config[0]}"
         iniSet "app" "$app"
-        chown $user: "$romdir/steam/$fname.ml" 2>/dev/null
+        chown $user:$group "$romdir/steam/$fname.ml" 2>/dev/null
     done
 }
 

--- a/scriptmodules/supplementary/resetromdirs.sh
+++ b/scriptmodules/supplementary/resetromdirs.sh
@@ -17,8 +17,8 @@ function gui_resetromdirs() {
     printHeading "Resetting $romdir ownershop/permissions"
     mkUserDir "$romdir"
     mkUserDir "$biosdir"
-    chown -R $user:$user "$romdir"
-    chown -R $user:$user "$biosdir"
+    chown -R $user: "$romdir"
+    chown -R $user: "$biosdir"
     chmod -R ug+rwX "$romdir"
     chmod -R ug+rwX "$biosdir"
 }

--- a/scriptmodules/supplementary/resetromdirs.sh
+++ b/scriptmodules/supplementary/resetromdirs.sh
@@ -17,8 +17,8 @@ function gui_resetromdirs() {
     printHeading "Resetting $romdir ownershop/permissions"
     mkUserDir "$romdir"
     mkUserDir "$biosdir"
-    chown -R $user: "$romdir"
-    chown -R $user: "$biosdir"
+    chown -R $user:$group "$romdir"
+    chown -R $user:$group "$biosdir"
     chmod -R ug+rwX "$romdir"
     chmod -R ug+rwX "$biosdir"
 }

--- a/scriptmodules/supplementary/retronetplay.sh
+++ b/scriptmodules/supplementary/retronetplay.sh
@@ -22,7 +22,7 @@ __netplayhostip="$__netplayhostip"
 __netplayhostip_cfile="$__netplayhostip_cfile"
 __netplaynickname="'$__netplaynickname'"
 _EOF_
-    chown $user:$user "$conf"
+    chown $user: "$conf"
     printMsgs "dialog" "Configuration has been saved to $conf"
 }
 

--- a/scriptmodules/supplementary/retronetplay.sh
+++ b/scriptmodules/supplementary/retronetplay.sh
@@ -22,7 +22,7 @@ __netplayhostip="$__netplayhostip"
 __netplayhostip_cfile="$__netplayhostip_cfile"
 __netplaynickname="'$__netplaynickname'"
 _EOF_
-    chown $user: "$conf"
+    chown $user:$group "$conf"
     printMsgs "dialog" "Configuration has been saved to $conf"
 }
 

--- a/scriptmodules/supplementary/retropie-manager.sh
+++ b/scriptmodules/supplementary/retropie-manager.sh
@@ -28,7 +28,7 @@ function sources_retropie-manager() {
 
 function install_retropie-manager() {
     cd "$md_inst"
-    chown -R $user:$user "$md_inst"
+    chown -R $user: "$md_inst"
     sudo -u $user make install
 }
 

--- a/scriptmodules/supplementary/retropie-manager.sh
+++ b/scriptmodules/supplementary/retropie-manager.sh
@@ -28,7 +28,7 @@ function sources_retropie-manager() {
 
 function install_retropie-manager() {
     cd "$md_inst"
-    chown -R $user: "$md_inst"
+    chown -R $user:$group "$md_inst"
     sudo -u $user make install
 }
 

--- a/scriptmodules/supplementary/retropiemenu.sh
+++ b/scriptmodules/supplementary/retropiemenu.sh
@@ -38,7 +38,7 @@ function configure_retropiemenu()
     local rpdir="$home/RetroPie/retropiemenu"
     mkdir -p "$rpdir"
     cp -Rv "$md_data/icons" "$rpdir/"
-    chown -R $user: "$rpdir"
+    chown -R $user:$group "$rpdir"
 
     isPlatform "rpi" && rm -f "$rpdir/dispmanx.rp"
 

--- a/scriptmodules/supplementary/retropiemenu.sh
+++ b/scriptmodules/supplementary/retropiemenu.sh
@@ -38,7 +38,7 @@ function configure_retropiemenu()
     local rpdir="$home/RetroPie/retropiemenu"
     mkdir -p "$rpdir"
     cp -Rv "$md_data/icons" "$rpdir/"
-    chown -R $user:$user "$rpdir"
+    chown -R $user: "$rpdir"
 
     isPlatform "rpi" && rm -f "$rpdir/dispmanx.rp"
 
@@ -137,7 +137,7 @@ function launch_retropiemenu() {
         retroarch.rp)
             joy2keyStop
             cp "$configdir/all/retroarch.cfg" "$configdir/all/retroarch.cfg.bak"
-            chown $user:$user "$configdir/all/retroarch.cfg.bak"
+            chown $user: "$configdir/all/retroarch.cfg.bak"
             su $user -c "XDG_RUNTIME_DIR=/run/user/$SUDO_UID \"$emudir/retroarch/bin/retroarch\" --menu --config \"$configdir/all/retroarch.cfg\""
             iniConfig " = " '"' "$configdir/all/retroarch.cfg"
             iniSet "config_save_on_exit" "false"

--- a/scriptmodules/supplementary/retropiemenu.sh
+++ b/scriptmodules/supplementary/retropiemenu.sh
@@ -137,7 +137,7 @@ function launch_retropiemenu() {
         retroarch.rp)
             joy2keyStop
             cp "$configdir/all/retroarch.cfg" "$configdir/all/retroarch.cfg.bak"
-            chown $user: "$configdir/all/retroarch.cfg.bak"
+            chown $user:$group "$configdir/all/retroarch.cfg.bak"
             su $user -c "XDG_RUNTIME_DIR=/run/user/$SUDO_UID \"$emudir/retroarch/bin/retroarch\" --menu --config \"$configdir/all/retroarch.cfg\""
             iniConfig " = " '"' "$configdir/all/retroarch.cfg"
             iniSet "config_save_on_exit" "false"

--- a/scriptmodules/supplementary/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand.sh
@@ -43,11 +43,11 @@ function install_bin_runcommand() {
         iniSet "governor" ""
         iniSet "disable_menu" "0"
         iniSet "image_delay" "2"
-        chown $user:$user "$configdir/all/runcommand.cfg"
+        chown $user: "$configdir/all/runcommand.cfg"
     fi
     if [[ ! -f "$configdir/all/runcommand-launch-dialog.cfg" ]]; then
         dialog --create-rc "$configdir/all/runcommand-launch-dialog.cfg"
-        chown $user:$user "$configdir/all/runcommand-launch-dialog.cfg"
+        chown $user: "$configdir/all/runcommand-launch-dialog.cfg"
     fi
 
     # needed for KMS modesetting (debian buster or later only)
@@ -90,14 +90,14 @@ function governor_runcommand() {
     if [[ -n "$choice" ]]; then
         governor="${governors[$choice]}"
         iniSet "governor" "$governor"
-        chown $user:$user "$config"
+        chown $user: "$config"
     fi
 }
 
 function gui_runcommand() {
     local config="$configdir/all/runcommand.cfg"
     iniConfig " = " '"' "$config"
-    chown $user:$user "$config"
+    chown $user: "$config"
 
     local cmd
     local option

--- a/scriptmodules/supplementary/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand.sh
@@ -43,11 +43,11 @@ function install_bin_runcommand() {
         iniSet "governor" ""
         iniSet "disable_menu" "0"
         iniSet "image_delay" "2"
-        chown $user: "$configdir/all/runcommand.cfg"
+        chown $user:$group "$configdir/all/runcommand.cfg"
     fi
     if [[ ! -f "$configdir/all/runcommand-launch-dialog.cfg" ]]; then
         dialog --create-rc "$configdir/all/runcommand-launch-dialog.cfg"
-        chown $user: "$configdir/all/runcommand-launch-dialog.cfg"
+        chown $user:$group "$configdir/all/runcommand-launch-dialog.cfg"
     fi
 
     # needed for KMS modesetting (debian buster or later only)
@@ -90,14 +90,14 @@ function governor_runcommand() {
     if [[ -n "$choice" ]]; then
         governor="${governors[$choice]}"
         iniSet "governor" "$governor"
-        chown $user: "$config"
+        chown $user:$group "$config"
     fi
 }
 
 function gui_runcommand() {
     local config="$configdir/all/runcommand.cfg"
     iniConfig " = " '"' "$config"
-    chown $user: "$config"
+    chown $user:$group "$config"
 
     local cmd
     local option

--- a/scriptmodules/supplementary/scraper.sh
+++ b/scriptmodules/supplementary/scraper.sh
@@ -205,7 +205,7 @@ function gui_scraper() {
 
     iniConfig " = " '"' "$configdir/all/scraper.cfg"
     eval $(_load_config_scraper)
-    chown $user: "$configdir/all/scraper.cfg"
+    chown $user:$group "$configdir/all/scraper.cfg"
 
     local default
     while true; do

--- a/scriptmodules/supplementary/scraper.sh
+++ b/scriptmodules/supplementary/scraper.sh
@@ -205,7 +205,7 @@ function gui_scraper() {
 
     iniConfig " = " '"' "$configdir/all/scraper.cfg"
     eval $(_load_config_scraper)
-    chown $user:$user "$configdir/all/scraper.cfg"
+    chown $user: "$configdir/all/scraper.cfg"
 
     local default
     while true; do

--- a/scriptmodules/supplementary/skyscraper.sh
+++ b/scriptmodules/supplementary/skyscraper.sh
@@ -193,7 +193,7 @@ function configure_skyscraper() {
     done
 
     _init_config_skyscraper
-    chown -R $user: "$configdir/all/skyscraper"
+    chown -R $user:$group "$configdir/all/skyscraper"
 }
 
 function _init_config_skyscraper() {

--- a/scriptmodules/supplementary/skyscraper.sh
+++ b/scriptmodules/supplementary/skyscraper.sh
@@ -193,7 +193,7 @@ function configure_skyscraper() {
     done
 
     _init_config_skyscraper
-    chown -R $user:$user "$configdir/all/skyscraper"
+    chown -R $user: "$configdir/all/skyscraper"
 }
 
 function _init_config_skyscraper() {

--- a/scriptmodules/supplementary/skyscraper.sh
+++ b/scriptmodules/supplementary/skyscraper.sh
@@ -470,7 +470,7 @@ function gui_skyscraper() {
 
     iniConfig " = " '"' "$configdir/all/skyscraper.cfg"
     eval $(_load_config_skyscraper)
-    chown "$user":"$user" "$configdir/all/skyscraper.cfg"
+    chown $user:$group "$configdir/all/skyscraper.cfg"
 
     local -a s_source
     local -a s_source_names

--- a/scriptmodules/supplementary/splashscreen.sh
+++ b/scriptmodules/supplementary/splashscreen.sh
@@ -266,7 +266,7 @@ function preview_splashscreen() {
 
 function download_extra_splashscreen() {
     gitPullOrClone "$datadir/splashscreens/retropie-extra" https://github.com/HerbFargus/retropie-splashscreens-extra
-    chown -R $user: "$datadir/splashscreens/retropie-extra"
+    chown -R $user:$group "$datadir/splashscreens/retropie-extra"
 }
 
 function gui_splashscreen() {

--- a/scriptmodules/supplementary/splashscreen.sh
+++ b/scriptmodules/supplementary/splashscreen.sh
@@ -71,11 +71,11 @@ _EOF_
         iniConfig "=" '"' "$configdir/all/$md_id.cfg"
         iniSet "RANDOMIZE" "disabled"
     fi
-    chown $user:$user "$configdir/all/$md_id.cfg"
+    chown $user: "$configdir/all/$md_id.cfg"
 
     mkUserDir "$datadir/splashscreens"
     echo "Place your own splashscreens in here." >"$datadir/splashscreens/README.txt"
-    chown $user:$user "$datadir/splashscreens/README.txt"
+    chown $user: "$datadir/splashscreens/README.txt"
 }
 
 function enable_plymouth_splashscreen() {
@@ -194,7 +194,7 @@ function randomize_splashscreen() {
     local cmd=(dialog --backtitle "$__backtitle" --menu "Choose an option." 22 86 16)
     local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
     iniConfig "=" '"' "$configdir/all/$md_id.cfg"
-    chown $user:$user "$configdir/all/$md_id.cfg"
+    chown $user: "$configdir/all/$md_id.cfg"
 
     case "$choice" in
         0)
@@ -266,7 +266,7 @@ function preview_splashscreen() {
 
 function download_extra_splashscreen() {
     gitPullOrClone "$datadir/splashscreens/retropie-extra" https://github.com/HerbFargus/retropie-splashscreens-extra
-    chown -R $user:$user "$datadir/splashscreens/retropie-extra"
+    chown -R $user: "$datadir/splashscreens/retropie-extra"
 }
 
 function gui_splashscreen() {

--- a/scriptmodules/supplementary/splashscreen.sh
+++ b/scriptmodules/supplementary/splashscreen.sh
@@ -71,11 +71,11 @@ _EOF_
         iniConfig "=" '"' "$configdir/all/$md_id.cfg"
         iniSet "RANDOMIZE" "disabled"
     fi
-    chown $user: "$configdir/all/$md_id.cfg"
+    chown $user:$group "$configdir/all/$md_id.cfg"
 
     mkUserDir "$datadir/splashscreens"
     echo "Place your own splashscreens in here." >"$datadir/splashscreens/README.txt"
-    chown $user: "$datadir/splashscreens/README.txt"
+    chown $user:$group "$datadir/splashscreens/README.txt"
 }
 
 function enable_plymouth_splashscreen() {
@@ -194,7 +194,7 @@ function randomize_splashscreen() {
     local cmd=(dialog --backtitle "$__backtitle" --menu "Choose an option." 22 86 16)
     local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
     iniConfig "=" '"' "$configdir/all/$md_id.cfg"
-    chown $user: "$configdir/all/$md_id.cfg"
+    chown $user:$group "$configdir/all/$md_id.cfg"
 
     case "$choice" in
         0)

--- a/scriptmodules/supplementary/steamcontroller.sh
+++ b/scriptmodules/supplementary/steamcontroller.sh
@@ -27,7 +27,7 @@ function sources_steamcontroller() {
 
 function install_steamcontroller() {
     cd "$md_inst"
-    chown -R "$user:$user"  "$md_inst"
+    chown -R "$user:"  "$md_inst"
     sudo -u $user bash -c "\
         virtualenv -p python3 --no-site-packages \"$md_inst\"; \
         source bin/activate; \

--- a/scriptmodules/supplementary/steamcontroller.sh
+++ b/scriptmodules/supplementary/steamcontroller.sh
@@ -27,7 +27,7 @@ function sources_steamcontroller() {
 
 function install_steamcontroller() {
     cd "$md_inst"
-    chown -R "$user:"  "$md_inst"
+    chown -R "$user:$group"  "$md_inst"
     sudo -u $user bash -c "\
         virtualenv -p python3 --no-site-packages \"$md_inst\"; \
         source bin/activate; \

--- a/scriptmodules/supplementary/usbromservice/01_retropie_copyroms
+++ b/scriptmodules/supplementary/usbromservice/01_retropie_copyroms
@@ -68,7 +68,7 @@ find "$retropie_path/roms" -mindepth 1 -maxdepth 1 -type d -printf "$usb_path/ro
 for dir in roms BIOS; do
     log info "Syncing $dir ..."
     log_cmd rsync -rtu --exclude '._*' --max-delete=-1 "$usb_path/$dir" "$retropie_path/"
-    chown -R $user:$user "$retropie_path/$dir"
+    chown -R $user: "$retropie_path/$dir"
 done
 
 log info "Syncing configs ..."
@@ -85,7 +85,7 @@ for from in $(find "$usb_path_to_rp/" -mindepth 1 -maxdepth 1); do
     to=${path_mapping[$from_bn]}
     if [[ -n "$to" ]]; then
         log_cmd rsync -rtu --exclude '._*' --max-delete=-1 "$from/" "$to/"
-        chown -R $user:$user "$to"
+        chown -R $user: "$to"
     fi
 done
 

--- a/scriptmodules/supplementary/usbromservice/01_retropie_copyroms
+++ b/scriptmodules/supplementary/usbromservice/01_retropie_copyroms
@@ -68,7 +68,7 @@ find "$retropie_path/roms" -mindepth 1 -maxdepth 1 -type d -printf "$usb_path/ro
 for dir in roms BIOS; do
     log info "Syncing $dir ..."
     log_cmd rsync -rtu --exclude '._*' --max-delete=-1 "$usb_path/$dir" "$retropie_path/"
-    chown -R $user: "$retropie_path/$dir"
+    chown -R $user:$group "$retropie_path/$dir"
 done
 
 log info "Syncing configs ..."
@@ -85,7 +85,7 @@ for from in $(find "$usb_path_to_rp/" -mindepth 1 -maxdepth 1); do
     to=${path_mapping[$from_bn]}
     if [[ -n "$to" ]]; then
         log_cmd rsync -rtu --exclude '._*' --max-delete=-1 "$from/" "$to/"
-        chown -R $user: "$to"
+        chown -R $user:$group "$to"
     fi
 done
 

--- a/scriptmodules/supplementary/virtualgamepad.sh
+++ b/scriptmodules/supplementary/virtualgamepad.sh
@@ -28,7 +28,7 @@ function remove_virtualgamepad() {
 
 function sources_virtualgamepad() {
     gitPullOrClone "$md_inst"
-    chown -R $user:$user "$md_inst"
+    chown -R $user: "$md_inst"
 }
 
 function install_virtualgamepad() {

--- a/scriptmodules/supplementary/virtualgamepad.sh
+++ b/scriptmodules/supplementary/virtualgamepad.sh
@@ -28,7 +28,7 @@ function remove_virtualgamepad() {
 
 function sources_virtualgamepad() {
     gitPullOrClone "$md_inst"
-    chown -R $user: "$md_inst"
+    chown -R $user:$group "$md_inst"
 }
 
 function install_virtualgamepad() {


### PR DESCRIPTION
Fix the assumption that user group matches the user name in installation scripts by setting group variable in `retropie_packgages.sh` script. 

Based on the [PR made by kmcfate](https://github.com/RetroPie/RetroPie-Setup/pull/3577) - thanks for the prework!