### PR TITLE
amiberry: update to version 5.6.3

### DIFF
--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -13,7 +13,7 @@ rp_module_id="amiberry"
 rp_module_desc="Amiga emulator with JIT support (forked from uae4arm)"
 rp_module_help="ROM Extension: .adf .chd .ipf .lha .zip\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir/amiga"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/BlitterStudio/amiberry/master/LICENSE"
-rp_module_repo="git https://github.com/BlitterStudio/amiberry v5.6.2"
+rp_module_repo="git https://github.com/BlitterStudio/amiberry v5.6.3"
 rp_module_section="opt"
 rp_module_flags="!all arm rpi3 rpi4 rpi5"
 


### PR DESCRIPTION
Changes since 5.6.2 (https://github.com/BlitterStudio/amiberry/releases/tag/v5.6.3)

 * Optionally keep a backup of existing file, when downloading updates
 * Show SDL2 render thread option in the GUI
 * Disable SDL2 render thread checkbox on KMSDRM
 * Improved DMS support