### PR TITLE
emulationstation: allow gles for all platforms

### DIFF
--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -167,8 +167,19 @@ function build_emulationstation() {
         # force GLESv1 on videocore due to performance issue with GLESv2
         isPlatform "videocore" && params+=(-DUSE_GLES1=On)
     elif isPlatform "x11"; then
-        local gl_ver=$(sudo -u $user glxinfo -B | grep -oP 'Max compat profile version:\s\K.*')
-        compareVersions $gl_ver gt 2.0 && params+=(-DUSE_GL21=On)
+        if isPlatform "gles"; then
+            params+=(-DGLES=On)
+            local gles_ver=$(sudo -u $user glxinfo -B | grep -oP 'Max GLES[23] profile version:\s\K.*')
+            compareVersions $gles_ver lt 2.0  && params+=(-DUSE_GLES1=On)
+        else
+            params+=(-DGL=On)
+            local gl_ver=$(sudo -u $user glxinfo -B | grep -oP 'Max compat profile version:\s\K.*')
+            compareVersions $gl_ver gt 2.0 && params+=(-DUSE_GL21=On)
+        fi
+    elif isPlatform "gles"; then
+        params+=(-DGLES=On)
+    elif isPlatform "gl"; then
+        params+=(-DGL=On)
     fi
     if isPlatform "dispmanx"; then
         params+=(-DOMX=On)


### PR DESCRIPTION
gles can be used under x11, wayland, kms, dispmanx and fb. Respect gles platform flag and build emulationstation with gles renderer if requested.