### PR TITLE
lr-dosbox: fix building with GCC 11+

### DIFF
--- a/scriptmodules/libretrocores/lr-dosbox.sh
+++ b/scriptmodules/libretrocores/lr-dosbox.sh
@@ -31,6 +31,7 @@ function build_lr-dosbox() {
         fi
     fi
     make clean
+    [[ "$__gcc_version" -gt 10 ]] && CXXFLAGS="$CXXFLAGS -std=gnu++11"
     make "${params[@]}"
     md_ret_require="$md_build/dosbox_libretro.so"
 }


### PR DESCRIPTION
Reported upstream, but not fixed. Workaround is to force C++11 as dialect, suggested in https://github.com/libretro/dosbox-libretro/issues/137