### PR TITLE
scummvm: update standalone emulator to 2.8.1

### DIFF
--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -13,7 +13,7 @@ rp_module_id="scummvm"
 rp_module_desc="ScummVM"
 rp_module_help="Copy your ScummVM games to $romdir/scummvm"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/scummvm/scummvm/master/COPYING"
-rp_module_repo="git https://github.com/scummvm/scummvm.git v2.8.0"
+rp_module_repo="git https://github.com/scummvm/scummvm.git v2.8.1"
 rp_module_section="opt"
 rp_module_flags="sdl2"
 


### PR DESCRIPTION
The 2.8.1 is a bugfix release and includes upgrades for the following engines: AGI, AGS, GRIM, SWORD2, MM (which is now enabled, it was skipped it in 2.8.0 by accident), mTropolis, NANCY, SCUMM, TWINE, Ultima, and V-Cruise.

Full changelog at https://downloads.scummvm.org/frs/scummvm/2.8.1/ReleaseNotes.html.