### PR TITLE
dosbox-staging: update dependencies and build options

### DIFF
--- a/scriptmodules/emulators/dosbox-staging.sh
+++ b/scriptmodules/emulators/dosbox-staging.sh
@@ -27,7 +27,11 @@ function _get_branch_dosbox-staging() {
 }
 
 function depends_dosbox-staging() {
-    getDepends cmake libasound2-dev libglib2.0-dev libopusfile-dev libpng-dev libsdl2-dev libsdl2-net-dev libsdl2-image-dev libspeexdsp-dev meson ninja-build
+    local depends
+    depends=(cmake libasound2-dev libglib2.0-dev libopusfile-dev libpng-dev libsdl2-dev libsdl2-net-dev libspeexdsp-dev meson ninja-build zlib1g-dev)
+    [[ "$__os_debian_ver" -ge 11 ]] && depends+=(libslirp-dev libfluidsynth-dev)
+
+    getDepends "${depends[@]}"
 }
 
 function sources_dosbox-staging() {
@@ -40,7 +44,7 @@ function sources_dosbox-staging() {
 }
 
 function build_dosbox-staging() {
-    local params=(-Dprefix="$md_inst" -Ddatadir="resources")
+    local params=(-Dprefix="$md_inst" -Ddatadir="resources" -Dtry_static_libs="iir,mt32emu")
     # use the build local Meson installation if found
     local meson_cmd="meson"
     [[ -f "$md_build/meson/meson.py" ]] && meson_cmd="python3 $md_build/meson/meson.py"


### PR DESCRIPTION
1. I've noticed that on newer version of Meson, dependendant packages like `iir` and `mt32emu` are no longer built and linked statically. Instead, they're created and then installed as dynamic libraries. The installation goes to `$md_inst/lib/<host-triplet>`, so the resulting binary doesn't work out-of-the-box, but the more important issue is that the `libmt32emu` library is not copied. As a result, `dosbox` will not be able to run on such a system.

   The issue above doesn't seem to affect the RaspiOS (32/64bit) builds, but I had it happening on Debian Trixie (testing) and a recent Armbian Jammy 22.04 for OrangePi 5.

   To make sure the above issue doesn't happen, link the `iir` and `mt32emu` libraries statically. They're always downloaded and built via Meson _wraps_, since there are no Debian packages for them.

2. Updated the dependency list so that:
   * `libslirp` and `fluidsynth` (v2) are installed on Bullseye or newer Debian, so they're not built via Meson wraps
   * `sdl2-image-dev` is not needed by `dosbox-staging` anymore.
   *  added `zlib` as an explicit dependency