### PR TITLE
Create lr-citra

### DIFF
--- a/scriptmodules/libretrocores/lr-citra
+++ b/scriptmodules/libretrocores/lr-citra
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-citra"
+rp_module_desc="Nintendo 3DS Emulator - libretro port of Citra"
+rp_module_help="ROM Extensions: .3ds .cia .cci .elf \n\nCopy your Nintendo 3DS roms to $romdir/3ds"
+rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/citra/master/license.txt"
+rp_module_section="exp"
+rp_module_flags=" !all 64bit"
+
+function depends_lr-citra() {
+    getDepends cmake  libsdl2-dev
+}
+
+function sources_lr-citra() {
+    gitPullOrClone "$md_build" https://github.com/libretro/citra.git
+}
+
+function build_lr-citra() {
+    mkdir -p build
+    cd build
+    cmake -DENABLE_LIBRETRO=1 -DENABLE_SDL2=0 -DENABLE_QT=0 -DCMAKE_BUILD_TYPE="Release" -DENABLE_WEB_SERVICE=0 --target citra_libretro ..
+    make clean
+    make
+    md_ret_require="$md_build/build/src/citra_libretro/citra_libretro.so"
+}
+
+function install_lr-citra() {
+    md_ret_files=(
+        'build/src/citra_libretro/citra_libretro.so'
+    )
+}
+
+function configure_lr-citra() {
+    mkRomDir "3ds"
+    ensureSystemretroconfig "3ds"
+
+    addEmulator 0 "$md_id" "3ds" "$md_inst/citra_libretro.so"
+    addSystem "3ds"
+}


### PR DESCRIPTION
This is an updated version of the script that @joolswills wrote to install citra on retropie. This includes a list of supported rom extensions previously not included.  Since 64 bit is now available on the raspberry pi, I believe this is worth experimenting with. I would also argue that this should be a separate system from the nds because the 3ds in relation to the nds is best compared to that of the wii and gamecube. Also citra is not backwards compatible like the 3ds, and cannot run nds roms. It may be best to separate the systems just of avoid confusion 