### PR TITLE
xroar: update to 1.5.3

### DIFF
--- a/scriptmodules/emulators/xroar.sh
+++ b/scriptmodules/emulators/xroar.sh
@@ -13,12 +13,12 @@ rp_module_id="xroar"
 rp_module_desc="Dragon / CoCo emulator XRoar"
 rp_module_help="ROM Extensions: .cas .wav .bas .asc .dmk .jvc .os9 .dsk .vdk .rom .ccc .sna\n\nCopy your Dragon roms to $romdir/dragon32\n\nCopy your CoCo games to $romdir/coco\n\nCopy the required BIOS files d32.rom (Dragon 32), bas13.rom (CoCo), coco3.rom/coco3p.rom (CoCo3) to $biosdir"
 rp_module_licence="GPL3 http://www.6809.org.uk/xroar/"
-rp_module_repo="git http://www.6809.org.uk/git/xroar.git 1.3"
+rp_module_repo="git http://www.6809.org.uk/git/xroar.git 1.5.3"
 rp_module_section="opt"
 rp_module_flags=""
 
 function depends_xroar() {
-    local depends=(libsdl2-dev automake libasound2-dev texinfo zlib1g-dev)
+    local depends=(libsdl2-dev automake libasound2-dev libsndfile1-dev texinfo zlib1g-dev)
     isPlatform "x11" && depends+=(libpulse-dev)
     getDepends "${depends[@]}"
 }


### PR DESCRIPTION
New features in version 1.5:

*  Add ability to change Picture Area, seeing more or less border
*  New option -vo-picture
*  Respect -geometry dimensions in SDL-based UIs
*  Add optional 60Hz vertical scaling (on by default)
*  New option -no-vo-scale-60hz disables 60Hz scaling
*  Faster ROM intercept based printing on CoCo and MC-10
*  GIME: respect X offset and HVEN in COCO mode
*  MPI slot config moved from global to per-cart, included in -config-print
*  Add screenshot to PNG from menu or Control+Shift+S
*  Fix printing after switching machines [Jak Fearon]
*  Better rendering of paths in Windows dialogs
*  Fix some CoCo 3 cartridge behaviour [Christian Haitian]
*  GIME: reset video address later (fixes Androne) [Russ Le Blang]
*  GIME: fix various $FExx access problems