### PR TITLE
add platform flag vulkan

### DIFF
--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -143,7 +143,7 @@ function build_ppsspp() {
         params+=(-DCMAKE_TOOLCHAIN_FILE="$md_data/tinker.armv7.cmake")
     fi
     isPlatform "vero4k" && params+=(-DCMAKE_TOOLCHAIN_FILE="cmake/Toolchains/vero4k.armv8.cmake")
-    if isPlatform "arm" && ! isPlatform "x11"; then
+    if isPlatform "arm" && ! isPlatform "vulkan"; then
         params+=(-DARM_NO_VULKAN=ON)
     fi
     if [[ "$md_id" == "lr-ppsspp" ]]; then

--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -21,7 +21,8 @@ function depends_retroarch() {
     isPlatform "gles" && ! isPlatform "vero4k" && depends+=(libgles2-mesa-dev)
     isPlatform "mesa" && depends+=(libx11-xcb-dev)
     isPlatform "mali" && depends+=(mali-fbdev)
-    isPlatform "x11" && depends+=(libx11-xcb-dev libpulse-dev libvulkan-dev mesa-vulkan-drivers)
+    isPlatform "x11" && depends+=(libx11-xcb-dev libpulse-dev)
+    isPlatform "vulkan" && depends+=(libvulkan-dev mesa-vulkan-drivers)
     isPlatform "vero4k" && depends+=(vero3-userland-dev-osmc zlib1g-dev libfreetype6-dev)
     isPlatform "kms" && depends+=(libgbm-dev)
 
@@ -58,8 +59,8 @@ function build_retroarch() {
     isPlatform "kms" && params+=(--enable-kms --enable-egl)
     isPlatform "arm" && params+=(--enable-floathard)
     isPlatform "neon" && params+=(--enable-neon)
-    isPlatform "x11" && params+=(--enable-vulkan)
-    ! isPlatform "x11" && params+=(--disable-vulkan --disable-wayland)
+    isPlatform "vulkan" && params+=(--enable-vulkan) || params+=(--disable-vulkan)
+    ! isPlatform "x11" && params+=(--disable-wayland)
     isPlatform "vero4k" && params+=(--enable-mali_fbdev --with-opengles_libs='-L/opt/vero3/lib')
     ./configure --prefix="$md_inst" "${params[@]}"
     make clean

--- a/scriptmodules/libretrocores/lr-flycast.sh
+++ b/scriptmodules/libretrocores/lr-flycast.sh
@@ -57,7 +57,8 @@ function build_lr-flycast() {
     fi
     isPlatform "aarch64" && params+=("WITH_DYNAREC=arm64" "HOST_CPU_FLAGS=-DTARGET_LINUX_ARMv8")
     isPlatform "arm" && params+=("WITH_DYNAREC=arm")
-    ! isPlatform "x86" && params+=("HAVE_GENERIC_JIT=0" "HAVE_VULKAN=0")
+    ! isPlatform "x86" && params+=("HAVE_GENERIC_JIT=0")
+    isPlatform "vulkan" && params+=("HAVE_VULKAN=1") || params+=("HAVE_VULKAN=0")
     make "${params[@]}" clean
     CFLAGS+=" ${add_flags[@]}" make "${params[@]}"
     md_ret_require="$md_build/flycast_libretro.so"

--- a/scriptmodules/supplementary/sdl2.sh
+++ b/scriptmodules/supplementary/sdl2.sh
@@ -77,7 +77,7 @@ function build_sdl2() {
         # disable vulkan and X11 video support
         conf_flags+=("--disable-video-x11")
     fi
-    ! isPlatform "x11" && conf_flags+=("--disable-video-vulkan")
+    isPlatform "vulkan" && conf_flags+=("--enable-video-vulkan") || conf_flags+=("--disable-video-vulkan")
     isPlatform "mali" && conf_flags+=("--enable-video-mali" "--disable-video-opengl")
     isPlatform "rpi" && conf_flags+=("--enable-video-rpi")
     isPlatform "kms" || isPlatform "rpi" && conf_flags+=("--enable-video-kmsdrm")

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -569,37 +569,37 @@ function platform_odroid-xu() {
 
 function platform_tegra-x1() {
     cpu_armv8 "cortex-a57+crypto"
-    __platform_flags+=(x11 gl)
+    __platform_flags+=(x11 gl vulkan)
 }
 
 function platform_tegra-x2() {
     cpu_armv8 "cortex-a57+crypto"
-    __platform_flags+=(x11 gl)
+    __platform_flags+=(x11 gl vulkan)
 }
 
 function platform_xavier() {
     cpu_armv8 "native"
-    __platform_flags+=(x11 gl)
+    __platform_flags+=(x11 gl vulkan)
 }
 
 function platform_tegra-3() {
     cpu_armv7 "cortex-a9"
-    __platform_flags+=(x11 gles)
+    __platform_flags+=(x11 gles vulkan)
 }
 
 function platform_tegra-4() {
     cpu_armv7 "cortex-a15"
-    __platform_flags+=(x11 gles)
+    __platform_flags+=(x11 gles vulkan)
 }
 
 function platform_tegra-k1-32() {
     cpu_armv7 "cortex-a15"
-    __platform_flags+=(x11 gl)
+    __platform_flags+=(x11 gl vulkan)
 }
 
 function platform_tegra-k1-64() {
     cpu_armv8 "native"
-    __platform_flags+=(x11 gl)
+    __platform_flags+=(x11 gl vulkan)
 }
 
 function platform_tinker() {
@@ -611,7 +611,7 @@ function platform_tinker() {
 
 function platform_native() {
     __default_cpu_flags="-march=native"
-    __platform_flags+=(gl)
+    __platform_flags+=(gl vulkan)
     if [[ "$__has_kms" -eq 1 ]]; then
         __platform_flags+=(kms)
     else


### PR DESCRIPTION
Don't mix Vulkan with x86 and x11 platform flags. Vulkan can be used with other system platforms and wayland / drmkms / fb. Add a "vulkan" platform flag which can be used to enable it if applicable.