### PR TITLE
helpers / hasPackage - fix package detection on a multiarch system

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -180,7 +180,8 @@ function hasPackage() {
 
     local ver
     local status
-    local out=$(dpkg-query -W --showformat='${Status} ${Version}' $1 2>/dev/null)
+    # extract the first line only (for cases where both amd64 & i386 versions of a package are installed)
+    local out=$(dpkg-query -W --showformat='${Status} ${Version}\n' $1 2>/dev/null | head -n1)
     if [[ "$?" -eq 0 ]]; then
         ver="${out##* }"
         status="${out% *}"


### PR DESCRIPTION
On a multiarch system both amd64 and i386 versions of a package may be installed.

This would cause both to be returned by dpkg-query on a single line causing the extracting of version and install status to fail.

It now splits the output onto multiple lines and grabs the first line to workaround this.

Fixes #3679