### PR TITLE
lr-scummvm: added `zip` as dependency

### DIFF
--- a/scriptmodules/libretrocores/lr-scummvm.sh
+++ b/scriptmodules/libretrocores/lr-scummvm.sh
@@ -16,6 +16,10 @@ rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/scummvm/main/
 rp_module_repo="git https://github.com/libretro/scummvm.git main"
 rp_module_section="exp"
 
+function depends_lr-scummvm() {
+    getDepends zip
+}
+
 function sources_lr-scummvm() {
     gitPullOrClone
 }


### PR DESCRIPTION
Fixes the creation of the `scummvm.zip` bundle file during building.