### PR TITLE
amiberry: update to 5.6.1

### DIFF
--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -13,7 +13,7 @@ rp_module_id="amiberry"
 rp_module_desc="Amiga emulator with JIT support (forked from uae4arm)"
 rp_module_help="ROM Extension: .adf .chd .ipf .lha .zip\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir/amiga"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/BlitterStudio/amiberry/master/LICENSE"
-rp_module_repo="git https://github.com/BlitterStudio/amiberry v5.6.0"
+rp_module_repo="git https://github.com/BlitterStudio/amiberry v5.6.1"
 rp_module_section="opt"
 rp_module_flags="!all arm rpi3 rpi4"
 


### PR DESCRIPTION
Among others, fixes some input issues, one of them reported in the forums, and a Vero4k black screen during emulation. Full changelog at https://github.com/BlitterStudio/amiberry/releases/tag/v5.6.1

Bugfixes:

- Hardfile properties were always set to default (fixes #1077)
- cycle exact was incorrect enabled sometimes (fixes #1075)
- Fix foreign disk image support when drive is standard Amiga 3.5" DD
- hsync events should be before misc events
- fixed uaegfx board parameters
- uaegfx board name is UAE, not uaegfx.card
- Fix helptext formatting in CPU panel (fixes #1088)
- use double-quotes to denote inches in GUI
- when using --autoload with a filename in the current path, Amiberry would crash (fixes #1091)
- fix build errors with GCC 13.1 (fixes #1100)
- savestate cmd line option would not use filename (fixes #1081)
- second controller buttons would not be registered in retroarch (fixes #1092)
- Fullscreen toggle would no longer work since v5.3 (fixes #1103)
- reverted copying of prefs on hard reset (fixes #1068)

Improvements:

- VGA mode resolution autoswitch update
- VGA autoswitch update to support new OS 3.2 monitors
- Upgraded FloppyDriveBridge to v1.4
- improve message when Main ROM is not found (fixes #1095)
- improve Floppy GUI panel (fixes #1094)
- use BGR888 for 32-bit modes (fixes #1080)