### PR TITLE
mame - fix building 7zip/lzma on armv7 due to missing hardware crc

### DIFF
--- a/scriptmodules/emulators/mame.sh
+++ b/scriptmodules/emulators/mame.sh
@@ -34,6 +34,8 @@ function depends_mame() {
 
 function sources_mame() {
     gitPullOrClone
+    # lzma assumes hardware crc support on arm which breaks when building on armv7
+    isPlatform "armv7" && applyPatch "$md_data/lzma_armv7_crc.diff"
 }
 
 function build_mame() {

--- a/scriptmodules/emulators/mame/lzma_armv7_crc.diff
+++ b/scriptmodules/emulators/mame/lzma_armv7_crc.diff
@@ -1,0 +1,12 @@
+diff --git a/3rdparty/lzma/C/7zCrc.c b/3rdparty/lzma/C/7zCrc.c
+index f186324d..f39fe1c9 100644
+--- a/3rdparty/lzma/C/7zCrc.c
++++ b/3rdparty/lzma/C/7zCrc.c
+@@ -71,7 +71,7 @@ UInt32 MY_FAST_CALL CrcUpdateT1(UInt32 v, const void *data, size_t size, const U
+ 
+ #ifdef MY_CPU_LE
+ 
+-#if defined(MY_CPU_ARM_OR_ARM64)
++#if defined(MY_CPU_ARM_OR_ARM64) && 0
+ 
+ // #pragma message("ARM*")


### PR DESCRIPTION
7zip/lzma assumes hardware crc support on arm, which breaks compilation on armv7.

Disable the check so it falls back to a software implementation.