### PR TITLE
helpers: map 'xorg' for Pi5 and for 'legacy' exclusion

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -299,6 +299,13 @@ function _mapPackage() {
         libfreetype6-dev)
             [[ "$__os_debian_ver" -gt 10 ]] || compareVersions "$__os_ubuntu_ver" gt 23.04 && pkg="libfreetype-dev"
             ;;
+        xorg)
+            # outside X11, don't install the 'xserver-xorg-legacy' package, even if recommended by 'apt'
+            # since it breaks launching x11 apps with 'runcommand'
+            ! isPlatform "x11" && pkg+=" xserver-xorg-legacy-"
+            # Pi5 needs an additional package for xserver to start
+            isPlatform "rpi5" && pkg+=" gldriver-test"
+            ;;
     esac
     echo "$pkg"
 }


### PR DESCRIPTION
The 'xorg' (meta)-package will install the necessary packages to run an Xorg server and to launch applications under an Xorg environment. We need to map 'xorg' for:

 - Pi5 needs an additional package that provides configuration for Xorg, without it the server will not start. Unfortunately the package has no reverse dependency (for now), so it must be installed explicitely.
 - One of the recommended packages installed is the 'xserver-xorg-legacy' package, which breaks our x11 apps launched from `runcommand`. We already uninstall it when the setup script starts (regardless of how it was installed), but let's not install it ourselves when 'xorg' is a dependency for one of our own scriptmodules. NOTE: `runcommand` breakage under `-legacy` is due to our redirection of STDIN/STDOUT. The `-legacy` provided wrapper checks whether the current controlling tty is a 'real console' tty by looking at the major/minor device numbers and bails out if it's not 4/1.