### PR TITLE
lr-mame/lr-mess: modify build parameters

### DIFF
--- a/scriptmodules/libretrocores/lr-mame.sh
+++ b/scriptmodules/libretrocores/lr-mame.sh
@@ -18,7 +18,7 @@ rp_module_section="exp"
 rp_module_flags=""
 
 function _get_params_lr-mame() {
-    local params=(OSD=retro RETRO=1 NOWERROR=1 OS=linux TARGETOS=linux CONFIG=libretro NO_USE_MIDI=1 TARGET=mame PYTHON_EXECUTABLE=python3)
+    local params=(OSD=retro RETRO=1 NOWERROR=1 OS=linux OPTIMIZE=2 TARGETOS=linux CONFIG=libretro NO_USE_MIDI=1 NO_USE_PORTAUDIO=1 TARGET=mame)
     isPlatform "64bit" && params+=(PTR64=1)
     echo "${params[@]}"
 }


### PR DESCRIPTION
Update the build parameters so:

  - optimization level matches RetroPie's compiler options (-O2)
  - removed `PYTHON` pre-set since it's set now to `python3` by default
  - disable PortAudio, not needed since audio is handled by RetroArch