### PR TITLE
packages.sh - function rp_hasNewerModule - variable length commit hash

### DIFF
--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -601,10 +601,10 @@ function rp_hasNewerModule() {
                     local repo_commit="$(rp_resolveRepoParam "${__mod_info[$id/repo_commit]}")"
                     # if we are locked to a single commit, then we compare against the current module commit only
                     if [[ -n "$repo_commit" && "$repo_commit" != "HEAD" ]]; then
-                        # if we are using git and the module has an 8 character commit hash, then adjust
-                        # the package commit to 8 characters also for the comparison
-                        if [[ "$repo_type" == "git" && "${#repo_commit}" -eq 8 ]]; then
-                            pkg_repo_commit="${pkg_repo_commit::8}"
+                        # if we are using git and the module has a commit hash, then adjust
+                        # the package commit length for the comparison
+                        if [[ "$repo_type" == "git" && "${#repo_commit}" -ge 4 ]]; then
+                            pkg_repo_commit="${pkg_repo_commit::${#repo_commit}}"
                         fi
                         if [[ "$pkg_repo_commit" != "$repo_commit" ]]; then
                             ret=0


### PR DESCRIPTION
Allows proper update detection for modules with 7-character commit sha, such as some RetroPie-Extra modules.