### PR TITLE
Skyscraper - update source repo and scriptmodule

### DIFF
--- a/scriptmodules/supplementary/skyscraper.sh
+++ b/scriptmodules/supplementary/skyscraper.sh
@@ -10,13 +10,13 @@
 #
 
 rp_module_id="skyscraper"
-rp_module_desc="Scraper for EmulationStation by Lars Muldjord"
-rp_module_licence="GPL3 https://raw.githubusercontent.com/muldjord/skyscraper/master/LICENSE"
-rp_module_repo="git https://github.com/muldjord/skyscraper :_get_branch_skyscraper"
+rp_module_desc="Scraper for EmulationStation"
+rp_module_licence="GPL3 https://raw.githubusercontent.com/Gemba/skyscraper/master/LICENSE"
+rp_module_repo="git https://github.com/Gemba/skyscraper :_get_branch_skyscraper"
 rp_module_section="opt"
 
 function _get_branch_skyscraper() {
-    download https://api.github.com/repos/muldjord/skyscraper/releases/latest - | grep -m 1 tag_name | cut -d\" -f4
+    download https://api.github.com/repos/Gemba/skyscraper/releases/latest - | grep -m 1 tag_name | cut -d\" -f4
 }
 
 function depends_skyscraper() {
@@ -44,11 +44,15 @@ function install_skyscraper() {
         'artwork.xml.example2'
         'artwork.xml.example3'
         'artwork.xml.example4'
+        'platforms.json'
+        'screenscraper.json'
+        'mobygames.json'
         'tgdb_developers.json'
         'tgdb_publishers.json'
         'mameMap.csv'
         'aliasMap.csv'
-        'hints.txt'
+        'hints.xml'
+        'docs'
         'import'
         'resources'
         'cache/priorities.xml.example'
@@ -133,7 +137,7 @@ function _get_ver_skyscraper() {
 
 function _check_ver_skyscraper() {
     ver=$(_get_ver_skyscraper)
-    if compareVersions "$ver" lt "3.5" ]]; then
+    if compareVersions "$ver" lt "3.5"; then
         printMsgs "dialog" "The version of Skyscraper you currently have installed is incompatible with options used by this script. Please update Skyscraper to the latest version to continue."
         return 1
     fi
@@ -201,42 +205,21 @@ function _init_config_skyscraper() {
 
     # Make sure the `artwork.xml` and other conf file(s) are present, but don't overwrite them on upgrades
     local f_conf
-    for f_conf in artwork.xml aliasMap.csv; do
-        if [[ -f "$scraper_conf_dir/$f_conf" ]]; then
-            cp -f "$md_inst/$f_conf" "$scraper_conf_dir/$f_conf.default"
-        else
-            cp "$md_inst/$f_conf" "$scraper_conf_dir"
-        fi
+    for f_conf in artwork.xml aliasMap.csv platforms.json screenscraper.json; do
+        copyDefaultConfig "$md_inst/$f_conf" "$scraper_conf_dir/$f_conf"
     done
 
     # If we don't have a previous config.ini file, copy the example one
-    if [[ ! -f "$scraper_conf_dir/config.ini" ]]; then
-        cp "$md_inst/config.ini.example" "$scraper_conf_dir/config.ini"
-        sed -i 's/\[esgamelist\]/[esgamelist]\ncacheScreenshots="false"/' "$scraper_conf_dir/config.ini"
-    fi
+    [[ ! -f "$scraper_conf_dir/config.ini" ]] && cp "$md_inst/config.ini.example" "$scraper_conf_dir/config.ini"
 
-    # Try to find the rest of the necessary files from the qmake build file
-    # They should be listed in the `unix:examples.file` configuration line
-    if [[ $(grep unix:examples.files "$md_build/skyscraper.pro" 2>/dev/null | cut -d= -f2-) ]]; then
-        local files=$(grep unix:examples.files "$md_build/skyscraper.pro" | cut -d= -f2-)
-        local file
+    # Artwork example files
+    cp -f "$md_inst/artwork.xml.example"* "$scraper_conf_dir"
 
-        for file in $files; do
-            # Copy the files to the configuration folder. Skip config.ini, artwork.xml and aliasMap.csv
-            if [[ $file != "artwork.xml" && $file != "config.ini" && $file != "aliasMap.csv" ]]; then
-                cp -f "$md_build/$file" "$scraper_conf_dir"
-            fi
-        done
-    else
-        # Fallback to the known resource files list
-        cp -f "$md_inst/artwork.xml.example"* "$scraper_conf_dir"
-
-        # Copy resources and readme
-        local resource_file
-        for resource_file in README.md mameMap.csv tgdb_developers.json tgdb_publishers.json hints.txt; do
-            cp -f "$md_inst/$resource_file" "$scraper_conf_dir"
-        done
-    fi
+    # Copy remaining resources
+    local resource_file
+    for resource_file in mameMap.csv tgdb_developers.json tgdb_publishers.json hints.xml mobygames.json; do
+        cp -f "$md_inst/$resource_file" "$scraper_conf_dir"
+    done
 
     # Copy the rest of the folders
     cp -rf "$md_inst/resources" "$scraper_conf_dir"
@@ -249,7 +232,7 @@ function _init_config_skyscraper() {
     cp -rf "$md_inst/import" "$scraper_conf_dir"
 
     # Create the cache folder and add the sample 'priorities.xml' file to it
-    mkdir -p "$scraper_conf_dir/cache"
+    mkUserDir "$scraper_conf_dir/cache"
     cp -f "$md_inst/priorities.xml.example" "$scraper_conf_dir/cache"
 }
 
@@ -342,7 +325,7 @@ function _scrape_chosen_skyscraper() {
     # Confirm with the user that scraping can start
     dialog --clear --colors --yes-label "Proceed" --no-label "Abort" --yesno "This will start the gathering process, which can take a long time if you have a large game collection.\n\nYou can interrupt this process anytime by pressing \ZbCtrl+C\Zn.\nProceed ?" 12 70 2>&1 >/dev/tty
     [[ ! $? -eq 0 ]] && return 1
-    
+
     local choice
 
     for choice in "${choices[@]}"; do
@@ -371,7 +354,7 @@ function _generate_chosen_skyscraper() {
     fi
 
     local choices
-    local cmd=(dialog --backtitle "$__backtitle" --ok-label "Start" --cancel-label "Back" --checklist " Select platforms for gamelist(s) generation\n\n" 22 60 16) 
+    local cmd=(dialog --backtitle "$__backtitle" --ok-label "Start" --cancel-label "Back" --checklist " Select platforms for gamelist(s) generation\n\n" 22 60 16)
 
     choices=($("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty))
 
@@ -523,7 +506,7 @@ function gui_skyscraper() {
     while true; do
         [[ -z "$ver" ]] && ver="v(Git)"
 
-        local cmd=(dialog --backtitle "$__backtitle"  --colors --cancel-label "Exit" --help-button --no-collapse --cr-wrap --default-item "$default" --menu "   Skyscraper: game scraper by Lars Muldjord ($ver)\\n \\n" 22 60 12)
+        local cmd=(dialog --backtitle "$__backtitle"  --colors --cancel-label "Exit" --help-button --no-collapse --cr-wrap --default-item "$default" --menu "   Skyscraper: game scraper for EmulationStation ($ver)\\n \\n" 22 60 12)
 
         local options=(
             "-" "GATHER and cache resources"


### PR DESCRIPTION
- Update source repo to active fork: https://github.com/Gemba/skyscraper

- Scriptmodule enhancements and fixes (co-authored by @Gemba)

(Original first post follows):
> Upstream repository is currently not accepting pull requests, to focus on developing other projects. So I've made a couple of patches to update the source with one bug fix and one QOL improvement.
> 
> (BUG) Apple2 exts: normally, most roms are cached by hashing the file content. However, apple2 disk images are volatile and may change content. Patch `01_apple2_exts.patch` adds apple2 exts to list of exceptions, to be cached by file name instead.
> 
> (QOL) tg16 system: Many themes support an independent 'tg16' system folder. Patch `02_add_tg16_system.patch` adds tg16 alias for pcengine titles.