### PR TITLE
bookworm: fix Mame2015/Mame2016 not building. 

### DIFF
--- a/scriptmodules/libretrocores/lr-mame2015.sh
+++ b/scriptmodules/libretrocores/lr-mame2015.sh
@@ -23,6 +23,7 @@ function _update_hook_lr-mame2015() {
 
 function sources_lr-mame2015() {
     gitPullOrClone
+    applyPatch "$md_data/01-python3-irgen.diff"
 }
 
 function build_lr-mame2015() {

--- a/scriptmodules/libretrocores/lr-mame2015/01-python3-irgen.diff
+++ b/scriptmodules/libretrocores/lr-mame2015/01-python3-irgen.diff
@@ -1,0 +1,61 @@
+diff --git a/src/emu/cpu/m6502/m6502make.py b/src/emu/cpu/m6502/m6502make.py
+index da29fc7..3de641d 100755
+--- a/src/emu/cpu/m6502/m6502make.py
++++ b/src/emu/cpu/m6502/m6502make.py
+@@ -16,7 +16,7 @@ def load_opcodes(fname):
+     opcodes = []
+     logging.info("load_opcodes: %s", fname)
+     try:
+-        f = open(fname, "rU")
++        f = open(fname, "r")
+     except Exception:
+         err = sys.exc_info()[1]
+         logging.error("cannot read opcodes file %s [%s]", fname, err)
+@@ -39,7 +39,7 @@ def load_disp(fname):
+     logging.info("load_disp: %s", fname)
+     states = []
+     try:
+-        f = open(fname, "rU")
++        f = open(fname, "r")
+     except Exception:
+         err = sys.exc_info()[1]
+         logging.error("cannot read display file %s [%s]", fname, err)
+diff --git a/src/emu/cpu/m6809/m6809make.py b/src/emu/cpu/m6809/m6809make.py
+index c3d5b0f..79f6f90 100644
+--- a/src/emu/cpu/m6809/m6809make.py
++++ b/src/emu/cpu/m6809/m6809make.py
+@@ -14,7 +14,7 @@ def load_file(fname, lines):
+ 	if path != "":
+ 		path += '/'
+ 	try:
+-		f = open(fname, "rU")
++		f = open(fname, "r")
+ 	except Exception:
+ 		err = sys.exc_info()[1]
+ 		sys.stderr.write("Cannot read opcodes file %s [%s]\n" % (fname, err))
+diff --git a/src/emu/cpu/mcs96/mcs96make.py b/src/emu/cpu/mcs96/mcs96make.py
+index ec5ec37..7ab806a 100644
+--- a/src/emu/cpu/mcs96/mcs96make.py
++++ b/src/emu/cpu/mcs96/mcs96make.py
+@@ -71,7 +71,7 @@ class OpcodeList:
+         self.ea = {}
+         self.macros = {}
+         try:
+-            f = open(fname, "rU")
++            f = open(fname, "r")
+         except Exception:
+             err = sys.exc_info()[1]
+             sys.stderr.write("Cannot read opcodes file %s [%s]\n" % (fname, err))
+diff --git a/src/emu/cpu/tms57002/tmsmake.py b/src/emu/cpu/tms57002/tmsmake.py
+index 6209209..78f9fe4 100755
+--- a/src/emu/cpu/tms57002/tmsmake.py
++++ b/src/emu/cpu/tms57002/tmsmake.py
+@@ -326,7 +326,7 @@ def ins_cmp_dasm(a, b):
+ def LoadLst(filename):
+     instructions = []
+     ins = None
+-    for n, line in enumerate(open(filename, "rU")):
++    for n, line in enumerate(open(filename, "r")):
+         line = line.rstrip()
+         if not line and ins:
+             # new lines separate intructions

--- a/scriptmodules/libretrocores/lr-mame2016.sh
+++ b/scriptmodules/libretrocores/lr-mame2016.sh
@@ -23,6 +23,7 @@ function depends_lr-mame2016() {
 
 function sources_lr-mame2016() {
     gitPullOrClone
+    applyPatch "${md_path%/*}/lr-mame2016/01-python3-irgen.diff"
 }
 
 function build_lr-mame2016() {

--- a/scriptmodules/libretrocores/lr-mame2016/01-python3-irgen.diff
+++ b/scriptmodules/libretrocores/lr-mame2016/01-python3-irgen.diff
@@ -1,0 +1,61 @@
+diff --git a/src/devices/cpu/m6502/m6502make.py b/src/devices/cpu/m6502/m6502make.py
+index 8bcd85f8..557b1759 100755
+--- a/src/devices/cpu/m6502/m6502make.py
++++ b/src/devices/cpu/m6502/m6502make.py
+@@ -18,7 +18,7 @@ def load_opcodes(fname):
+     opcodes = []
+     logging.info("load_opcodes: %s", fname)
+     try:
+-        f = open(fname, "rU")
++        f = open(fname, "r")
+     except Exception:
+         err = sys.exc_info()[1]
+         logging.error("cannot read opcodes file %s [%s]", fname, err)
+@@ -41,7 +41,7 @@ def load_disp(fname):
+     logging.info("load_disp: %s", fname)
+     states = []
+     try:
+-        f = open(fname, "rU")
++        f = open(fname, "r")
+     except Exception:
+         err = sys.exc_info()[1]
+         logging.error("cannot read display file %s [%s]", fname, err)
+diff --git a/src/devices/cpu/m6809/m6809make.py b/src/devices/cpu/m6809/m6809make.py
+index 8838b960..e1ea25db 100644
+--- a/src/devices/cpu/m6809/m6809make.py
++++ b/src/devices/cpu/m6809/m6809make.py
+@@ -16,7 +16,7 @@ def load_file(fname, lines):
+ 	if path != "":
+ 		path += '/'
+ 	try:
+-		f = open(fname, "rU")
++		f = open(fname, "r")
+ 	except Exception:
+ 		err = sys.exc_info()[1]
+ 		sys.stderr.write("Cannot read opcodes file %s [%s]\n" % (fname, err))
+diff --git a/src/devices/cpu/mcs96/mcs96make.py b/src/devices/cpu/mcs96/mcs96make.py
+index b4844942..207208d2 100644
+--- a/src/devices/cpu/mcs96/mcs96make.py
++++ b/src/devices/cpu/mcs96/mcs96make.py
+@@ -73,7 +73,7 @@ class OpcodeList:
+         self.ea = {}
+         self.macros = {}
+         try:
+-            f = open(fname, "rU")
++            f = open(fname, "r")
+         except Exception:
+             err = sys.exc_info()[1]
+             sys.stderr.write("Cannot read opcodes file %s [%s]\n" % (fname, err))
+diff --git a/src/devices/cpu/tms57002/tmsmake.py b/src/devices/cpu/tms57002/tmsmake.py
+index e2e12b5a..942ec095 100755
+--- a/src/devices/cpu/tms57002/tmsmake.py
++++ b/src/devices/cpu/tms57002/tmsmake.py
+@@ -323,7 +323,7 @@ class Instruction:
+ def LoadLst(filename):
+     instructions = []
+     ins = None
+-    for n, line in enumerate(open(filename, "rU")):
++    for n, line in enumerate(open(filename, "r")):
+         line = line.rstrip()
+         if not line and ins:
+             # new lines separate intructions

--- a/scriptmodules/libretrocores/lr-mess2016.sh
+++ b/scriptmodules/libretrocores/lr-mess2016.sh
@@ -23,6 +23,7 @@ function depends_lr-mess2016() {
 
 function sources_lr-mess2016() {
     gitPullOrClone
+    applyPatch "${md_path%/*}/lr-mame2016/01-python3-irgen.diff"
 }
 
 function build_lr-mess2016() {


### PR DESCRIPTION
Looks like some deprecation in python3.11 breaks building both cores due to some codegen including python scripts.
Upstream has a PR proposed in https://github.com/libretro/mame2015-libretro/pull/98, but not applied, so create one locally for each scriptmodule.