### PR TITLE
Add multi disc functionality by default

### DIFF
--- a/scriptmodules/emulators/dolphin.sh
+++ b/scriptmodules/emulators/dolphin.sh
@@ -105,6 +105,10 @@ RenderToMain = True
 KeepWindowOnTop = True
 [Interface]
 ConfirmStop = False
+[General]
+ISOPath0 = "$home/RetroPie/roms/gc"
+[Core]
+AutoDiscChange = True
 _EOF_
     fi
     # use the GLES(3) render path on platforms where it's available

--- a/scriptmodules/emulators/dolphin.sh
+++ b/scriptmodules/emulators/dolphin.sh
@@ -107,6 +107,7 @@ KeepWindowOnTop = True
 ConfirmStop = False
 [General]
 ISOPath0 = "$home/RetroPie/roms/gc"
+ISOPath1 = "$home/RetroPie/roms/wii"
 [Core]
 AutoDiscChange = True
 _EOF_


### PR DESCRIPTION
Mentioned here (https://retropie.org.uk/forum/topic/35203/dolphin-gamecube-wiiware-wii-compatibility-on-pi-5/45?_=1710677064715), am I right in thinking the path will be set as /home/ username /RetroPie/roms/gc ?

