### PR TITLE
splashcreen: increase the DispmanX layer

### DIFF
--- a/scriptmodules/supplementary/splashscreen/asplashscreen.sh
+++ b/scriptmodules/supplementary/splashscreen/asplashscreen.sh
@@ -43,7 +43,7 @@ do_start () {
         while ! pgrep "dbus" >/dev/null; do
             sleep 1
         done
-        omxplayer --no-osd -o both -b --layer 10000 "$line"
+        omxplayer --no-osd -o both -b --layer 10001 "$line"
     elif $(echo "$line" | grep -q "$REGEX_IMAGE"); then
         if [ "$RANDOMIZE" = "disabled" ]; then
             local count=$(wc -l <"$config")
@@ -57,9 +57,9 @@ do_start () {
         [ -z "$DURATION" ] && DURATION=12
         local delay=$((DURATION/count))
         if [ "$RANDOMIZE" = "disabled" ]; then
-            "$omxiv" --once -t $delay -b --layer 1000 -f "$config" >/dev/null 2>&1
+            "$omxiv" --once -t $delay -b --layer 10001 -f "$config" >/dev/null 2>&1
         else
-            "$omxiv" --once -t $delay -b --layer 1000 -r "$line" >/dev/null 2>&1
+            "$omxiv" --once -t $delay -b --layer 10001 -r "$line" >/dev/null 2>&1
         fi
     fi
     exit 0


### PR DESCRIPTION
EmulationStation, when using the RPI videodrivers, displays at layer 10000. Increased the layer index for video/images in order to run above EmulationStation.