### PR TITLE
lr-scummvm: fix interactive prompt from unzip

### DIFF
--- a/scriptmodules/libretrocores/lr-scummvm.sh
+++ b/scriptmodules/libretrocores/lr-scummvm.sh
@@ -49,7 +49,7 @@ function configure_lr-scummvm() {
     defaultRAConfig "scummvm"
 
     # unpack the data files to system dir
-    runCmd unzip -q "$md_inst/scummvm.zip" -d "$biosdir"
+    runCmd unzip -q -o "$md_inst/scummvm.zip" -d "$biosdir"
     chown -R $user:$user "$biosdir/scummvm"
 
     # basic initial configuration (if config file not found)


### PR DESCRIPTION
Modified the `unzip` command for the core system files to overwrite unconditionally the files, otherwise we get a prompt when upgrading.