### PR TITLE
ppsspp - only apply gles2 patch on ppsspp v1.16.6

### DIFF
--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -53,8 +53,10 @@ function sources_ppsspp() {
     # ensure Pi vendor libraries are available for linking of shared library
     sed -n -i "p; s/^set(CMAKE_EXE_LINKER_FLAGS/set(CMAKE_SHARED_LINKER_FLAGS/p" cmake/Toolchains/raspberry.armv?.cmake
 
-    # fix missing defines on opengles2
-    applyPatch "$md_data/gles2_fix.diff"
+    # fix missing defines on opengles2 on v1.16.6
+    if [[ "$md_id" == "ppsspp" && "$(_get_release_ppsspp)" == "v1.16.6" ]]; then
+        applyPatch "$md_data/gles2_fix.diff"
+    fi
 
     if hasPackage cmake 3.6 lt; then
         cd ..


### PR DESCRIPTION
The fix has been included upstream for inclusion in v1.17.0 https://github.com/hrydgard/ppsspp/pull/18433