### PR TITLE
systems: add support for Armbian

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -261,6 +261,10 @@ function _mapPackage() {
                         isPlatform "rpi5" && pkg="linux-headers-rpi-2712"
                     fi
                 fi
+            elif isPlatform "armbian"; then
+                local branch="$(grep -oP "BRANCH=\K.*"      /etc/armbian-release)"
+                local family="$(grep -oP "LINUXFAMILY=\K.*" /etc/armbian-release)"
+                pkg="linux-headers-${branch}-${family}"
             elif [[ -z "$__os_ubuntu_ver" ]]; then
                 pkg="linux-headers-$(uname -r)"
             else

--- a/scriptmodules/supplementary/raspbiantools.sh
+++ b/scriptmodules/supplementary/raspbiantools.sh
@@ -164,8 +164,10 @@ function gui_raspbiantools() {
             3 "Remove some unneeded packages (pulseaudio / cups / wolfram)"
             4 "Disable screen blanker"
             5 "Enable needed kernel module uinput"
-            6 "$zram_status compressed memory (ZRAM)"
         )
+        # exclude ZRAM config for Armbian, it is handled by `armbian-config`
+        ! isPlatform "armbian" && options+=(6 "$zram_status compressed memory (ZRAM)")
+
         local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
         if [[ -n "$choice" ]]; then
             case "$choice" in

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -311,6 +311,11 @@ function get_os_version() {
 
     [[ -n "$error" ]] && fatalError "$error\n\n$(lsb_release -idrc)"
 
+    # check for Armbian, which can be built on Debian/Ubuntu
+    if [[ -f /etc/armbian-release ]]; then
+        __platform_flags+=("armbian")
+    fi
+
     # configure Raspberry Pi graphics stack
     isPlatform "rpi" && get_rpi_video
 }


### PR DESCRIPTION
Added support for detecting if running on a Armbian built system. Armbian is built on Debian/Ubuntu, so we're not changing the OS release/name.

* Added support for Armbian's Linux kernel package naming, in order to be able to install the kernel headers.
* Removed the ZRAM config from our own menu, Since Armbian has its own configuration tool (`armbian-config`) that handles it. ZRAM is configured and enabled by default on Armbian images.

NOTE: I'll probably add some changes later on to add `armbian-config` to the menu, replacing `raspi-config`. I just need to create a proper/usable icon for it.