### PR TITLE
minivmac - include patch to fix building on gcc 10+

### DIFF
--- a/scriptmodules/emulators/minivmac.sh
+++ b/scriptmodules/emulators/minivmac.sh
@@ -23,6 +23,8 @@ function depends_minivmac() {
 
 function sources_minivmac() {
     gitPullOrClone
+    # apply fix for building on gcc 10+
+    applyPatch "$md_data/gcc10_fix.diff"
 }
 
 function build_minivmac() {

--- a/scriptmodules/emulators/minivmac/gcc10_fix.diff
+++ b/scriptmodules/emulators/minivmac/gcc10_fix.diff
@@ -1,0 +1,51 @@
+--- a/src/MYOSGLUE.c
++++ b/src/MYOSGLUE.c
+@@ -29,6 +29,24 @@
+ 
+ #include "STRCONST.h"
+ 
++/* SDL2 window */
++SDL_Window *window;
++
++/* SDL2 renderer */
++SDL_Renderer *renderer;
++
++/* SDL2 texture */
++SDL_Texture *texture;
++
++/* SDL2 blitting rects for hw scaling 
++ * ratio correction using SDL_RenderCopy() */
++SDL_Rect src_rect;
++SDL_Rect dst_rect;
++
++/* SDL2 physical screen dimensions */
++int displayWidth;
++int displayHeight;
++
+ /* --- some simple utilities --- */
+ 
+ GLOBALPROC MyMoveBytes(anyp srcPtr, anyp destPtr, si5b byteCount)
+--- a/src/MYOSGLUE.h
++++ b/src/MYOSGLUE.h
+@@ -401,21 +401,3 @@ EXPORTPROC MyEvtQOutDone(void);
+ 
+ #include <SDL2/SDL.h>
+ #include <SDL2/SDL_keycode.h>
+-
+-/* SDL2 window */
+-SDL_Window *window;
+-
+-/* SDL2 renderer */
+-SDL_Renderer *renderer;
+-
+-/* SDL2 texture */
+-SDL_Texture *texture;
+-
+-/* SDL2 blitting rects for hw scaling 
+- * ratio correction using SDL_RenderCopy() */
+-SDL_Rect src_rect;
+-SDL_Rect dst_rect;
+-
+-/* SDL2 physical screen dimensions */
+-int displayWidth;
+-int displayHeight;


### PR DESCRIPTION
Move the SDL declarations from MYOSGLUE.h to MYOSGLUE.c This fixes building on GCC 10+ due to the MYOSGLUE.h header being included by every source file.

PR has been sent upstream https://github.com/vanfanel/minivmac_sdl2/pull/3