### PR TITLE
joy2key: refactor stop action

### DIFF
--- a/scriptmodules/admin/joy2key.sh
+++ b/scriptmodules/admin/joy2key.sh
@@ -70,8 +70,9 @@ case "\$mode" in
         "$md_inst/\$script" "\$device" "\${params[@]}" || exit 1
         ;;
     stop)
-        pkill -f "\$script"
-        sleep 1
+        if pid=\$(pgrep -f "\$script"); then
+            /sbin/start-stop-daemon --stop --oknodo --pid \$pid --retry 1
+        fi
         ;;
 esac
 exit 0


### PR DESCRIPTION
Modified the 'stop' action to use `start-stop-daemon` [1] instead of a simple `pkill`.

The advantage is that we don't need to use `sleep` to ensure the script is stopped, since `start-stop-daemon` monitors the process and will exit when is stopped. The `retry` action is to send a SIGKILL after 1 second, to ensure the process is stopped.

The modification will shorten the time it takes to 'stop' the joystick handling utility, since we don't have to wait - unconditionally - for 1 sec every stop. This will shorten the runtime of `runcommand` .

[1] https://man7.org/linux/man-pages/man8/start-stop-daemon.8.html. Since it's part of `dpkg`, it's basically present on every Debian based system.