### PR TITLE
lr-scummvm: update build recipe, upgrade the core to v2.6.1

### DIFF
--- a/scriptmodules/libretrocores/lr-scummvm.sh
+++ b/scriptmodules/libretrocores/lr-scummvm.sh
@@ -12,8 +12,8 @@
 rp_module_id="lr-scummvm"
 rp_module_desc="ScummVM port for libretro"
 rp_module_help="Copy your ScummVM games to $romdir/scummvm\n\nThe name of your game directories must be suffixed with '.svm' for direct launch in EmulationStation."
-rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/scummvm/master/COPYING"
-rp_module_repo="git https://github.com/libretro/scummvm.git master"
+rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/scummvm/main/LICENSE"
+rp_module_repo="git https://github.com/libretro/scummvm.git main"
 rp_module_section="exp"
 
 function sources_lr-scummvm() {
@@ -21,22 +21,17 @@ function sources_lr-scummvm() {
 }
 
 function build_lr-scummvm() {
-    make clean -C backends/platform/libretro/build
-
-    local params=(HAVE_MT32EMU=1)
-    local platform
-    isPlatform "arm" && platform+="armv"
-    isPlatform "neon" && platform+="neon"
-    [[ -n "$platform" ]] && params+=(platform="$platform")
-
-    make "${params[@]}" -C backends/platform/libretro/build
-    md_ret_require="$md_build/backends/platform/libretro/build/scummvm_libretro.so"
+    make clean
+    make HAVE_MT32EMU=1
+    make datafiles
+    md_ret_require="$md_build/scummvm_libretro.so"
 }
 
 function install_lr-scummvm() {
     md_ret_files=(
-        "backends/platform/libretro/build/scummvm_libretro.so"
-        "COPYING"
+        "scummvm_libretro.so"
+        "scummvm.zip"
+        "LICENSE"
     )
 }
 
@@ -49,8 +44,8 @@ function configure_lr-scummvm() {
     mkRomDir "scummvm"
     defaultRAConfig "scummvm"
 
-    # download and extract auxiliary data (theme, extra)
-    downloadAndExtract "https://github.com/libretro/scummvm/raw/master/backends/platform/libretro/aux-data/scummvm.zip" "$biosdir"
+    # unpack the data files to system dir
+    runCmd unzip -q "$md_inst/scummvm.zip" -d "$biosdir"
     chown -R $user:$user "$biosdir/scummvm"
 
     # basic initial configuration (if config file not found)
@@ -60,7 +55,7 @@ function configure_lr-scummvm() {
         iniSet "extrapath" "$biosdir/scummvm/extra"
         iniSet "themepath" "$biosdir/scummvm/theme"
         iniSet "soundfont" "$biosdir/scummvm/extra/Roland_SC-55.sf2"
-        iniSet "gui_theme" "scummmodern"
+        iniSet "gui_theme" "scummremastered"
         iniSet "subtitles" "true"
         iniSet "multi_midi" "true"
         iniSet "gm_device" "fluidsynth"


### PR DESCRIPTION
Recently, upstream re-organized the repository and changed the build process. This commit adapts the scriptmodule to the new structure:

 - building is done directly from the main repo source
 - data files neeed for the core is built with `make datafiles` and copied to our package
 - ScummVM is upgraded to current stable (v2.6.1) in the process. NOTE: WIP engines are not built by default and are not included
 - switched the theme the `scummremastered`, added in 2019 in ScummVM
 - license changed to GPLv3 (same as the main ScummVM project)

Fixes: #3617 