### PR TITLE
amiberry: update to v5.6.4

### DIFF
--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -13,7 +13,7 @@ rp_module_id="amiberry"
 rp_module_desc="Amiga emulator with JIT support (forked from uae4arm)"
 rp_module_help="ROM Extension: .adf .chd .ipf .lha .zip\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir/amiga"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/BlitterStudio/amiberry/master/LICENSE"
-rp_module_repo="git https://github.com/BlitterStudio/amiberry v5.6.3"
+rp_module_repo="git https://github.com/BlitterStudio/amiberry v5.6.4"
 rp_module_section="opt"
 rp_module_flags="!all arm rpi3 rpi4 rpi5"
 


### PR DESCRIPTION
This should fix the regression from 5.6.2+ on DispmanX platforms.

Changelog (https://github.com/BlitterStudio/amiberry/releases/tag/v5.6.4):

Fixes:
 * Fixed problems writing parition tables to HDFs after latest updates
 * Fixed crash in Add Harddrive dialog
 * Quickstart did not select correct ROM for A4000T
 * The default.uae could not be deleted
 * GUI would not use default screenmode
 * DMX targets would crash when opening the GUI
 * CD images were not activated on Reset, only on Restart
 * A3000 emulation didn't work
 * Keyboard reset would not restore keys

New/Improved:
 * increase size of text field in Create Hardfile dialog
 * Use CD Image name as a fallback for screenshot filename, if no floppy was found
 * Accept archive formats as disk images also (e.g. .zip, .lha, .7z)