### PR TITLE
yabasanshiro: remove missing python-pip package

### DIFF
--- a/scriptmodules/emulators/yabasanshiro.sh
+++ b/scriptmodules/emulators/yabasanshiro.sh
@@ -18,7 +18,7 @@ rp_module_section="exp"
 rp_module_flags="!all rpi !videocore"
 
 function depends_yabasanshiro() {
-    local depends=(cmake pkg-config python-pip protobuf-compiler libprotobuf-dev libsecret-1-dev libssl-dev libsdl2-dev libboost-all-dev)
+    local depends=(cmake pkg-config protobuf-compiler libprotobuf-dev libsecret-1-dev libssl-dev libsdl2-dev libboost-all-dev)
     getDepends "${depends[@]}"
 }
 


### PR DESCRIPTION
Debian >= 10 has no python-pip package. Use python3-pip instead.