### PR TITLE
gzdoom - fix building 7zip/lzma on armv7 due to missing hardware crc

### DIFF
--- a/scriptmodules/ports/gzdoom.sh
+++ b/scriptmodules/ports/gzdoom.sh
@@ -41,6 +41,8 @@ function sources_gzdoom() {
     gitPullOrClone zmusic https://github.com/ZDoom/ZMusic
     # workaround for Ubuntu 20.04 older vpx/wepm dev libraries
     sed -i 's/IMPORTED_TARGET libw/IMPORTED_TARGET GLOBAL libw/' CMakeLists.txt
+    # lzma assumes hardware crc support on arm which breaks when building on armv7
+    isPlatform "armv7" && applyPatch "$md_data/lzma_armv7_crc.diff"
 }
 
 function build_gzdoom() {

--- a/scriptmodules/ports/gzdoom/lzma_armv7_crc.diff
+++ b/scriptmodules/ports/gzdoom/lzma_armv7_crc.diff
@@ -1,0 +1,11 @@
+--- a/libraries/lzma/C/7zCrc.c
++++ b/libraries/lzma/C/7zCrc.c
+@@ -71,7 +71,7 @@
+ 
+ #ifdef MY_CPU_LE
+ 
+-#if defined(MY_CPU_ARM_OR_ARM64)
++#if defined(MY_CPU_ARM_OR_ARM64) && 0
+ 
+ // #pragma message("ARM*")
+ 


### PR DESCRIPTION
7zip/lzma assumes hardware crc support on arm, which breaks compilation on armv7.

Disable the check so it falls back to a software implementation.

Same fix as for mame with 508f3d1e64359fe4ebcd166eb27e87215bbbb524