### PR TITLE
bashwelcometweak: fix GPU temp reading

### DIFF
--- a/scriptmodules/supplementary/bashwelcometweak.sh
+++ b/scriptmodules/supplementary/bashwelcometweak.sh
@@ -44,8 +44,8 @@ function retropie_welcome() {
         cpuTempC=$(($(cat /sys/class/thermal/thermal_zone0/temp)/1000)) && cpuTempF=$((cpuTempC*9/5+32))
     fi
 
-    if [[ -f "/opt/vc/bin/vcgencmd" ]]; then
-        if gpuTempC=$(/opt/vc/bin/vcgencmd measure_temp); then
+    if [[ -n $(command -v vcgencmd) ]]; then
+        if gpuTempC=$(vcgencmd measure_temp); then
             gpuTempC=${gpuTempC:5:2}
             gpuTempF=$((gpuTempC*9/5+32))
         else


### PR DESCRIPTION
On RasPI OS 11/12 (bullseye/bookworm) the `vcgencmd` command has moved to `/usr/bin`. Use the normal path first when running `vcgencmd measure_temp` to get the GPU temperature, otherwise nothing is shown.