### PR TITLE
emulationstation: modify wayland detection

### DIFF
--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -257,7 +257,7 @@ if [[ "\$(uname --machine)" != *86* ]]; then
 fi
 
 # use SDL2 wayland video driver if wayland session is detected
-[[ "$XDG_SESSION_TYPE" == "wayland" ]] && export SDL_VIDEODRIVER=wayland
+[[ "\$WAYLAND_DISPLAY" == wayland* ]] && export SDL_VIDEODRIVER=wayland
 
 # save current tty/vt number for use with X so it can be launched on the correct tty
 TTY=\$(tty)


### PR DESCRIPTION
I have done some tests running weston/wayland from CLI with a rpi4/raspbian-lite. After startup of weston $XDG_SESSION_TYPE is still "tty". If I start a weston/wayland session with graphical login (display manager sddm or gdm3) $XDG_SESSION_TYPE is "wayland". $WAYLAND_DISPLAY can be found in both constellations and seems to be more reliable. On a rpi4 $WAYLAND_DISPLAY=wayland-0. Just replace $XDG_SESSION_TYPE with $WAYLAND_DISPLAY.