### PR TITLE
emulationstation: use SDL2 wayland videodriver if applicable

### DIFF
--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -245,6 +245,9 @@ if [[ "\$(uname --machine)" != *86* ]]; then
     fi
 fi
 
+# use SDL2 wayland video driver if wayland session is detected
+[[ "$XDG_SESSION_TYPE" == "wayland" ]] && export SDL_VIDEODRIVER=wayland
+
 # save current tty/vt number for use with X so it can be launched on the correct tty
 TTY=\$(tty)
 export TTY="\${TTY:8:1}"


### PR DESCRIPTION
If a Gnome/Wayland or Weston/Wayland session is started under Ubuntu 22.04, SDL2 falls back to x11 videodriver. There is ARM hardware which runs much faster, and without graphical glitches, if the SDL2 wayland video driver is used. To prevent SDL2 from using x11 video driver, export "SDL_VIDEODRIVER=wayland", if Wayland session is detected.