### PR TITLE
dolphin: fix initial config

### DIFF
--- a/scriptmodules/emulators/dolphin.sh
+++ b/scriptmodules/emulators/dolphin.sh
@@ -108,6 +108,7 @@ ConfirmStop = False
 [General]
 ISOPath0 = "$home/RetroPie/roms/gc"
 ISOPath1 = "$home/RetroPie/roms/wii"
+ISOPaths = 2
 [Core]
 AutoDiscChange = True
 _EOF_


### PR DESCRIPTION
The initial config is missing the 'ISOPaths' option, without it the game paths added in the initial configuration are ignored by Dolphin.