### PR TITLE
xroar: update to version 1.3

### DIFF
--- a/scriptmodules/emulators/xroar.sh
+++ b/scriptmodules/emulators/xroar.sh
@@ -13,7 +13,7 @@ rp_module_id="xroar"
 rp_module_desc="Dragon / CoCo emulator XRoar"
 rp_module_help="ROM Extensions: .cas .wav .bas .asc .dmk .jvc .os9 .dsk .vdk .rom .ccc .sna\n\nCopy your Dragon roms to $romdir/dragon32\n\nCopy your CoCo games to $romdir/coco\n\nCopy the required BIOS files d32.rom (Dragon 32), bas13.rom (CoCo), coco3.rom/coco3p.rom (CoCo3) to $biosdir"
 rp_module_licence="GPL3 http://www.6809.org.uk/xroar/"
-rp_module_repo="git http://www.6809.org.uk/git/xroar.git 1.0.9"
+rp_module_repo="git http://www.6809.org.uk/git/xroar.git 1.3"
 rp_module_section="opt"
 rp_module_flags=""
 
@@ -31,7 +31,7 @@ function sources_xroar() {
 function build_xroar() {
     local params=(--without-gtk2 --without-gtkgl --without-oss)
     if ! isPlatform "x11"; then
-        params+=(--without-pulse --disable-kbd-translate --without-x)
+        params+=(--without-pulse --without-x)
     fi
     ./autogen.sh
     ./configure --prefix="$md_inst" "${params[@]}"


### PR DESCRIPTION
The yearly XRoar update. The `--disable-kbd-translate` config option is no longer valid, so it has been removed from the build step.

Notable chanes since 1.0.9:

- version 1.1, Thu 21 Jul 2022
  * New GDB monitor commands [by Tormod Volden]
  * Support 1M or 2M in CoCo 3 [with Christopher Hawks]
  * Support K7 cassette image files (read-only)
  * Support UTF-8 block characters in -type for MC-10
  * Type ASCII BASIC from file on MC-10
  * NEW Matra & Hachette Alice support (keyboard layout, built-in profile)
  * New meta-options -machine-opt and -cart-opt
  * New ide-addr=address cart-opt
  * 6801/6803: fix some illegal instruction timings [George Phillips]
  * Fixed uppercase 'G', lowercase 'j' and 'w' glyphs for 6847T1 [Tim Lindner]

- version 1.2, Thu 27 Oct 2022
  * Fixed comma, lowercase 'm', lowercase 'Ã¸' glyphs for GIME [Tim Lindner]
  * Fix SDL-only builds
  * 6809: flesh out some illegal instruction behaviours [David Banks]
  * 6309: flesh out some undocumented behaviour [David Banks]
  * Fleshed out T1-compatibility in CoCo 3 GIME [R. Allen Murphy]

- version 1.3, Wed  4 Jan 2023
  * Add -no-ratelimit option to start at maximum speed
  * Further fixes to 6809 TFR/EXG involving CC/DP [Tim Lindner]
  * Fix Delta density select [Phill Harvey-Smith]
  * Track floppy disk 'dirty' state to avoid unnecessary image rewrites
  * IMPORTANT: disk write-back now defaults to ENABLED
  * Better Vertical SCroll register behaviour in GIME [Ralph Serpas]
  * 6309 timing fix for bit operations