### PR TITLE
mupen64plus.sh: use extracted configVersion in GlideN64 config section

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -321,6 +321,10 @@ function configure_mupen64plus() {
     # on the rp-dist file. This preserves any user configs from modification and allows us to have
     # a default config for reference
     if [[ -f "$config" ]]; then
+        # patch existing mupen64plus config because Gliden64 overwrites GlideN64 user configs
+        # if configVersion is wrong 
+        grep -q "configVersion" "$config" && iniConfig " = " "" "$config" && iniSet "configVersion" "$(cat $md_inst/share/mupen64plus/GLideN64_config_version.ini)"
+    
         mv "$config" "$config.user"
         su "$user" -c "$cmd"
         mv "$config" "$config.rp-dist"
@@ -345,7 +349,7 @@ function configure_mupen64plus() {
             echo "[Video-GLideN64]" >> "$config"
         fi
         # Settings version. Don't touch it.
-        iniSet "configVersion" "29"
+        iniSet "configVersion" "$(cat $md_inst/share/mupen64plus/GLideN64_config_version.ini)"
         # Bilinear filtering mode (0=N64 3point, 1=standard)
         iniSet "bilinearMode" "1"
         iniSet "EnableFBEmulation" "True"


### PR DESCRIPTION
We already extract GlideN64 config version. Use it to finally set right config version in mupen64plus package script. Mupen64plus startup script should do this as well, but it is not wrong to do it here. -set right GlideN64 config version in "$config.rp-dist" -set right GlideN64 config version in "$config" because GlideN64 overwrites user settings if config version is wrong fixes: https://github.com/RetroPie/RetroPie-Setup/issues/3654