### PR TITLE
initfuncs: change `sed` separator for `iniGet`

### DIFF
--- a/scriptmodules/inifuncs.sh
+++ b/scriptmodules/inifuncs.sh
@@ -152,7 +152,7 @@ function iniGet() {
         value_m="\([^\r]*\)"
     fi
 
-    ini_value="$(sed -n "s/^[ |\t]*$key[ |\t]*$delim_strip[ |\t]*$value_m.*/\1/p" "$file" | tail -1)"
+    ini_value="$(sed -n "s#^[ |\t]*$key[ |\t]*$delim_strip[ |\t]*$value_m.*#\1#p" "$file" | tail -1)"
 }
 
 # @fn retroarchIncludeToEnd()


### PR DESCRIPTION
Use `#` instead of `/` for SED's substitution command separator. 

This makes the `iniGet` command work for key values containing `/` (like Dolphin's input configuration files). The `#` character is usually reserved for comment lines in an `.ini` file, so it should be relatively safe to use as separator; `sed` accepts any ccharacter besides `*` or newline for separator, so `#` should also be safe here.