### PR TITLE
xpadneo: upgrade to the latest v0.9.x version

### DIFF
--- a/scriptmodules/supplementary/xpadneo.sh
+++ b/scriptmodules/supplementary/xpadneo.sh
@@ -12,7 +12,7 @@
 rp_module_id="xpadneo"
 rp_module_desc="Advanced Linux driver for Xbox One wireless gamepads"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/atar-axis/xpadneo/master/LICENSE"
-rp_module_repo="git https://github.com/atar-axis/xpadneo.git v0.9.5"
+rp_module_repo="git https://github.com/atar-axis/xpadneo.git v0.9.6"
 rp_module_section="driver"
 rp_module_flags="nobin"
 


### PR DESCRIPTION
Upgrade to version 0.9.6, last maintenance release in the v0.9 series.

Main features:
  * Add support for GuliKit KingKong2 PRO controllers
  * Move paddles to range BTN_TRIGGER_HAPPY5
  * Actually save rumble test values before we replace them
  * Support GameSir T4 Cyclone models
  * Fix documentation about Share button