### PR TITLE
retoarch - disable cheevos hardcore mode by default

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -281,6 +281,9 @@ function configure_retroarch() {
     # enable video shaders
     iniSet "video_shader_enable" "true"
 
+    # disable cheevos hardcore mode
+    iniSet "cheevos_hardcore_mode_enable" "false"
+
     copyDefaultConfig "$config" "$configdir/all/retroarch.cfg"
     rm "$config"
 
@@ -299,6 +302,9 @@ function configure_retroarch() {
 
     # enable video shaders on existing configs
     _set_config_option_retroarch "video_shader_enable" "true"
+
+    # disable hardcore mode on existing configs
+    _set_config_option_retroarch "cheevos_hardcore_mode_enable" "false"
 
     # (compat) keep all core options in a single file
     _set_config_option_retroarch "global_core_options" "true"


### PR DESCRIPTION
Since RetroArch 1.10, cheevos hardcore mode is enabled by default. Should this be "corrected" in RP's own defaults?

As I understand, `_set_config_option_retroarch` only sets the option if it's not explicitly set already. So users who use cheevos, but haven't explicitly set hardcore mode, will see it suddenly disabled -- just as it suddenly *enabled* last year when the default was changed.

https://retropie.org.uk/forum/post/273128