### PR TITLE
runcommand: fix ROM substitution with `bash` 5.2

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -95,6 +95,11 @@ XRANDR="xrandr"
 
 source "$ROOTDIR/lib/inifuncs.sh"
 
+# disable the `patsub_replacement` shell option, it breaks the string substitution when replacement contains '&'
+if shopt -s patsub_replacement 2>/dev/null; then
+    shopt -u patsub_replacement
+fi
+
 function get_config() {
     declare -Ag MODE_MAP
 


### PR DESCRIPTION
`bash` 5.2 introduced a new option (`patsub_replacement`) which affects how `%ROM%` is replaced in the command line:

> x. New shell option: patsub_replacement. When enabled, a `&' in the replacement
>   string of the pattern substitution expansion is replaced by the portion of
>   the string that matched the pattern. Backslash will escape the `&' and
>   insert a literal `&'.

This breaks the substitution of `%ROM%` when the replacement string (ROM name) has a `&`.

1. with `bash` version 5.1
```
$ COMMAND="run %ROM%" && COMMAND=${COMMAND//%ROM%/a & b.rom} && echo $COMMAND
run a & b.rom
```
2. with `bash` version 5.2
```
$ COMMAND="run %ROM%" && COMMAND=${COMMAND//%ROM%/a & b.rom} && echo $COMMAND
run a %ROM% b.rom
```
3. with `bash` version 5.2, option disabled $ shopt -u patsub_replacement 
```
$ COMMAND="run %ROM%" && COMMAND=${COMMAND//%ROM%/a & b.rom} && echo $COMMAND 
run a & b.rom
```

Disable this option in `runcommand` for now so users won't be affected by it when using Ubuntu 22.10+/Debian 12 (bookworm)