### PR TITLE
Fix device name sanitization within ES controller configscripts

### DIFF
--- a/scriptmodules/supplementary/emulationstation/configscripts/mupen64plus.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/mupen64plus.sh
@@ -230,8 +230,9 @@ function onend_mupen64plus_joystick() {
     if [[ -f "$file" ]]; then
         # backup current config file
         cp "$file" "${file}.bak"
-        sed -i /"${DEVICE_NAME}_START"/,/"${DEVICE_NAME}_END"/d "$file"
-        if grep -q "$DEVICE_NAME" "$file" ; then
+        local escaped_device_name=$(echo "$DEVICE_NAME" | sed 's|[]\[^$.*/]|\\&|g')
+        sed -i /"${escaped_device_name}_START"/,/"${escaped_device_name}_END"/d "$file"
+        if grep -Fq "$DEVICE_NAME" "$file" ; then
             rm /tmp/mp64tempconfig.cfg
             return
         fi

--- a/scriptmodules/supplementary/emulationstation/configscripts/openmsx.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/openmsx.sh
@@ -150,7 +150,7 @@ function onend_openmsx_joystick() {
     local conf
 
     # sanitize filename
-    conf=${DEVICE_NAME//[\?\<\>\\\/:\*\|]/}
+    conf=${DEVICE_NAME//[:><?\"\/\\|*]/}
 
     mkdir -p "$home/.openMSX/share/joystick/game"
     cat > "$home/.openMSX/share/joystick/${conf}.tcl" <<_EOF_

--- a/scriptmodules/supplementary/emulationstation/configscripts/reicast.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/reicast.sh
@@ -20,7 +20,7 @@ function onstart_reicast_joystick() {
             file="$configdir/dreamcast/mappings/controller_xboxdrv.cfg"
             ;;
         *)
-            file="$configdir/dreamcast/mappings/evdev_${DEVICE_NAME//[:><?\"]/-}.cfg"
+            file="$configdir/dreamcast/mappings/evdev_${DEVICE_NAME//[:><?\"\/\\|*]/-}.cfg"
             ;;
     esac
 
@@ -221,7 +221,7 @@ function onend_reicast_joystick() {
             file="$configdir/dreamcast/mappings/controller_xboxdrv.cfg"
             ;;
         *)
-            file="$configdir/dreamcast/mappings/evdev_${DEVICE_NAME//[:><?\"]/-}.cfg"
+            file="$configdir/dreamcast/mappings/evdev_${DEVICE_NAME//[:><?\"\/\\|*]/-}.cfg"
             ;;
     esac
 

--- a/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh
@@ -387,7 +387,7 @@ function onend_retroarch_joystick() {
     done < <(grep -Fl "\"$DEVICE_NAME\"" "$dir/"*.cfg 2>/dev/null)
 
     # sanitise filename
-    file="${DEVICE_NAME//[\?\<\>\\\/:\*\|]/}.cfg"
+    file="${DEVICE_NAME//[:><?\"\/\\|*]/}.cfg"
 
     if [[ -f "$dir/$file" ]]; then
         mv "$dir/$file" "$dir/$file.bak"

--- a/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh
@@ -241,7 +241,7 @@ function map_retroarch_joystick() {
     declare -A hat_map=([1]="up" [2]="right" [4]="down" [8]="left")
     iniGet "input_driver"
     local input_driver="$ini_value"
-    local autoconfig_preset=$(grep -rwl "$rootdir/emulators/retroarch/autoconfig-presets/$input_driver" -e "$DEVICE_NAME" | head -1)
+    local autoconfig_preset=$(grep -rwFl "$rootdir/emulators/retroarch/autoconfig-presets/$input_driver" -e "$DEVICE_NAME" | head -1)
     for key in "${keys[@]}"; do
         case "$input_type" in
             hat)


### PR DESCRIPTION
This fixes a few of the EmulationStation controller configscripts to properly sanitize the `DEVICE_NAME` when it's used as part of filenames and `sed` / `grep` commands.

## Context

Earlier this year, a [change](https://github.com/paroj/xpad/commit/4a64f5caefb2e571d90240f9b1a2bbe1a8950a74) was made to `xpad` in which certain 8BitDo controller started to register with the system using the name "8BitDo Ultimate Wireless / Pro 2 Wired Controller".  When I attempted to set up this controller, a few of the configscripts were failing when they weren't with the prior name -- "8BitDo Ultimate Wireless Controller".

While working through the issue, I found that there was some existing code that applied sanitization to the `DEVICE_NAME` within the ES configscripts:

https://github.com/RetroPie/RetroPie-Setup/blob/6bf638afecfbab7094909c3f03683db90e8a25b9/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh#L390

https://github.com/RetroPie/RetroPie-Setup/blob/6bf638afecfbab7094909c3f03683db90e8a25b9/scriptmodules/supplementary/emulationstation/configscripts/reicast.sh#L23

However, this sanitizing wasn't applied consistently across all configscripts.

## How to reproduce

To reproduce, you can run the following:

```sh
cat > $HOME/.emulationstation/es_temporaryinput.cfg <<EOF
<?xml version="1.0"?>
<inputList>
  <inputConfig type="joystick" deviceName="8BitDo Ultimate Wireless / Pro 2 Wired Controller" deviceGUID="03000000c82d00000631000000010000">
    <input name="b" type="button" id="0" value="1" />
    <input name="a" type="button" id="1" value="1" />
    <input name="select" type="button" id="8" value="1" />
    <input name="hotkeyenable" type="button" id="8" value="1" />
    <input name="down" type="hat" id="0" value="4" />
    <input name="left" type="hat" id="0" value="8" />
    <input name="right" type="hat" id="0" value="2" />
    <input name="up" type="hat" id="0" value="1" />
    <input name="leftshoulder" type="button" id="4" value="1" />
    <input name="leftthumb" type="button" id="11" value="1" />
    <input name="lefttrigger" type="button" id="6" value="1" />
    <input name="leftanalogleft" type="axis" id="0" value="-1" />
    <input name="leftanalogright" type="axis" id="0" value="1" />
    <input name="leftanalogup" type="axis" id="1" value="-1" />
    <input name="leftanalogdown" type="axis" id="1" value="1" />
    <input name="rightshoulder" type="button" id="5" value="1" />
    <input name="rightthumb" type="button" id="12" value="1" />
    <input name="righttrigger" type="button" id="7" value="1" />
    <input name="rightanalogleft" type="axis" id="2" value="-1" />
    <input name="rightanalogright" type="axis" id="2" value="1" />
    <input name="rightanalogup" type="axis" id="3" value="-1" />
    <input name="rightanalogdown" type="axis" id="3" value="1" />
    <input name="start" type="button" id="9" value="1" />
    <input name="y" type="button" id="2" value="1" />
    <input name="x" type="button" id="3" value="1" />
  </inputConfig>
</inputList>
EOF

/opt/retropie/supplementary/emulationstation/scripts/inputconfiguration.sh
```

This will produce the following output:

```
Input type is 'joystick'.
Configuring 'daphne'
Keymap not found in /opt/retropie/configs/daphne/dapinput-forcekey.ini
Keymap not found in /opt/retropie/configs/daphne/dapinput-forcekey.ini
Keymap not found in /opt/retropie/configs/daphne/dapinput-forcekey.ini
Keymap not found in /opt/retropie/configs/daphne/dapinput-forcekey.ini
Keymap not found in /opt/retropie/configs/daphne/dapinput-forcekey.ini
Keymap not found in /opt/retropie/configs/daphne/dapinput-forcekey.ini
Keymap not found in /opt/retropie/configs/daphne/dapinput-forcekey.ini
Keymap not found in /opt/retropie/configs/daphne/dapinput-forcekey.ini
Keymap not found in /opt/retropie/configs/daphne/dapinput-forcekey.ini
Keymap not found in /opt/retropie/configs/daphne/dapinput-forcekey.ini
Configuring 'emulationstation'
Configuring 'mupen64plus'
sed: -e expression #1, char 30: extra characters after command
Configuring 'openmsx'
Configuring 'reicast'
/opt/retropie/supplementary/emulationstation/scripts/configscripts/reicast.sh: line 34: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
touch: cannot touch '/opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg': No such file or directory
sed: cannot stat /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/lib/inifuncs.sh: line 82: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
/opt/retropie/supplementary/emulationstation/scripts/configscripts/reicast.sh: line 229: /opt/retropie/configs/dreamcast/mappings/evdev_8BitDo Ultimate Wireless / Pro 2 Wired Controller.cfg: No such file or directory
Configuring 'retroarch'
```

As you can see, there are some errors that are generated by this.  The `openmsx` and `retroarch` configscripts currently generate the following files (correctly):

```
$ ls $HOME/.openMSX/share/joystick/ | cat
8BitDo Ultimate Wireless  Pro 2 Wired Controller.tcl
game
README.txt

$ ls /opt/retropie/configs/all/retroarch/autoconfig/ | cat
8BitDo Ultimate Wireless  Pro 2 Wired Controller.cfg
8BitDo Ultimate Wireless  Pro 2 Wired Controller.cfg.bak
```

However, the dreamcast and n64 mappings aren't present.

After the changes in this PR are made, the output is:

```sh
Input type is 'joystick'.
Configuring 'daphne'
Keymap not found in /opt/retropie/configs/daphne/dapinput-forcekey.ini
Keymap not found in /opt/retropie/configs/daphne/dapinput-forcekey.ini
Keymap not found in /opt/retropie/configs/daphne/dapinput-forcekey.ini
Keymap not found in /opt/retropie/configs/daphne/dapinput-forcekey.ini
Keymap not found in /opt/retropie/configs/daphne/dapinput-forcekey.ini
Keymap not found in /opt/retropie/configs/daphne/dapinput-forcekey.ini
Keymap not found in /opt/retropie/configs/daphne/dapinput-forcekey.ini
Keymap not found in /opt/retropie/configs/daphne/dapinput-forcekey.ini
Keymap not found in /opt/retropie/configs/daphne/dapinput-forcekey.ini
Keymap not found in /opt/retropie/configs/daphne/dapinput-forcekey.ini
Configuring 'emulationstation'
Configuring 'mupen64plus'
Configuring 'openmsx'
Configuring 'reicast'
Configuring 'retroarch'
```

And the generated outputs for `reicast` and `mupen64plus` are:

```sh
$ ls /opt/retropie/configs/dreamcast/mappings/ | cat
evdev_8BitDo Ultimate Wireless - Pro 2 Wired Controller.cfg

$ cat /opt/retropie/configs/n64/InputAutoCfg.ini | grep 8BitDo
; 8BitDo Ultimate Wireless / Pro 2 Wired Controller_START 
[8BitDo Ultimate Wireless / Pro 2 Wired Controller]
; 8BitDo Ultimate Wireless / Pro 2 Wired Controller_END 
```

## Changes

To support this, I had to make changes to the following places:

* If `DEVICE_NAME` was included in a filename, replace the following special characters:
  * `:`
  * `>`
  * `<`
  * `?`
  * `"`
  * `/`
  * `\`
  * `|`
  * `*`
* If we were grepping for `DEVICE_NAME`, use the `-F` flag to enable fixed string searches since there aren't any cases where we want characters from the device name to be interpreted with regular expression syntax.
* If we were using `DEVICE_NAME` within a `sed` command, ensure that `DEVICE_NAME` is first escaped according to characters that have special meaning in `sed`, including the following characters:
  * `[`
  * `]`
  * `^`
  * `$`
  * `.`
  * `*`
  * `\`

Additionally, I ensured that the bash sanitization syntax was applied consistently across all configscripts (i.e. I updated retroarch and openmsx to use the same syntax as reicast -- except those continue to delete the special characters instead of subbing them with `-`).

## Testing

To test this (beyond running the `inputconfiguration.sh` script and validating the outputs), I ran the following to confirm the sanitization / escaping code:

sed:
```sh
$ echo '- [ - ] - ^ - $ - . - * - \' | sed 's|[]\[^$.*/]|\\&|g'
- \[ - \] - \^ - \$ - \. - \* - \\
```

grep:
```sh
$ cat > /tmp/test.out <<EOF
CA*B
EOF

$ grep 'CA*B' /tmp/test.out

$ grep -F 'CA*B' /tmp/test.out
CA*B
```

bash:
```
$ DEVICE_NAME='- : - > - < - ? - " - / - \ - * - |'

$ echo "$DEVICE_NAME"
- : - > - < - ? - " - / - \ - * - |

$ echo "${DEVICE_NAME//[:><?\"\/\\|*]/-}"
- - - - - - - - - - - - - - - - - -
```

Additionally, I tested running `inputconfiguration.sh` prior to https://github.com/paroj/xpad/commit/4a64f5caefb2e571d90240f9b1a2bbe1a8950a74 and after to confirm that the additional `/` character is what was causing the issue.

## References

Some additional PRs / links that were referenced in making these changes:
* https://github.com/RetroPie/RetroPie-Setup/pull/2992
* https://github.com/skmp/reicast-emulator/commit/8b5c2a3fac54bb74e8e79ff17fe0890af9044273