### PR TITLE
drivers: disable GPIO kernel module drivers on Pi5

### DIFF
--- a/scriptmodules/supplementary/gamecondriver.sh
+++ b/scriptmodules/supplementary/gamecondriver.sh
@@ -13,7 +13,7 @@ rp_module_id="gamecondriver"
 rp_module_desc="Gamecon & Db9 drivers GPIO drivers"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/marqs85/gamecon_gpio_rpi/master/gamecon_gpio_rpi-1.4/gamecon_gpio_rpi.c"
 rp_module_section="driver"
-rp_module_flags="!all rpi"
+rp_module_flags="!all rpi !rpi5"
 
 function depends_gamecondriver() {
     getDepends dkms LINUX-HEADERS

--- a/scriptmodules/supplementary/mkarcadejoystick.sh
+++ b/scriptmodules/supplementary/mkarcadejoystick.sh
@@ -15,7 +15,7 @@ rp_module_help="Installs the GPIO driver from https://github.com/cmitu/mk_arcade
 rp_module_licence="GPL2 https://raw.githubusercontent.com/recalbox/mk_arcade_joystick_rpi/master/LICENSE"
 rp_module_repo="git https://github.com/cmitu/mk_arcade_joystick_rpi retropie"
 rp_module_section="driver"
-rp_module_flags="noinstclean !all rpi"
+rp_module_flags="noinstclean !all rpi !rpi5"
 
 function _version_mkarcadejoystick() {
     echo "0.1.7"

--- a/scriptmodules/supplementary/snesdev.sh
+++ b/scriptmodules/supplementary/snesdev.sh
@@ -13,7 +13,7 @@ rp_module_id="snesdev"
 rp_module_desc="SNESDev (Driver for the RetroPie GPIO-Adapter)"
 rp_module_section="driver"
 rp_module_repo="git https://github.com/petrockblog/SNESDev-RPi.git master"
-rp_module_flags="noinstclean"
+rp_module_flags="noinstclean !all rpi !rpi5"
 
 function sources_snesdev() {
     gitPullOrClone "$md_inst"


### PR DESCRIPTION
The Pi5 uses a different architecture for the GPIO pins, which is not compatible with previous models. All GPIO functions are now handled by the RP1 [1] southbridge chip and the GPIO reading mechanism used in previous models doesn't work here.

Disabled drivers:
 - gamecond and db9 (gamecondriver)
 - mk_arcadejoystick_rpi
 - snesdev

[1] https://www.raspberrypi.com/documentation/microcontrollers/rp1.html