### PR TITLE
retropiemenu.sh: add mc 7zip support

### DIFF
--- a/scriptmodules/supplementary/retropiemenu.sh
+++ b/scriptmodules/supplementary/retropiemenu.sh
@@ -24,7 +24,7 @@ function _update_hook_retropiemenu() {
 }
 
 function depends_retropiemenu() {
-    getDepends mc
+    getDepends mc p7zip
 }
 
 function install_bin_retropiemenu() {


### PR DESCRIPTION
Midnight Commander needs package p7zip to open 7z archives.