### PR TITLE
dependencies: handle obsolete `librasbperrypi-bin`

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -19,7 +19,7 @@ rp_module_flags="sdl2"
 
 function depends_mupen64plus() {
     local depends=(cmake libsamplerate0-dev libspeexdsp-dev libsdl2-dev libpng-dev libfreetype6-dev fonts-freefont-ttf libboost-filesystem-dev)
-    isPlatform "rpi" && depends+=(libraspberrypi-bin libraspberrypi-dev)
+    isPlatform "videocore" && depends+=(libraspberrypi-dev)
     isPlatform "mesa" && depends+=(libgles2-mesa-dev)
     isPlatform "gl" && depends+=(libglew-dev libglu1-mesa-dev)
     isPlatform "x86" && depends+=(nasm)

--- a/scriptmodules/supplementary/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand.sh
@@ -25,7 +25,7 @@ function _update_hook_runcommand() {
 
 function depends_runcommand() {
     local depends=()
-    isPlatform "rpi" && depends+=(libraspberrypi-bin)
+    isPlatform "rpi" && isPlatform "dispmanx" && depends+=(libraspberrypi-bin)
     isPlatform "rpi" || isPlatform "kms" && depends+=(fbi fbset)
     isPlatform "x11" && depends+=(feh)
     getDepends "${depends[@]}"


### PR DESCRIPTION
The `libraspberrypi-bin` package has been deprecated in RaspiOS's latest Bookworm release [1], being replaced with `raspi-utils`. We need this package for `tvservice`, but on KMS platforms this utility is obsolete and always returns an error.

The changes will:

 - leave the `libraspberrypi-bin` dependency in `runcommand` just for RPI+DispmanX platforms (Buster and eariler Raspbian)
 - replace the `mupen64plus` dependency with the correct one  (`libraspberrypi0`), since this is where the (E)GL(ES) VC drivers are located.

[1] RasPiOS 06.Dec.2023 release, list of included packages: https://downloads.raspberrypi.com/raspios_arm64/images/raspios_arm64-2023-12-06/2023-12-05-raspios-bookworm-arm64.info
    Previous (and initial) Bookworm release contained the `libraspberrypi-bin` package: https://downloads.raspberrypi.com/raspios_arm64/images/raspios_arm64-2023-10-10/2023-10-10-raspios-bookworm-arm64.info