### PR TITLE
system: add support for the Rockchip 3588 platform

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -445,6 +445,9 @@ function get_platform() {
                         *imx8mm*)
                             __platform="imx8mm"
                             ;;
+                        *rk3588*)
+                            __platform="rk3588"
+                            ;;
                     esac
                 elif [[ -e "/sys/devices/soc0/family" ]]; then
                     case "$(tr -d '\0' < /sys/devices/soc0/family)" in
@@ -650,6 +653,11 @@ function platform_imx8mm() {
     cpu_armv8 "cortex-a53"
     __platform_flags+=(x11 gles)
     [[ -d /sys/class/drm/card0/device/driver/etnaviv ]] && __platform_flags+=(mesa)
+}
+
+function platform_rk3588() {
+    cpu_armv8 "cortex-a76.cortex-a55"
+    __platform_flags+=(x11 gles gles3 gles32)
 }
 
 function platform_vero4k() {


### PR DESCRIPTION
Added basic support for detecting and building on the Rockchip 3588(s) SOC. The SOC is used in several ARM based SBC including Radxa Rock 5(A/B), Orange Pi 5(B), Khadas Edge 2. The CPU is an octocore package with 4x Cortex-A76 + 4x Cortex-A55 cores.

There are several distributions that support these systems, vendor provided images including a proprietary Mali blob with OpenGLES 3.2/OpenCL support or community provided images using either a Mesa fork for GLES/X11/Wayland support. For now, the platform has an `x11` flag to allow most of the emulators to be installed, but we might switch to dynamically detecting the desktop platform (i.e. `wayland` / `x11` depending on the system).