### PR TITLE
Fix building of ti99sim / ti99sim-sdl1 on recent g++

### DIFF
--- a/scriptmodules/emulators/ti99sim-sdl1.sh
+++ b/scriptmodules/emulators/ti99sim-sdl1.sh
@@ -23,6 +23,8 @@ function depends_ti99sim-sdl1() {
 
 function sources_ti99sim-sdl1() {
     downloadAndExtract "$md_repo_url" "$md_build" --strip-components 1
+    # add missing include to fix compilation on newer g++
+    applyPatch "$md_data/missing_cstdio.diff"
 }
 
 function build_ti99sim-sdl1() {

--- a/scriptmodules/emulators/ti99sim-sdl1/missing_cstdio.diff
+++ b/scriptmodules/emulators/ti99sim-sdl1/missing_cstdio.diff
@@ -1,0 +1,10 @@
+--- a/include/common.hpp
++++ b/include/common.hpp
+@@ -30,6 +30,7 @@
+ #define COMMON_HPP_
+ 
+ #include <cstdlib>	// For definition of size_t
++#include <cstdio>
+ 
+ //----------------------------------------------------------------------------
+ // Determine platform & OS

--- a/scriptmodules/emulators/ti99sim.sh
+++ b/scriptmodules/emulators/ti99sim.sh
@@ -27,6 +27,8 @@ function depends_ti99sim() {
 
 function sources_ti99sim() {
     downloadAndExtract "$md_repo_url" "$md_build" --strip-components 1
+    # add missing include to fix compilation on newer g++
+    applyPatch "$md_data/missing_cstring.diff"
 }
 
 function build_ti99sim() {

--- a/scriptmodules/emulators/ti99sim/missing_cstring.diff
+++ b/scriptmodules/emulators/ti99sim/missing_cstring.diff
@@ -1,0 +1,10 @@
+--- a/src/core/device-support.cpp
++++ b/src/core/device-support.cpp
+@@ -26,6 +26,7 @@
+ //
+ //----------------------------------------------------------------------------
+ 
++#include <cstring>
+ #include <regex>
+ #include "idevice.hpp"
+ #include "icomputer.hpp"


### PR DESCRIPTION
ti99sim:
src/core/device-support.cpp was missing a cstring include which throws an error on recent g++

ti99sim-sdl1:
include/common.hpp was missing a cstdio include required for fclose