### PR TITLE
samba: add a Web Service Discovery service

### DIFF
--- a/scriptmodules/supplementary/samba.sh
+++ b/scriptmodules/supplementary/samba.sh
@@ -50,6 +50,12 @@ function install_shares_samba() {
     add_share_samba "bios" "$home/RetroPie/BIOS"
     add_share_samba "configs" "$configdir"
     add_share_samba "splashscreens" "$datadir/splashscreens"
+
+    # Add `wsdd` so that RetroPie is easily discovered by Windows clients
+    # Only available on Debian 12/Ubuntu 22.04 and later
+    if apt-cache -qq madison wsdd; then
+        aptInstall wsdd
+    fi
     restart_samba
 }
 


### PR DESCRIPTION
[From: https://github.com/christgau/wsdd]
With Windows 10 version 1511, support for SMBv1 and thus NetBIOS device discovery was disabled by default. This causes hosts running Samba not to be listed in the Explorer's "Network (Neighborhood)" views. While there is no connectivity problem and Samba will still run fine, users might want to have their Samba hosts to be listed by Windows automatically.

This should fix the discoverability issues with recent Windows versions, especially since the SMBv1 client is not available anymore in Win11 (as some ill-advised instructions are trying to fix this problem).