### PR TITLE
scummvm: update to 2.7.1 and tweak startup script

### DIFF
--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -86,7 +86,10 @@ function configure_scummvm() {
 #!/bin/bash
 game="\$1"
 pushd "$romdir/scummvm" >/dev/null
-$md_inst/bin/scummvm --fullscreen --joystick=0 --extrapath="$md_inst/extra" "\$game"
+if ! grep -qs extrapath "\$HOME/.config/scummvm/scummvm.ini"; then
+    params="--extrapath="$md_inst/extra""
+fi
+$md_inst/bin/scummvm --fullscreen \$params --joystick=0 "\$game"
 while read id desc; do
     echo "\$desc" > "$romdir/scummvm/\$id.svm"
 done < <($md_inst/bin/scummvm --list-targets | tail -n +3)

--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -13,7 +13,7 @@ rp_module_id="scummvm"
 rp_module_desc="ScummVM"
 rp_module_help="Copy your ScummVM games to $romdir/scummvm"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/scummvm/scummvm/master/COPYING"
-rp_module_repo="git https://github.com/scummvm/scummvm.git v2.7.0"
+rp_module_repo="git https://github.com/scummvm/scummvm.git v2.7.1"
 rp_module_section="opt"
 rp_module_flags="sdl2"
 


### PR DESCRIPTION
Changes included: 

* updated the version to 2.7.1, released at the end of July. A short changelog is in the commit message, but it's mainly bugfixes.
* modified the startup script so `extrapath` is only set when the user hasn't configured it. It should fix the issue reported in #3748.