### PR TITLE
micropolis: fix path and display

### DIFF
--- a/scriptmodules/ports/micropolis.sh
+++ b/scriptmodules/ports/micropolis.sh
@@ -29,7 +29,7 @@ function remove_micropolis() {
 
 function configure_micropolis() {
     local binary="/usr/games/micropolis"
-    ! isPlatform "x11" && binary="XINIT-WM:/usr/bin/micropolis"
+    ! isPlatform "x11" && binary="XINIT-WMC:/usr/games/micropolis"
 
     addPort "$md_id" "micropolis" "Micropolis" "$binary"
 }


### PR DESCRIPTION
Broken by my previuos PR.

Micropolis runs in a maximized window, but doesn't have any fullscreen option and it relies on the WM cursor to operate, so use the WM + Cursor option for it.