### PR TITLE
Add lr-dirksimple setup script

### DIFF
--- a/scriptmodules/libretrocores/lr-dirksimple.sh
+++ b/scriptmodules/libretrocores/lr-dirksimple.sh
@@ -36,6 +36,7 @@ function install_lr-dirksimple() {
     md_ret_files=(
         'build/dirksimple_libretro.so'
         'data'
+        'LICENSE.txt'
     )
 }
 

--- a/scriptmodules/libretrocores/lr-dirksimple.sh
+++ b/scriptmodules/libretrocores/lr-dirksimple.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-dirksimple"
+rp_module_desc="laserdisc emu - DirkSimple"
+rp_module_help="ROM Extensions: .ogv .dirksimple\n\nCopy your laserdisc movies in Ogg Theora format to $romdir/dirksimple"
+rp_module_licence="zlib https://raw.githubusercontent.com/icculus/DirkSimple/main/LICENSE.txt"
+rp_module_repo="git https://github.com/icculus/DirkSimple.git main"
+rp_module_section="exp"
+
+function depends_lr-dirksimple() {
+    local depends=(cmake)
+    getDepends "${depends[@]}"
+}
+
+function sources_lr-dirksimple() {
+    gitPullOrClone
+}
+
+function build_lr-dirksimple() {
+    local params=(
+        '-DDIRKSIMPLE_LIBRETRO=ON'
+        '-DDIRKSIMPLE_SDL=OFF'
+        '-DCMAKE_BUILD_TYPE=Release'
+    )
+
+    isPlatform "neon" && params+=' -DCMAKE_C_FLAGS="-mfpu=neon"'
+
+    rm -fr build && mkdir build
+    cd build
+    echo "cmake" "${params[@]}" ..
+    cmake "${params[@]}" ..
+    make dirksimple_libretro
+    md_ret_require="$md_build/build/dirksimple_libretro.so"
+}
+
+function install_lr-dirksimple() {
+    md_ret_files=(
+        'build/dirksimple_libretro.so'
+    )
+
+    rm -rf "$biosdir/DirkSimple"
+    mkUserDir "$biosdir/DirkSimple"
+    cp -rf "$md_build/data" "$biosdir/DirkSimple/"
+    chown -R $user:$user "$biosdir/DirkSimple"
+}
+
+function configure_lr-dirksimple() {
+    mkRomDir "dirksimple"
+    defaultRAConfig "dirksimple"
+
+    addEmulator 0 "$md_id" "dirksimple" "$md_inst/dirksimple_libretro.so"
+    addSystem "dirksimple"
+}
+

--- a/scriptmodules/libretrocores/lr-dirksimple.sh
+++ b/scriptmodules/libretrocores/lr-dirksimple.sh
@@ -11,14 +11,13 @@
 
 rp_module_id="lr-dirksimple"
 rp_module_desc="laserdisc emu - DirkSimple"
-rp_module_help="ROM Extensions: .ogv .dirksimple\n\nCopy your laserdisc movies in Ogg Theora format to $romdir/dirksimple"
+rp_module_help="ROM Extensions: .ogv .dirksimple\n\nCopy your laserdisc movies in Ogg Theora format to $romdir/daphne"
 rp_module_licence="zlib https://raw.githubusercontent.com/icculus/DirkSimple/main/LICENSE.txt"
 rp_module_repo="git https://github.com/icculus/DirkSimple.git main"
 rp_module_section="exp"
 
 function depends_lr-dirksimple() {
-    local depends=(cmake)
-    getDepends "${depends[@]}"
+    getDepends cmake
 }
 
 function sources_lr-dirksimple() {
@@ -26,18 +25,9 @@ function sources_lr-dirksimple() {
 }
 
 function build_lr-dirksimple() {
-    local params=(
-        '-DDIRKSIMPLE_LIBRETRO=ON'
-        '-DDIRKSIMPLE_SDL=OFF'
-        '-DCMAKE_BUILD_TYPE=Release'
-    )
-
-    isPlatform "neon" && params+=' -DCMAKE_C_FLAGS="-mfpu=neon"'
-
     rm -fr build && mkdir build
     cd build
-    echo "cmake" "${params[@]}" ..
-    cmake "${params[@]}" ..
+    cmake -DDIRKSIMPLE_LIBRETRO=ON -DDIRKSIMPLE_SDL=OFF ..
     make dirksimple_libretro
     md_ret_require="$md_build/build/dirksimple_libretro.so"
 }
@@ -45,19 +35,20 @@ function build_lr-dirksimple() {
 function install_lr-dirksimple() {
     md_ret_files=(
         'build/dirksimple_libretro.so'
+        'data'
     )
-
-    rm -rf "$biosdir/DirkSimple"
-    mkUserDir "$biosdir/DirkSimple"
-    cp -rf "$md_build/data" "$biosdir/DirkSimple/"
-    chown -R $user:$user "$biosdir/DirkSimple"
 }
 
 function configure_lr-dirksimple() {
-    mkRomDir "dirksimple"
-    defaultRAConfig "dirksimple"
+    mkRomDir "daphne"
+    defaultRAConfig "daphne"
 
-    addEmulator 0 "$md_id" "dirksimple" "$md_inst/dirksimple_libretro.so"
-    addSystem "dirksimple"
+    rm -rf "$biosdir/DirkSimple"
+    mkUserDir "$biosdir/DirkSimple"
+    cp -rf "$md_inst/data" "$biosdir/DirkSimple/"
+    chown -R $user:$user "$biosdir/DirkSimple"
+
+    addEmulator 0 "$md_id" "daphne" "$md_inst/dirksimple_libretro.so"
+    addSystem "daphne"
 }
 


### PR DESCRIPTION
This is an setup script to install the [DirkSimple](https://github.com/icculus/DirkSimple) libretro core.

DirkSimple is a laserdisc game player that implements specific titles from scratch, so it uses an arcade game's video content but not its roms. It takes game data in Ogg Theora format, so the "rom" that the core needs is a single .ogv file per game.

Currently, it plays [Dragon's Lair](https://en.wikipedia.org/wiki/Dragon%27s_Lair) and [Cliff Hanger](https://en.wikipedia.org/wiki/Cliff_Hanger_(video_game)), with other titles planned for the future. RetroArch ships DirkSimple as a standard core, including to their Steam builds. It offers a libretro option for playing some laserdisc titles, so you get all the consistent controller support, hotkeys and state serialization magic, in case running Daphne as a standalone emulator is too cumbersome without those features.

This is a draft pull request at the moment, because RetroPie setup scripts are totally new to me, so feedback and criticism is definitely welcome.

This also needs to figure out what to do with EmulationStation, too: should this be a new system, or should this slide in to the Daphne section? etc.