### PR TITLE
Don't set dispmanx flag on arm64 systems

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -354,7 +354,7 @@ function get_rpi_video() {
 
     if [[ "$__has_kms" -eq 1 ]]; then
         __platform_flags+=(mesa kms)
-        if [[ -z "$__has_dispmanx" ]]; then
+        if ! isPlatform "aarm64" && [[ -z "$__has_dispmanx" ]]; then
             if [[ "$__chroot" -eq 1 ]]; then
                 # in a chroot default to fkms (supporting dispmanx) when debian is older than 11 (bullseye)
                 [[ "$__os_debian_ver" -lt 11 ]] && __has_dispmanx=1
@@ -365,7 +365,10 @@ function get_rpi_video() {
         fi
         [[ "$__has_dispmanx" -eq 1 ]] && __platform_flags+=(dispmanx)
     else
-        __platform_flags+=(videocore dispmanx)
+        __platform_flags+=(videocore)
+        if ! isPlatform "aarm64"; then
+            __platform_flags+=(dispmanx)
+        fi
     fi
 
     # delete legacy pkgconfig that conflicts with Mesa (may be installed via rpi-update)


### PR DESCRIPTION
omxplayer does not have a build available for aarch64 platform. So when building emulationstation from source on arm64 systems we need to skip this dependency, otherwise the dependency installation fails and we can't install emulationstation