### PR TITLE
ppsspp - fix building on Raspberry Pi with proprietary drivers

### DIFF
--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -53,6 +53,9 @@ function sources_ppsspp() {
     # ensure Pi vendor libraries are available for linking of shared library
     sed -n -i "p; s/^set(CMAKE_EXE_LINKER_FLAGS/set(CMAKE_SHARED_LINKER_FLAGS/p" cmake/Toolchains/raspberry.armv?.cmake
 
+    # fix missing defines on opengles2
+    applyPatch "$md_data/gles2_fix.diff"
+
     if hasPackage cmake 3.6 lt; then
         cd ..
         mkdir -p cmake

--- a/scriptmodules/emulators/ppsspp/gles2_fix.diff
+++ b/scriptmodules/emulators/ppsspp/gles2_fix.diff
@@ -1,0 +1,33 @@
+diff --git a/Common/GPU/OpenGL/DataFormatGL.cpp b/Common/GPU/OpenGL/DataFormatGL.cpp
+index 425f247..ea690d8 100644
+--- a/Common/GPU/OpenGL/DataFormatGL.cpp
++++ b/Common/GPU/OpenGL/DataFormatGL.cpp
+@@ -146,12 +146,14 @@ bool Thin3DFormatToGLFormatAndType(DataFormat fmt, GLuint &internalFormat, GLuin
+ 		alignment = 16;
+ 		break;
+ 
++#ifdef GL_COMPRESSED_RGBA_ASTC_4x4_KHR
+ 	case DataFormat::ASTC_4x4_UNORM_BLOCK:
+ 		internalFormat = GL_COMPRESSED_RGBA_ASTC_4x4_KHR;
+ 		format = GL_RGBA;
+ 		type = GL_FLOAT;
+ 		alignment = 16;
+ 		break;
++#endif
+ 
+ 	default:
+ 		return false;
+diff --git a/Common/GPU/OpenGL/GLFeatures.cpp b/Common/GPU/OpenGL/GLFeatures.cpp
+index c17f1d1..fa3463e 100644
+--- a/Common/GPU/OpenGL/GLFeatures.cpp
++++ b/Common/GPU/OpenGL/GLFeatures.cpp
+@@ -592,7 +592,9 @@ bool CheckGLExtensions() {
+ 		for (int i = 0; i < numCompressedFormats; i++) {
+ 			switch (compressedFormats[i]) {
+ 			case GL_COMPRESSED_RGB8_ETC2: gl_extensions.supportsETC2 = true; break;
++#ifdef GL_COMPRESSED_RGBA_ASTC_4x4_KHR
+ 			case GL_COMPRESSED_RGBA_ASTC_4x4_KHR: gl_extensions.supportsASTC = true; break;
++#endif
+ #ifndef USING_GLES2
+ 			case GL_COMPRESSED_RGBA_S3TC_DXT5_EXT: gl_extensions.supportsBC123 = true; break;
+ 			case GL_COMPRESSED_RGBA_BPTC_UNORM: gl_extensions.supportsBC7 = true; break;


### PR DESCRIPTION
GL_COMPRESSED_RGBA_ASTC_4x4_KHR isn't available in the videocore iv gles2 includes, and documentation suggests this is an opengles 3 extension.

Add ifdefs to not include this if it isn't defined.