### PR TITLE
ppsspp: revert to v1.13.2 for RPI and older Mesa

### DIFF
--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -13,9 +13,18 @@ rp_module_id="ppsspp"
 rp_module_desc="PlayStation Portable emulator PPSSPP"
 rp_module_help="ROM Extensions: .iso .pbp .cso\n\nCopy your PlayStation Portable roms to $romdir/psp"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/hrydgard/ppsspp/master/LICENSE.TXT"
-rp_module_repo="git https://github.com/hrydgard/ppsspp.git v1.16.6"
+rp_module_repo="git https://github.com/hrydgard/ppsspp.git :_get_release_ppsspp"
 rp_module_section="opt"
 rp_module_flags=""
+
+function _get_release_ppsspp() {
+    local tagged_version="v1.16.6"
+    #  the V3D Mesa driver before 21.x has issues with v1.14 and later
+    if [[ "$__os_debian_ver" -lt 11 ]] && isPlatform "kms" && isPlatform "rpi"; then
+        tagged_version="v1.13.2"
+    fi
+    echo $tagged_version
+}
 
 function depends_ppsspp() {
     local depends=(cmake libsdl2-dev libsnappy-dev libzip-dev zlib1g-dev)

--- a/scriptmodules/libretrocores/lr-ppsspp.sh
+++ b/scriptmodules/libretrocores/lr-ppsspp.sh
@@ -13,7 +13,7 @@ rp_module_id="lr-ppsspp"
 rp_module_desc="PlayStation Portable emu - PPSSPP port for libretro"
 rp_module_help="ROM Extensions: .iso .pbp .cso\n\nCopy your PlayStation Portable roms to $romdir/psp"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/RetroPie/ppsspp/master/LICENSE.TXT"
-rp_module_repo="git https://github.com/hrydgard/ppsspp.git v1.16.6"
+rp_module_repo="git https://github.com/hrydgard/ppsspp.git :_get_release_ppsspp"
 rp_module_section="opt"
 rp_module_flags=""
 


### PR DESCRIPTION
The 'ubershaders' introduced in v1.14 are not handled efficiently by the Mesa v3d driver, causing a performance regression [1]. Since the slowdown is not present in the Mesa version from Bullseye/Bookworm (which caused in part the version upgrade), install v1.13.2 just on Buster/RPI.

[1] https://github.com/hrydgard/ppsspp/issues/18388