### PR TITLE
Switch to using VLC for splashscreen

### DIFF
--- a/scriptmodules/supplementary/splashscreen.sh
+++ b/scriptmodules/supplementary/splashscreen.sh
@@ -13,7 +13,7 @@ rp_module_id="splashscreen"
 rp_module_desc="Configure Splashscreen"
 rp_module_section="main"
 rp_module_repo="git https://github.com/RetroPie/retropie-splashscreens.git master"
-rp_module_flags="noinstclean !all rpi !osmc !xbian !aarch64"
+rp_module_flags="noinstclean !all rpi !osmc !xbian"
 
 function _update_hook_splashscreen() {
     # make sure splashscreen is always up to date if updating just RetroPie-Setup
@@ -32,9 +32,14 @@ function _video_exts_splashscreen() {
 }
 
 function depends_splashscreen() {
-    local params=(insserv)
-    isPlatform "32bit" && params+=(omxplayer)
-    getDepends "${params[@]}"
+    # pin archive.raspberrypi.org version of VLC on buster as updated "security" vanilla version doesn't have mmal output
+    if [[ "$__os_debian_ver" -lt 11 ]]; then
+        cp "$md_data/rp-vlc" /etc/apt/preferences.d/
+        # try and install vlc to force downgrade
+        aptInstall --allow-downgrades vlc
+    else
+        getDepends vlc
+    fi
 }
 
 function install_bin_splashscreen() {
@@ -48,6 +53,7 @@ ConditionPathExists=$md_inst/asplashscreen.sh
 
 [Service]
 Type=oneshot
+User=$__user
 ExecStart=$md_inst/asplashscreen.sh
 RemainAfterExit=yes
 
@@ -55,13 +61,20 @@ RemainAfterExit=yes
 WantedBy=sysinit.target
 _EOF_
 
-    rp_installModule "omxiv" "_autoupdate_"
-
     gitPullOrClone "$md_inst"
 
     cp "$md_data/asplashscreen.sh" "$md_inst"
 
     iniConfig "=" '"' "$md_inst/asplashscreen.sh"
+
+    if isPlatform "videocore"; then
+        # set vlc mmal layer for videocore
+        iniSet "CMD_OPTS" " --mmal-layer 10001"
+    else
+        # install script to kill splashscreen before running autostart scripts when using kms
+        cp "$md_data/05-splash.sh" /etc/profile.d/
+    fi
+
     iniSet "ROOTDIR" "$rootdir"
     iniSet "DATADIR" "$datadir"
     iniSet "REGEX_IMAGE" "$(_image_exts_splashscreen)"
@@ -107,9 +120,6 @@ function disable_splashscreen() {
 function configure_splashscreen() {
     [[ "$md_mode" == "remove" ]] && return
 
-    # remove legacy service
-    [[ -f "/etc/init.d/asplashscreen" ]] && insserv -r asplashscreen && rm -f /etc/init.d/asplashscreen
-
     disable_plymouth_splashscreen
     enable_splashscreen
     [[ ! -f /etc/splashscreen.list ]] && default_splashscreen
@@ -118,8 +128,9 @@ function configure_splashscreen() {
 function remove_splashscreen() {
     enable_plymouth_splashscreen
     disable_splashscreen
-    rp_callModule "omxiv" remove
     rm -f /etc/splashscreen.list /etc/systemd/system/asplashscreen.service
+    rm -f /etc/apt/preferences.d/rp-vlc
+    rm -f /etc/profile.d/05-splash.sh
     systemctl daemon-reload
 }
 
@@ -229,7 +240,7 @@ function preview_splashscreen() {
 
     local path
     local file
-    local omxiv="/opt/retropie/supplementary/omxiv/omxiv"
+    local splash_cmd="sudo -u $__user XDG_RUNTIME_DIR=/run/user/$SUDO_UID vlc --intf dummy --quiet --play-and-exit --image-duration 6"
     while true; do
         local cmd=(dialog --backtitle "$__backtitle" --menu "Choose an option." 22 86 16)
         local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
@@ -241,13 +252,13 @@ function preview_splashscreen() {
                 1)
                     file=$(choose_splashscreen "$path" "image")
                     [[ -z "$file" ]] && break
-                    $omxiv -b "$file"
+                    $splash_cmd "$file"
                     ;;
                 2)
                     file=$(mktemp)
                     find "$path" -type f ! -regex ".*/\..*" ! -regex ".*LICENSE" ! -regex ".*README.*" ! -regex ".*\.sh" | sort > "$file"
                     if [[ -s "$file" ]]; then
-                        $omxiv -t 6 -T blend -b --once -f "$file"
+                        tr "\n" "\0" <"$file" | xargs -0 $splash_cmd
                     else
                         printMsgs "dialog" "There are no splashscreens installed in $path"
                     fi
@@ -257,7 +268,7 @@ function preview_splashscreen() {
                 3)
                     file=$(choose_splashscreen "$path" "video")
                     [[ -z "$file" ]] && break
-                    omxplayer --no-osd -b --layer 10000 "$file"
+                    $splash_cmd "$file"
                     ;;
             esac
         done

--- a/scriptmodules/supplementary/splashscreen.sh
+++ b/scriptmodules/supplementary/splashscreen.sh
@@ -281,10 +281,6 @@ function download_extra_splashscreen() {
 }
 
 function gui_splashscreen() {
-    if [[ ! -d "$md_inst" ]]; then
-        rp_callModule splashscreen depends
-        rp_callModule splashscreen install
-    fi
     local cmd=(dialog --backtitle "$__backtitle" --menu "Choose an option." 22 86 16)
     while true; do
         local enabled=0

--- a/scriptmodules/supplementary/splashscreen/05-splash.sh
+++ b/scriptmodules/supplementary/splashscreen/05-splash.sh
@@ -1,0 +1,8 @@
+PID_FILE=/dev/shm/rp-splashscreen.pid
+if [ "`tty`" = "/dev/tty1" ] && [ -z "$DISPLAY" ] && [ -f "$PID_FILE" ]; then
+    PID=`cat $PID_FILE`
+    if ps -p $PID >/dev/null; then
+        kill $PID >/dev/null 2>&1
+    fi
+    rm $PID_FILE
+fi

--- a/scriptmodules/supplementary/splashscreen/asplashscreen.sh
+++ b/scriptmodules/supplementary/splashscreen/asplashscreen.sh
@@ -4,6 +4,8 @@ ROOTDIR=""
 DATADIR=""
 REGEX_VIDEO=""
 REGEX_IMAGE=""
+CMD="vlc --intf dummy --quiet --no-video-title-show --play-and-exit"
+CMD_OPTS=""
 
 # Load user settings
 . /opt/retropie/configs/all/splashscreen.cfg
@@ -20,11 +22,8 @@ do_start () {
     local config="/etc/splashscreen.list"
     local line
     local re="$REGEX_VIDEO\|$REGEX_IMAGE"
-    local omxiv="/opt/retropie/supplementary/omxiv/omxiv"
+    local cmd="$CMD $CMD_OPTS"
     case "$RANDOMIZE" in
-        disabled)
-            line="$(head -1 "$config")"
-            ;;
         retropie)
             line="$(find "$ROOTDIR/supplementary/splashscreen" -type f | grep "$re" | shuf -n1)"
             ;;
@@ -38,36 +37,38 @@ do_start () {
             line="$(cat "$config" | shuf -n1)"
             ;;
     esac
-    if $(echo "$line" | grep -q "$REGEX_VIDEO"); then
-        # wait for dbus
-        while ! pgrep "dbus" >/dev/null; do
-            sleep 1
-        done
-        omxplayer --no-osd -o both -b --layer 10001 "$line"
-    elif $(echo "$line" | grep -q "$REGEX_IMAGE"); then
-        if [ "$RANDOMIZE" = "disabled" ]; then
-            local count=$(wc -l <"$config")
-        else
-            local count=1
-        fi
-        [ $count -eq 0 ] && count=1
-        [ $count -gt 12 ] && count=12
 
-        # Default duration is 12 seconds, check if configured otherwise
-        [ -z "$DURATION" ] && DURATION=12
-        local delay=$((DURATION/count))
-        if [ "$RANDOMIZE" = "disabled" ]; then
-            "$omxiv" --once -t $delay -b --layer 10001 -f "$config" >/dev/null 2>&1
-        else
-            "$omxiv" --once -t $delay -b --layer 10001 -r "$line" >/dev/null 2>&1
-        fi
+    if [ "$RANDOMIZE" = "disabled" ]; then
+        local count=$(wc -l <"$config")
+    else
+        local count=1
     fi
+
+    [ $count -eq 0 ] && count=1
+    [ $count -gt 12 ] && count=12
+
+    # Default duration is 12 seconds, check if configured otherwise
+    [ -z "$DURATION" ] && DURATION=12
+    local delay=$((DURATION/count))
+
+    cmd="$cmd --image-duration $delay"
+    local pid
+    if [ "$RANDOMIZE" = "disabled" ]; then
+        tr "\n" "\0" <"$config" | xargs -0 $cmd & 2>/dev/null
+        # get cmd pid (child of xargs)
+        pid=`pgrep -P $!`
+    else
+        $cmd "$line" & 2>/dev/null
+        pid=$!
+    fi
+    echo "$pid" >/dev/shm/rp-splashscreen.pid
+
     exit 0
 }
 
 case "$1" in
     start|"")
-        do_start &
+        do_start
         ;;
     restart|reload|force-reload)
         echo "Error: argument '$1' not supported" >&2

--- a/scriptmodules/supplementary/splashscreen/asplashscreen.sh
+++ b/scriptmodules/supplementary/splashscreen/asplashscreen.sh
@@ -10,14 +10,6 @@ CMD_OPTS=""
 # Load user settings
 . /opt/retropie/configs/all/splashscreen.cfg
 
-is_fkms() {
-    if grep -q okay /proc/device-tree/soc/v3d@7ec00000/status 2> /dev/null || grep -q okay /proc/device-tree/soc/firmwarekms@7e600000/status 2> /dev/null ; then
-        return 0
-    else
-        return 1
-    fi
-}
-
 do_start () {
     local config="/etc/splashscreen.list"
     local line

--- a/scriptmodules/supplementary/splashscreen/rp-vlc
+++ b/scriptmodules/supplementary/splashscreen/rp-vlc
@@ -1,0 +1,7 @@
+Package: vlc*
+Pin: origin archive.raspberrypi.org
+Pin-Priority: 1001
+
+Package: libvlc*
+Pin: origin archive.raspberrypi.org
+Pin-Priority: 1001


### PR DESCRIPTION
Here is a possible solution for splashscreen support that works on bullseye.

omxiv / omxplayer only works on the Raspberry Pi legacy and fkms drivers.

This change switches to vlc for both utilities, as it supports mmal output on the Raspberry Pi legacy drivers, and drm output on KMS on Raspberry Pi OS (on bullseye).

This change includes stopping vlc before launching ES on kms as ES will fail to open the display otherwise. Maybe we should introduce an option to "wait" for vlc to finish before we start ES. May be useful for video splashes etc.

From my testing:

### On Buster:

#### RPI3
**Legacy Driver (default config)**

- omxiv - ES displays over splashscreen
- vlc - ES displays over splashscreen

**FKMS**

- omxiv - ES displays under splashscreen
- vlc - ES displays under splashscreen (mmal_vout)

**KMS**

- omxiv - no output (no openmax)
- vlc - no output (version in Buster doesn't have drm support)

#### RPI4

**FKMS (default config)**

- omxiv - ES displays under splashscreen
- vlc - ES displays under splashscreen

**KMS**

- omxiv - no output
- vlc - no output

### On Bullseye:

#### RPI3/RPI4

**KMS**

- omxiv - not available
- vlc - uses drm_vout - need to stop VLC before ES launches or it will fail