### PR TITLE
esthemes: make it possible to patch themes locally

### DIFF
--- a/scriptmodules/supplementary/esthemes.sh
+++ b/scriptmodules/supplementary/esthemes.sh
@@ -61,6 +61,13 @@ function install_theme_esthemes() {
 
     mkdir -p "/etc/emulationstation/themes"
     gitPullOrClone "/etc/emulationstation/themes/$name" "https://github.com/$repo/es-theme-$theme.git" "$branch"
+
+    # apply any patches for themes broken due to ES fixes
+    if [[ "$pixel_pos" == 1 && -f "$md_data/patch-$repo-$theme.diff" ]]; then
+        pushd "/etc/emulationstation/themes/$name"
+        applyPatch "$md_data/patch-$repo-$theme.diff"
+        popd
+    fi
 }
 
 function uninstall_theme_esthemes() {

--- a/scriptmodules/supplementary/esthemes/patch-ruckage-famicom-mini.diff
+++ b/scriptmodules/supplementary/esthemes/patch-ruckage-famicom-mini.diff
@@ -1,0 +1,161 @@
+diff -u -r famicom-mini-master/layouts/1024x768.xml famicom-mini-mod/layouts/1024x768.xml
+--- famicom-mini-master/layouts/1024x768.xml	2017-08-07 02:15:59.000000000 +0300
++++ famicom-mini-mod/layouts/1024x768.xml	2023-11-19 20:50:59.665662200 +0200
+@@ -10,10 +10,10 @@
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<size>0.573 0.5481481481481481</size>
+-			<pos>0.38 0.2185185185185185</pos>			
++			<size>0.5715 0.630208333333333</size>
++			<pos>0.3807 0.1860</pos>
+ 			<lineSpacing>1.39</lineSpacing>
+-			<selectorHeight>0.0740740740740741</selectorHeight>
++			<selectorHeight>0.0795</selectorHeight>
+ 			<selectorOffsetY>0</selectorOffsetY>
+ 			<horizontalMargin>0.0166666666666667</horizontalMargin>
+ 		</textlist>
+diff -u -r famicom-mini-master/layouts/1280x720.xml famicom-mini-mod/layouts/1280x720.xml
+--- famicom-mini-master/layouts/1280x720.xml	2017-08-07 02:15:59.000000000 +0300
++++ famicom-mini-mod/layouts/1280x720.xml	2023-11-19 20:18:09.217099000 +0200
+@@ -8,8 +8,8 @@
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<pos>0.2854166666666667 0.2185185185185185</pos>
+-			<size>0.4291666666666667 0.5481481481481481</size>
++			<pos>0.2854166666666667 0.1890</pos>
++			<size>0.4291666666666667 0.629166666666667</size>
+ 			<lineSpacing>1.3975</lineSpacing>
+ 			<selectorHeight>0.0740740740740741</selectorHeight>
+ 			<selectorOffsetY>0</selectorOffsetY>
+diff -u -r famicom-mini-master/layouts/1280x960.xml famicom-mini-mod/layouts/1280x960.xml
+--- famicom-mini-master/layouts/1280x960.xml	2017-08-07 02:15:59.000000000 +0300
++++ famicom-mini-mod/layouts/1280x960.xml	2023-11-19 20:55:57.216498200 +0200
+@@ -10,10 +10,10 @@
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<size>0.5725 0.5481481481481481</size>
+-			<pos>0.3805555555555556 0.2185185185185185</pos>			
++			<size>0.5715 0.630208333333333</size>
++			<pos>0.3807 0.1860</pos>
+ 			<lineSpacing>1.395</lineSpacing>
+-			<selectorHeight>0.0740740740740741</selectorHeight>
++			<selectorHeight>0.0795</selectorHeight>
+ 			<selectorOffsetY>0</selectorOffsetY>
+ 			<horizontalMargin>0.0166666666666667</horizontalMargin>
+ 		</textlist>
+diff -u -r famicom-mini-master/layouts/1366x768.xml famicom-mini-mod/layouts/1366x768.xml
+--- famicom-mini-master/layouts/1366x768.xml	2017-08-07 02:15:59.000000000 +0300
++++ famicom-mini-mod/layouts/1366x768.xml	2023-11-19 20:33:51.952952100 +0200
+@@ -8,8 +8,8 @@
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<pos>0.2854166666666667 0.2185185185185185</pos>		
+-			<size>0.4291666666666667 0.5481481481481481</size>
++			<pos>0.2854166666666667 0.1890</pos>
++			<size>0.4291666666666667 0.629166666666667</size>
+ 			<lineSpacing>1.39</lineSpacing>
+ 			<selectorHeight>0.0740740740740741</selectorHeight>
+ 			<selectorOffsetY>0</selectorOffsetY>
+diff -u -r famicom-mini-master/layouts/1440x1080.xml famicom-mini-mod/layouts/1440x1080.xml
+--- famicom-mini-master/layouts/1440x1080.xml	2017-08-07 02:15:59.000000000 +0300
++++ famicom-mini-mod/layouts/1440x1080.xml	2023-11-19 20:56:45.019045900 +0200
+@@ -10,10 +10,10 @@
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<size>0.5722222222222222 0.5481481481481481</size>
+-			<pos>0.3805555555555556 0.2185185185185185</pos>			
++			<size>0.5715 0.630208333333333</size>
++			<pos>0.3807 0.1860</pos>
+ 			<lineSpacing>1.375</lineSpacing>
+-			<selectorHeight>0.0740740740740741</selectorHeight>
++			<selectorHeight>0.0795</selectorHeight>
+ 			<selectorOffsetY>0</selectorOffsetY>
+ 			<horizontalMargin>0.0166666666666667</horizontalMargin>
+ 		</textlist>
+diff -u -r famicom-mini-master/layouts/1920x1080.xml famicom-mini-mod/layouts/1920x1080.xml
+--- famicom-mini-master/layouts/1920x1080.xml	2017-08-07 02:15:59.000000000 +0300
++++ famicom-mini-mod/layouts/1920x1080.xml	2023-11-19 20:18:27.434632200 +0200
+@@ -8,8 +8,8 @@
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<pos>0.2854166666666667 0.2185185185185185</pos>		
+-			<size>0.4291666666666667 0.5481481481481481</size>
++			<pos>0.2854166666666667 0.1890</pos>		
++			<size>0.4291666666666667 0.629166666666667</size>
+ 			<lineSpacing>1.375</lineSpacing>
+ 			<selectorHeight>0.0740740740740741</selectorHeight>
+ 			<selectorOffsetY>0</selectorOffsetY>
+diff -u -r famicom-mini-master/layouts/320x240.xml famicom-mini-mod/layouts/320x240.xml
+--- famicom-mini-master/layouts/320x240.xml	2017-08-07 02:15:59.000000000 +0300
++++ famicom-mini-mod/layouts/320x240.xml	2023-11-19 20:53:08.112267000 +0200
+@@ -10,10 +10,10 @@
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<size>0.5722222222222222 0.5481481481481481</size>
+-			<pos>0.3805555555555556 0.2185185185185185</pos>			
++			<size>0.5715 0.6302</size>
++			<pos>0.3807 0.1860</pos>
+ 			<lineSpacing>1.395</lineSpacing>
+-			<selectorHeight>0.0740740740740741</selectorHeight>
++			<selectorHeight>0.0795</selectorHeight>
+ 			<selectorOffsetY>0</selectorOffsetY>
+ 			<horizontalMargin>0.0166666666666667</horizontalMargin>
+ 		</textlist>
+diff -u -r famicom-mini-master/layouts/640x480.xml famicom-mini-mod/layouts/640x480.xml
+--- famicom-mini-master/layouts/640x480.xml	2017-08-07 02:15:59.000000000 +0300
++++ famicom-mini-mod/layouts/640x480.xml	2023-11-19 20:53:09.551257200 +0200
+@@ -10,10 +10,10 @@
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<size>0.575 0.5481481481481481</size>
+-			<pos>0.378 0.2185185185185185</pos>			
++			<size>0.5715 0.6302</size>
++			<pos>0.3807 0.1860</pos>
+ 			<lineSpacing>1.395</lineSpacing>
+-			<selectorHeight>0.0740740740740741</selectorHeight>
++			<selectorHeight>0.0795</selectorHeight>
+ 			<selectorOffsetY>0</selectorOffsetY>
+ 			<horizontalMargin>0.0166666666666667</horizontalMargin>
+ 		</textlist>
+diff -u -r famicom-mini-master/layouts/800x600.xml famicom-mini-mod/layouts/800x600.xml
+--- famicom-mini-master/layouts/800x600.xml	2017-08-07 02:15:59.000000000 +0300
++++ famicom-mini-mod/layouts/800x600.xml	2023-11-19 20:51:45.383240000 +0200
+@@ -10,10 +10,10 @@
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<size>0.5722222222222222 0.5481481481481481</size>
+-			<pos>0.3805555555555556 0.2185185185185185</pos>			
++			<size>0.5715 0.6302</size>
++			<pos>0.3807 0.1860</pos>
+ 			<lineSpacing>1.395</lineSpacing>
+-			<selectorHeight>0.0740740740740741</selectorHeight>
++			<selectorHeight>0.0795</selectorHeight>
+ 			<selectorOffsetY>0</selectorOffsetY>
+ 			<horizontalMargin>0.0166666666666667</horizontalMargin>
+ 		</textlist>
+diff -u -r famicom-mini-master/layouts/ntsc.xml famicom-mini-mod/layouts/ntsc.xml
+--- famicom-mini-master/layouts/ntsc.xml	2017-08-07 02:15:59.000000000 +0300
++++ famicom-mini-mod/layouts/ntsc.xml	2023-11-19 20:59:02.098705000 +0200
+@@ -10,10 +10,10 @@
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<size>0.5722222222222222 0.5481481481481481</size>
+-			<pos>0.3805555555555556 0.2185185185185185</pos>			
++			<size>0.5715 0.630208333333333</size>
++			<pos>0.3807 0.1860</pos>
+ 			<lineSpacing>1.395</lineSpacing>
+-			<selectorHeight>0.0740740740740741</selectorHeight>
++			<selectorHeight>0.0795</selectorHeight>
+ 			<selectorOffsetY>0</selectorOffsetY>
+ 			<horizontalMargin>0.0166666666666667</horizontalMargin>
+ 		</textlist>

--- a/scriptmodules/supplementary/esthemes/patch-ruckage-nes-mini.diff
+++ b/scriptmodules/supplementary/esthemes/patch-ruckage-nes-mini.diff
@@ -1,0 +1,115 @@
+--- nes-mini/layouts/1024x768.xml	Wed May  2 15:18:27 2018
++++ nes-mini/layouts/1024x768.xml	Mon Nov 20 16:04:57 2023
+@@ -10,8 +10,8 @@
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<size>0.544 0.5481481481481481</size>
+-			<pos>0.3944444444444444 0.2185185185185185</pos>			
++			<size>0.5443  0.6302</size>
++			<pos>0.3942 0.1890</pos>
+ 			<lineSpacing>1.39</lineSpacing>
+ 			<selectorHeight>0.0592592592592593</selectorHeight>
+ 			<selectorOffsetY>0.0074074074074074</selectorOffsetY>
+--- nes-mini/layouts/1280x720.xml	Wed May  2 15:18:27 2018
++++ nes-mini/layouts/1280x720.xml	Mon Nov 20 15:56:00 2023
+@@ -8,8 +8,8 @@
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<pos>0.2958333333333333 0.2185185185185185</pos>
+-			<size>0.408 0.5481481481481481</size>
++			<size>0.408 0.629166666666667</size>
++			<pos>0.2960 0.1890</pos>
+ 			<lineSpacing>1.3975</lineSpacing>
+ 			<selectorHeight>0.0592592592592593</selectorHeight>
+ 			<selectorOffsetY>0.0074074074074074</selectorOffsetY>
+--- nes-mini/layouts/1280x960.xml	Wed May  2 15:18:27 2018
++++ nes-mini/layouts/1280x960.xml	Mon Nov 20 16:03:07 2023
+@@ -10,8 +10,8 @@
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<size>0.5444444444444444 0.5481481481481481</size>
+-			<pos>0.3944444444444444 0.2185185185185185</pos>			
++			<size>0.5443  0.6302</size>
++			<pos>0.3942 0.1890</pos>
+ 			<lineSpacing>1.396</lineSpacing>
+ 			<selectorHeight>0.0592592592592593</selectorHeight>
+ 			<selectorOffsetY>0.0074074074074074</selectorOffsetY>
+--- nes-mini/layouts/1366x768.xml	Wed May  2 15:18:27 2018
++++ nes-mini/layouts/1366x768.xml	Mon Nov 20 15:56:46 2023
+@@ -8,8 +8,8 @@
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<pos>0.2958333333333333 0.2185185185185185</pos>		
+-			<size>0.408 0.5481481481481481</size>
++			<size>0.408 0.629166666666667</size>
++			<pos>0.2960 0.1890</pos>
+ 			<lineSpacing>1.39</lineSpacing>
+ 			<selectorHeight>0.0592592592592593</selectorHeight>
+ 			<selectorOffsetY>0.0074074074074074</selectorOffsetY>
+--- nes-mini/layouts/1920x1080.xml	Wed May  2 15:18:27 2018
++++ nes-mini/layouts/1920x1080.xml	Mon Nov 20 15:57:24 2023
+@@ -8,8 +8,8 @@
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<pos>0.2958333333333333 0.2185185185185185</pos>		
+-			<size>0.4083333333333333 0.5481481481481481</size>
++			<pos>0.2960 0.1890</pos>
++			<size>0.408 0.629166666666667</size>
+ 			<lineSpacing>1.375</lineSpacing>
+ 			<selectorHeight>0.0592592592592593</selectorHeight>
+ 			<selectorOffsetY>0.0074074074074074</selectorOffsetY>
+--- nes-mini/layouts/320x240.xml	Wed May  2 15:18:27 2018
++++ nes-mini/layouts/320x240.xml	Tue Nov 21 14:08:33 2023
+@@ -10,11 +10,11 @@
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<size>0.546 0.5481481481481481</size>
+-			<pos>0.3944444444444444 0.2185185185185185</pos>			
++			<size>0.5475 0.6310</size>
++			<pos>0.3935 0.1878</pos>
+ 			<lineSpacing>1.395</lineSpacing>
+-			<selectorHeight>0.064</selectorHeight>
+-			<selectorOffsetY>0.007</selectorOffsetY>
++			<selectorHeight>0.060</selectorHeight>
++			<selectorOffsetY>0.008</selectorOffsetY>
+ 		</textlist>
+ 		
+ 	</view>
+--- nes-mini/layouts/640x480.xml	Wed May  2 15:18:27 2018
++++ nes-mini/layouts/640x480.xml	Tue Nov 21 08:39:50 2023
+@@ -10,10 +10,10 @@
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<size>0.546 0.5481481481481481</size>
+-			<pos>0.394 0.2185185185185185</pos>			
++			<size>0.5452 0.6310</size>
++			<pos>0.3941 0.1882</pos>
+ 			<lineSpacing>1.395</lineSpacing>
+-			<selectorHeight>0.06</selectorHeight>
++			<selectorHeight>0.0615</selectorHeight>
+ 			<selectorOffsetY>0.007</selectorOffsetY>
+ 		</textlist>
+ 		
+--- nes-mini/layouts/800x600.xml	Wed May  2 15:18:27 2018
++++ nes-mini/layouts/800x600.xml	Wed Nov 22 13:54:40 2023
+@@ -10,10 +10,10 @@
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<size>0.544 0.5481481481481481</size>
+-			<pos>0.3944444444444444 0.2185185185185185</pos>			
++			<size>0.5443 0.6302</size>
++			<pos>0.3954 0.1882</pos>
+ 			<lineSpacing>1.4</lineSpacing>
+-			<selectorHeight>0.06</selectorHeight>
++			<selectorHeight>0.0592</selectorHeight>
+ 			<selectorOffsetY>0.0074074074074074</selectorOffsetY>
+ 		</textlist>
+ 		

--- a/scriptmodules/supplementary/esthemes/patch-ruckage-snes-mini.diff
+++ b/scriptmodules/supplementary/esthemes/patch-ruckage-snes-mini.diff
@@ -1,0 +1,144 @@
+diff --git a/layouts/1024x768.xml b/layouts/1024x768.xml
+index 0fa2e6d..2b29a33 100644
+--- a/layouts/1024x768.xml
++++ b/layouts/1024x768.xml
+@@ -10,12 +10,12 @@ author:			ruckage
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<size>0.5611111111111111 0.5481481481481481</size>
+-			<pos>0.9861111111111111 0.2259259259259259</pos>			
++			<size>0.5615234375 0.630208333333333</size>
++			<pos>0.986328125 0.1953125</pos>			
+ 			<lineSpacing>1.39</lineSpacing>
+ 			<origin>1 0</origin>
+-			<selectorHeight>0.0814814814814815</selectorHeight>
+-			<selectorOffsetY>-0.0111111111111111</selectorOffsetY>
++			<selectorHeight>0.08203125</selectorHeight>
++			<selectorOffsetY>-0.01171875</selectorOffsetY>
+ 		</textlist>
+ 		
+ 	</view>
+diff --git a/layouts/1280x720.xml b/layouts/1280x720.xml
+index f7fae91..0ad84f2 100644
+--- a/layouts/1280x720.xml
++++ b/layouts/1280x720.xml
+@@ -8,10 +8,10 @@ author:			ruckage
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<pos>${listx} 0.2259259259259259</pos>		
+-			<size>${listWidth} 0.5481481481481481</size>
++			<pos>${listx} 0.195833333333333</pos>		
++			<size>${listWidth} 0.629166666666667</size>
+ 			<lineSpacing>1.395</lineSpacing>
+-			<selectorHeight>0.0814814814814815</selectorHeight>
++			<selectorHeight>0.081944444444444</selectorHeight>
+ 			<selectorOffsetY>-0.0111111111111111</selectorOffsetY>
+ 		</textlist>
+ 		
+diff --git a/layouts/1280x960.xml b/layouts/1280x960.xml
+index acb687f..dc17453 100644
+--- a/layouts/1280x960.xml
++++ b/layouts/1280x960.xml
+@@ -10,12 +10,12 @@ author:			ruckage
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<size>0.5611111111111111 0.5481481481481481</size>
+-			<pos>0.9861111111111111 0.2259259259259259</pos>			
++			<size>0.5611111111111111 0.630208333333333</size>
++			<pos>0.9861111111111111 0.195833333333333</pos>			
+ 			<lineSpacing>1.4</lineSpacing>
+ 			<origin>1 0</origin>
+-			<selectorHeight>0.0814814814814815</selectorHeight>
+-			<selectorOffsetY>-0.0111111111111111</selectorOffsetY>
++			<selectorHeight>0.08125</selectorHeight>
++			<selectorOffsetY>-0.011458333333333</selectorOffsetY>
+ 		</textlist>
+ 		
+ 	</view>
+diff --git a/layouts/1366x768.xml b/layouts/1366x768.xml
+index 0c268c3..6131217 100644
+--- a/layouts/1366x768.xml
++++ b/layouts/1366x768.xml
+@@ -8,11 +8,11 @@ author:			ruckage
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<pos>${listx} 0.2259259259259259</pos>		
+-			<size>${listWidth} 0.5481481481481481</size>
++			<pos>${listx} 0.1953125</pos>		
++			<size>${listWidth} 0.630208333333333</size>
+ 			<lineSpacing>1.39</lineSpacing>
+-			<selectorHeight>0.0814814814814815</selectorHeight>
+-			<selectorOffsetY>-0.0111111111111111</selectorOffsetY>
++			<selectorHeight>0.08203125</selectorHeight>
++			<selectorOffsetY>-0.01171875</selectorOffsetY>
+ 		</textlist>
+ 		
+ 	</view>
+diff --git a/layouts/1440x1080.xml b/layouts/1440x1080.xml
+index 044758d..f3d6fe4 100644
+--- a/layouts/1440x1080.xml
++++ b/layouts/1440x1080.xml
+@@ -10,8 +10,8 @@ author:			ruckage
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<size>0.5611111111111111 0.5481481481481481</size>
+-			<pos>0.9861111111111111 0.2259259259259259</pos>			
++			<size>0.5611111111111111 0.62962962962963</size>
++			<pos>0.9861111111111111 0.19537037037037</pos>			
+ 			<lineSpacing>1.375</lineSpacing>
+ 			<origin>1 0</origin>
+ 			<selectorHeight>0.0814814814814815</selectorHeight>
+diff --git a/layouts/1920x1080.xml b/layouts/1920x1080.xml
+index f4c55ef..13008ed 100644
+--- a/layouts/1920x1080.xml
++++ b/layouts/1920x1080.xml
+@@ -8,8 +8,8 @@ author:			ruckage
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<pos>${listx} 0.2259259259259259</pos>		
+-			<size>${listWidth} 0.5481481481481481</size>
++			<pos>${listx} 0.19537037037037</pos>		
++			<size>${listWidth} 0.62962962962963</size>
+ 			<lineSpacing>1.375</lineSpacing>
+ 			<selectorHeight>0.0814814814814815</selectorHeight>
+ 			<selectorOffsetY>-0.0111111111111111</selectorOffsetY>
+diff --git a/layouts/640x480.xml b/layouts/640x480.xml
+index c58ca21..05f0a24 100644
+--- a/layouts/640x480.xml
++++ b/layouts/640x480.xml
+@@ -10,11 +10,11 @@ author:			ruckage
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<size>0.5611111111111111 0.5481481481481481</size>
+-			<pos>0.9861111111111111 0.2259259259259259</pos>			
++			<size>0.5609375 0.629166666666667</size>
++			<pos>0.9859375 0.195833333333333</pos>			
+ 			<lineSpacing>1.395</lineSpacing>
+ 			<origin>1 0</origin>
+-			<selectorHeight>0.0814814814814815</selectorHeight>
++			<selectorHeight>0.08125</selectorHeight>
+ 			<selectorOffsetY>-0.0111111111111111</selectorOffsetY>
+ 		</textlist>
+ 		
+diff --git a/layouts/800x600.xml b/layouts/800x600.xml
+index c58ca21..c32d8af 100644
+--- a/layouts/800x600.xml
++++ b/layouts/800x600.xml
+@@ -10,8 +10,8 @@ author:			ruckage
+     <view name="basic, detailed,video">
+ 
+ 		<textlist name="gamelist">
+-			<size>0.5611111111111111 0.5481481481481481</size>
+-			<pos>0.9861111111111111 0.2259259259259259</pos>			
++			<size>0.5611111111111111 0.63</size>
++			<pos>0.9861111111111111 0.195</pos>			
+ 			<lineSpacing>1.395</lineSpacing>
+ 			<origin>1 0</origin>
+ 			<selectorHeight>0.0814814814814815</selectorHeight>


### PR DESCRIPTION
Added the ability to patch themes locally to fix the gamelist layout bugs in themes, surfaced after EmulationStation's fixes for positioning, added a in 2.10.x. Mostly done to fix @ruckage's themes, which haven't been updated after the new EmulationStation version.

Fixes included:

 * for the 'snes-mini' theme, based on https://github.com/ruckage/es-theme-snes-mini/pull/26, submitted by @makofee
 * for the 'nes-mini' theme, started from https://github.com/ruckage/es-theme-nes-mini/pulls/13, submitted by @grosa1, which in turn is based on https://retropie.org.uk/forum/topic/12583/snes-mini-theme/929?_=1699852993853 (?). Followed by some testing and fixing for the other resolutions which are not covered by the initial changes.
 * for the 'famicom-mini' theme, adapted from the previous patch with some adjustments added after testing each resolution supported.