### PR TITLE
aarch64: add PS1 and SNES emulators to default installation

### DIFF
--- a/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
+++ b/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
@@ -14,7 +14,7 @@ rp_module_desc="Playstation emulator - PCSX (arm optimised) port for libretro"
 rp_module_help="ROM Extensions: .bin .cue .cbn .img .iso .m3u .mdf .pbp .toc .z .znx\n\nCopy your PSX roms to $romdir/psx\n\nCopy the required BIOS file SCPH1001.BIN to $biosdir"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/pcsx_rearmed/master/COPYING"
 rp_module_repo="git https://github.com/libretro/pcsx_rearmed.git master"
-rp_module_section="opt arm=main"
+rp_module_section="opt arm=main aarch64=main"
 
 function depends_lr-pcsx-rearmed() {
     local depends=(libpng-dev)

--- a/scriptmodules/libretrocores/lr-snes9x.sh
+++ b/scriptmodules/libretrocores/lr-snes9x.sh
@@ -14,7 +14,7 @@ rp_module_desc="Super Nintendo emu - Snes9x (current) port for libretro"
 rp_module_help="ROM Extensions: .bin .smc .sfc .fig .swc .mgd .zip\n\nCopy your SNES roms to $romdir/snes"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/snes9x/master/LICENSE"
 rp_module_repo="git https://github.com/libretro/snes9x.git master"
-rp_module_section="opt armv8=main x86=main"
+rp_module_section="main armv6=opt armv7=opt"
 
 function sources_lr-snes9x() {
     gitPullOrClone


### PR DESCRIPTION
Included `lr-snes9x` and `lr-pcsx-rearmed` in the main section when `aarch64` is detected, otherwise they won't be installed during a basic installation.