### PR TITLE
skyscraper.sh function _get_ver_skyscraper - perform version check as $user, not as root

### DIFF
--- a/scriptmodules/supplementary/skyscraper.sh
+++ b/scriptmodules/supplementary/skyscraper.sh
@@ -147,7 +147,7 @@ function _purge_platform_skyscraper() {
 
 function _get_ver_skyscraper() {
     if [[ -f "$md_inst/Skyscraper" ]]; then
-        echo $("$md_inst/Skyscraper" -h | grep 'Running Skyscraper'  | cut -d' '  -f 3 | tr -d v 2>/dev/null)
+        echo $(sudo -u "$user" "$md_inst/Skyscraper" --version | cut -d' ' -f2 2>/dev/null)
     fi
 }
 


### PR DESCRIPTION
Fixes gather and generate actions, which were broken with the new package version.

https://retropie.org.uk/forum/topic/34771/skyscraper-usage-script-doesn-t-work-after-package-update