### PR TITLE
lr-x1: switch to the libretro repository

### DIFF
--- a/scriptmodules/libretrocores/lr-x1.sh
+++ b/scriptmodules/libretrocores/lr-x1.sh
@@ -12,7 +12,8 @@
 rp_module_id="lr-x1"
 rp_module_desc="Sharp X1 emulator - X Millenium port for libretro"
 rp_module_help="ROM Extensions: .dx1 .zip .2d .2hd .tfd .d88 .88d .hdm .xdf .dup .cmd\n\nCopy your X1 roms to $romdir/x1\n\nCopy the required BIOS files IPLROM.X1 and IPLROM.X1T to $biosdir"
-rp_module_repo="git https://github.com/r-type/xmil-libretro.git master"
+rp_module_repo="git https://github.com/libretro/xmil-libretro.git master"
+rp_module_licence="BSD https://raw.githubusercontent.com/libretro/xmil-libretro/master/LICENSE"
 rp_module_section="exp"
 
 function sources_lr-x1() {


### PR DESCRIPTION
Changed the source repository to the libretro fork of the core, since it gets a bit of maintenance than the original repo (`r-type/xmil-libretro`) and I noticed a few more core options have been added over the time. The original core repository hasn't been updated since 2017.

Added the licence from the libretro fork.