### PR TITLE
helpers: skip APT recommended packages by default

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -218,7 +218,7 @@ function aptUpdate() {
 ## @brief Calls apt-get install with the packages provided.
 function aptInstall() {
     aptUpdate
-    apt-get install -y "$@"
+    apt-get install -y --no-install-recommends "$@"
     return $?
 }
 
@@ -352,7 +352,7 @@ function getDepends() {
        rp_callModule "$pkg" _auto_
     done
 
-    aptInstall --no-install-recommends "${apt_pkgs[@]}"
+    aptInstall "${apt_pkgs[@]}"
 
     local failed=()
     # check the required packages again rather than return code of apt-get,

--- a/scriptmodules/supplementary/raspbiantools.sh
+++ b/scriptmodules/supplementary/raspbiantools.sh
@@ -23,7 +23,7 @@ function apt_upgrade_raspbiantools() {
 }
 
 function lxde_raspbiantools() {
-    aptInstall --no-install-recommends xorg lxde
+    aptInstall xorg lxde
     aptInstall raspberrypi-ui-mods rpi-chromium-mods gvfs
     # On `buster`, disable PulseAudio since it messes up the audio settings
     # remove the lxpanel plugin for PulseAudio volume, to prevent a crash due to missing PulseAudio


### PR DESCRIPTION
Instruct `apt` to install without recommended packages. `getDepends` already does it, but `aptInstall` does not.
Modified `aptInstall` to run `apt` with `--no-install-recommands` and removed the parameter from any other `aptInstall` calls.