### PR TITLE
helpers - added inputBox function that uses the OSK

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -133,6 +133,33 @@ function editFile() {
     [[ -n "$choice" ]] && echo "$choice" >"$file"
 }
 
+## @fn inputBox()
+## @param title title of dialog
+## @param text default text
+## @param minchars minimum chars to accept
+## @brief Opens an inputbox dialog and echoes resulting text. Uses the OSK if installed.
+function inputBox() {
+    local title="$1"
+    local text="$2"
+    local minchars="$3"
+    [[ -z "$minchars" ]] && minchars=0
+    local params=(--backtitle "$__backtitle" --inputbox "$title")
+    local osk="$(rp_getInstallPath joy2key)/osk.py"
+
+    if [[ -f "$osk" ]]; then
+        params+=(--minchars "$minchars")
+        text=$(python3 "$osk" "${params[@]}" 2>&1 >/dev/tty) || return $?
+    else
+        while true; do
+            text=$(dialog "${params[@]}" 10 60 "$text" 2>&1 >/dev/tty) || return $?
+            [[ "${#text}" -ge "$minchars" ]] && break
+            dialog --msgbox "$title must have at least $minchars characters" 8 60 2>&1 >/dev/tty
+        done
+    fi
+
+    echo "$text"
+}
+
 ## @fn hasPackage()
 ## @param package name of Debian package
 ## @param version requested version (optional)

--- a/scriptmodules/supplementary/wifi.sh
+++ b/scriptmodules/supplementary/wifi.sh
@@ -74,13 +74,9 @@ function connect_wifi() {
     choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
     [[ -z "$choice" ]] && return
 
-    local osk
-    osk="$(rp_getInstallPath joy2key)/osk.py"
-
     local hidden=0
     if [[ "$choice" == "H" ]]; then
-        cmd=(python3 "$osk" --backtitle "$__backtitle" --inputbox "ESSID" --minchars 4)
-        essid=$("${cmd[@]}" 2>&1 >/dev/tty)
+        essid=$(inputBox "ESSID" "" 4)
         [[ -z "$essid" ]] && return
         cmd=(dialog --backtitle "$__backtitle" --nocancel --menu "Please choose the WiFi type" 12 40 6)
         options=(
@@ -104,10 +100,10 @@ function connect_wifi() {
             key_min=5
         fi
 
-        cmd=(python3 $osk --backtitle "$__backtitle" --inputbox "WiFi key/password" --minchars $key_min)
+        cmd=(inputBox "WiFi key/password" "" $key_min)
         local key_ok=0
         while [[ $key_ok -eq 0 ]]; do
-            key=$("${cmd[@]}" 2>&1 >/dev/tty) || return
+            key=$("${cmd[@]}") || return
             key_ok=1
         done
     fi


### PR DESCRIPTION
If the OSK is installed it will be used for input, otherwise it will fall back to using dialog --inputbox

function takes 3 parameters:

The title of the dialog, the default text and a minimum number of characters to accept.

Adjusted wifi module to use the new inputBox. There is no need to redirect cmd output with 2>&1 >/dev/tty as the inputBox function does this.