### PR TITLE
mame: fix building latest version with old 'libzstd'

### DIFF
--- a/scriptmodules/emulators/mame.sh
+++ b/scriptmodules/emulators/mame.sh
@@ -29,7 +29,7 @@ function depends_mame() {
 
     # Install required libraries required for compilation and running
     # Note: libxi-dev is required as of v0.210, because of flag changes for XInput
-    local depends=(libfontconfig1-dev libsdl2-ttf-dev libflac-dev libxinerama-dev libxi-dev libpulse-dev libzstd-dev)
+    local depends=(libfontconfig1-dev libsdl2-ttf-dev libflac-dev libxinerama-dev libxi-dev libpulse-dev)
     # build the MAME debugger only on X11 (desktop) platforms
     isPlatform "x11" && depends+=(qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools)
 
@@ -50,7 +50,7 @@ function build_mame() {
         rpSwap on 8192
     fi
 
-    local params=(NOWERROR=1 ARCHOPTS=-U_FORTIFY_SOURCE PYTHON_EXECUTABLE=python3 OPTIMIZE=2 USE_SYSTEM_LIB_FLAC=1 USE_SYSTEM_LIB_ZSTD=1)
+    local params=(NOWERROR=1 ARCHOPTS=-U_FORTIFY_SOURCE PYTHON_EXECUTABLE=python3 OPTIMIZE=2 USE_SYSTEM_LIB_FLAC=1)
     isPlatform "x11" && params+=(USE_QTDEBUG=1) || params+=(USE_QTDEBUG=0)
     # when building on ARM enable 'fsigned-char' for compiled code, fixes crashes in a few drivers
     isPlatform "arm" || isPlatform "aarch64" && params+=(ARCHOPTS_CXX=-fsigned-char)


### PR DESCRIPTION
Version 0.263 introduced support for ZSTD compression for CHD files, but the version in Debian 10 Buster is not recent enough to compile MAME. Use the bundled source for `libzstd` instead of the system provided libraries for now.