### PR TITLE
Update Yamagi Quake 2 to version 8.30

### DIFF
--- a/scriptmodules/ports/yquake2.sh
+++ b/scriptmodules/ports/yquake2.sh
@@ -12,7 +12,7 @@
 rp_module_id="yquake2"
 rp_module_desc="yquake2 - The Yamagi Quake II client"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/yquake2/yquake2/master/LICENSE"
-rp_module_repo="git https://github.com/yquake2/yquake2.git QUAKE2_8_20"
+rp_module_repo="git https://github.com/yquake2/yquake2.git QUAKE2_8_30"
 rp_module_section="exp"
 rp_module_flags=""
 
@@ -25,8 +25,8 @@ function depends_yquake2() {
 function sources_yquake2() {
     gitPullOrClone
     # get the add-ons sources
-    gitPullOrClone "$md_build/xatrix" "https://github.com/yquake2/xatrix" "XATRIX_2_11"
-    gitPullOrClone "$md_build/rogue" "https://github.com/yquake2/rogue" "ROGUE_2_10"
+    gitPullOrClone "$md_build/xatrix" "https://github.com/yquake2/xatrix" "XATRIX_2_12"
+    gitPullOrClone "$md_build/rogue" "https://github.com/yquake2/rogue" "ROGUE_2_11"
 }
 
 function build_yquake2() {


### PR DESCRIPTION
Released today, this includes [gyro aiming for Nintendo Switch controllers in RetroPie](https://retropie.org.uk/forum/topic/32772/quake-2-with-gyro-aiming-using-a-switch-controller), and cvars like `ogg_pausewithgame`, which pauses music when the game is paused, and `g_swap_speed`, cheat to speed up weapon switch animations.
Expansions / Mission Packs have been updated as well, mostly with bug fixes.
Once again, no performance lost from previous versions.