### PR TITLE
samba: update restart to remove old service name

### DIFF
--- a/scriptmodules/supplementary/samba.sh
+++ b/scriptmodules/supplementary/samba.sh
@@ -41,7 +41,7 @@ _EOF_
 }
 
 function restart_samba() {
-    service samba restart || service smbd restart
+    systemctl -q is-active smbd.service && systemctl -q reload-or-restart smbd.service
 }
 
 function install_shares_samba() {


### PR DESCRIPTION
Removed the `samba` service name, it's not used since _stretch_.

Thank you @gizmo for the reminder.
Should fix #3643 