### PR TITLE
steamlink: update dependencies and runtime config

### DIFF
--- a/scriptmodules/ports/steamlink.sh
+++ b/scriptmodules/ports/steamlink.sh
@@ -13,11 +13,11 @@ rp_module_id="steamlink"
 rp_module_desc="Steam Link for Raspberry Pi 3 or later"
 rp_module_licence="PROP https://steamcommunity.com/app/353380/discussions/0/1743353164093954254/"
 rp_module_section="exp"
-rp_module_flags="!all rpi3 rpi4"
+rp_module_flags="!all rpi3 rpi4 !64bit"
 rp_module_help="Stream games from your computer with Steam"
 
 function depends_steamlink() {
-    getDepends python3-dev libinput10 libxkbcommon-x11-0 matchbox-window-manager xorg zenity
+    getDepends libxkbcommon-x11-0 libinput10 libpulse0 libx11-6 libx11-xcb1 cec-utils openssl
 }
 
 function install_bin_steamlink() {
@@ -29,7 +29,6 @@ function remove_steamlink() {
 }
 
 function configure_steamlink() {
-    local sl_script="$md_inst/steamlink_xinit.sh"
     local sl_dir="$home/.local/share/SteamLink"
     local valve_dir="$home/.local/share/Valve Corporation"
 
@@ -43,15 +42,7 @@ function configure_steamlink() {
         touch "$valve_dir/SteamLink/streaming_args.txt"
         chown $user:$user "$valve_dir/SteamLink/streaming_args.txt"
         moveConfigFile "$valve_dir/SteamLink/streaming_args.txt" "$md_conf_root/$md_id/streaming_args.txt"
-
-        cat > "$sl_script" << _EOF_
-#!/bin/bash
-xset -dpms s off s noblank
-matchbox-window-manager &
-/usr/bin/steamlink
-_EOF_
-        chmod +x "$sl_script"
     fi
 
-    addPort "$md_id" "steamlink" "Steam Link" "XINIT:$sl_script"
+    addPort "$md_id" "steamlink" "Steam Link" "steamlink"
 }


### PR DESCRIPTION
* removed the launcher through Xorg since Steam Link can now run with a desktop env on both RaspiOS 10 and 11, choosing between the DRM or MMAL drivers. Tested on a RPI 3 (RaspiOS 10) and RPI 4 (RaspiOS 11).

* adjusted the dependencies to remove xorg/matchbox/zenity since they're not strictly necessary and added a few packages which might not be automatically installed on RetroPie. The list of the packages that `steamlink` tries to install on first run in is `$XDG_DATA_HOME/SteamLink/steamlinkdeps.txt`, I just picked the ones that are not already part of existing dependencies (`vlc` will install most of them).

* disabled the package on 64bit, since is not available there (see https://steamcommunity.com/app/353380/discussions/0/1649917420735113143/)