### PR TITLE
dosbox-staging - disable speexdsp simd support on armv6 devices

### DIFF
--- a/scriptmodules/emulators/dosbox-staging.sh
+++ b/scriptmodules/emulators/dosbox-staging.sh
@@ -40,6 +40,9 @@ function build_dosbox-staging() {
     local meson_cmd="meson"
     [[ -f "$md_build/meson/meson.py" ]] && meson_cmd="python3 $md_build/meson/meson.py"
 
+    # disable speexdsp simd support on armv6 devices
+    isPlatform "arm6" && params+=(-Dspeexdsp:simd=false)
+
     $meson_cmd setup "${params[@]}" build
     $meson_cmd compile -j${__jobs} -C build
 


### PR DESCRIPTION
This fixes building on armv6 devices such as the RPI1.

The meson speexdsp script will test for neon support by building for armv7+neon. This will cause neon to be enabled when building for the RPI1, breaking compilation.

Fixes #3651