### PR TITLE
runcommand: have XINIT start a wm by default

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -1213,6 +1213,8 @@ function get_sys_command() {
         # remove XINIT:
         COMMAND="${COMMAND:6}"
         XINIT=1
+        # start with a window manager and hide the cursor by default
+        XINIT_WM=1
     fi
 }
 


### PR DESCRIPTION
Before the introduction of backends, emulator commands prefixed with `XINIT` would also start a WM (matchbox-window-manager). Now the WM is started only for emulators configured with backends `x11`/`x11-c`.

This change restores the previous behavior for `XINIT`-ed emulators for which no `x11` based backend is configured (i.e. non-SDL2 emulators like Dolphin or Duckstation).