### PR TITLE
retroarch: upgrade to v1.18.0

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -12,7 +12,7 @@
 rp_module_id="retroarch"
 rp_module_desc="RetroArch - frontend to the libretro emulator cores - required by all lr-* emulators"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/RetroArch/master/COPYING"
-rp_module_repo="git https://github.com/retropie/RetroArch.git retropie-v1.16.0"
+rp_module_repo="git https://github.com/retropie/RetroArch.git retropie-v1.18.0"
 rp_module_section="core"
 
 function depends_retroarch() {
@@ -71,9 +71,6 @@ function build_retroarch() {
 
 function install_retroarch() {
     make install
-    md_ret_files=(
-        'retroarch.cfg'
-    )
 }
 
 function update_shaders_retroarch() {
@@ -282,6 +279,13 @@ function configure_retroarch() {
     # enable video shaders
     iniSet "video_shader_enable" "true"
 
+    # enable overlays by default
+    iniSet "input_overlay_enable" "true"
+
+    # disable save paths under sub-folders
+    iniSet "sort_savestates_enable" "false"
+    iniSet "sort_savefiles_enable" "false"
+
     copyDefaultConfig "$config" "$configdir/all/retroarch.cfg"
     rm "$config"
 
@@ -313,6 +317,13 @@ function configure_retroarch() {
     # don't save input remaps by default
     _set_config_option_retroarch "remap_save_on_exit" "false"
 
+    # enable overlays by default on upgrades
+    _set_config_option_retroarch "input_overlay_enable" "true"
+
+    # don't sort save files in sub-folders
+    _set_config_option_retroarch "sort_savefiles_enable" "false"
+    _set_config_option_retroarch "sort_savestates_enable" "false"
+
     # remapping hack for old 8bitdo firmware
     addAutoConf "8bitdo_hack" 0
 }
@@ -338,7 +349,7 @@ function keyboard_retroarch() {
         local value
         local values
         readarray -t values <<<"$choice"
-        iniConfig " = " "" "$configdir/all/retroarch.cfg"
+        iniConfig " = " '"' "$configdir/all/retroarch.cfg"
         i=0
         for value in "${values[@]}"; do
             iniSet "${key[$i]}" "$value" >/dev/null
@@ -438,7 +449,7 @@ function _set_config_option_retroarch()
 {
     local option="$1"
     local value="$2"
-    iniConfig " = " "\"" "$configdir/all/retroarch.cfg"
+    iniConfig " = " '"' "$configdir/all/retroarch.cfg"
     iniGet "$option"
     if [[ -z "$ini_value" ]]; then
         iniSet "$option" "$value"


### PR DESCRIPTION
Upgraded RetroArch to version ~~1.17.0~~ 1.18.0. You can pull from https://github.com/cmitu/RetroArch/tree/retropie-v1.18.0, which contains 1.18.0 + our patches.


Notable changes, cherry-picked from:

 - https://www.libretro.com/index.php/retroarch-1-17-0-release/
 - https://github.com/libretro/RetroArch/commit/9e492f74c8378582bde6f115a8715ab08e945303

 * Netplay
   - expanded the protocol to allow multiplayer games running on separate consoles/computers.
     Cores like 'Dosbox-Pure' or 'gPSP' support the new protocol.
   - add support for joining MITM servers from command line
 * Cheevos
    - upgrade to v11.0
    - don’t track disc changes when achievements are disabled
    - inform user when server is unreachable
    - fix crash on first load of game with achievements with threaded video
  * Input
    - fix ghost input when setting RETROK_UNKNOWN
    - default ‘Bind Hold’ to 0 to prevent problems with controllers not resting at null state
    - don’t save mouse buttons to autoconfig
    - add a setting to allow turbo d-pad directions
    - change event detection to polling in udev_joypad
    - add option for merging ‘Hotkey Enable’ device types
    - fix input state combos including R3 and false triggers of RETROK_UNKNOWN (1.18.0)
    - add a new turbo mode, "Classic (Toggle)" (1.18.0)
    - limit axis threshold setting to sensible values (1.18.0)
  * Menu
    - fix menu analog stick navigation (1.16.0.1)
    - fix word wrapped widget length
    - fix quit on content close option
    - don’t process menu events while input is being flushed (1.16.0.2)
    - add help text to controller drivers
    - fix text scaling in 16:9 (RGUI)
    - thumbnail related fixes (missing thumbnail bar, fullscreen thumbnail flashing, sidebar focus, OZONE)
    - background images take precedence over color themes, default image opacity set the same as color theme opacity (XMB)
    - fix segmentation fault when background image is missing (XMB)
    - layout/thumbnail fixes – Thumbnail layout adjustments, Header title improvements, Handheld layout adjustments (XMB)
    - add sublabels for input bind common entries (1.18.0)
    - don't disable fast forward when entering menu (1.18.0)
    - add option to disable initial disk change (1.18.0)
    - visibility option for disk control notifications (1.18.0)
  * Video
    - use video refresh rate instead of core refresh rate for menu frame limiting
    - limit paused video refresh rate
    - enforce swap interval 1 in menu if vsync is on
    - add FinalViewportSize support to GLSL
    - change rotation type to int to maximize compatibility

  * Patching
    - add support for XDelta-formatted patches.
    - fix patching for cores that support contentless mode

  * Other
    - Frame Rest, experimental sleep feature aiming to lower CPU usage and temperature when using certain CPU hungry vsync modes
    - introduce wp_fractional_scale_v1 protocol for proper fractional scaling (Wayland)
    - update wayland-protocols version to 1.31 (Wayland)

RetroPie module changes:

 RetroPie module changes:

 - make `iniConfig` use the same parameters every time
 - removed spurious `ret` files on `_install`
 - set `input_overlay_enable` to enabled, since the default changed (to 'false') in 1.17.0.
   It helps overlay users that didn't explicitely set this parameter in the overlay overrides they're using.
 - set `sort_savestates_enable` and `sort_savefiles_enable` to `false`, since in 1.18.0 RetroArch would otherwise create sub-folders under the content path folder for save states and save files (`.srm`) (see RA issue https://github.com/libretro/RetroArch/issues/16430).