### PR TITLE
packages: amend update detection for untracked modules

### DIFF
--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -644,6 +644,8 @@ function rp_hasNewerModule() {
                 local repo_dir="$scriptdir"
                 [[ "$vendor" != "RetroPie" ]] && repo_dir+="/ext/$vendor"
                 local module_date="$(sudo -u "$user" git -C "$repo_dir" log -1 --format=%cI -- "${__mod_info[$id/path]}")"
+                # just in case the module is not known to git, get the file last modified date
+                [[ -z "$module_date" ]] && module_date="$(date -Iseconds -r "${__mod_info[$id/path]}")"
                 if rp_dateIsNewer "$pkg_date" "$module_date"; then
                     ret=0
                 fi


### PR DESCRIPTION
Added a fallback for getting the `modified_date` of a module if the module's file is not tracked by `git`. If the module is just copied in the `scriptmodules` folder or under `ext`, but not part of a `git` repo, use the modification date of the file. This avoids re-building the module when a mass update is run.

Noticed this in [this forum topic](https://retropie.org.uk/forum/topic/33922/need-help-with-openbor-retropie-extra-exarkuniv/15), seems like [RetroPie-Extra](https://github.com/Exarkuniv/RetroPie-Extra) copies selected module files under `ext`, while the main repository folder is kept separately.