### PR TITLE
lr-gpsp: fix installation due to missing file

### DIFF
--- a/scriptmodules/libretrocores/lr-gpsp.sh
+++ b/scriptmodules/libretrocores/lr-gpsp.sh
@@ -36,7 +36,6 @@ function install_lr-gpsp() {
         'gpsp_libretro.so'
         'COPYING'
         'readme.txt'
-        'game_config.txt'
     )
 }
 


### PR DESCRIPTION
Removed obsolete installed file, since it was removed upstream.