### PR TITLE
emulationstation: use OpenGL2 for RPI+Mesa platform

### DIFF
--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -163,7 +163,7 @@ function build_emulationstation() {
     if isPlatform "rpi"; then
         params+=(-DRPI=On)
         # use OpenGL on RPI/KMS for now
-        isPlatform "mesa" && params+=(-DGL=On)
+        isPlatform "mesa" && params+=("-DGL=On" "-DUSE_GL21=On")
         # force GLESv1 on videocore due to performance issue with GLESv2
         isPlatform "videocore" && params+=(-DUSE_GLES1=On)
     elif isPlatform "x11"; then


### PR DESCRIPTION
The last runtime detection changes for the build instructions enable the GL21 renderer only on non-RPI platforms. The V3D Mesa driver supports OpenGL 2.1, so enable the GL21 renderer when it's used on a Raspberry Pi.

Without this change, the build will use the GL1.4 renderer.