### PR TITLE
runcommand: Fix filenames with multiple consecutive spaces in them not loading

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -1312,11 +1312,11 @@ function launch_command() {
     if [[ "$CONSOLE_OUT" -eq 1 ]]; then
         # turn cursor on
         tput cnorm
-        eval $COMMAND </dev/tty 2>>"$LOG"
+        eval "$COMMAND" </dev/tty 2>>"$LOG"
         ret=$?
         tput civis
     else
-        eval $COMMAND </dev/tty &>>"$LOG"
+        eval "$COMMAND" </dev/tty &>>"$LOG"
         ret=$?
     fi
     return $ret


### PR DESCRIPTION
This fixes games failing to launch when their filename contains multiple consecutive.  The fix is implemented by updating runcommand's `eval` to preserve all of the characters of `$COMMAND` by quoting the variable.

## Context

For one of my systems (tic-80), some of the games contain filenames that have multiple consecutive spaces in them.  For example: `C L A Y  P I G E O N.tlc`.  I'll admit, this is rare and unusual but this is done to match where I've sourced the game from.  When launching this game, it fails and returns to Emulationstation.

This *can* be fixed by simply removing the consecutive spaces and updating the gamelist, but my goal is to ensure that my game files match their source.  Fixing the root cause I hope might also solve similar issues others encounter in the future.

## Observing the issue

You can observe this issue by changing the filename in any system to have multiple consecutive spaces and launching it.  Below I've shown the output for launching `C L A Y  P I G E O N.tic`:

```
Executing: /opt/retropie/emulators/retroarch/bin/retroarch -L /opt/retropie/libretrocores/lr-tic80/tic80_libretro.so --config /opt/retropie/configs/tic80/retroarch.cfg --verbose "/home/pi/RetroPie/roms/tic80/C L A Y  P I G E O N.tic" --appendconfig /dev/shm/retroarch.cfg
[INFO] [Config]: Loading config from: "/opt/retropie/configs/tic80/retroarch.cfg".
[INFO] [Config]: Appending config "/dev/shm/retroarch.cfg".
[WARN] [GameMode]: GameMode cannot be enabled on this system ("dlopen failed - libgamemode.so: cannot open shared object file: No such file or directory.") https://github.com/FeralInteractive/gamemode needs to be installed.
[WARN] [Config]: GameMode unsupported - disabling...
[INFO] RetroArch 1.10.0 (Git e9e85f3)
[INFO] === Build =======================================
[INFO] Capabilities:  NEON VFPv3 VFPv4
[INFO] Built: Jun 15 2022
[INFO] Version: 1.10.0
[INFO] Git: e9e85f3
[INFO] =================================================
[INFO] [Input]: Found input driver: "x".
[INFO] [Core]: Loading dynamic libretro core from: "/opt/retropie/libretrocores/lr-tic80/tic80_libretro.so"
[INFO] [Overrides]: No core-specific overrides found at "/home/pi/.config/retroarch/config/TIC-80/TIC-80.cfg".
[INFO] [Overrides]: No content-dir-specific overrides found at "/home/pi/.config/retroarch/config/TIC-80/tic80.cfg".
[INFO] [Overrides]: No game-specific overrides found at "/home/pi/.config/retroarch/config/TIC-80/C L A Y P I G E O N.cfg".
```

Now, this log is a little confusing at first.  The "Executing" log looks right -- we see the 2 spaces preserved.  However, the libretro core shows differently -- the filename now only has 1 space between "C L A Y" and "P I G E O N".

If you watch `ps` during launch, you'll see the actual command being executed is:

```
/opt/retropie/emulators/retroarch/bin/retroarch -L /opt/retropie/libretrocores/lr-tic80/tic80_libretro.so --config /opt/retropie/configs/tic80/retroarch.cfg --verbose /home/pi/RetroPie/roms/tic80/C L A Y P I G E O N.tic --appendconfig /dev/shm/retroarch.cfg
```

## How to reproduce

At its core, you can reproduce the basic issue like so:

```bash
$ COMMAND='echo "A B  C"'
$ eval $COMMAND
A B C
$ eval "$COMMAND"
A B  C
```

## The fix

My proposal for fixing this is to quote the variable in order to preserve all characters.  I tested this across many of the systems I use on RetroPie and I haven't observed any regressions or changes to any other part of the command yet.  Some of the more "interesting" test cases included:

* ppsspp
* dosbox-staging
* mupen64plus-GLideN64-highres
* mupen64plus-GLideN64

These emulators had emulator commands that were a little different than your standard libretro cores, so I thought they might be interesting use cases.

I'm curious if there are other edge cases that I've missed here?

After the fix, observe the output:

```
Executing: /opt/retropie/emulators/retroarch/bin/retroarch -L /opt/retropie/libretrocores/lr-tic80/tic80_libretro.so --config /opt/retropie/configs/tic80/retroarch.cfg --verbose "/home/pi/RetroPie/roms/tic80/C L A Y  P I G E O N.tic" --appendconfig /dev/shm/retroarch.cfg
[INFO] [Config]: Loading config from: "/opt/retropie/configs/tic80/retroarch.cfg".
[INFO] [Config]: Appending config "/dev/shm/retroarch.cfg".
[WARN] [GameMode]: GameMode cannot be enabled on this system ("dlopen failed - libgamemode.so: cannot open shared object file: No such file or directory.") https://github.com/FeralInteractive/gamemode needs to be installed.
[WARN] [Config]: GameMode unsupported - disabling...
[INFO] RetroArch 1.10.0 (Git e9e85f3)
[INFO] === Build =======================================
[INFO] Capabilities:  NEON VFPv3 VFPv4
[INFO] Built: Jun 15 2022
[INFO] Version: 1.10.0
[INFO] Git: e9e85f3
[INFO] =================================================
[INFO] [Input]: Found input driver: "x".
[INFO] [Core]: Loading dynamic libretro core from: "/opt/retropie/libretrocores/lr-tic80/tic80_libretro.so"
[INFO] [Overrides]: No core-specific overrides found at "/home/pi/.config/retroarch/config/TIC-80/TIC-80.cfg".
[INFO] [Overrides]: No content-dir-specific overrides found at "/home/pi/.config/retroarch/config/TIC-80/tic80.cfg".
[INFO] [Overrides]: Game-specific overrides found at "/home/pi/.config/retroarch/config/TIC-80/C L A Y  P I G E O N.cfg".
```

## Related issues

* https://github.com/Aloshi/EmulationStation/issues/794