### PR TITLE
smw: switch to @mmatyas's fork; upgrade to 2.0

### DIFF
--- a/scriptmodules/ports/smw.sh
+++ b/scriptmodules/ports/smw.sh
@@ -10,14 +10,14 @@
 #
 
 rp_module_id="smw"
-rp_module_desc="Super Mario War"
-rp_module_licence="GPL http://supermariowar.supersanctuary.net/"
-rp_module_repo="git https://github.com/HerbFargus/Super-Mario-War.git master"
+rp_module_desc="Super Mario War - A fan-made multiplayer Super Mario Bros. style deathmatch game"
+rp_module_licence="GPL2 https://smwstuff.net"
+rp_module_repo="git https://github.com/mmatyas/supermariowar master"
 rp_module_section="opt"
-rp_module_flags="sdl1 !mali"
+rp_module_flags="sdl2"
 
 function depends_smw() {
-    getDepends libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev
+    getDepends cmake libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev zlib1g-dev
 }
 
 function sources_smw() {
@@ -25,14 +25,23 @@ function sources_smw() {
 }
 
 function build_smw() {
-    ./configure --prefix="$md_inst"
-    make clean
-    make
-    md_ret_require="$md_build/smw"
+    local params=(-DUSE_SDL2_LIBS=ON -DSMW_INSTALL_PORTABLE=ON)
+    isPlatform "gles2" && params+=(-DSDL2_FORCE_GLES=ON)
+    rm -fr build
+    mkdir -p build && cd build
+    cmake .. "${params[@]}"
+    make smw
+    md_ret_require="$md_build/build/smw"
 }
 
 function install_smw() {
-    make install
+    md_ret_files=(
+        "build/smw"
+        "data"
+        "docs"
+        "README.md"
+        "CREDITS"
+    )
 }
 
 function configure_smw() {
@@ -40,7 +49,9 @@ function configure_smw() {
 
     [[ "$md_mode" == "remove" ]] && return
 
-    isPlatform "dispmanx" && setBackend "$md_id" "dispmanx"
-
-    moveConfigFile "$home/.smw.options.bin" "$md_conf_root/smw/.smw.options.bin"
+    moveConfigDir "$home/.smw" "$md_conf_root/smw"
+    # try to migrate existing settings to the new conf folder
+    if [[ -f "$md_conf_root/smw/.smw.options.bin" ]] ; then
+         mv "$md_conf_root/smw/.smw.options.bin" "$md_conf_root/smw/options.bin"
+    fi
 }


### PR DESCRIPTION
The fork from https://github.com/mmatyas/supermariowar is still active and it has the options to use SDL2 instead of SDL1. Switched the scriptmodule to it with updated dependencies and build instructions. New version also changed the configuration location, now in a dedicated folder.

Main changes since 1.8

 * Experimental online mode, including an online lobby server
 * Lots and lots and lots of bugfixes (seriously, there's at least 200)
 * Added Web, ARM and (an experimental) Android ports, and improved support for Windows, Linux and OSX
 * Improved music and sound quality
 * Ported all parts of the game to SDL2, for hardware accelerated drawing and improved support for many platforms
 * Major cleanup of the source code and the build system

NOTES: 
  - I've updated the license to GPL2, since this is what's declared in the CMake build file.
  - ~~On exit, there's a segfault due to the usage of `atexit(SDL_Quit)`, which is due to Mesa's usage of the same exit handler. An older 'bug', which may be corrected upstream.~~ fixed in https://github.com/mmatyas/supermariowar/issues/258