### PR TITLE
mupen64plus.sh: fix issue #3138

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -370,6 +370,13 @@ function configure_mupen64plus() {
             setAutoConf mupen64plus_audio 1
             setAutoConf mupen64plus_compatibility_check 1
         elif isPlatform "mesa"; then
+            # Create Video-Rice section in .cfg
+            if ! grep -q "\[Video-Rice\]" "$config"; then
+                echo "[Video-Rice]" >> "$config"
+            fi
+            # Fix flickering and black screen issues with rice video plugin
+            iniSet "ScreenUpdateSetting" "7"
+
             setAutoConf mupen64plus_audio 0
             setAutoConf mupen64plus_compatibility_check 0
         fi


### PR DESCRIPTION
Video output of rice plugin flickers or is black with ScreenUpdateSetting=1 with rpi mesa driver. ScreenUpdateSetting=7 fixes it. Fix issue #3138.