### PR TITLE
steamcontroller: switch to a different upstream source

### DIFF
--- a/scriptmodules/supplementary/steamcontroller.sh
+++ b/scriptmodules/supplementary/steamcontroller.sh
@@ -10,45 +10,52 @@
 #
 
 rp_module_id="steamcontroller"
-rp_module_desc="Standalone Steam Controller Driver"
-rp_module_help="Steam Controller Driver from https://github.com/ynsta/steamcontroller"
-rp_module_licence="MIT https://raw.githubusercontent.com/ynsta/steamcontroller/master/LICENSE"
-rp_module_repo="git https://github.com/ynsta/steamcontroller.git master"
+rp_module_desc="User-mode driver for Steam Controller"
+rp_module_help="Steam Controller Driver from https://github.com/Ryochan7/sc-controller"
+rp_module_licence="GPL2 https://raw.githubusercontent.com/Ryochan7/sc-controller/python3/LICENSE"
+rp_module_repo="git https://github.com/Ryochan7/sc-controller python3"
 rp_module_section="driver"
-rp_module_flags="noinstclean"
 
+function _update_hook_steamcontroller() {
+    # remove the start command from the previous scriptmodule version
+    if rp_isInstalled "$md_id"; then
+        sed -i "/bin\/sc-.*.py/d" /etc/rc.local
+    fi
+}
 function depends_steamcontroller() {
-    getDepends virtualenv python3-dev
+    getDepends python3-virtualenv python3-dev python3-setuptools
 }
 
 function sources_steamcontroller() {
-    gitPullOrClone "$md_inst"
+    gitPullOrClone
 }
 
 function install_steamcontroller() {
-    cd "$md_inst"
-    chown -R "$user:$user"  "$md_inst"
-    sudo -u $user bash -c "\
-        virtualenv -p python3 --no-site-packages \"$md_inst\"; \
-        source bin/activate; \
-        pip3 install libusb1; \
-        python3 setup.py install; \
-    "
+    # build the driver in a virtualenv created in $md_inst
+    virtualenv -p python3 "$md_inst"
+    source "$md_inst/bin/activate"
+    pip3 install libusb1 evdev
+    pip3 install "sccontroller @ file://$md_build"
+    deactivate
+
+    # copy the default controller profiles
+    md_ret_files=("default_profiles")
 }
 
 function enable_steamcontroller() {
-    local mode="$1"
-    [[ -z "$mode" ]] && mode="xbox"
+    local profile="$1"
+    [[ -z "$profile" ]] && profile="XBox Controller"
 
-    local config="\"$md_inst/bin/sc-$mode.py\" start"
+    local config="\"$md_inst/bin/scc-daemon\" \"$md_inst/default_profiles/$profile.sccprofile\" start"
 
     disable_steamcontroller
     sed -i "s|^exit 0$|${config}\\nexit 0|" /etc/rc.local
-    printMsgs "dialog" "$md_id enabled in /etc/rc.local with the following config\n\n$config\n\nIt will be started on next boot."
+    printMsgs "dialog" "Steamcontroller enabled in /etc/rc.local with the following profile:\n\n$profile\n\nIt will be started on next boot."
 }
 
 function disable_steamcontroller() {
-    sed -i "/bin\/sc-.*.py/d" /etc/rc.local
+    sed -i "/bin\/sc-.*.py/d" /etc/rc.local           # previous version
+    sed -i "/bin\/scc-daemon.*start/d" /etc/rc.local  # current version
 }
 
 function remove_steamcontroller() {
@@ -61,6 +68,9 @@ function configure_steamcontroller() {
 # Steam controller keyboard/mouse mode
 SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", GROUP="input", MODE="0660"
 
+# Valve HID devices over bluetooth hidraw
+KERNEL=="hidraw*", KERNELS=="*28de:*", MODE="0660", GROUP="input", TAG+="uaccess"
+
 # Steam controller gamepad mode
 KERNEL=="uinput", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput"
 _EOF_
@@ -69,19 +79,19 @@ _EOF_
 function gui_steamcontroller() {
     local cmd=(dialog --backtitle "$__backtitle" --menu "Choose an option." 22 86 16)
     local options=(
-        1 "Enable steamcontroller (xbox 360 mode)"
-        2 "Enable steamcontroller (desktop mouse/keyboard mode)"
-        3 "Disable steamcontroller"
+        1 "Enable Steamcontroller (Xbox controller mode)"
+        2 "Enable Steamcontroller (Desktop mouse/keyboard mode)"
+        3 "Disable Steamcontroller"
     )
     while true; do
         local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
         if [[ -n "$choice" ]]; then
             case "$choice" in
                 1)
-                    enable_steamcontroller xbox
+                    enable_steamcontroller "XBox Controller"
                     ;;
                 2)
-                    enable_steamcontroller desktop
+                    enable_steamcontroller "Desktop"
                     ;;
                 3)
                     disable_steamcontroller


### PR DESCRIPTION
Changed to use the driver from https://github.com/Ryochan7/sc-controller since it offers a Python3 compatible version.

Module has been updatd updated/reworked:

 - the driver repo is no longer cloned to $md_inst, so 'noinstclean' flag is not necessary
 - installation is still done `virtualenv`, in Bookworm and later this becomes mandatory Note: the `--no-site-packages` was removed in the `virtualenv` call since it's ignored in v15 (version from Buster) and was removed in v20
 - the `install` function is a mix of build/install, but since `install` cleans up $md_inst, it's necessary to have them there.
 - added an update hook that removes the old driver start-up sequence in `/etc/rc.local`
 - some minor re-wording of the text shown in the dialogs

Untested with a real controller, unfortunately, since I don't have one.