### PR TITLE
audiosettings: ensure ALSA configuration folder exists

### DIFF
--- a/scriptmodules/supplementary/audiosettings.sh
+++ b/scriptmodules/supplementary/audiosettings.sh
@@ -50,6 +50,7 @@ function _reset_alsa_audiosettings() {
 function _move_old_config_audiosettings() {
     if [[ -f "$home/.asoundrc" && ! -f "/etc/alsa/conf.d/99-retropie.conf" ]]; then
         if dialog --yesno "The ALSA audio configuration for RetroPie has moved from $home/.asoundrc to /etc/alsa/conf.d/99-retropie.conf\n\nYou have a configuration in $home/.asoundrc - do you want to move it to the new location? If $home/.asoundrc contains your own changes you should choose 'No'." 20 76 2>&1 >/dev/tty; then
+            mkdir -p /etc/alsa/conf.d
             mv "$home/.asoundrc" "/etc/alsa/conf.d/"
         fi
     fi
@@ -224,6 +225,7 @@ ctl.!default {
 EOF
     fi
     local dest="/etc/alsa/conf.d/99-retropie.conf"
+    mkdir -p /etc/alsa/conf.d
     mv "$tmpfile" "$dest"
     chmod 644 "$dest"
 }


### PR DESCRIPTION
On RaspiOS (10/11), the ALSA configurations folder doesn't exist, so make sure we're creating it before saving/moving the ALSA configuration file we generate with the scriptmodule.