### PR TITLE
retroarch: add back the commented config

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -71,6 +71,9 @@ function build_retroarch() {
 
 function install_retroarch() {
     make install
+    md_ret_files=(
+        'retroarch.cfg'
+    )
 }
 
 function update_shaders_retroarch() {


### PR DESCRIPTION
Previous commit removed the `retroarch.cfg` from upstream. While the configuration will set the right options in a new config file, we traditionally used the upstream's config as starting point, since it's largely commented and provides pointers for various configuration options.

Restore the previous behavior by including the upstream `retroarch.cfg` in `$md_inst`, since the makefile doesn't copy it during the install target.