### PR TITLE
xpadneo: update to version 0.9.5

### DIFF
--- a/scriptmodules/supplementary/xpadneo.sh
+++ b/scriptmodules/supplementary/xpadneo.sh
@@ -12,7 +12,7 @@
 rp_module_id="xpadneo"
 rp_module_desc="Advanced Linux driver for Xbox One wireless gamepads"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/atar-axis/xpadneo/master/LICENSE"
-rp_module_repo="git https://github.com/atar-axis/xpadneo.git v0.9.3"
+rp_module_repo="git https://github.com/atar-axis/xpadneo.git v0.9.5"
 rp_module_section="driver"
 rp_module_flags="nobin"
 


### PR DESCRIPTION
This is a hotfix release to fix broken SDL/Steam mappings. Previous version (0.9.4) was just a re-release of 0.9.3 which adds a missing uhid warning and fixes the module version number.