### PR TITLE
lr-ppsspp - split out lr-ppsspp specific patches

### DIFF
--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -54,13 +54,8 @@ function sources_ppsspp() {
     sed -n -i "p; s/^set(CMAKE_EXE_LINKER_FLAGS/set(CMAKE_SHARED_LINKER_FLAGS/p" cmake/Toolchains/raspberry.armv?.cmake
 
     # fix missing defines on opengles2 on v1.16.6 lr-ppsspp/ppsspp
-    if [[ "$md_id" =~ ^(lr-)?ppsspp$ && "$(_get_release_ppsspp)" == "v1.16.6" ]]; then
+    if [[ "$md_id" == "ppsspp" && "$(_get_release_ppsspp)" == "v1.16.6" ]]; then
         applyPatch "${__mod_info[ppsspp/path]%/*}/ppsspp/gles2_fix.diff"
-    fi
-
-    # fix missing exported symbol for libretro on v1.13.2
-    if [[ "$md_id" == "lr-ppsspp" && "$(_get_release_ppsspp)" == "v1.13.2" ]]; then
-        applyPatch "$md_data/v13-libretro_fix.diff"
     fi
 
     if hasPackage cmake 3.6 lt; then

--- a/scriptmodules/libretrocores/lr-ppsspp.sh
+++ b/scriptmodules/libretrocores/lr-ppsspp.sh
@@ -23,6 +23,16 @@ function depends_lr-ppsspp() {
 
 function sources_lr-ppsspp() {
     sources_ppsspp
+
+    # fix missing defines on opengles2 on v1.16.6 lr-ppsspp
+    if [[ "$(_get_release_ppsspp)" == "v1.16.6" ]]; then
+        applyPatch "${__mod_info[ppsspp/path]%/*}/ppsspp/gles2_fix.diff"
+    fi
+
+    # fix missing exported symbol for libretro on v1.13.2
+    if [[ "$(_get_release_ppsspp)" == "v1.13.2" ]]; then
+        applyPatch "$md_data/v13-libretro_fix.diff"
+    fi
 }
 
 function build_lr-ppsspp() {


### PR DESCRIPTION
This fixes binary builds not triggering due to the changes being in ppsspp.