### PR TITLE
wikidocs scriptmodule: add missing dependencies

### DIFF
--- a/scriptmodules/admin/wikidocs.sh
+++ b/scriptmodules/admin/wikidocs.sh
@@ -14,7 +14,7 @@ rp_module_desc="Generate mkdocs documentation from wiki"
 rp_module_section=""
 
 function depends_wikidocs() {
-    getDepends python3 python3-pip libyaml-dev
+    getDepends python3 python3-pip libyaml-dev python3-setuptools python3-wheel
     pip3 install --upgrade mkdocs mkdocs-material mdx_truly_sane_lists git+https://github.com/cmitu/mkdocs-altlink-plugin
 }
 


### PR DESCRIPTION
I noticed these error when running `sudo RetroPie-Setup/retropie_packages.sh wikidocs` on  a prisitine RetroPie installation (RetroPie-Setup commit 058f096c)

```
= = = = = = = = = = = = = = = = = = = = =
Installing dependencies for 'wikidocs' : Generate mkdocs documentation from wiki
= = = = = = = = = = = = = = = = = = = = =

Looking in indexes: https://pypi.org/simple, https://www.piwheels.org/simple
Collecting git+https://github.com/cmitu/mkdocs-altlink-plugin
  Cloning https://github.com/cmitu/mkdocs-altlink-plugin to /tmp/pip-req-build-wwu4cdtd
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    ModuleNotFoundError: No module named 'setuptools'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-req-build-wwu4cdtd/
/home/pi/RetroPie-Setup/tmp/build/wikidocs /home/pi/RetroPie-Setup
```

and
```
Building wheels for collected packages: mkdocs-altlink-plugin
  Running setup.py bdist_wheel for mkdocs-altlink-plugin ... error
  Complete output from command /usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-req-build-el2rfcuh/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/pip-wheel-3uwy9tb1 --python-tag cp37:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help
  
  error: invalid command 'bdist_wheel'
  
  ----------------------------------------
  Failed building wheel for mkdocs-altlink-plugin
  Running setup.py clean for mkdocs-altlink-plugin
Failed to build mkdocs-altlink-plugin
```

This PR adds the missing dependencies and remediates the errors.