### PR TITLE
hypseus: update runtime parameters for ARM

### DIFF
--- a/scriptmodules/emulators/hypseus.sh
+++ b/scriptmodules/emulators/hypseus.sh
@@ -72,6 +72,8 @@ function configure_hypseus() {
     ln -sf "$md_conf_root/daphne/hypinput.ini" "$md_inst/hypinput.ini"
 
     local common_args="-framefile \"\$dir/\$name.txt\" -homedir \"$md_inst\" -fullscreen \$params"
+    # prevents SDL doing an internal software conversion since 2.0.16+
+    isPlatform "arm" && common_args="-texturestream $common_args"
 
     cat >"$md_inst/hypseus.sh" <<_EOF_
 #!/bin/bash


### PR DESCRIPTION
Since SDL has been updated, make sure we don't encounter the performance issue reported on 2.0.16+ with RPI. After 2.0.16, using `SDL_TEXTUREACCESS_TARGET` for a `SDL_Texture` leads to an extra conversion inside SDL, so avoid it by telling `hypseus` to use `SDL_TEXTUREACCESS_STREAMING`.

Previous discussion and analysis of the performance impact:
 * https://github.com/DirtBagXon/hypseus-singe/issues/66
 * https://retropie.org.uk/forum/topic/18505/