### PR TITLE
xpad: don't force the triggers-as-buttons option

### DIFF
--- a/scriptmodules/supplementary/xpad.sh
+++ b/scriptmodules/supplementary/xpad.sh
@@ -42,14 +42,10 @@ function build_xpad() {
 
 function remove_xpad() {
     dkmsManager remove xpad "$(_version_xpad)"
-    rm -f /etc/modprobe.d/xpad.conf
 }
 
 function configure_xpad() {
     [[ "$md_mode" == "remove" ]] && return
 
-    if [[ ! -f /etc/modprobe.d/xpad.conf ]]; then
-        echo "options xpad triggers_to_buttons=1" >/etc/modprobe.d/xpad.conf
-    fi
     dkmsManager reload xpad "$(_version_xpad)"
 }


### PR DESCRIPTION
The `xpad` kernel module is patched locally in order for the 'triggers_to_buttons' option to work on any supported controller. During installation, the option is also enabled automatically. Historically, this has been used to work-around EmulationStation not detecting the analog shoulder triggers, but the detection works now and this extra option is not needed for EmulationStation.

Leaving the option enabled by default has the side effect of breaking SDL's Gamecontroller API DB mappings (no of buttons and axis are different then the upstream mapping). Since more and more applications/games/emulators/etc. are using this SDL sub-system, it's better we don't enable it anymore.

This change removes the module configuration handled by the scriptmodule - both installation and removal. Users can manually add/remove the configuration if they wish - I will update the docs after this and maybe the RP version can be bumped to have a milestone for this change.

Closes: https://github.com/RetroPie/RetroPie-Setup/issues/3379