### PR TITLE
amiberry: bump version and enable for Pi5

### DIFF
--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -13,9 +13,9 @@ rp_module_id="amiberry"
 rp_module_desc="Amiga emulator with JIT support (forked from uae4arm)"
 rp_module_help="ROM Extension: .adf .chd .ipf .lha .zip\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir/amiga"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/BlitterStudio/amiberry/master/LICENSE"
-rp_module_repo="git https://github.com/BlitterStudio/amiberry v5.6.1"
+rp_module_repo="git https://github.com/BlitterStudio/amiberry v5.6.2"
 rp_module_section="opt"
-rp_module_flags="!all arm rpi3 rpi4"
+rp_module_flags="!all arm rpi3 rpi4 rpi5"
 
 function _update_hook_amiberry() {
     local rom


### PR DESCRIPTION
New version has Pi5 support, so we can enable it.
~~Not released yet, so we'll need to wait a bit.~~

Changes in 5.6.2 (complete changelog at https://github.com/BlitterStudio/amiberry/releases/tag/v5.6.2):

Added:
  * improved help text in DiskSwapper panel
  * don't disable CD drive if no image path is specified
  * if start_minimized is specified, do not show a window on startup
  * hide the Linux hidden directories from dialogs
  * added VSync option
  * added missing help text in GUI->Priority

Fixed:
  * fixed crash if Restart was pressed
  * fixed crash on startup on x86_64 platform
  * DiskSwapper slots should be 10
  * Virtual Keyboard options were not saved correctly
  * fixed several memory leaks from the GUI

Platforms:
  * added Raspberry Pi5
  * added RISC-V 64bit (no JIT)