### PR TITLE
lr-beetle-pce: add accurate PC Engine/CD/SuperGrafx core

### DIFF
--- a/scriptmodules/libretrocores/lr-beetle-pce.sh
+++ b/scriptmodules/libretrocores/lr-beetle-pce.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-beetle-pce"
+rp_module_desc="PC Engine/CD/SuperGrafx emulator - Mednafen PCE port for libretro"
+rp_module_help="ROM Extensions: .7z .ccd .chd .cue .pce .sgx\n\nCopy your PC Engine roms to $romdir/pcengine\n\nCopy the required BIOS file syscard3.pce to $biosdir"
+rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/beetle-pce-libretro/master/COPYING"
+rp_module_repo="git https://github.com/libretro/beetle-pce-libretro.git master"
+rp_module_section="main"
+rp_module_flags="!armv6"
+
+function sources_lr-beetle-pce() {
+    gitPullOrClone
+}
+
+function build_lr-beetle-pce() {
+    make clean
+    make
+    md_ret_require="$md_build/mednafen_pce_libretro.so"
+}
+
+function install_lr-beetle-pce() {
+    md_ret_files=(
+        'mednafen_pce_libretro.so'
+        'COPYING'
+        'README.md'
+    )
+}
+
+function configure_lr-beetle-pce() {
+    mkRomDir "pcengine"
+    defaultRAConfig "pcengine"
+
+    addEmulator 1 "$md_id" "pcengine" "$md_inst/mednafen_pce_libretro.so"
+    addSystem "pcengine"
+
+    [[ "$md_mode" == "remove" ]] && return
+
+    # Set core options
+    setRetroArchCoreOption "pce_aspect_ratio" "4:3"
+    setRetroArchCoreOption "pce_multitap" "disabled"
+    setRetroArchCoreOption "pce_scaling" "hires"
+}
+


### PR DESCRIPTION
Following the [discussion](https://retropie.org.uk/forum/topic/32181/add-the-accurate-version-of-beetle-pce/13), let's try adding that nice core into Retropie. 

This one truly shines, at least on RPi4 and allows for accurate emulation of PC Engine/TurboGrafx-16, PC Engine CD and SuperGrafx. If you ever had issue with a (CD-ROM²) game you should give this one a try.

* Single core for 3 systems: PC Engine/TurboGrafx-16, PC Engine CD and SuperGrafx.
* Accurate given any games I've tried ran without issues or glitches (unlike lr-beetle-pce-fast) including CD-ROM².
* Work with `.chd` and `.7z` without issue.
* More info on the [core page](https://github.com/libretro/beetle-pce-libretro).

About the script itself, I've tried my best to follow the Retropie's conventions. Anyhow the script was already robust enough thanks to @Darksavior (who originally created the script).

* Few core options are set otherwise you might end up with messy screen or gfx artifacts (eg. Art of Fighting/Ryuuko no Ken)
* Multitap is also disabled as some games won't work with it (eg. Cho Aniki).
* Tested only on RPi4 where all games run fullspeed (roughly 400+ titles tested). I don't know if it works the same on RPi3 or older models. Hence why the `!armv6`.
* [lr-beetle-pce-fast](https://github.com/libretro/beetle-pce-fast-libretro) as well as [lr-beetle-supergrafx](https://github.com/libretro/beetle-supergrafx-libretro) remain valid alternatives for very low-spec devices.

For those interesting in testing try first the [Arcade CD-ROM² titles](https://necretro.org/CD-ROM%C2%B2_systems#Arcade_CD-ROM.C2.B2). Those should be more demanding.

Thanks again to @Darksavior for the work done.