### PR TITLE
add OrangePi Board-Family

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -455,9 +455,24 @@ function get_platform() {
                         *imx8mm*)
                             __platform="imx8mm"
                             ;;
-                        *rk3588*)
-                            __platform="rk3588"
+                        *sun8i-h2*)
+                            __platform="sun8i-h3"
                             ;;
+                        *sun8i-h3*)
+                            __platform="sun8i-h3"
+                            ;;
+                        *sun50i-h616*)
+                           __platform="sun50i-h616"
+                           ;;
+                        *sun50i-h6*)
+                            __platform="sun50i-h6"
+                            ;;
+                        *rk3399*)
+                           __platform="rk3399"
+                           ;;
+                        *rk3588*)
+                           __platform="rk3588"
+                           ;;
                     esac
                 elif [[ -e "/sys/devices/soc0/family" ]]; then
                     case "$(tr -d '\0' < /sys/devices/soc0/family)" in
@@ -679,4 +694,24 @@ function platform_vero4k() {
     cpu_armv7 "cortex-a7"
     __default_cflags="-I/opt/vero3/include -L/opt/vero3/lib"
     __platform_flags+=(mali gles)
+}
+
+function platform_sun8i-h3() {
+    cpu_armv7
+    __platform_flags+=(armbian kms gles)
+}
+
+function platform_sun50i-h6() {
+    cpu_armv8 "cortex-a53"
+    __platform_flags+=(armbian kms gles gles3 gles31)
+}
+
+function platform_sun50i-h616() {
+    cpu_armv8 "cortex-a53"
+    __platform_flags+=(armbian kms gles gles3 gles31)
+}
+
+function platform_rk3399() {
+    cpu_armv8 "cortex-a53"
+    __platform_flags+=(armbian kms gles gles3 gles31)
 }


### PR DESCRIPTION
add OrangePi Board-Family
Tested with Orange PI PC(H3), Orange PI Lite(H3), Orange PI Zero2(H616), Orange PI3 LTS(H6) Armbian 22.11.0 _bullseye 5.15.79
