### PR TITLE
pegasus: add new module and small updates

### DIFF
--- a/scriptmodules/supplementary/autostart.sh
+++ b/scriptmodules/supplementary/autostart.sh
@@ -10,7 +10,7 @@
 #
 
 rp_module_id="autostart"
-rp_module_desc="Auto-start Emulation Station / Pegasus / Kodi on boot"
+rp_module_desc="Auto-start EmulationStation / Pegasus / Kodi on boot"
 rp_module_section="config"
 
 function _update_hook_autostart() {
@@ -115,17 +115,17 @@ function gui_autostart() {
         if isPlatform "x11"; then
             local x11_autostart
             if [[ -f "$home/.config/autostart/retropie.desktop" ]]; then
-                options=(1 "Autostart Emulation Station after login (Enabled)")
+                options=(1 "Autostart EmulationStation after login (Enabled)")
                 x11_autostart=1
             else
-                options=(1 "Autostart Emulation Station after login (Disabled)")
+                options=(1 "Autostart EmulationStation after login (Disabled)")
                 x11_autostart=0
             fi
         else
             options=(
-                1 "Start Emulation Station at boot"
+                1 "Start EmulationStation at boot"
             )
-            [[ "$has_kodi" -eq 1 ]] && options+=(2 "Start Kodi at boot (exit starts Emulation Station)")
+            [[ "$has_kodi" -eq 1 ]] && options+=(2 "Start Kodi at boot (exit starts EmulationStation)")
             [[ "$has_pegasus" -eq 1 ]] && options+=(3 "Start Pegasus at boot")
             options+=(
                 E "Manually edit $configdir/all/autostart.sh"
@@ -148,15 +148,15 @@ function gui_autostart() {
                     if isPlatform "x11"; then
                         if [[ "$x11_autostart" -eq 0 ]]; then
                             enable_autostart
-                            printMsgs "dialog" "Emulation Station is set to autostart after login."
+                            printMsgs "dialog" "EmulationStation is set to autostart after login."
                         else
                             disable_autostart
-                            printMsgs "dialog" "Autostarting of Emulation Station is disabled."
+                            printMsgs "dialog" "Autostarting of EmulationStation is disabled."
                         fi
                         x11_autostart=$((x11_autostart ^ 1))
                     else
                         enable_autostart
-                        printMsgs "dialog" "Emulation Station is set to launch at boot."
+                        printMsgs "dialog" "EmulationStation is set to launch at boot."
                     fi
                     ;;
                 2)

--- a/scriptmodules/supplementary/autostart.sh
+++ b/scriptmodules/supplementary/autostart.sh
@@ -10,7 +10,7 @@
 #
 
 rp_module_id="autostart"
-rp_module_desc="Auto-start Emulation Station / Kodi on boot"
+rp_module_desc="Auto-start Emulation Station / Pegasus / Kodi on boot"
 rp_module_section="config"
 
 function _update_hook_autostart() {
@@ -41,6 +41,9 @@ _EOF_
     case "$mode" in
         kodi)
             echo -e "kodi-standalone #auto\nemulationstation #auto" >>"$script"
+            ;;
+        pegasus)
+            echo "pegasus-fe #auto" >> "$script"
             ;;
         es|*)
             echo "emulationstation #auto" >>"$script"
@@ -102,6 +105,12 @@ function remove_autostart() {
 
 function gui_autostart() {
     cmd=(dialog --backtitle "$__backtitle" --menu "Choose the desired boot behaviour." 22 76 16)
+    local has_pegasus=0
+    local has_kodi=0
+
+    command -v pegasus-fe >/dev/null && has_pegasus=1
+    command -v kodi-standalone >/dev/null && has_kodi=1
+
     while true; do
         if isPlatform "x11"; then
             local x11_autostart
@@ -115,7 +124,10 @@ function gui_autostart() {
         else
             options=(
                 1 "Start Emulation Station at boot"
-                2 "Start Kodi at boot (exit for Emulation Station)"
+            )
+            [[ "$has_kodi" -eq 1 ]] && options+=(2 "Start Kodi at boot (exit starts Emulation Station)")
+            [[ "$has_pegasus" -eq 1 ]] && options+=(3 "Start Pegasus at boot")
+            options+=(
                 E "Manually edit $configdir/all/autostart.sh"
             )
             if [[ "$__os_id" == "Raspbian" ]]; then
@@ -150,6 +162,10 @@ function gui_autostart() {
                 2)
                     enable_autostart kodi
                     printMsgs "dialog" "Kodi is set to launch at boot."
+                    ;;
+                3)
+                    enable_autostart pegasus
+                    printMsgs "dialog" "Pegasus is set to launch at boot."
                     ;;
                 E)
                     editFile "$configdir/all/autostart.sh"

--- a/scriptmodules/supplementary/pegasus-fe-dev.sh
+++ b/scriptmodules/supplementary/pegasus-fe-dev.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="pegasus-fe-dev"
+rp_module_desc="Pegasus: A cross platform, customizable graphical frontend (lastest master)"
+rp_module_help="Pegasus is a cross platform, customizable graphical frontend for launching emulators and managing your game collection.\nThis package provides source installation on platforms not covered by the upstream project pre-built binaries (i.e. ARM 64bit)."
+rp_module_licence="GPL3 https://raw.githubusercontent.com/mmatyas/pegasus-frontend/master/LICENSE.md"
+rp_module_section="exp"
+rp_module_repo="git https://github.com/mmatyas/pegasus-frontend master"
+rp_module_flags="!mali frontend"
+
+function depends_pegasus-fe-dev() {
+    if [[ "$__os_debian_ver" -lt 11 ]]; then
+        md_ret_errors+=("Pegasus (dev) requires Debian 11 (bullseye) or later. Please install the 'pegasus-fe' package instead.")
+        return 1
+    fi
+
+    if [[ -n "$__os_ubuntu_ver" ]] && compareVersions "$__os_ubuntu_ver" lt 22.04; then
+        md_ret_errors+=("Pegasus (dev) requires Ubuntu 22.04 or later. Please install the 'pegasus-fe' package instead.")
+        return 1
+    fi
+
+    local depends=(
+        fontconfig
+        gstreamer1.0-alsa
+        gstreamer1.0-libav
+        gstreamer1.0-plugins-good
+        libqt5multimedia5-plugins
+        libsdl2-dev
+        pkg-config
+        policykit-1
+        qml-module-qtgraphicaleffects qml-module-qtmultimedia qml-module-qtqml
+        qml-module-qtqml-models2
+        qml-module-qtquick-controls qml-module-qtquick-controls2
+        qml-module-qtquick-layouts qml-module-qtquick-templates2
+        qml-module-qtquick-window2 qml-module-qtquick2
+        qml-module-qt-labs-qmlmodels qml-module-qtquick-shapes
+    )
+    # Qt build dependencies
+    depends+=(qtbase5-private-dev qtdeclarative5-dev qtmultimedia5-dev libqt5svg5-dev qttools5-dev)
+    getDepends "${depends[@]}"
+}
+
+function sources_pegasus-fe-dev() {
+    gitPullOrClone
+    # on KMS, apply a patch to fix lanching games
+    isPlatform "kms" && applyPatch "$md_build/etc/rpi4/kms_launch_fix.diff"
+}
+
+function build_pegasus-fe-dev() {
+    rm -fr release && mkdir -p release
+    pushd release
+    qmake .. QMAKE_CXXFLAGS+="$__cxxflags" QMAKE_LIBS_LIBDL=-ldl USE_SDL_GAMEPAD=1 USE_SDL_POWER=1 INSTALLDIR="$md_inst"
+    make
+    md_ret_require=(
+        "$md_build/release/src/app/pegasus-fe"
+    )
+}
+
+function install_pegasus-fe-dev() {
+    make -C release install
+    _add_launcher_pegasus-fe
+}
+
+function remove_pegasus-fe-dev() {
+    remove_pegasus-fe
+}
+
+function configure_pegasus-fe-dev() {
+    configure_pegasus-fe
+}


### PR DESCRIPTION
Since the static binaries provided upstream are no longer working on newer RaspiOS or on 32bit ARM, create a standard scriptmodule to build Pegasus with `pegasus-fe-dev`. The new scriptmodule is meant to work similarly to the `es`/`es-dev` pair, only one can work at a time and they share a set of common functions. Note that due to the Qt5 version needed, the new scriptmodule is meant to be used on Debian 11/Ubuntu 22.04 and later.

Modified the original scriptmodule and added a theme download function, using @mmatyas's themes. More can be found at [2].

A 2nd commit adds `pegasus-fe` as an auto-start item, similar to Kodi/ES, while fixing the spelling of 'EmulationStation'.

Notes:
 * the `pegasus-fe` launcher doesn't need the previous TTY set-up, it's now handled by `runcommand`.
 * sometimes the `/dev/dri/card0` is not the right card node since the order of the `cardX` inodes is not guaranteed.
   Find the right card node dynamically (see [1]) and tell Qt about it with a minimal config file used in the launcher

[1] https://forums.raspberrypi.com/viewtopic.php?t=351263
[2] https://github.com/mmatyas/pegasus-theme-gallery-db/blob/master/repos.txt

Closes #3586.