### PR TITLE
Don't use compareVersions for GCC version comparisons

### DIFF
--- a/scriptmodules/emulators/dolphin.sh
+++ b/scriptmodules/emulators/dolphin.sh
@@ -20,14 +20,14 @@ rp_module_flags="!all 64bit"
 function _get_branch_dolphin() {
     local branch="master"
     # current HEAD of dolphin doesn't build on Ubuntu 16.04 (with  gcc 5.4)
-    compareVersions $__gcc_version lt 6 && branch="5.0"
+    [[ "$__gcc_version" -lt 6 ]] && branch="5.0"
     echo "$branch"
 }
 
 function depends_dolphin() {
     local depends=(cmake pkg-config libao-dev libasound2-dev libavcodec-dev libavformat-dev libbluetooth-dev libenet-dev liblzo2-dev libminiupnpc-dev libopenal-dev libpulse-dev libreadline-dev libsfml-dev libsoil-dev libsoundtouch-dev libswscale-dev libusb-1.0-0-dev libxext-dev libxi-dev libxrandr-dev portaudio19-dev zlib1g-dev libudev-dev libevdev-dev libmbedtls-dev libcurl4-openssl-dev libegl1-mesa-dev qtbase5-private-dev)
     # current HEAD of dolphin doesn't build gtk2 UI anymore
-    compareVersions $__gcc_version lt 6 && depends+=(libgtk2.0-dev libwxbase3.0-dev libwxgtk3.0-dev)
+    [[ "$__gcc_version" -lt 6 ]] && depends+=(libgtk2.0-dev libwxbase3.0-dev libwxgtk3.0-dev)
     getDepends "${depends[@]}"
 }
 

--- a/scriptmodules/emulators/mame.sh
+++ b/scriptmodules/emulators/mame.sh
@@ -22,7 +22,7 @@ function _get_branch_mame() {
 }
 
 function depends_mame() {
-    if compareVersions $__gcc_version lt 7; then
+    if [[ "$__gcc_version" -lt 7 ]]; then
         md_ret_errors+=("Sorry, you need an OS with gcc 7 or newer to compile $md_id")
         return 1
     fi

--- a/scriptmodules/emulators/openmsx.sh
+++ b/scriptmodules/emulators/openmsx.sh
@@ -20,9 +20,9 @@ rp_module_flags=""
 function _get_commit_openmsx() {
     local commit
     # latest code requires at least GCC 8.3 (Debian Buster) for full C++17 support
-    compareVersions $__gcc_version lt 8 && commit="c8d90e70"
+    [[ "$__gcc_version" -lt 8 ]] && commit="c8d90e70"
     # for GCC before 7, build from an earlier commit, before C++17 support was added
-    compareVersions $__gcc_version lt 7 && commit="5ee25b62"
+    [[ "$__gcc_version" -lt 7 ]] && commit="5ee25b62"
     echo "$commit"
 }
 

--- a/scriptmodules/emulators/ti99sim.sh
+++ b/scriptmodules/emulators/ti99sim.sh
@@ -18,7 +18,7 @@ rp_module_section="exp"
 rp_module_flags=""
 
 function depends_ti99sim() {
-    if compareVersions $__gcc_version lt 8; then
+    if [[ "$__gcc_version" -lt 8 ]]; then
         md_ret_errors+=("Sorry, you need an OS with gcc 8 or newer to compile $md_id")
         return 1
     fi

--- a/scriptmodules/libretrocores/lr-bsnes.sh
+++ b/scriptmodules/libretrocores/lr-bsnes.sh
@@ -18,7 +18,7 @@ rp_module_section="opt"
 rp_module_flags="!armv6"
 
 function depends_lr-bsnes() {
-    if compareVersions $__gcc_version lt 7; then
+    if [[ "$__gcc_version" -lt 7 ]]; then
         md_ret_errors+=("You need an OS with gcc 7 or newer to compile $md_id")
         return 1
     fi

--- a/scriptmodules/libretrocores/lr-mame.sh
+++ b/scriptmodules/libretrocores/lr-mame.sh
@@ -24,7 +24,7 @@ function _get_params_lr-mame() {
 }
 
 function depends_lr-mame() {
-    if compareVersions $__gcc_version lt 7; then
+    if [[ "$__gcc_version" -lt 7 ]]; then
         md_ret_errors+=("Sorry, you need an OS with gcc 7 or newer to compile $md_id")
         return 1
     fi

--- a/scriptmodules/ports/dxx-rebirth.sh
+++ b/scriptmodules/ports/dxx-rebirth.sh
@@ -19,7 +19,7 @@ rp_module_flags="!mali"
 function _get_commit_dxx-rebirth() {
     local commit="15bd145d"
     # latest code requires gcc 7+
-    compareVersions "$__gcc_version" lt 7 && commit="a1b3a86c"
+    [[ "$__gcc_version" -lt 7 ]] && commit="a1b3a86c"
     echo "$commit"
 }
 

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -88,6 +88,10 @@ function conf_binary_vars() {
 
 function conf_build_vars() {
     __gcc_version=$(gcc -dumpversion)
+    # extract only the major version
+    # gcc -dumpversion on GCC >= 7 seems to provide the major version but the documentation
+    # suggests this depends on how it's configured
+    __gcc_version="${__gcc_version%%.*}"
 
     # calculate build concurrency based on cores and available memory
     __jobs=1


### PR DESCRIPTION
gcc -dumpversion on GCC >= 7 seems to provide the major version but the documentation suggests this depends on how it's configured. We only need to test the major version so using compareVersions isn't required.

https://gcc.gnu.org/onlinedocs/gcc/Developer-Options.html states:
>Print the compiler version (for example, 3.0, 6.3.0 or 7)—and don’t do anything else. This is the compiler
>version used in filesystem paths and specs. Depending on how the compiler has been configured it can be
>just a single number (major version), two numbers separated by a dot (major and minor version) or three
>numbers separated by dots (major, minor and patchlevel version).

Ensure __gcc_version only contains the major version just in case in system.sh