### PR TITLE
Builder fixes

### DIFF
--- a/scriptmodules/admin/builder.sh
+++ b/scriptmodules/admin/builder.sh
@@ -102,10 +102,6 @@ function chroot_build_builder() {
         local archive_dir="tmp/archives/$(_get_info_image "$dist" "name")"
 
         local distcc_hosts="$__builder_distcc_hosts"
-        if [[ -d "$rootdir/admin/crosscomp/$dist" ]]; then
-            rp_callModule crosscomp switch_distcc "$dist"
-            [[ -z "$distcc_hosts" ]] && distcc_hosts="$ip"
-        fi
 
         local use_ccache="$__builder_use_ccache"
 


### PR DESCRIPTION
[builder - allow automatic switching to different remote branch](https://github.com/RetroPie/RetroPie-Setup/commit/c44eb50a0da3af8834ec54aeabe0ad4aaca08110)

ENV variables __builder_repo && __builder_branch are used to switch to another repository/branch for building.

This is used to more easily build binaries before branches are merged into master. Primarily for SDL binaries, but simplifies testing for other modules.

[builder - remove old unused code](https://github.com/RetroPie/RetroPie-Setup/commit/3e1be9410523e3b492211767071f48a1edd2409e)