### PR TITLE
love - switch to 11.5 stable release

### DIFF
--- a/scriptmodules/ports/love.sh
+++ b/scriptmodules/ports/love.sh
@@ -13,7 +13,7 @@ rp_module_id="love"
 rp_module_desc="Love - 2d Game Engine"
 rp_module_help="Copy your Love games to $romdir/love"
 rp_module_licence="ZLIB https://raw.githubusercontent.com/love2d/love/master/license.txt"
-rp_module_repo="git https://github.com/love2d/love main"
+rp_module_repo="git https://github.com/love2d/love 11.5"
 rp_module_section="opt"
 rp_module_flags="!aarch64"
 


### PR DESCRIPTION
Love has switched over to cmake, so the scriptmodule was failing.

Their main branch is considered development, so switch to the last stable tag 11.5 (December 2023).

Their documentation still references the old build system so safer to stick with a stable release for this module. We can revisit this with the next release.