### PR TITLE
Add recognition of NXP imx socs i.MX6 dual lite, i.MX6 quad and i.MX8M mini 

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -430,6 +430,12 @@ function get_platform() {
                         *rockpro64*)
                             __platform="rockpro64"
                             ;;
+                        *imx6dl*)
+                            __platform="imx6"
+                            ;;
+                        *imx6q*)
+                            __platform="imx6"
+                            ;;
                         *imx8mm*)
                             __platform="imx8mm"
                             ;;
@@ -631,6 +637,7 @@ function platform_armv7-mali() {
 
 function platform_imx6() {
     cpu_armv7 "cortex-a9"
+    [[ -d /sys/class/drm/card0/device/driver/etnaviv ]] && __platform_flags+=(x11 gles mesa)
 }
 
 function platform_imx8mm() {

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -430,6 +430,9 @@ function get_platform() {
                         *rockpro64*)
                             __platform="rockpro64"
                             ;;
+                        *imx8mm*)
+                            __platform="imx8mm"
+                            ;;
                     esac
                 elif [[ -e "/sys/devices/soc0/family" ]]; then
                     case "$(tr -d '\0' < /sys/devices/soc0/family)" in
@@ -628,6 +631,12 @@ function platform_armv7-mali() {
 
 function platform_imx6() {
     cpu_armv7 "cortex-a9"
+}
+
+function platform_imx8mm() {
+    cpu_armv8 "cortex-a53"
+    __platform_flags+=(x11 gles)
+    [[ -d /sys/class/drm/card0/device/driver/etnaviv ]] && __platform_flags+=(mesa)
 }
 
 function platform_vero4k() {


### PR DESCRIPTION
-not officially supported.
-tested with NXP i.MX8M mini and i.MX6 dual lite with kernel 6.1 mainline and Ubuntu 22.04.   
-use mesa etnaviv driver if kernel uses etnaviv kernel driver.
-not tested with NXP gpu kernel module and driver blob vivante/galcore.   