### PR TITLE
lr-prboom: workaround a recent regression

### DIFF
--- a/scriptmodules/libretrocores/lr-prboom.sh
+++ b/scriptmodules/libretrocores/lr-prboom.sh
@@ -12,7 +12,7 @@
 rp_module_id="lr-prboom"
 rp_module_desc="Doom/Doom II engine - PrBoom port for libretro"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/libretro-prboom/master/COPYING"
-rp_module_repo="git https://github.com/libretro/libretro-prboom.git master"
+rp_module_repo="git https://github.com/libretro/libretro-prboom.git master ddaa6e34"
 rp_module_section="opt"
 
 function sources_lr-prboom() {


### PR DESCRIPTION
Until [1] is resolved - one way or another - use a good known commit to build the PrBoom core. Upstream core is relatively static, so we're not loosing much for pinning the version.

[1] https://github.com/libretro/libretro-prboom/issues/181