### PR TITLE
retroarch: upgrade to v1.16.0

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -12,7 +12,7 @@
 rp_module_id="retroarch"
 rp_module_desc="RetroArch - frontend to the libretro emulator cores - required by all lr-* emulators"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/RetroArch/master/COPYING"
-rp_module_repo="git https://github.com/retropie/RetroArch.git retropie-v1.15.0"
+rp_module_repo="git https://github.com/retropie/RetroArch.git retropie-v1.16.0"
 rp_module_section="core"
 
 function depends_retroarch() {
@@ -257,6 +257,8 @@ function configure_retroarch() {
     iniSet "menu_show_load_content_animation" "false"
     # disable core cache file
     iniSet "core_info_cache_enable" "false"
+    # disable game runtime logging
+    iniSet "content_runtime_log" "false"
 
     # disable unnecessary xmb menu tabs
     iniSet "xmb_show_add" "false"


### PR DESCRIPTION
Upgraded RetroArch to current v1.16.0 version and added a new configuration option to disable creation of runtime logs (saved when the content is closed by the core).

Updated RetroArch source with our patches can be pulled into our repo from https://github.com/cmitu/RetroArch/tree/retropie-v1.16.0. Source is rebased over the latest 1.16.0 bugfix tag (1.16.0.3).

-----------------

Notable changes in v1.16.0, selected from the full release announcement (https://www.libretro.com/index.php/retroarch-1-16-0-release/):

 General:
  - Add new API for microphone support (no core supports this at the moment)
  - Make cmd interface more useful for replay information
  - Use refresh rate instead of core fps for frameskip timing
  - Allow RETRO_ENVIRONMENT_SET_MEMORY_MAPS also after core startup. Change the comment in libretro.h about the removed limit and handle the environment call during core runtime in RetroArch.
  - Add new API for querying the device's power state.
  - Don't count frames while paused
  - Improve ZIP decompression This reduces the amount of memory Retroarch needs to extract a ROM file. It will only need the size of the ROM plus 128KiB to extract the file from the ZIP. Previously it needed as much as twice that amount if the compression ratio was not great. This is useful on memory constrained platforms and has no impact on platforms with plenty of memory. Handles all cases correctly (with and without MMAP, for cores that require fullpath or not, small and big ZIP files).
  - Fix corrupt task progress percentage

 Netplay/Networking:
  - Enhance netpacket interface
  - Enable core host to refuse connecting new players to limit the number of connected players
  - Enable a core to flush outgoing packets and read incoming packets without waiting for the next frame (can be used for lower latency or blocking reads)

 Video:
  - (SWITCHRES) Don't always force core aspect ratio
  - (SWITCHRES) Add PAL threshold option for automatic refresh rate switch
  - (SWITCHRES) Add KMS modeswitch
  - Correct rotated core provided aspect ratio
  - Minor adjustments to refresh rate switch behavior
  - Use "nearest" scaling in menus (SDL2 video driver)
  - Fix windowed viewport with libretro rotation
  - Add frame callback after egl_swap_buffers to improve latency when max_swapchain <= 2
  - (VULKAN) Ignore Fast-Forward Frameskip option
  - (VULKAN) Support screen refresh rate with Vulkan KHR_Display context

 Audio:
  - Fast-Forward Audio Resampling
  - Count audio samples in stats when rate control is disabled
  - Support device list for PulseAudio
  - Show MIDI output first in settings
  - Fix RetroArch fails to restart streaming when video re-inits and instead starts recording

 Cheevos:
  - Upgrade to rcheevos 10.7
  - Add progress tracker widget
  - Collapse trackers with same value definition
  - Eliminate leaderboard tracker stutter
  - Expand leaderboard visibility settings
  - disallow 'video_swap_interval' and 'black_frame_insertion' in hardcore

  Input:
   - (LINUX) Input driver fix 8+ joypads. It was reported that controllers beyond 8 worked only partially (analogs yes, but not buttons), and the found fix was also confirmed.
   - Combo hold + 'enable_hotkey' correction. Fixed issue with having menu toggle hold combo in different button than 'enable_hotkey', which caused 'enable_hotkey' to also act as menu toggle if held long enough, and simplified and unified duplicate code in start+select holds to a single function.
   - Don't check hotkey binds when device is RETRO_DEVICE_POINTER
   - Add 'Save As' option for remaps and overrides
   - Send keyboard events for modifiers before other keys (for correct modifier+key input if hitboxes overlap)
   - Log mouse devices in info level (udev driver)
   - First working version of udev driver with touchscreen support and gestures.
   - Add Wayland to input driver list
   - Remember currently set keyboard mapping bits during same config read, because otherwise customized keybinds can get cleared out of the bits on the next iteration, causing keyboard events to get passed to the core when they should get blocked.
   - move port X binds into retropad binds submenu and add appropriate help text and sublabels to discourage people from messing around in there unnecessarily
   - Revive/rewrite Keyboard Overlay and OSK Toggle. Add keyboard overlay preset, keyboard submenu, and osk_toggle hotkey. Use overlay caching for osk_toggle.
   - Stop always reseting to defaults on remap delete
   - Fix rumble on PS4/PS5 controllers connected via Bluetooth with the SDL2 input driver

  Menu:
   - Reorganize 'Saving' menu
   - Start directory browsing from current value
   - Fix menu toggle combo hold with same 'enable_hotkey'
   - Various cleanups and labels additions/updates
   - Change network port menu options to 'allow_input' mode
   - Add menu scroll home+end actions
   - Move 'systemfiles_in_content_dir' from Saving to Core
   - Menu navigation acceleration adjustments
   - Remove advanced option flag from video rotation + orientation
   - Add missing menu visibility option for content dir override
   - Fix certain audio drivers from hanging when menu pause is enabled with menu sounds
   - (OSD) Show current video + audio drivers in statistics
   - (OSD) Ensure statistics text is aligned left
   - Fix menu sounds stopping after fullscreen toggle / video reinit
   - Search box usability improvements
   - Fraction setting wraparound rounding correction