### PR TITLE
helpers: handle deprecation of 'libfreetype6-dev'

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -280,6 +280,9 @@ function _mapPackage() {
                 [[ "$own_sdl2" -eq 1 ]] && pkg="RP sdl2 $pkg"
             fi
             ;;
+        libfreetype6-dev)
+            [[ "$__os_debian_ver" -gt 10 ]] || compareVersions "$__os_ubuntu_ver" gt 23.04 && pkg="libfreetype-dev"
+            ;;
     esac
     echo "$pkg"
 }


### PR DESCRIPTION
The 'libfreetype6-dev' package has been replaced with `libfreetype-dev` since Debian 11 _bullseye_ [1]. It's not present in the current Debian testing (_trixie_) and Ubuntu 23.10 [2]

Added a mapping for the package, since it will help installing RetroPie on Ubuntu 23.10. When we stop supporting _buster_, we can remove the mapping and replace any `libfreetype6-dev` dependencies in the scriptmodules with the new package.

[1] https://packages.debian.org/bullseye/libfreetype6-dev - marked as 'transitional'
[2] https://packages.ubuntu.com/search?keywords=libfreetype6-dev - removed from Ubuntu 23.10