### PR TITLE
lr-picodrive: fix building from source

### DIFF
--- a/scriptmodules/libretrocores/lr-picodrive.sh
+++ b/scriptmodules/libretrocores/lr-picodrive.sh
@@ -42,7 +42,7 @@ function install_lr-picodrive() {
         'AUTHORS'
         'COPYING'
         'picodrive_libretro.so'
-        'README'
+        'README.md'
     )
 }
 


### PR DESCRIPTION
Upstream changed the README filename

Fixes #3801 