### PR TITLE
retroarch: update to v1.15 & change a few defaults

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -12,7 +12,7 @@
 rp_module_id="retroarch"
 rp_module_desc="RetroArch - frontend to the libretro emulator cores - required by all lr-* emulators"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/RetroArch/master/COPYING"
-rp_module_repo="git https://github.com/retropie/RetroArch.git retropie-v1.12.0"
+rp_module_repo="git https://github.com/retropie/RetroArch.git retropie-v1.15.0"
 rp_module_section="core"
 
 function depends_retroarch() {
@@ -176,9 +176,6 @@ function configure_retroarch() {
     iniSet "system_directory" "$biosdir"
     iniSet "config_save_on_exit" "false"
     iniSet "video_aspect_ratio_auto" "true"
-    iniSet "rgui_browser_directory" "$romdir"
-    iniSet "rgui_switch_icons" "false"
-
     if ! isPlatform "x86"; then
         iniSet "video_threaded" "true"
     fi
@@ -236,6 +233,10 @@ function configure_retroarch() {
     # rgui by default
     iniSet "menu_driver" "rgui"
     iniSet "rgui_aspect_ratio_lock" "2"
+    iniSet "rgui_browser_directory" "$romdir"
+    iniSet "rgui_switch_icons" "false"
+    iniSet "menu_rgui_shadows" "true"
+    iniSet "rgui_menu_color_theme" "29" # Tango Dark theme
 
     # hide online updater menu options and the restart option
     iniSet "menu_show_core_updater" "false"
@@ -244,13 +245,18 @@ function configure_retroarch() {
     # disable the search action
     iniSet "menu_disable_search_button" "true"
 
-    # remove some options from quick menu
+    # remove some rarely used entries from the quick menu
     iniSet "quick_menu_show_close_content" "false"
     iniSet "quick_menu_show_add_to_favorites" "false"
+    iniSet "quick_menu_show_replay" "false"
+    iniSet "quick_menu_show_start_recording" "false"
+    iniSet "quick_menu_show_start_streaming" "false"
     iniSet "menu_show_overlays" "false"
 
     # disable the load notification message with core and game info
     iniSet "menu_show_load_content_animation" "false"
+    # disable core cache file
+    iniSet "core_info_cache_enable "false"
 
     # disable unnecessary xmb menu tabs
     iniSet "xmb_show_add" "false"


### PR DESCRIPTION
Updated the script for v1.15. Pull from https://github.com/cmitu/retroarch/tree/retropie-v1.15.0 into https://github.com/retropie/retroarch/ for our patches on-top of the lastest v1.15.

Changed a few options in the default config:

 - removed some rarely used Quick Menu actions to shorten it by default. Rewind/Replay/Record have been toggled off.
 - changed the default RGUI look & feel by configuring it to use the 'Tango Dark' theme, similar to the default RGUI theme.
 ![](https://user-images.githubusercontent.com/38211560/50895738-d785c580-13fe-11e9-941b-41d59a1d4c6a.png)
 - removed the core cache info file read/writing, since it's not useful for our configuration.

Biggest breaking change since v1.12 is the hotkey handling for keyboard inputs. Previously, when a gamepad was connected and keyboard didn't define any hotkey enable key, the hotkey action on the keyboard would trigger only when the hotkey enable btn on the gamepad was pressed. Current behavior is to trigger the hotkey action on the keyboard without the hotkey btn pressed. Note that this mainly affects configurations when keyboard/gamepad were used simultaneously, for standalone keyboard based configurations the difference wouldn't matter.

The hotkey btn regression I reported was fixed in the re-release (!) of v1.15 and it's part of our RetroPie branch.

Here's an abriged changelog for v1.13-v1.15, focused on new features/updates and major bugfixes. Detailed changelogs:
 * 1.13 - https://www.libretro.com/index.php/retroarch-1-13-0-release/
 * 1.14 - https://www.libretro.com/index.php/retroarch-1-14-0-release/
 * 1.15 - https://www.libretro.com/index.php/retroarch-1-15-0-release/
 * 1.15 redo - https://www.libretro.com/index.php/dirksimple-core-added/

* General
  - Start unpause restriction. Limit the feature using retropad start button to unpause RA to the setting it was made for; "pause on controller disconnect".
  - Ignore system subdir replacement if subdir has subdirs.
  - Add support for system subdirs per core/database. Added the trivial and graceful automatic ability to send a different system directory to cores if it exists, for keeping the system dir more sane. First by using the core/library name just like in configs and saves, and then by playlist name, like in thumbnails, and of course default to the current global system dir.
  - Restore cached video driver always on quit
  - Added _Automatic Frame Delay_  Helped delay to decrease easier when it should and helped delay to stay put when it should when triggering pause & menu with or without pause & fast-forward & slow-motion & geometry change
  - Add _Preemptive Frames_ to Latency Settings, RunAhead alternative that reruns core logic to "rewrite history" before the current frame. Frames are only rerun when the controller state changes, so it’s faster overall.
  - Allow selecting -1 Auto slot with hotkeys
  - Allow wrap-around from -1 to 999 save states and backwards
  - Show failure message when trying to load a state that does not exist instead of plain “Loading state”
  - Shorten the duration of save slot change notification
  - Change the Save States widget type to the same type as shader toggle for better back and forth action.
  - Allow manual video swap interval forcing. The addition of auto swap interval effectively prevented manual forcing, which is beneficial when the rate is not reported properly. Therefore use the interval in the calculation only when using automatic interval.
  - Restore framelimit on fastforward toggle. Fast-forward was broken after toggling vrr_runloop off, since it will force frame limit to 1.0 (even on every frame) and never restores it. So let’s make sure the wanted ratio is applied when toggling FF (Fastforward).
  - Don’t init SRAM saving without content (gets rid of the redundant logging)
  - Use non-rendering pause mode when frameadvance is triggered
  - Core option setting type checks. Added checks for getting and setting core option type, since otherwise there will be a crash on close content after browsing to core option categories. Also fixed the no-show switch icon for lone wolf "Lock Installed Core"
  - Restore framelimit on fastforward toggle

* Cheevos
  - Allow repositioning of RetroAchievement notifications
  - MENU: Add Achievements Visibility submenu option
  - MENU: Startup Summary split off from Verbose Mode, added option to hide for games with zero core cheevos
  - MENU: ‘Unlocks/Mastery’ split into two options
  - MENU: ‘Account/Login Messages’ split off from ‘Verbose’, gated all login success/error messages
  - Fix construction of Cheevos badge path
  - Upgrade to rcheevos 10.5

* Input
  - Fixed the way devices were previously indexed. Input devices were only being indexed in order and would stop at the first time an input has no device connected to it. The problem is when a device gets disconnected, that input will have no devices connected to it, but the next input may still have a device connected. So, that makes changing the port of the currently connected devices impossible.
  - Add option for pause on controller disconnect
  - Enable menu navigation also with right analog stick
  - Add option for pause on controller disconnect
  - Add option for swapping menu scrolling buttons
  - Hotkeys - Fix shader toggle and add hotkey + sublabel
  - Hotkeys cleanups and corrections * keep hotkey pause and menu pause separate in order to not trigger unwanted pause when toggling menu regardless if menu will pause or not * allow unpausing with Start (makes resuming more convenient after controller disconnect if menu does not pause)
  - Don't show override notification with appendconfig alone
  - Further reorder internal hotkey items for consistency and removed SEND_DEBUG_INFO, OVERLAY_NEXT and OSK from visible hotkey bind list.
  - Disable "pause on controller disconnect" by default
  - Device Index menu refactor
  - Allowing keyboard hotkeys to work without hotkey modifier if modifier is only mapped to RetroPad
  - Allowing keyboard hotkey keys for typing if hotkey modifier is set to keyboard but not pressed
  - Allowing keyboard RetroPad keys for typing if emulated device type is "None"
  - (Linux/udev)  Fix udev guns input when id_mouse is not id_joystick
  - Check for "enable_hotkey" also from autoconf binds (1.15bis)
  - Unload restores current global config
  - Saving an empty override removes the file if it exists, and won’t save when it does not
  - Removing a file does not unload current override

* Shaders - added stacking shader presets

* Menu
  - Rename "Standalone Cores" to "Contentless Cores"
  - Relocated items to a more logical order
  - Corrected some title capitalizations
  - Allow toggling info off with the same button
  - Allow menu wallpaper/background reset.
  - Cleanup of help texts
  - Add dropdown menu for audio device
  - Help for turbo modes (#14919). Help text added for each of the selectable turbo modes.
  - Allowed and fixed input bind saving to overrides
  - Overhauled override menu, override bind save + menu manager overhaul
  - Allowed and fixed input bind saving to overrides
  - Add unified back action to all menu drivers.
  - Pressing Start on the top active file entry reloads current overrides as startup would
  - Added missing icons in cheats
  - Fix disabled menu item color on RGUI. The effect was not working properly, since transparency meant using the core output color as background.
  - Fixed label capitalization in cheats
  - Add scrolling sounds for RGUI, XMB, MaterialUI and Ozone.
  - Better scrolling sound implementation, add new "notice back" sound
  - Show square sized widget on volume mute
  - Various fixes and improvements for XMB, Ozone and MaterialUI drivers
  - Notification font + statistics adjustments for OSD
  - Show Frame Delay without VSync
  - Fix RGUI on Vulkan on platforms that don’t have _pack16 VkFormats