### PR TITLE
crosscomp - add support for building bookwork arm cross compiler

### DIFF
--- a/scriptmodules/admin/crosscomp.sh
+++ b/scriptmodules/admin/crosscomp.sh
@@ -62,6 +62,17 @@ function sources_crosscomp() {
                 [mpc]=1.2.0
             )
             ;;
+        bookworm)
+            pkgs=(
+                [binutils]=2.40
+                [gcc]=12.2.0
+                [glibc]=2.36
+                [gmp]=6.2.1
+                [kernel]=6.1
+                [mpfr]=4.2.0
+                [mpc]=1.3.1
+            )
+            ;;
         *)
             md_ret_errors+=("Unsupported distribution $dist")
             return 1
@@ -86,10 +97,14 @@ function sources_crosscomp() {
 
     # apply glibc patch required when compiling with GCC 10+
     # see https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=49348beafe9ba150c9bd48595b3f372299bddbb0
-    # as well as a fix for an incorrect header include.
     if [[ "$dist" == "bullseye" ]]; then
         applyPatch "$md_data/bullseye.diff"
     fi
+    # fix incorrect limits.h include.
+    if compareVersions "${pkgs[gcc]}" ge 10; then
+        applyPatch "$md_data/asan_limits.diff"
+    fi
+
 }
 
 function build_crosscomp() {

--- a/scriptmodules/admin/crosscomp/asan_limits.diff
+++ b/scriptmodules/admin/crosscomp/asan_limits.diff
@@ -1,0 +1,12 @@
+# fixes gcc/libsanitizer/asan/asan_linux.cpp:217:21: error: ‘PATH_MAX’ was not declared in this scope
+--- a/gcc/libsanitizer/asan/asan_linux.cpp
++++ b/gcc/libsanitizer/asan/asan_linux.cpp
+@@ -31,7 +31,7 @@
+ #include <sys/types.h>
+ #include <dlfcn.h>
+ #include <fcntl.h>
+-#include <limits.h>
++#include <linux/limits.h>
+ #include <pthread.h>
+ #include <stdio.h>
+ #include <unistd.h>

--- a/scriptmodules/admin/crosscomp/bullseye.diff
+++ b/scriptmodules/admin/crosscomp/bullseye.diff
@@ -134,15 +134,3 @@ index 84a8b94c74..0a5a40430e 100644
  
  # These files quiet sNaNs in a way that is optimized away without
 
-# fixes gcc/libsanitizer/asan/asan_linux.cpp:217:21: error: ‘PATH_MAX’ was not declared in this scope
---- a/gcc/libsanitizer/asan/asan_linux.cpp
-+++ b/gcc/libsanitizer/asan/asan_linux.cpp
-@@ -31,7 +31,7 @@
- #include <sys/types.h>
- #include <dlfcn.h>
- #include <fcntl.h>
--#include <limits.h>
-+#include <linux/limits.h>
- #include <pthread.h>
- #include <stdio.h>
- #include <unistd.h>


### PR DESCRIPTION
Split out header include fix from bullseye.diff into own patch file as it's also needed on gcc 12.x.

Apply patch for GCC versions greater than 10.