### PR TITLE
dosbox-staging: pin version for videocore

### DIFF
--- a/scriptmodules/emulators/dosbox-staging.sh
+++ b/scriptmodules/emulators/dosbox-staging.sh
@@ -18,6 +18,11 @@ rp_module_section="opt"
 rp_module_flags="sdl2"
 
 function _get_branch_dosbox-staging() {
+    # use 0.80.1 for VideoCore devices, 0.81 and later require OpenGL
+    if isPlatform "videocore"; then
+        echo "v0.80.1"
+        return
+    fi
     download https://api.github.com/repos/dosbox-staging/dosbox-staging/releases/latest - | grep -m 1 tag_name | cut -d\" -f4
 }
 


### PR DESCRIPTION
Latest (0.81) version of Dosbox Staging doesn't go along with the legacy GPU VideoCore drivers, resulting in a SDL window initialization crash. Pin the 0.80.1 version for these devices, maybe a GLES2-only rendering path will be added later on, which would solve this issue.