### PR TITLE
openmsx: update the RetroPie initialization script

### DIFF
--- a/scriptmodules/emulators/openmsx/retropie-init.tcl
+++ b/scriptmodules/emulators/openmsx/retropie-init.tcl
@@ -5,16 +5,13 @@ proc init {} {
     set config_dir [file normalize "$::env(OPENMSX_USER_DATA)/joystick"]
 
     # Sanitize rom name
-    regsub -all {[\?\<\>\\\/:\*\|]} $rom_name "" rom_name
+    regsub -all {[:><?\"\/\\|*]} $rom_name "" rom_name
 
     # Auto-configure the 1st plugged in joystick, but only if present
     # openMSX automatically loads the plugged in joysticks in 'autoplug.tcl'
     if {![info exists ::joystick1_config]} {
         return
     }
-
-    # Disable the OSD menu box added by osd_menu.tcl
-    osd destroy main_menu_pop_up_button
 
     if { !($rom_name eq "") } {
         if { [ file exists "$config_dir/game/$rom_name.tcl" ] } {
@@ -26,7 +23,7 @@ proc init {} {
     if { [catch {exec udevadm info --name=/dev/input/js0 | grep -q "ID_INPUT_JOYSTICK=1"}] == 0 } {
         set path [exec udevadm info --name=/dev/input/js0 --query=name]
         set joy_name [exec cat /sys/class/$path/device/name]
-        regsub -all {[\?\<\>\\\/:\*\|]} $joy_name "" joy_name$
+        regsub -all {[:><?\"\/\\|*]} $joy_name "" joy_name
         if { [file exists "$config_dir/$joy_name.tcl"] } {
                 load_config_joystick $joy_name "$config_dir/$joy_name.tcl"
         }


### PR DESCRIPTION
* fixed a typo in the joystick name cleanup instruction. When the joystick name contained the cleaned up characters, the auto-loading didn't work
* simplified the regex for both joystick and rom name cleanup instructions
* removed the 'osd' menu hiding from our code, since openMSX is now doing it itself (after a small delay). This prevents a warning message showed if the 'osd' menu cannot be found