### PR TITLE
system: handle Pi5's xorg configuration

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -322,6 +322,10 @@ function get_os_version() {
 
 function get_retropie_depends() {
     local depends=(git subversion dialog curl gcc g++ build-essential unzip xmlstarlet python3-pyudev ca-certificates dirmngr)
+    # on RaspiOS, install an extra package for X11 support on Pi5
+    if isPlatform "rpi5" && [[ "$__os_id" == "Raspbian" ]]; then
+        depends+=(gldriver-test)
+    fi
 
     [[ -n "$DISTCC_HOSTS" ]] && depends+=(distcc)
 


### PR DESCRIPTION
 Pi5 needs an additional X11 configuration stanza for xorg-xserver to start properly. This configuration is handled by the `gldriver-test` package, which installs a couple of services that create the needed configuration files based on the displays connected to the board (HDMI/DSI/etc.). Technically, once the services have run the package can be removed IIF the type of display connection will not change (i.e. will always use HDMI or DSI, etc.)

 Since this package is only installed with `raspberrrypi-ui-mods` (i.e. the RaspiOS desktop), let's install it by default on Pi5. The only dependency for the package is `raspi-config`, which is already present on any RaspiOS installation.