### PR TITLE
dolphin: fix Qt6 Svg dependency for Ubuntu

### DIFF
--- a/scriptmodules/emulators/dolphin.sh
+++ b/scriptmodules/emulators/dolphin.sh
@@ -19,7 +19,7 @@ rp_module_flags="!all 64bit"
 
 function _get_commit_dolphin() {
     local commit
-    local has_qt6=$(apt-cache madison qt6-base-private-dev 2>/dev/null | cut -d'|' -f1)
+    local has_qt6=$(apt-cache -qq madison qt6-base-private-dev | cut -d'|' -f1)
     # current HEAD of dolphin doesn't build without a C++20 capable compiler ..
     [[ "$__gcc_version" -lt 10 ]] && commit="f59f1a2a"
     # .. and without QT6
@@ -36,9 +36,15 @@ function depends_dolphin() {
         return 1
     fi
     # check if qt6 is available, otherwise use qt5
-    local has_qt6=$(apt-cache madison qt6-base-private-dev 2>/dev/null | cut -d'|' -f1)
+    local has_qt6=$(apt-cache -qq madison qt6-base-private-dev | cut -d'|' -f1)
     if [[ -n "$has_qt6" ]]; then
-        depends+=(qt6-base-private-dev qt6-svg-dev)
+        depends+=(qt6-base-private-dev)
+        # Older Ubuntu versions provide libqt6svg6-dev instead of Debian's qt6-svg-dev
+        if [[ -n "$__os_ubuntu_ver" ]] && compareVersions "$__os_ubuntu_ver" lt 23.04; then
+            depends+=(libqt6svg6-dev)
+        else
+            depends+=(qt6-svg-dev)
+        fi
     else
         depends+=(qtbase5-private-dev)
     fi


### PR DESCRIPTION
Ubuntu seems to have different names for the QtSvg module, so try to install the available package depending on the distro release.

Fixes #3756.