### PR TITLE
joy2key: fix generic mappings definition

### DIFF
--- a/scriptmodules/admin/joy2key/joy2key_sdl.py
+++ b/scriptmodules/admin/joy2key/joy2key_sdl.py
@@ -196,8 +196,8 @@ def get_all_ra_config(def_buttons: list) -> list:
     generic_dev = InputDev("*", "*")
     generic_dev.add_mappings(
         {},  # no axis
-        {0: [(1, 'up'), (8, 'left'), (4, 'down'), (2, 'right')]},  # D-Pad as 'hat0'
-        {0: 'b', 1: 'a', 3: 'y', 4: 'x'}  # 4 buttons
+        {0: 'b', 1: 'a', 3: 'y', 4: 'x'},  # 4 buttons
+        {0: [(1, 'up'), (8, 'left'), (4, 'down'), (2, 'right')]}  # 1 D-Pad as 'hat0'
     )
     ra_config_list.append(generic_dev)
     js_cfg_dir = CONFIG_DIR + '/all/retroarch-joypads/'


### PR DESCRIPTION
Besides the mappings parsed from RetroArch's auto-configuration profiles, there's a generic mapping used for gamepads that don't have a profile saved. Unfortunately this never worked, since the initialization of the mapping - in the `add_mappings` function - had the buttons and hats parameters switched. This changeset fixes this, creating a correct mapping.

The issue was reported in https://retropie.org.uk/forum/topic/35063/, `joy2key_sdl` would crash with a Python3 error since the (wrong) generic mapping would produce the incorrect data type and values for the `filter_active_events` method.