### PR TITLE
netplay: use the OSK to configure netplay options

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -138,17 +138,22 @@ function editFile() {
 ## @param text default text
 ## @param minchars minimum chars to accept
 ## @brief Opens an inputbox dialog and echoes resulting text. Uses the OSK if installed.
+## @details The input dialog has OK/Cancel buttons and can be cancelled by the user.
+## The dialog will enforce the minimum number of characters expected, re-prompting the user.
+## @retval 0 when the user entered the text and chose the OK button
+## @retval != 0 when the user chose the Cancel button
+
 function inputBox() {
     local title="$1"
     local text="$2"
     local minchars="$3"
     [[ -z "$minchars" ]] && minchars=0
-    local params=(--backtitle "$__backtitle" --inputbox "$title")
+    local params=(--backtitle "$__backtitle" --inputbox "Enter the $title")
     local osk="$(rp_getInstallPath joy2key)/osk.py"
 
     if [[ -f "$osk" ]]; then
         params+=(--minchars "$minchars")
-        text=$(python3 "$osk" "${params[@]}" 2>&1 >/dev/tty) || return $?
+        text=$(python3 "$osk" "${params[@]}" "$text" 2>&1 >/dev/tty) || return $?
     else
         while true; do
             text=$(dialog "${params[@]}" 10 60 "$text" 2>&1 >/dev/tty) || return $?

--- a/scriptmodules/supplementary/retronetplay.sh
+++ b/scriptmodules/supplementary/retronetplay.sh
@@ -20,7 +20,7 @@ __netplaymode="$__netplaymode"
 __netplayport="$__netplayport"
 __netplayhostip="$__netplayhostip"
 __netplayhostip_cfile="$__netplayhostip_cfile"
-__netplaynickname="'$__netplaynickname'"
+__netplaynickname="$__netplaynickname"
 _EOF_
     chown $user:$user "$conf"
     printMsgs "dialog" "Configuration has been saved to $conf"
@@ -57,16 +57,14 @@ function rps_retronet_mode() {
 }
 
 function rps_retronet_port() {
-    cmd=(dialog --backtitle "$__backtitle" --inputbox "Please enter the port to be used for netplay (default: 55435)." 22 76 $__netplayport)
-    choice=$("${cmd[@]}" 2>&1 >/dev/tty)
+    choice=$(inputBox "Port for netplay" "$__netplayport" 4)
     if [[ -n "$choice" ]]; then
         __netplayport="$choice"
     fi
 }
 
 function rps_retronet_hostip() {
-    cmd=(dialog --backtitle "$__backtitle" --inputbox "Please enter the IP address of the host." 22 76 $__netplayhostip)
-    choice=$("${cmd[@]}" 2>&1 >/dev/tty)
+    choice=$(inputBox "IP Address of the host" "$__netplayhostip" 8)
     if [[ -n "$choice" ]]; then
         __netplayhostip="$choice"
         if [[ $__netplaymode == "H" ]]; then
@@ -78,8 +76,7 @@ function rps_retronet_hostip() {
 }
 
 function rps_retronet_nickname() {
-    cmd=(dialog --backtitle "$__backtitle" --inputbox "Please enter the nickname you wish to use (default: RetroPie)" 22 76 $__netplaynickname)
-    choice=$("${cmd[@]}" 2>&1 >/dev/tty)
+    choice=$(inputBox "Nickname you wish to use" "$__netplaynickname" 4)
     if [[ -n "$choice" ]]; then
         __netplaynickname="$choice"
     fi
@@ -92,12 +89,12 @@ function gui_retronetplay() {
     local ip_ext=$(download http://ipecho.net/plain -)
 
     while true; do
-        cmd=(dialog --backtitle "$__backtitle" --menu "Configure RetroArch Netplay.\nInternal IP: $ip_int External IP: $ip_ext" 22 76 16)
+        cmd=(dialog --backtitle "$__backtitle" --cancel-label "Exit" --menu "Configure RetroArch Netplay.\nInternal IP: $ip_int External IP: $ip_ext" 22 76 16)
         options=(
             1 "Set mode, (H)ost or (C)lient. Currently: $__netplaymode"
             2 "Set port. Currently: $__netplayport"
             3 "Set host IP address (for client mode). Currently: $__netplayhostip"
-            4 "Set netplay nickname. Currently: $__netplaynickname"
+            4 "Set netplay nickname. Currently: '$__netplaynickname'"
             5 "Save configuration"
         )
         choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)


### PR DESCRIPTION
Replaced the `dialog` based inputboxes for host/nick/port in the netplay configuration prompts with the new `inputBox` helper, which uses the OSK (when installed).
Should make it easier to configure netplay without a keyboard.

Additional changes:
* the `osk.py` script was modified to accept an existing value instead of always starting with an empty input.
* modified the `inputBox` and added some notes on return value. Also changed the `dialog` based input prompt to be similar to how `osk.py` shows it (_Enter the `$value`_). 
