### PR TITLE
lr-flycast-dev: add upstream libretro core

### DIFF
--- a/scriptmodules/libretrocores/lr-flycast-dev.sh
+++ b/scriptmodules/libretrocores/lr-flycast-dev.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-flycast-dev"
+rp_module_desc="Multiplatform Sega Dreamcast, Naomi, Naomi 2 and Atomiswave emulator"
+rp_module_help="Dreamcast ROM Extensions: .cdi .gdi .chd .m3u, Naomi/Atomiswave ROM Extension: .zip\n\nCopy your Dreamcast/Naomi roms to $romdir/dreamcast\n\nCopy the required Dreamcast BIOS files dc_boot.bin and dc_flash.bin to $biosdir/dc\n\nCopy the required Naomi/Atomiswave BIOS files naomi.zip/naomigd.zip and awbios.zip to $biosdir/dc"
+rp_module_licence="GPL2 https://raw.githubusercontent.com/flyinghead/flycast/master/LICENSE"
+rp_module_repo="git https://github.com/flyinghead/flycast.git master"
+rp_module_section="exp"
+rp_module_flags="!armv6 !videocore"
+
+function depends_lr-flycast-dev() {
+    if [[ "$__gcc_version" -lt 9 ]]; then
+        md_ret_errors+=("Sorry, you need an OS with gcc 9 or newer to compile $md_id")
+        return 1
+    fi
+    local depends=(zlib1g-dev libgl-dev)
+    getDepends "${depends[@]}"
+}
+
+function sources_lr-flycast-dev() {
+    gitPullOrClone
+}
+
+function build_lr-flycast-dev() {
+    local params=("-DLIBRETRO=ON -DWITH_SYSTEM_ZLIB=ON -DCMAKE_BUILD_TYPE=Release")
+
+    if isPlatform "gles3"; then
+            params+=("-DUSE_GLES=ON")
+    elif isPlatform "gles2"; then
+            params+=("-DUSE_GLES2=ON")
+    fi
+    isPlatform "vulkan" && params+=("-DUSE_VULKAN=ON") || params+=("-DUSE_VULKAN=OFF")
+
+    rm -fr build && mkdir build
+    cd build
+    cmake "${params[@]}" ..
+    make
+
+    md_ret_require="$md_build/build/flycast_libretro.so"
+}
+
+function install_lr-flycast-dev() {
+    md_ret_files=(
+        'build/flycast_libretro.so'
+        'LICENSE'
+    )
+}
+
+function configure_lr-flycast-dev() {
+    local sys
+    local def
+    for sys in "arcade" "dreamcast"; do
+        def=0
+        isPlatform "kms" && [[ "$sys" == "dreamcast" ]] && def=1
+        # segfaults on the rpi without redirecting stdin from </dev/null
+        addEmulator $def "$md_id" "$sys" "$md_inst/flycast_libretro.so </dev/null"
+        addSystem "$sys"
+    done
+
+    [[ "$md_mode" == "remove" ]] && return
+
+    for sys in "arcade" "dreamcast"; do
+        mkRomDir "$sys"
+        defaultRAConfig "$sys"
+    done
+
+    mkUserDir "$biosdir/dc"
+}


### PR DESCRIPTION
Added the libretro core from upstream flyinghead/flycast, it supercedes the current libretro/flycast repository used for the current `lr-flycast` core. The new core doesn't work correctly with the legacy VideoCore GLES drivers [1], so it will have to co-exist with the current `lr-flycast` until we drop support for older RaspiOS versions still using the VideoCore drivers.

Due to an internal compiler error, the enw core doesn't build on Buster with the included `gcc8`, but works on `gcc9` and later, which means it can be installed on Debian 11/Ubuntu 20.04 and later.

Tested on RaspiOS _bookworm_ with `vulkan`, `glcore` and `gl` RetroArch video drivers, on a Pi4.

[1] https://github.com/flyinghead/flycast/issues/559