### PR TITLE
helpers: add support for the Bookworm Linux kernel header packages

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -248,7 +248,19 @@ function _mapPackage() {
         # handle our custom package alias LINUX-HEADERS
         LINUX-HEADERS)
             if isPlatform "rpi"; then
-                pkg="raspberrypi-kernel-headers"
+                if [[ "$__os_debian_ver" -lt 12 ]]; then
+                    pkg="raspberrypi-kernel-headers"
+                else
+                    # on RaspiOS bookworm and later, kernel packages are separated by arch and model
+                    isPlatform "rpi0" || isPlatform "rpi1" && pkg="linux-headers-rpi-v6"
+                    if isPlatform "32bit"; then
+                        isPlatform "rpi2" || isPlatform "rpi3" && pkg="linux-headers-rpi-v7"
+                        isPlatform "rpi4" && pkg="linux-headers-rpi-v7l"
+                    else
+                        isPlatform "rpi3" || isPlatform "rpi4" && pkg="linux-headers-rpi-v8"
+                        isPlatform "rpi5" && pkg="linux-headers-rpi-2712"
+                    fi
+                fi
             elif [[ -z "$__os_ubuntu_ver" ]]; then
                 pkg="linux-headers-$(uname -r)"
             else


### PR DESCRIPTION
Starting with the Bookworm RaspiOS release, the Linux kernel package is no longer a monolithic package and it has been split in several packages, named after their build configuration, which in turn is dictated by the Pi model and architecture (`armhf`/`aarch64`).

This change adds support for the Linux kernel headers packages on the new OS release, which followed a similar split from the previously used `raspberrypi-kernel-headers` package.

NOTES:
 * mixed kernel/userland archs are not supported. By default, an `armhf` RaspiOS installation will boot the Pi4/Pi5 with the 64bit kernel, but the corresponding headers package is not installable. While the Pi4 can still boot a 32bit kernel by adding `arm_64bit=0` to `/boot{/firmware}/config.txt`, the Pi5 does not have this capability.
 * on the RaspiOS Bookworm images the Linux kernel images/headers are already installed, the mapping and installation will have effect if the user explicitely removes the header packages.