### PR TITLE
runcommand: disable powersave when XINIT is used

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -959,6 +959,7 @@ _EOF_
                 cat >>"$xinitrc" <<_EOF_
 matchbox-window-manager ${params[@]} &
 sleep 0.5
+xset -dpms s off s noblank
 _EOF_
             fi
 


### PR DESCRIPTION
Add the `xset` commands to disable the display powersave and screen blanking, since gamepad activity is ignored by Xorg and the display will go to sleep if no keyboard/mouse is active. 

I removed the script launchers ccbee7c05a, but the `xset` commands haven't been added `XINIT-WM` launchers.