### PR TITLE
scummvm: upgrade to v2.8.0

### DIFF
--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -13,7 +13,7 @@ rp_module_id="scummvm"
 rp_module_desc="ScummVM"
 rp_module_help="Copy your ScummVM games to $romdir/scummvm"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/scummvm/scummvm/master/COPYING"
-rp_module_repo="git https://github.com/scummvm/scummvm.git v2.7.1"
+rp_module_repo="git https://github.com/scummvm/scummvm.git v2.8.0"
 rp_module_section="opt"
 rp_module_flags="sdl2"
 
@@ -21,7 +21,7 @@ function depends_scummvm() {
     local depends=(
         liba52-0.7.4-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libgif-dev libmad0-dev libpng-dev
         libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev
-        libjpeg-dev libasound2-dev libcurl4-openssl-dev
+        libjpeg-dev libasound2-dev libcurl4-openssl-dev libmikmod-dev libvpx-dev
     )
     if isPlatform "vero4k"; then
         depends+=(vero3-userland-dev-osmc)
@@ -41,8 +41,9 @@ function sources_scummvm() {
 function build_scummvm() {
     rpSwap on 750
     local params=(
+        --prefix="$md_inst"
         --enable-release --enable-vkeybd
-        --disable-debug --disable-eventrecorder --prefix="$md_inst"
+        --disable-debug --disable-eventrecorder --disable-sonivox
     )
     isPlatform "rpi" && isPlatform "32bit" && params+=(--host=raspberrypi)
     isPlatform "rpi" && [[ "$md_id" == "scummvm-sdl1" ]] && params+=(--opengl-mode=none)


### PR DESCRIPTION
Added a few new depedencies needed in 2.8.0. The 'sonivox' option is disabled for now, since the package(s) needed are available starting with Debian 12 (bookwork) and Ubuntu 23.04 and thus not available everywhere.

ScummVM 2.8.0: Mysteries, Mammoths, and Muppets changelog (announced in https://www.scummvm.org/news/20231230/, full log at https://downloads.scummvm.org/frs/scummvm/2.8.0/ReleaseNotes.html)

New games added:

   * Adibou 1
   * Classical Cats
   * The Dark Eye
   * Dark Side
   * Escape From Hell
   * Gadget: Invention Travel and Adventure
   * Gobliiins 5
   * The Excavation of Hob's Barrow
   * Kingdom: The Far Reaches
   * Might and Magic Book One
   * Muppet Treasure Island
   * Nancy Drew: The Final Scene
   * Nancy Drew: Message in a Haunted Mansion
   * Nancy Drew: Secrets Can Kill
   * Nancy Drew: Stay Tuned for Danger
   * Nancy Drew: Treasure in the Royal Tower
   * Primordia
   * Reah: Face the Unknown
   * Schizm: Mysterious Journey
   * Shardlight
   * Strangeland
   * Syberia and Syberia II (macOS versions only)
   * Technobabylon
   * The Vampire Diaries
   * Whispers of a Machine
   * Wrath of the Gods and four other Director titles.
   * 14 AGS titles by Stranga and Cloak and Dagger

New Platforms:
   * Libretro, now part of the mainline sources
   * Atari, added as native port

Engine enhancements:
   * AGS engine has been upgraded to 3.6.0.53 from upstream
   * Added support for numerous Chinese and Japanese game variants in various engines.
   * Implemented a lot of native GUI dialogs for SCUMM games, bringing them closer to the original experience.
   * Re-implemented the sound engine for SCUMM Humongous Entertainment games, making them flawless.
   * Performed a deep review of the Broken Sword 1 game engine, implementing some small, previously unnoticed things like scene transitions, in-game menu peculiarities, accurate fonts, idle animations, and more. Now, the game is absolutely faithful to the original.