### PR TITLE
make git <branch> parameter also optional in rp_hasNewerModule() 

### DIFF
--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -598,6 +598,9 @@ function rp_hasNewerModule() {
                     ;;
                 git|svn)
                     local repo_branch="$(rp_resolveRepoParam "${__mod_info[$id/repo_branch]}")"
+                    if [[ "$repo_type" == "git" ]] && [[ -z "$repo_branch" ]] ; then
+                        repo_branch="master"
+                    fi
                     local repo_commit="$(rp_resolveRepoParam "${__mod_info[$id/repo_commit]}")"
                     # if we are locked to a single commit, then we compare against the current module commit only
                     if [[ -n "$repo_commit" && "$repo_commit" != "HEAD" ]]; then


### PR DESCRIPTION
The function `rp_hasNewerModule() ` has the git <branch> parameter mandatory and [bails out](https://github.com/Exarkuniv/RetroPie-Extra/pull/161#discussion_r1286379507) when the <branch> is missing. In contrast `gitPullOrClone()` assumes "master" when no branch parameter is present.

This PR fixes this optional/mandatory mismatch between the functions and allows <branch> to be optional in the `rp_module_repo` scriptmodule header for GIT repos.
 