### PR TITLE
lr-pcsx-rearmed - rework parameters to fix building on armv6

### DIFF
--- a/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
+++ b/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
@@ -31,11 +31,13 @@ function build_lr-pcsx-rearmed() {
 
     if isPlatform "arm"; then
         params+=(ARCH=arm DYNAREC=ari64)
+        if isPlatform "neon"; then
+            params+=(HAVE_NEON=1 HAVE_NEON_ASM=1 BUILTIN_GPU=neon)
+        else
+            params+=(BUILTIN_GPU=peops)
+        fi
     elif isPlatform "aarch64"; then
         params+=(ARCH=aarch64 DYNAREC=ari64)
-    fi
-    if isPlatform "neon"; then
-        params+=(HAVE_NEON=1 HAVE_NEON_ASM=1 BUILTIN_GPU=neon)
     fi
 
     make -f Makefile.libretro "${params[@]}" clean


### PR DESCRIPTION
https://github.com/libretro/pcsx_rearmed/commit/4b2392bb1d5331466ecf29896103f157c1f8e05a forces BUILTIN_GPU to neon for all arm platforms, as ARCH_DETECTED gets set to "arm" which is a substring of "arm64".

Workaround this in our scriptmodule by setting BUILTIN_GPU=peops on non neon arm platforms (eg. armv6).