### PR TITLE
mupen64plus.sh: update GlideN64 config version

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -345,7 +345,7 @@ function configure_mupen64plus() {
             echo "[Video-GLideN64]" >> "$config"
         fi
         # Settings version. Don't touch it.
-        iniSet "configVersion" "17"
+        iniSet "configVersion" "29"
         # Bilinear filtering mode (0=N64 3point, 1=standard)
         iniSet "bilinearMode" "1"
         iniSet "EnableFBEmulation" "True"


### PR DESCRIPTION
GlideN64 overwrites settings if config version is to old. Current config version is 29. https://github.com/gonetz/GLideN64/blob/1f4d04f43b53739bc9b128ab5577d20e3d60ed6a/src/Config.h#L8