### PR TITLE
kodi: fix installation on Bookworm/Bullseye

### DIFF
--- a/scriptmodules/ports/kodi.sh
+++ b/scriptmodules/ports/kodi.sh
@@ -34,6 +34,14 @@ function depends_kodi() {
                 apt-key del 4096R/BAA567BB >/dev/null
             fi
         fi
+        if [[ "$__os_debian_ver" -gt 10 ]]; then
+            # install Kodi from the RPI repos directly
+            # make sure we're not installing Debian/Raspbian version by pinning the origin of the packages
+            local apt_pin_file="/etc/apt/preferences.d/01-rpie-pin-kodi"
+            if [[ ! -f "$apt_pin_file" ]]; then
+                echo -e "Package: kodi*\nPin: release o=Raspberry Pi Foundation\nPin-Priority: 900" > "$apt_pin_file"
+            fi
+        fi
     # ubuntu
     elif [[ -n "$__os_ubuntu_ver" ]] && isPlatform "x86"; then
         if [[ "$md_mode" == "install" ]]; then

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -190,7 +190,7 @@ function get_os_version() {
 
             # 64bit Raspberry Pi OS identifies as Debian, but functions (currently) as Raspbian
             # we will check package sources and set to Raspbian
-            if isPlatform "aarch64" && apt-cache policy | grep -q "archive.raspberrypi.org"; then
+            if isPlatform "aarch64" && apt-cache policy | grep -qE "archive.raspberrypi.(com|org)"; then
                 __os_id="Raspbian"
             fi
 


### PR DESCRIPTION
Since Bullseye, `kodi` should be installed from the RPT repos, since it's built with the necessary patches/optimization directly by the RP folks.
However, the version in the repos don't always overrides the version present in the upstream Debian/Raspbian repositories [1] and installation fails.

Added a workaround to always prefer the Kodi packages originating from archive.raspberrypi.com/archive.raspberrypi.org and also fixed the Raspbian detection on Bookworm.

I think Bullseye and previous had 'archive.raspberrypi.org' for RP repositories, while Bookworm has switched to 'archive.raspberrypi.com', so we can't use the URL for pinning. Added a pin based on the 'l'(Location ?) field of the release from the repository.

[1] https://github.com/raspberrypi/bookworm-feedback/issues/144

NB: for Netflix/Amazon/Disney+/etc. (basically DRM-enabled content), `kodi` can use the `libwidevinecdm0` package to enable streaming. Not sure if we want it enabled/added by default or just mention it in the documentation.   