### PR TITLE
bombermaan: fix build for Buster/Bullseye

### DIFF
--- a/scriptmodules/ports/bombermaaan.sh
+++ b/scriptmodules/ports/bombermaaan.sh
@@ -22,6 +22,7 @@ function depends_bombermaaan() {
 
 function sources_bombermaaan() {
     gitPullOrClone
+    applyPatch "$md_data/01-cmake-sdl-mixer.diff"
 }
 
 function build_bombermaaan() {

--- a/scriptmodules/ports/bombermaaan/01-cmake-sdl-mixer.diff
+++ b/scriptmodules/ports/bombermaaan/01-cmake-sdl-mixer.diff
@@ -1,0 +1,39 @@
+diff --git a/trunk/src/CMakeLists.txt b/trunk/src/CMakeLists.txt
+index 5be7af8..8a260bb 100644
+--- a/trunk/src/CMakeLists.txt
++++ b/trunk/src/CMakeLists.txt
+@@ -165,7 +165,13 @@ source_group("Header Files" FILES ${BOMBERMAAAN_HEADERS} ${BOMBERMAAAN_DX_HEADER
+ source_group("Source Files" FILES ${BOMBERMAAAN_SOURCES} ${BOMBERMAAAN_DX_SOURCES} ${BOMBERMAAAN_NET_SOURCES} ${WINREPLACE_SOURCES})
+ 
+ find_package(SDL2 REQUIRED)
+-find_package(SDL2_mixer REQUIRED)
++find_package(SDL2_mixer QUIET)
++if(NOT SDL2_mixer_FOUND)
++    find_library(SDL2_MIXER_LIBRARIES NAMES SDL2_mixer)
++    if(NOT SDL2_MIXER_LIBRARIES)
++        MESSAGE(FATAL_ERROR "SDL2_mixer libraries missing !")
++    endif()
++endif()
+ 
+ if(USE_ALLEGRO)
+   find_package(Allegro4 REQUIRED)
+@@ -182,7 +188,7 @@ if(CRASH_REPORT)
+ endif()
+ 
+ set(BOMBERMAAAN_INCLUDE_DIRS
+-  ${SDL2_INCLUDE_DIR}
++  ${SDL2_INCLUDE_DIR} ${SDL2_INCLUDE_DIRS}
+   ${SDL2_MIXER_INCLUDE_DIR}
+ )
+ 
+@@ -207,8 +213,8 @@ include_directories(
+ )
+ 
+ set(BOMBERMAAAN_LIBRARIES
+-  SDL2::SDL2
+-  SDL2_mixer::SDL2_mixer
++  $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,${SDL2_LIBRARIES}>
++  $<IF:$<TARGET_EXISTS:SDL2_mixer::SDL2_mixer>,SDL2_mixer::SDL2_mixer,${SDL2_MIXER_LIBRARIES}>
+   tinyxml
+ )
+ 


### PR DESCRIPTION
Added a patch for CMake to fix generating/building Bombermaaan with older SDL2/SDL2_mixer:

 - on Bullseye/Ubuntu 20.4, `sdl2_mixer-config.cmake` doesn't contain the target aliases in the `SDL2_mixer` namespace.
 - on Buster, `sdl2-config.cmake` doesn't contain the target aliases in the `SDL2` namespace and the includes/libraries are not correctly added to the compilation and linkage options.