### PR TITLE
skyscraper - prevent hall-of-mirrors effect

### DIFF
--- a/scriptmodules/supplementary/skyscraper.sh
+++ b/scriptmodules/supplementary/skyscraper.sh
@@ -210,7 +210,10 @@ function _init_config_skyscraper() {
     done
 
     # If we don't have a previous config.ini file, copy the example one
-    [[ ! -f "$scraper_conf_dir/config.ini" ]] && cp "$md_inst/config.ini.example" "$scraper_conf_dir/config.ini"
+    if [[ ! -f "$scraper_conf_dir/config.ini" ]]; then
+        cp "$md_inst/config.ini.example" "$scraper_conf_dir/config.ini"
+        sed -i 's/\[esgamelist\]/[esgamelist]\ncacheScreenshots="false"/' "$scraper_conf_dir/config.ini"
+    fi
 
     # Try to find the rest of the necessary files from the qmake build file
     # They should be listed in the `unix:examples.file` configuration line


### PR DESCRIPTION
By default, Skyscraper creates a composite image with screenshot, logo, and box art, and then saves this as a "screenshot" itself:

![Armored Core (USA) (Reprint)](https://user-images.githubusercontent.com/92833764/232385723-a9cff967-3924-4a53-a4f4-4ce31b87be44.png)


When the local `esgamelist` is then scraped after that, this already-processed "screenshot" (with logo and box art) has the logo and box art applied to it again, leading to a receding "hall of mirrors" effect. This effect is amplified with repeated scraping:

![Armored Core (USA) (Reprint) 2](https://user-images.githubusercontent.com/92833764/232385959-aa481f8b-cdb7-4b54-aa40-c424e9b721ea.png)

![Armored Core (USA) (Reprint) 3](https://user-images.githubusercontent.com/92833764/232386032-d7d067fa-235d-4129-9e7d-1d6229966844.png)


To prevent this, do not cache these already-processed screenshots when scraping the local `esgamelist` source.