### PR TITLE
Create lr-citra2018

### DIFF
--- a/scriptmodules/libretrocores/lr-citra2018
+++ b/scriptmodules/libretrocores/lr-citra2018
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-citra 2018"
+rp_module_desc="Nintendo 3DS Emulator - A Nintendo 3DS emulator targeting libretro exclusively. Based on an older snapshotted version of Citra. Lower compilation and build requirements. "
+rp_module_help="ROM Extensions: .3ds .cia .cci .elf \n\nCopy your Nintendo 3DS roms to $romdir/3ds"
+rp_module_licence="GPL2 https://github.com/libretro/citra2018/blob/master/license.txt"
+rp_module_section="exp"
+rp_module_flags=" !all 64bit"
+
+function depends_lr-citra() {
+    getDepends cmake  libsdl2-dev
+}
+
+function sources_lr-citra() {
+    gitPullOrClone "$md_build" https://github.com/libretro/citra2018.git
+}
+
+function build_lr-citra() {
+    mkdir -p build
+    cd build
+    cmake -DENABLE_LIBRETRO=1 -DENABLE_SDL2=0 -DENABLE_QT=0 -DCMAKE_BUILD_TYPE="Release" -DENABLE_WEB_SERVICE=0 --target citra_libretro ..
+    make clean
+    make
+    md_ret_require="$md_build/build/src/citra_libretro/citra_libretro.so"
+}
+
+function install_lr-citra() {
+    md_ret_files=(
+        'build/src/citra_libretro/citra_libretro.so'
+    )
+}
+
+function configure_lr-citra() {
+    mkRomDir "3ds"
+    ensureSystemretroconfig "3ds"
+
+    addEmulator 0 "$md_id" "3ds" "$md_inst/citra_libretro.so"
+    addSystem "3ds"
+}


### PR DESCRIPTION
This is an older version of citra that according to libretro themselves is "A Nintendo 3DS emulator targeting libretro exclusively. Based on an older snapshotted version of Citra. Lower compilation and build requirements. "