### PR TITLE
Retroarch Config:- Turn on SRM check and autosave feature

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -278,6 +278,9 @@ function configure_retroarch() {
     # disable 'press twice to quit'
     iniSet "quit_press_twice" "false"
 
+    # enable srm check saving at intervals rather than upon exit
+    iniSet "autosave_interval" = "10"
+
     # enable video shaders
     iniSet "video_shader_enable" "true"
 


### PR DESCRIPTION
When playing a game on RetroPie if there is a sudden disconnection that isn't clean (power cut, pulling out the power cable etc), the .srm save file isn't updated correctly. The "autosave_interval" feature checks if the .srm has been updated and if it has been updated it overwrites the original file. In the case of the user, this would be expected behaviour (if you saved your game the save file would write then, not when you exit Retroarch).

The feature itself isn't a significant strain on resources, playing N64, PS1 cores on a pi4 I didn't notice any difference in frame rates or performance.