### PR TITLE
xboxdrv: upgrade the build process to python3

### DIFF
--- a/scriptmodules/supplementary/xboxdrv.sh
+++ b/scriptmodules/supplementary/xboxdrv.sh
@@ -12,7 +12,7 @@
 rp_module_id="xboxdrv"
 rp_module_desc="Xbox / Xbox 360 gamepad driver"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/zerojay/xboxdrv/stable/COPYING"
-rp_module_repo="git https://github.com/zerojay/xboxdrv.git stable"
+rp_module_repo="git https://github.com/retropie/xboxdrv.git retropie-stable"
 rp_module_section="driver"
 
 function def_controllers_xboxdrv() {
@@ -24,7 +24,7 @@ function def_deadzone_xboxdrv() {
 }
 
 function depends_xboxdrv() {
-    getDepends libboost-dev libusb-1.0-0-dev libudev-dev libx11-dev scons pkg-config x11proto-core-dev libdbus-glib-1-dev
+    getDepends libboost-dev libusb-1.0-0-dev libudev-dev libx11-dev scons pkg-config python3 x11proto-core-dev libdbus-glib-1-dev
 }
 
 function sources_xboxdrv() {
@@ -32,7 +32,7 @@ function sources_xboxdrv() {
 }
 
 function build_xboxdrv() {
-    scons
+    python3 /usr/bin/scons
 }
 
 function install_xboxdrv() {


### PR DESCRIPTION
Python3 is the default in current Debian & friends distros (and `python2` was also recently [removed](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1027108) from Debian _sid_), but the current fork from zerojay/xboxdrv.git doesn't support it.

Upstream has moved back to Github [1] and added the necessary fixes for building with `python3`, so merge the upstream code with the various fixes added in zerojay/xboxdrv under retropie/xboxdrv.git. This fixes building under RaspiOS _bullseye_.

Since the new Sconsfile doesn't build with `python2` anymore, make the `python3` usage explicit for the `deps` and `build` phases.

[1] https://github.com/xboxdrv/xboxdrv