### PR TITLE
Update OS versions

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -264,8 +264,10 @@ function get_os_version() {
                 __os_debian_ver="9"
             elif compareVersions "$__os_release" lt 20.04; then
                 __os_debian_ver="10"
-            else
+            elif compareVersions "$__os_release" lt 22.10; then
                 __os_debian_ver="11"
+            else
+                __os_debian_ver="12"
             fi
             __os_ubuntu_ver="$__os_release"
             ;;

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -176,7 +176,7 @@ function get_os_version() {
 
             # Debian unstable is not officially supported though
             if [[ "$__os_release" == "unstable" ]]; then
-                __os_debian_ver=11
+                __os_debian_ver=13
             fi
 
             # we still allow Raspbian 8 (jessie) to work (We show an popup in the setup module)


### PR DESCRIPTION
-Update Debian unstable version. Current Debian trixie/unstable has version 13. Debian bookworm/testing has version 12. 
-Add Ubuntu 22.10. Ubuntu >= 22.10 and Debian >= 12 have the package libsdl2-tests. Set __os_debian_ver="12" for Ubuntu versions >= 22.10.