### PR TITLE
openmsx: bump version to 18.0 and update input config

### DIFF
--- a/scriptmodules/emulators/openmsx.sh
+++ b/scriptmodules/emulators/openmsx.sh
@@ -13,13 +13,15 @@ rp_module_id="openmsx"
 rp_module_desc="MSX emulator OpenMSX"
 rp_module_help="ROM Extensions: .cas .rom .mx1 .mx2 .col .dsk .zip\n\nCopy your MSX/MSX2 games to $romdir/msx\nCopy the BIOS files to $biosdir/openmsx"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/openMSX/openMSX/master/doc/GPL.txt"
-rp_module_repo="git https://github.com/openMSX/openMSX.git RELEASE_17_0 :_get_commit_openmsx"
+rp_module_repo="git https://github.com/openMSX/openMSX.git RELEASE_18_0 :_get_commit_openmsx"
 rp_module_section="opt"
 rp_module_flags=""
 
 function _get_commit_openmsx() {
     local commit
-    # latest code requires at least GCC 8.3 (Debian Buster) for full C++17 support
+    # latest code requires a C++ compiler with C++23 support (Debian Bullseye)
+    [[ "$__gcc_version" -lt 9 ]] && commit="127e2826"
+    # use a commit after release 17 for older GCC versions (gcc 8.x, Debian Buster)
     [[ "$__gcc_version" -lt 8 ]] && commit="c8d90e70"
     # for GCC before 7, build from an earlier commit, before C++17 support was added
     [[ "$__gcc_version" -lt 7 ]] && commit="5ee25b62"

--- a/scriptmodules/emulators/openmsx/retropie-init.tcl
+++ b/scriptmodules/emulators/openmsx/retropie-init.tcl
@@ -4,10 +4,10 @@ proc init {} {
     set rom_name [guess_title]
     set config_dir [file normalize "$::env(OPENMSX_USER_DATA)/joystick"]
 
-    # Sanitize rom name
+    # sanitize the rom name
     regsub -all {[:><?\"\/\\|*]} $rom_name "" rom_name
 
-    # Auto-configure the 1st plugged in joystick, but only if present
+    # auto-configure the 1st plugged in joystick, but only if present
     # openMSX automatically loads the plugged in joysticks in 'autoplug.tcl'
     if {![info exists ::joystick1_config]} {
         return
@@ -20,19 +20,18 @@ proc init {} {
         }
     }
 
-    if { [catch {exec udevadm info --name=/dev/input/js0 | grep -q "ID_INPUT_JOYSTICK=1"}] == 0 } {
-        set path [exec udevadm info --name=/dev/input/js0 --query=name]
-        set joy_name [exec cat /sys/class/$path/device/name]
-        regsub -all {[:><?\"\/\\|*]} $joy_name "" joy_name
-        if { [file exists "$config_dir/$joy_name.tcl"] } {
-                load_config_joystick $joy_name "$config_dir/$joy_name.tcl"
-        }
+    # get the 1st joystick name
+    set joy_name [machine_info pluggable joystick1]
+    # ... and sanitize it
+    regsub -all {[:><?\"\/\\|*]} $joy_name "" joy_name
+    if { [file exists "$config_dir/$joy_name.tcl"] } {
+             load_config_joystick $joy_name "$config_dir/$joy_name.tcl"
     }
 }
 
 proc load_config_joystick { conf_name conf_script } {
     source "$conf_script"
-    # Check for auto configuration function
+    # check for the joypad auto-configuration function
     if { [info procs "auto_config_joypad"] == "" } {
         return
     }


### PR DESCRIPTION
Updated to the 18.0 release, which requires GCC 9 and it's installable on Debian 11 (bullseye)/Ubuntu 20.04+.

The input auto-loading script has been updated to use the joystick's SDL name, while previously was using the 'udev' device name. This fixes the issues when the joystick nane (SDL) is different than the 'udev' reported name and thus prevented the auto-loading.