### PR TITLE
atari800: upgrade to 5.2.0

### DIFF
--- a/scriptmodules/emulators/atari800.sh
+++ b/scriptmodules/emulators/atari800.sh
@@ -13,7 +13,7 @@ rp_module_id="atari800"
 rp_module_desc="Atari 8-bit/800/5200 emulator"
 rp_module_help="ROM Extensions: .a52 .bas .bin .car .xex .atr .xfd .dcm .atr.gz .xfd.gz\n\nCopy your Atari800 games to $romdir/atari800\n\nCopy your Atari 5200 roms to $romdir/atari5200 You need to copy the Atari 800/5200 BIOS files (5200.ROM, ATARIBAS.ROM, ATARIOSB.ROM and ATARIXL.ROM) to the folder $biosdir and then on first launch configure it to scan that folder for roms (F1 -> Emulator Configuration -> System Rom Settings)"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/atari800/atari800/master/COPYING"
-rp_module_repo="git https://github.com/atari800/atari800.git ATARI800_5_0_0"
+rp_module_repo="git https://github.com/atari800/atari800.git ATARI800_5_2_0"
 rp_module_section="opt"
 rp_module_flags="sdl1 !mali"
 


### PR DESCRIPTION
Changes since 5.0.0:

   * Altirra OS updated to v3.41
   * Altirra BASIC updated to v1.58
   * Atari ST/TT/Falcon optimizations
   * Fixed keystrokes for inserting/deleting of line/character (#179)
   * SIO now resets BRKKEY (fixes Arsantica 3 demo)
   * Fixes CTRL and CAPS keys when using SDL12-compat library.
   * Show all input events on a single line during recording
   * RAM cartridges implementation
   * added XEX reading in monitor (useful for patches)
   * Added H: device rename; save it in setup file, possibility of renaming the host device (H:) to any letter but C: (cassette), E:, K: and S:

Full changelogs:
  - 5.1.0: https://github.com/atari800/atari800/releases/tag/ATARI800_5_1_0
  - 5.2.0: https://github.com/atari800/atari800/releases/tag/ATARI800_5_2_0