### PR TITLE
skyscraper.sh - use 'Skyscraper -h' for version interrogation. Require 'ge' match for version check.

### DIFF
--- a/scriptmodules/supplementary/skyscraper.sh
+++ b/scriptmodules/supplementary/skyscraper.sh
@@ -147,13 +147,13 @@ function _purge_platform_skyscraper() {
 
 function _get_ver_skyscraper() {
     if [[ -f "$md_inst/Skyscraper" ]]; then
-        echo $(sudo -u "$user" "$md_inst/Skyscraper" --version | cut -d' ' -f2 2>/dev/null)
+        echo $(sudo -u "$user" "$md_inst/Skyscraper" -h | grep 'Running Skyscraper' | cut -d' ' -f 3 | tr -d v 2>/dev/null)
     fi
 }
 
 function _check_ver_skyscraper() {
     ver=$(_get_ver_skyscraper)
-    if compareVersions "$ver" lt "3.5"; then
+    if ! compareVersions "$ver" ge "3.5"; then
         printMsgs "dialog" "The version of Skyscraper you currently have installed is incompatible with options used by this script. Please update Skyscraper to the latest version to continue."
         return 1
     fi


### PR DESCRIPTION
Re: https://github.com/RetroPie/RetroPie-Setup/pull/3793#issuecomment-1803364524

@cmitu said:

> The version interrogation can also be shortened to just
> 
>     "$md_inst/Skyscraper --version | cut -d' ' -f 2

This no longer returns a coherent value.

In 3.9.2, the `--version` option returns:

```
pi@retropie:~ $ Skyscraper --version 
 _______ __                                                     ___
|   _   |  |--.--.--.-----.----.----.---.-.-----.-----.----.   |"""|
|   1___|    <|  |  |__ --|  __|   _|  _  |  _  |  -__|   _|   |"""|
|____   |__|__|___  |_____|____|__| |___._|   __|_____|__|     |"""|
|:  1   |     |_____|                     |__|       3.9.2     |"""|
|::.. . |                                                      |"""|
`-------' by Lars Muldjord and contributors                   ""''''" 
```

So, with the `cut` command from the function it looks like:

```
pi@retropie:~ $ Skyscraper --version | cut -d' ' -f 2





.
by

pi@retropie:~ $
```

Now, this currently does "work" in that the non-numerical value returned is not "less than" anything, so it doesn't ~~fail the version check~~ *pass the "fails the version-check" check* and so the script will still gather resources and generate gamelists, but it's not actually returning a version number at all. In function `_check_ver_skyscraper`, if I change the test from:

    if compareVersions "$ver" lt "3.5"

...to:

    if ! compareVersions "$ver" ge "3.5"

...(changes "less than" to "not greater-or-equal") then it fails the check in 3.9.2, says not compatible and won't gather/generate (works fine with this change in 3.9.1).

The old way `Skyscraper -h | grep 'Running Skyscraper'` still works in 3.9.2, even with this change to "not greater":

```
pi@retropie:~ $ Skyscraper -h | grep 'Running Skyscraper'
Running Skyscraper v3.9.2 by Lars Muldjord
pi@retropie:~ $ Skyscraper -h | grep 'Running Skyscraper' | cut -d' ' -f 3 | tr -d v
3.9.2
```