### PR TITLE
Amiberry 5.6.6

### DIFF
--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -13,7 +13,7 @@ rp_module_id="amiberry"
 rp_module_desc="Amiga emulator with JIT support (forked from uae4arm)"
 rp_module_help="ROM Extension: .adf .chd .ipf .lha .zip\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir/amiga"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/BlitterStudio/amiberry/master/LICENSE"
-rp_module_repo="git https://github.com/BlitterStudio/amiberry v5.6.4"
+rp_module_repo="git https://github.com/BlitterStudio/amiberry v5.6.6"
 rp_module_section="opt"
 rp_module_flags="!all arm rpi3 rpi4 rpi5"
 
@@ -47,7 +47,7 @@ function _get_platform_amiberry() {
 }
 
 function depends_amiberry() {
-    local depends=(autoconf libpng-dev libmpeg2-4-dev zlib1g-dev libmpg123-dev libflac-dev libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libserialport-dev wget)
+    local depends=(cmake autoconf libpng-dev libmpeg2-4-dev zlib1g-dev libmpg123-dev libflac-dev libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libserialport-dev wget libportmidi-dev)
 
     isPlatform "dispmanx" && depends+=(libraspberrypi-dev)
     isPlatform "vero4k" && depends+=(vero3-userland-dev-osmc)

--- a/scriptmodules/emulators/amiberry/01_preserve_env.diff
+++ b/scriptmodules/emulators/amiberry/01_preserve_env.diff
@@ -1,18 +1,18 @@
-diff --git a/Makefile b/Makefile
-index 93ef345..75f5bd4 100644
---- a/Makefile
-+++ b/Makefile
-@@ -21,10 +21,10 @@ SDL_CONFIG ?= sdl2-config
+diff --git i/Makefile w/Makefile
+index cff286e2..40e3c05f 100644
+--- i/Makefile
++++ w/Makefile
+@@ -43,10 +43,10 @@ SDL_CONFIG ?= sdl2-config
  export SDL_CFLAGS := $(shell $(SDL_CONFIG) --cflags)
  export SDL_LDFLAGS := $(shell $(SDL_CONFIG) --libs)
-
--CPPFLAGS = -MD -MT $@ -MF $(@:%.o=%.d) $(SDL_CFLAGS) -Iexternal/libguisan/include -Isrc -Isrc/osdep -Isrc/threaddep -Isrc/include -Isrc/archivers -Isrc/floppybridge -DAMIBERRY -D_FILE_OFFSET_BITS=64
--CFLAGS=-pipe -Wno-shift-overflow -Wno-narrowing
-+CPPFLAGS += -MD -MT $@ -MF $(@:%.o=%.d) $(SDL_CFLAGS) -Iexternal/libguisan/include -Isrc -Isrc/osdep -Isrc/threaddep -Isrc/include -Isrc/archivers -Isrc/floppybridge -DAMIBERRY -D_FILE_OFFSET_BITS=64
-+CFLAGS +=-pipe -Wno-shift-overflow -Wno-narrowing
+ 
+-CPPFLAGS = -MD -MT $@ -MF $(@:%.o=%.d) $(SDL_CFLAGS) -Iexternal/libguisan/include -Isrc -Isrc/osdep -Isrc/threaddep -Isrc/include -Isrc/archivers -Isrc/floppybridge -Iexternal/mt32emu/src -D_FILE_OFFSET_BITS=64
+-CFLAGS=-pipe -Wno-shift-overflow -Wno-narrowing -fno-pie
++CPPFLAGS += -MD -MT $@ -MF $(@:%.o=%.d) $(SDL_CFLAGS) -Iexternal/libguisan/include -Isrc -Isrc/osdep -Isrc/threaddep -Isrc/include -Isrc/archivers -Isrc/floppybridge -Iexternal/mt32emu/src -D_FILE_OFFSET_BITS=64
++CFLAGS +=-pipe -Wno-shift-overflow -Wno-narrowing -fno-pie
  USE_LD ?= gold
--LDFLAGS = $(SDL_LDFLAGS) -lSDL2_image -lSDL2_ttf -lserialport -lguisan -Lexternal/libguisan/lib
-+LDFLAGS += $(SDL_LDFLAGS) -lSDL2_image -lSDL2_ttf -lserialport -lguisan -Lexternal/libguisan/lib
+-LDFLAGS = $(SDL_LDFLAGS) -lSDL2_image -lSDL2_ttf -lserialport -lportmidi -lguisan -Lexternal/libguisan/lib -lmt32emu -Lexternal/mt32emu
++LDFLAGS += $(SDL_LDFLAGS) -lSDL2_image -lSDL2_ttf -lserialport -lportmidi -lguisan -Lexternal/libguisan/lib -lmt32emu -Lexternal/mt32emu
  ifneq ($(strip $(USE_LD)),)
-    LDFLAGS += -fuse-ld=$(USE_LD)
+ 	LDFLAGS += -fuse-ld=$(USE_LD)
  endif


### PR DESCRIPTION
This bumps Amiberry from 5.6.4 -> 5.6.6.

Release notes:
https://github.com/BlitterStudio/amiberry/releases/tag/v5.6.5
https://github.com/BlitterStudio/amiberry/releases/tag/v5.6.6

Notably this changes the default vsync behaviour, which should fix https://github.com/BlitterStudio/amiberry/issues/1189  – render corruption when launching from EmulationStation on Pi5. (That was my own motivation, but I'm yet to confirm it has the desired outcome).

libportmidi-dev [has been added as a build dependency](https://github.com/BlitterStudio/amiberry/commit/e52bd6f44d776affc7017192b7ef691c496a3420). 