### PR TITLE
atari800: update to 5.0.0

### DIFF
--- a/scriptmodules/emulators/atari800.sh
+++ b/scriptmodules/emulators/atari800.sh
@@ -13,7 +13,7 @@ rp_module_id="atari800"
 rp_module_desc="Atari 8-bit/800/5200 emulator"
 rp_module_help="ROM Extensions: .a52 .bas .bin .car .xex .atr .xfd .dcm .atr.gz .xfd.gz\n\nCopy your Atari800 games to $romdir/atari800\n\nCopy your Atari 5200 roms to $romdir/atari5200 You need to copy the Atari 800/5200 BIOS files (5200.ROM, ATARIBAS.ROM, ATARIOSB.ROM and ATARIXL.ROM) to the folder $biosdir and then on first launch configure it to scan that folder for roms (F1 -> Emulator Configuration -> System Rom Settings)"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/atari800/atari800/master/COPYING"
-rp_module_repo="git https://github.com/atari800/atari800.git ATARI800_4_2_0"
+rp_module_repo="git https://github.com/atari800/atari800.git ATARI800_5_0_0"
 rp_module_section="opt"
 rp_module_flags="sdl1 !mali"
 


### PR DESCRIPTION
Updated to latest release tag. Use the `videocore` flag to activate the `rpi` target in the build configuration.

Notable changes in 5.0.0 (full changelog at https://github.com/atari800/atari800/releases/tag/ATARI800_5_0_0):

 * AVI video recording (Alt+V hotkey) by Rob McMullen
 * MP3 audio and other audio codecs for audio recording
 * New cartridge types supported:
   - 71: Super Cart 64 KB 5200 cartridge (32K banks)
   - 72: Super Cart 128 KB 5200 cartridge (32K banks)
   - 73: Super Cart 256 KB 5200 cartridge (32K banks)
   - 74: Super Cart 512 KB 5200 cartridge (32K banks)
   - 75: Atarimax 1 MB Flash cartridge (new) See DOC/cart.txt for details.
  * support for remapping of all function keys (START, SELECT, OPTION etc)
  * tool for creating cart files from ROM files
  * video triple buffering changed to double buffering
  * gamma values in NTSC filter presets updated
  * Altirra OS updated to v3.28
  * support for 64-512K Atari 5200 bank-switchable carts with Bryan's design
  * support for the alternate variant of MaxFlash 1 MB
  * video triple buffering changed to double buffering