### PR TITLE
retroarch - use --disable-crtswitchres on videocore

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -52,6 +52,7 @@ function build_retroarch() {
         isPlatform "gles31" && params+=(--enable-opengles3_1)
         isPlatform "gles32" && params+=(--enable-opengles3_2)
     fi
+    isPlatform "videocore" && params+=(--disable-crtswitchres)
     isPlatform "rpi" && isPlatform "mesa" && params+=(--disable-videocore)
     # Temporarily block dispmanx support for fkms until upstream support is fixed
     isPlatform "dispmanx" && ! isPlatform "kms" && params+=(--enable-dispmanx --disable-opengl1)


### PR DESCRIPTION
gfx/video_crt_switch.c doesn't currently build on videocore, due to definition of sr_state being in deps/switchres/switchres_wrapper.h which is not included on videocore.

I haven't used this functionality, so this is a quick workaround, rather than a proper fix. The fact that the code has ifdefs for videocore - I guess it did work, but will need to be looked at. But for now, just wanted to get RetroArch building again.