### PR TITLE
mupen64plus: buildfixes

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -170,6 +170,8 @@ function build_mupen64plus() {
             isPlatform "armv6" && params+=("HOST_CPU=armv6")
             isPlatform "armv7" && params+=("HOST_CPU=armv7")
             isPlatform "aarch64" && params+=("HOST_CPU=aarch64")
+            # we don't ship a Vulkan enabled front-end, so disable Vulkan in the core project
+            params+=("VULKAN=0")
 
             [[ "$dir" == "mupen64plus-ui-console" ]] && params+=("COREDIR=$md_inst/lib/" "PLUGINDIR=$md_inst/lib/mupen64plus/")
             make -C "$dir/projects/unix" "${params[@]}" clean
@@ -244,6 +246,8 @@ function install_mupen64plus() {
             isPlatform "armv7" && params+=("HOST_CPU=armv7")
             isPlatform "aarch64" && params+=("HOST_CPU=aarch64")
             isPlatform "x86" && params+=("SSE=SSE2")
+            # disable VULKAN for the core project
+            params+=("VULKAN=0")
             make -C "$source/projects/unix" PREFIX="$md_inst" OPTFLAGS="$CFLAGS -O3 -flto" "${params[@]}" install
         fi
     done


### PR DESCRIPTION
This includes 2 commits:

 - one to disable the VK API added for `mupen64-plus-core`, since it's built by default. We don't need that since we don't ship (for now) any video plugin or front-end that support Vulkan.
 - the other removes some bitrot from `mupen64plus-video-gles2rice`, allowing it to compile on `armhf` with a newer g++ (like the one from Raspi OS 12 _bookworm_).