### PR TITLE
openmsx: update to version 19.1

### DIFF
--- a/scriptmodules/emulators/openmsx.sh
+++ b/scriptmodules/emulators/openmsx.sh
@@ -13,7 +13,7 @@ rp_module_id="openmsx"
 rp_module_desc="MSX emulator OpenMSX"
 rp_module_help="ROM Extensions: .cas .rom .mx1 .mx2 .col .dsk .zip\n\nCopy your MSX/MSX2 games to $romdir/msx\nCopy the BIOS files to $biosdir/openmsx"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/openMSX/openMSX/master/doc/GPL.txt"
-rp_module_repo="git https://github.com/openMSX/openMSX.git RELEASE_18_0 :_get_commit_openmsx"
+rp_module_repo="git https://github.com/openMSX/openMSX.git RELEASE_19_1 :_get_commit_openmsx"
 rp_module_section="opt"
 rp_module_flags=""
 


### PR DESCRIPTION
Bumped the repo version to the 19.1 tag, so it's available for Bullseye and later platforms.

A brief description of things added in 19.x (full changelog at https://raw.githubusercontent.com/openMSX/openMSX/RELEASE_19_1/doc/release-notes.txt):

 - bugfixes for VDP and V9990 emulation
 - many improvements on machine and extension descriptions
 - added mapper for RetroHard MultiCart 31 in 1 cartridges
 - implemented (more) I/O port mirroring for S-1985 and S-3527 based machines for PSG, VDP, PPI, RTC, printer)
 - added mapper for Al Alamiah 30-in-1 cartridges
 - added mapper for RetroHard MultiCart 31 in 1 cartridges
 - improvements and additions to OSD Menu
 - many bugfixes and improvements to the disk manipulator
 - fixed SaI3xScaler
 - added MIDI input support to ALSA
 - added YM2151 recording to VGM recorder
 - added new machines: Sony HB-11 and Sony HB-F701xx, Polish Spectravideo SVI-738, Victor HC-90A, Nikko PC-70100 (hidden MSX) and Sanyo MPC-10mkII
 - added new extensions: Sunrise IDE with Nextor ROM, Swedish Spectravideo SVI-738, Yamaha SKW-01 Word Processor