### PR TITLE
emulationstation: add vendor/product ids to input scripts

### DIFF
--- a/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/retroarch.sh
@@ -25,6 +25,11 @@ function onstart_retroarch_joystick() {
     iniConfig " = " "\"" "/tmp/tempconfig.cfg"
     iniSet "input_device" "$DEVICE_NAME"
     iniSet "input_driver" "$input_joypad_driver"
+    # add vendor and product ids if non-empty
+    if [[ -n "$VENDOR_ID" && -n "$PRODUCT_ID" ]]; then
+        iniSet "input_vendor_id" "$VENDOR_ID"
+        iniSet "input_product_id" "$PRODUCT_ID"
+    fi
 }
 
 function onstart_retroarch_keyboard() {

--- a/scriptmodules/supplementary/emulationstation/inputconfiguration.sh
+++ b/scriptmodules/supplementary/emulationstation/inputconfiguration.sh
@@ -15,12 +15,13 @@
 ## @details
 ## @par global variables
 ##
-## There are 3 global variables which are set to the current device being processed
+## There are 5 global variables which are set to the current device being processed
 ##
 ## `DEVICE_TYPE` = device type is currently either joystick, keyboard or cec
 ## `DEVICE_NAME` = name of the device
 ## `DEVICE_GUID` = SDL2 joystick GUID of the device (-1 for keyboard, -2 for cec)
-##
+## `VENDOR_ID`   = the USB vendor ID of the device
+## `PRODUCT_ID`  = the USB product ID of the device
 ## @par Interface functions
 ##
 ## each input configuration module can have an optional function
@@ -80,6 +81,8 @@ function inputconfiguration() {
     DEVICE_TYPE=$(xmlstarlet sel --text -t -v "/inputList/inputConfig/@type" "$es_conf")
     DEVICE_NAME=$(xmlstarlet sel --text -t -v "/inputList/inputConfig/@deviceName" "$es_conf")
     DEVICE_GUID=$(xmlstarlet sel --text -t -v "/inputList/inputConfig/@deviceGUID" "$es_conf")
+    VENDOR_ID=$(xmlstarlet sel --text -t -v "/inputList/inputConfig/@vendorId" "$es_conf")
+    PRODUCT_ID=$(xmlstarlet sel --text -t -v "/inputList/inputConfig/@productId" "$es_conf")
 
     echo "Input type is '$DEVICE_TYPE'."
 


### PR DESCRIPTION
* modified the input configuration script to export Vendor/Product IDs, if exported by EmulationStation.
* added vendor/product to RetroArch's script for generating joypad profile.

Fixes #3398