### PR TITLE
lr-ppsspp: fix libretro runtime missing symbol

### DIFF
--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -58,6 +58,11 @@ function sources_ppsspp() {
         applyPatch "$md_data/gles2_fix.diff"
     fi
 
+    # fix missing exported symbol for libretro on v1.13.2
+    if [[ "$md_id" == "lr-ppsspp" && "$(_get_release_ppsspp)" == "v1.13.2" ]]; then
+        applyPatch "$md_data/v13-libretro_fix.diff"
+    fi
+
     if hasPackage cmake 3.6 lt; then
         cd ..
         mkdir -p cmake

--- a/scriptmodules/libretrocores/lr-ppsspp/v13-libretro_fix.diff
+++ b/scriptmodules/libretrocores/lr-ppsspp/v13-libretro_fix.diff
@@ -1,0 +1,42 @@
+diff --git a/Core/HLE/__sceAudio.cpp b/Core/HLE/__sceAudio.cpp
+index 3176d26..f05ad9d 100644
+--- a/Core/HLE/__sceAudio.cpp
++++ b/Core/HLE/__sceAudio.cpp
+@@ -82,6 +82,11 @@ static bool m_logAudio;
+ static int chanQueueMaxSizeFactor;
+ static int chanQueueMinSizeFactor;
+ 
++// Accessor for libretro
++int __AudioGetHostAttemptBlockSize() {
++	return hostAttemptBlockSize;
++}
++
+ static void hleAudioUpdate(u64 userdata, int cyclesLate) {
+ 	// Schedule the next cycle first.  __AudioUpdate() may consume cycles.
+ 	CoreTiming::ScheduleEvent(audioIntervalCycles - cyclesLate, eventAudioUpdate, 0);
+diff --git a/Core/HLE/__sceAudio.h b/Core/HLE/__sceAudio.h
+index ae9ca35..f26ae0d 100644
+--- a/Core/HLE/__sceAudio.h
++++ b/Core/HLE/__sceAudio.h
+@@ -50,6 +50,8 @@ int __AudioMix(short *outstereo, int numSamples, int sampleRate);
+ void __AudioGetDebugStats(char *buf, size_t bufSize);
+ void __PushExternalAudio(const s32 *audio, int numSamples);  // Should not be used in-game, only at the menu!
+ 
++int __AudioGetHostAttemptBlockSize();
++
+ // Audio Dumping stuff
+ void __StartLogAudio(const Path &filename);
+ void __StopLogAudio();
+diff --git a/libretro/libretro.cpp b/libretro/libretro.cpp
+index eacbca2..26f2cf6 100644
+--- a/libretro/libretro.cpp
++++ b/libretro/libretro.cpp
+@@ -379,7 +379,7 @@ class LibretroHost : public Host
+       void InitSound() override {}
+       void UpdateSound() override
+       {
+-         extern int hostAttemptBlockSize;
++         int hostAttemptBlockSize = __AudioGetHostAttemptBlockSize();
+          const int blockSizeMax = 512;
+          static int16_t audio[blockSizeMax * 2];
+          assert(hostAttemptBlockSize <= blockSizeMax);


### PR DESCRIPTION
Core on v1.13.2 fails to run on Pi4 with the error:

   ...
   [ERROR] Failed to open libretro core: "/opt/retropie/libretrocores/lr-ppsspp/ppsspp_libretro.so"
   Error(s): /opt/retropie/libretrocores/lr-ppsspp/ppsspp_libretro.so: undefined symbol: hostAttemptBlockSize

This was fixed upstream with commits 1cd34f9d2bef6c92ed457c6aa85bf4d9b5111e90 and 7c5d36eca76c905a122c1, which are combined in the .diff file in this commit.