### PR TITLE
lr-dosbox-pure - install g++ v9 on arm if v10 is the system default

### DIFF
--- a/scriptmodules/libretrocores/lr-dosbox-pure.sh
+++ b/scriptmodules/libretrocores/lr-dosbox-pure.sh
@@ -17,6 +17,12 @@ rp_module_repo="git https://github.com/libretro/dosbox-pure.git main"
 rp_module_section="exp"
 rp_module_flags=""
 
+function depends_lr-dosbox-pure() {
+    # lr-dosbox-pure will try and use g++ v9 on arm if the system default is v10 due to bugs
+    # see https://github.com/libretro/dosbox-pure/commit/603b1c7ae
+    isPlatform "arm" && [[ "$__gcc_version" -eq 10 ]] && getDepends g++-9
+}
+
 function sources_lr-dosbox-pure() {
     gitPullOrClone
 }


### PR DESCRIPTION
This fixes building on Bullseye.

According to https://github.com/libretro/dosbox-pure/commit/603b1c7ae

>Switch to gcc 9 to avoid buggy assembly genetation [sic] of gcc 10
>On armv7l, gcc 10.2 with -O2 on the file core_dynrec.cpp generates assembly that wrongfully passes NULL to the runcode function
>resulting in a segfault crash. It can be observed by writing block->cache.start to stdout twice where it is NULL at first
>and then the actual value thereafter. This affects upstream SVN DOSBox as well as this core.

This may be needed for dosbox-svn also if this also affects that. That needs testing.