### PR TITLE
lr-caprice32: work around an upstream cloning issue

### DIFF
--- a/scriptmodules/libretrocores/lr-caprice32.sh
+++ b/scriptmodules/libretrocores/lr-caprice32.sh
@@ -13,7 +13,7 @@ rp_module_id="lr-caprice32"
 rp_module_desc="Amstrad CPC emu - Caprice32 port for libretro"
 rp_module_help="ROM Extensions: .cdt .cpc .dsk\n\nCopy your Amstrad CPC games to $romdir/amstradcpc"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/libretro-cap32/master/cap32/COPYING.txt"
-rp_module_repo="git https://github.com/libretro/libretro-cap32.git master"
+rp_module_repo="git https://github.com/cmitu/libretro-cap32.git master"
 rp_module_section="main"
 
 function sources_lr-caprice32() {


### PR DESCRIPTION
Upstream uses a shallow submodule, but is tracking a rolling branch that changed since the submodule was added. Older `git` versions cannot fetch the ref registered in the parent repo and the recursive clone fails. It affects Debian _buster_ and Ubuntu 18.04, plus other downstream distros (Linux Mint 19.3).

Clone the repo temporarily and remove the submodule, since it's not used actively by the core. Issue was reporeted upstream in https://github.com/libretro/libretro-cap32/issues/116.