### PR TITLE
raspbiantools: disable PulseAudio on Buster after install

### DIFF
--- a/scriptmodules/supplementary/raspbiantools.sh
+++ b/scriptmodules/supplementary/raspbiantools.sh
@@ -25,6 +25,14 @@ function apt_upgrade_raspbiantools() {
 function lxde_raspbiantools() {
     aptInstall --no-install-recommends xorg lxde
     aptInstall raspberrypi-ui-mods rpi-chromium-mods gvfs
+    # On `buster`, disable PulseAudio since it messes up the audio settings
+    # remove the lxpanel plugin for PulseAudio volume, to prevent a crash due to missing PulseAudio
+    #  and install the volume lxpanel plugin that supports ALSA
+    if [[ "$__os_debian_ver" -lt 11 ]]; then
+       __toggle_pulseaudio_audiosettings "off"
+       aptRemove  lxplug-volumepulse
+       aptInstall lxplug-volume
+    fi
 
     setConfigRoot "ports"
     addPort "lxde" "lxde" "Desktop" "XINIT:startx"


### PR DESCRIPTION
PulseAudio is pulled by installing the desktop since [1] on `buster`. Changed the install procedure to disable it after adding the desktop and to replace the volume applet for `lxpanel` with the version that supports ALSA (otherwise `lxpanel` crashes, leaving the deskop unusable).

[1] https://www.raspberrypi.com/news/new-raspberry-pi-os-release-december-2020/