### PR TITLE
Distcc changes

### DIFF
--- a/scriptmodules/emulators/jzintv.sh
+++ b/scriptmodules/emulators/jzintv.sh
@@ -15,7 +15,7 @@ rp_module_help="ROM Extensions: .int .bin .rom\n\nCopy your Intellivision roms t
 rp_module_licence="GPL2 http://spatula-city.org/%7Eim14u2c/intv/"
 rp_module_repo="file $__archive_url/jzintv-20200712-src.zip"
 rp_module_section="opt"
-rp_module_flags="sdl2"
+rp_module_flags="sdl2 nodistcc"
 
 function depends_jzintv() {
     getDepends libsdl2-dev libreadline-dev
@@ -45,7 +45,7 @@ function build_jzintv() {
     cd jzintv/src
 
     make clean
-    DISTCC_HOSTS="" make
+    make
 
     md_ret_require="$md_build/jzintv/bin/jzintv"
 }

--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -15,7 +15,7 @@ rp_module_help="ROM Extensions: .z64 .n64 .v64\n\nCopy your N64 roms to $romdir/
 rp_module_licence="GPL2 https://raw.githubusercontent.com/mupen64plus/mupen64plus-core/master/LICENSES"
 rp_module_repo=":_pkg_info_mupen64plus"
 rp_module_section="main"
-rp_module_flags="sdl2"
+rp_module_flags="sdl2 nodistcc"
 
 function depends_mupen64plus() {
     local depends=(cmake libsamplerate0-dev libspeexdsp-dev libsdl2-dev libpng-dev libfreetype6-dev fonts-freefont-ttf libboost-filesystem-dev)
@@ -175,8 +175,7 @@ function build_mupen64plus() {
 
             [[ "$dir" == "mupen64plus-ui-console" ]] && params+=("COREDIR=$md_inst/lib/" "PLUGINDIR=$md_inst/lib/mupen64plus/")
             make -C "$dir/projects/unix" "${params[@]}" clean
-            # temporarily disable distcc due to segfaults with cross compiler and lto
-            DISTCC_HOSTS="" make -C "$dir/projects/unix" all "${params[@]}" OPTFLAGS="$CFLAGS -O3 -flto"
+            make -C "$dir/projects/unix" all "${params[@]}" OPTFLAGS="$CFLAGS -O3 -flto"
         fi
     done
 

--- a/scriptmodules/libretrocores/lr-picodrive.sh
+++ b/scriptmodules/libretrocores/lr-picodrive.sh
@@ -14,7 +14,7 @@ rp_module_desc="Sega 8/16 bit emu - picodrive arm optimised libretro core"
 rp_module_help="ROM Extensions: .32x .iso .cue .sms .smd .bin .gen .md .sg .zip\n\nCopy your Megadrive / Genesis roms to $romdir/megadrive\nMasterSystem roms to $romdir/mastersystem\nSega 32X roms to $romdir/sega32x and\nSegaCD roms to $romdir/segacd\nThe Sega CD requires the BIOS files us_scd1_9210.bin, eu_mcd1_9210.bin, jp_mcd1_9112.bin copied to $biosdir"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/picodrive/master/COPYING"
 rp_module_repo="git https://github.com/libretro/picodrive.git master"
-rp_module_section="main"
+rp_module_section="main nodistcc"
 
 function sources_lr-picodrive() {
     gitPullOrClone

--- a/scriptmodules/libretrocores/lr-snes9x.sh
+++ b/scriptmodules/libretrocores/lr-snes9x.sh
@@ -14,7 +14,7 @@ rp_module_desc="Super Nintendo emu - Snes9x (current) port for libretro"
 rp_module_help="ROM Extensions: .bin .smc .sfc .fig .swc .mgd .zip\n\nCopy your SNES roms to $romdir/snes"
 rp_module_licence="NONCOM https://raw.githubusercontent.com/libretro/snes9x/master/LICENSE"
 rp_module_repo="git https://github.com/libretro/snes9x.git master"
-rp_module_section="main armv6=opt armv7=opt"
+rp_module_section="main armv6=opt armv7=opt nodistcc"
 
 function sources_lr-snes9x() {
     gitPullOrClone
@@ -26,8 +26,7 @@ function build_lr-snes9x() {
 
     cd libretro
     make "${params[@]}" clean
-    # temporarily disable distcc due to segfaults with cross compiler and lto
-    DISTCC_HOSTS="" make "${params[@]}"
+    make "${params[@]}"
     md_ret_require="$md_build/libretro/snes9x_libretro.so"
 }
 

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -112,6 +112,16 @@ function rp_callModule() {
         return 3
     fi
 
+    # skip for modules 'builder' and 'setup' so that distcc settings do not propagate from them
+    if [[ "$md_id" != "builder" && "$md_id" != "setup" ]]; then
+        # if distcc is used and the module doesn't exclude it, add /usr/lib/distcc to PATH and MAKEFLAGS
+        if [[ -n "$DISTCC_HOSTS" ]] && ! hasFlag "${__mod_info[$md_id/flags]}" "nodistcc"; then
+            # use local variables so they are available to all child functions without changing the globals 
+            local PATH="/usr/lib/distcc:$PATH"
+            local MAKEFLAGS="$MAKEFLAGS PATH=$PATH"
+        fi
+    fi
+
     # parameters _auto_ _binary or _source_ (_source_ is used if no parameters are given for a module)
     case "$mode" in
         # install the module if not installed, and update if it is

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -145,12 +145,6 @@ function conf_build_vars() {
     export ASFLAGS="$__asflags"
     export MAKEFLAGS="$__makeflags"
 
-    # if using distcc, add /usr/lib/distcc to PATH/MAKEFLAGS
-    if [[ -n "$DISTCC_HOSTS" ]]; then
-        PATH="/usr/lib/distcc:$PATH"
-        MAKEFLAGS+=" PATH=$PATH"
-    fi
-
     # if __use_ccache is set, then add ccache to PATH/MAKEFLAGS
     if [[ "$__use_ccache" -eq 1 ]]; then
         PATH="/usr/lib/ccache:$PATH"


### PR DESCRIPTION
Only configure distcc variables if a module doesn't have the "nodistcc" flag.

Skip builder/setup modules to avoid having distcc changes propagate to modules built from them.

This allows easily disabling distcc for certain modules that are not compatible.

Remove DISTCC_HOSTS="" from mupen64plus, jzintv, and lr-snes9x and replace with the "nodistcc" flag

Add "nodistcc" to lr-picodrive, as on Raspberry PI OS Bullseye, the distcc wrapper fails at linking stage.