### PR TITLE
Detect rpi5 platform based on /proc/device-tree/compatible

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -458,6 +458,9 @@ function get_platform() {
                         *rk3588*)
                             __platform="rk3588"
                             ;;
+                        *bcm2712*)
+                            __platform="rpi5"
+                            ;;
                     esac
                 elif [[ -e "/sys/devices/soc0/family" ]]; then
                     case "$(tr -d '\0' < /sys/devices/soc0/family)" in


### PR DESCRIPTION
/proc/cpuinfo doesn't contain any Hardware line for Raspbery Pi 5, bookworm 64 bit OS image. See https://github.com/raspberrypi/linux/issues/5783.

Use /proc/device-tree/compatible instead, in the same way other platforms are detected.

Contents of /proc/device-tree/compatible on my rpi5:
raspberrypi,5-model-bbrcm,bcm2712

Before:
__platform_flags=([0]="" [1]="64bit" [2]="gl" [3]="vulkan" [4]="x11")

After:
__platform_flags=([0]="rpi5" [1]="64bit" [2]="aarch64" [3]="rpi" [4]="gles" [5]="gles3" [6]="gles31" [7]="mesa" [8]="kms")