### PR TITLE
amiberry: update to 5.6.0

### DIFF
--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -13,7 +13,7 @@ rp_module_id="amiberry"
 rp_module_desc="Amiga emulator with JIT support (forked from uae4arm)"
 rp_module_help="ROM Extension: .adf .chd .ipf .lha .zip\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir/amiga"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/BlitterStudio/amiberry/master/LICENSE"
-rp_module_repo="git https://github.com/BlitterStudio/amiberry v5.5.1"
+rp_module_repo="git https://github.com/BlitterStudio/amiberry v5.6.0"
 rp_module_section="opt"
 rp_module_flags="!all arm rpi3 rpi4"
 
@@ -47,7 +47,7 @@ function _get_platform_amiberry() {
 }
 
 function depends_amiberry() {
-    local depends=(autoconf libpng-dev libmpeg2-4-dev zlib1g-dev libmpg123-dev libflac-dev libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev wget)
+    local depends=(autoconf libpng-dev libmpeg2-4-dev zlib1g-dev libmpg123-dev libflac-dev libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libserialport-dev wget)
 
     isPlatform "dispmanx" && depends+=(libraspberrypi-dev)
     isPlatform "vero4k" && depends+=(vero3-userland-dev-osmc)

--- a/scriptmodules/emulators/amiberry/01_preserve_env.diff
+++ b/scriptmodules/emulators/amiberry/01_preserve_env.diff
@@ -1,18 +1,18 @@
 diff --git a/Makefile b/Makefile
-index 29969690..dc798edf 100644
+index 93ef345..75f5bd4 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -17,10 +17,10 @@ SDL_CONFIG ?= sdl2-config
+@@ -21,10 +21,10 @@ SDL_CONFIG ?= sdl2-config
  export SDL_CFLAGS := $(shell $(SDL_CONFIG) --cflags)
  export SDL_LDFLAGS := $(shell $(SDL_CONFIG) --libs)
- 
+
 -CPPFLAGS = -MD -MT $@ -MF $(@:%.o=%.d) $(SDL_CFLAGS) -Iexternal/libguisan/include -Isrc -Isrc/osdep -Isrc/threaddep -Isrc/include -Isrc/archivers -Isrc/floppybridge -DAMIBERRY -D_FILE_OFFSET_BITS=64
 -CFLAGS=-pipe -Wno-shift-overflow -Wno-narrowing
 +CPPFLAGS += -MD -MT $@ -MF $(@:%.o=%.d) $(SDL_CFLAGS) -Iexternal/libguisan/include -Isrc -Isrc/osdep -Isrc/threaddep -Isrc/include -Isrc/archivers -Isrc/floppybridge -DAMIBERRY -D_FILE_OFFSET_BITS=64
-+CFLAGS += -pipe -Wno-shift-overflow -Wno-narrowing
++CFLAGS +=-pipe -Wno-shift-overflow -Wno-narrowing
  USE_LD ?= gold
--LDFLAGS = $(SDL_LDFLAGS) -lSDL2_image -lSDL2_ttf -lguisan -Lexternal/libguisan/lib
-+LDFLAGS += $(SDL_LDFLAGS) -lSDL2_image -lSDL2_ttf -lguisan -Lexternal/libguisan/lib
+-LDFLAGS = $(SDL_LDFLAGS) -lSDL2_image -lSDL2_ttf -lserialport -lguisan -Lexternal/libguisan/lib
++LDFLAGS += $(SDL_LDFLAGS) -lSDL2_image -lSDL2_ttf -lserialport -lguisan -Lexternal/libguisan/lib
  ifneq ($(strip $(USE_LD)),)
- 	LDFLAGS += -fuse-ld=$(USE_LD)
+    LDFLAGS += -fuse-ld=$(USE_LD)
  endif


### PR DESCRIPTION
Release notes - https://github.com/BlitterStudio/amiberry/releases/tag/v5.6.0

Changelog for 5.6.0, with modifications added after 5.5.1:

* New features

    - implemented On-Screen Virtual Keyboard
    - added VKBD retroarch mapping support and VKBD default toggle key
    - decrease mouse map sensitivity on joystick handling
    - added new default options in amiberry.conf
    - added Warp reset option in Misc Panel
    - GUI improvements
    - implemented turbo boot option
    - added 1024x600 RTG resolution
    - allow on-the-fly change of virtual mouse driver
    - increased width of dropdowns in Input Panel
    - automatically center GUI window when opening
    - updated WHDLoad XML to latest version
    - updated game controllers db to latest version

* Changes

    - refactored input event handling to minimize latency
    - rewrite Serial port support, using libserialport
    - refactored controller input logic
    - decrease mouse map sensitivity on joystick handling
    - added more logging during retroarch event handling

* Bugfixes

    - fix "default" button setting not fully enabling CD32 pad mode when CD32 was configured.
    - detection of hotplug controllers didn't work after 5.4
    - restart would cause crashes sometimes
    - fixed controller axis should be separate from joystick axis handling
    - memory pattern would cause graphics glitches in some cases
    - virtual keyboard now works with CD32 mode as well
    - fixed crash if something triggered a CPU HALT3
    - fixed various compiler warnings
    - revert custom, blitter and drawing to WinUAE 4.4.0 standard
    - improve scrolling smoothness under 50Hz
    - don't use SDL_Quit until we actually quit Amiberry

Closes #3634 