### PR TITLE
echo the applied command line options of Skyscraper; add two scrape modules

### DIFF
--- a/scriptmodules/supplementary/skyscraper.sh
+++ b/scriptmodules/supplementary/skyscraper.sh
@@ -290,17 +290,21 @@ function _init_config_skyscraper() {
     rm -f "$home/.bash_completion.d/Skyscraper.bash"
 }
 
-# Scrape one system, passed as parameter
-function _scrape_skyscraper() {
-    local system="$1"
+# read scriptmodule's skyscraper.cfg and prepare the command line parameters
+function _get_clioptions_skyscraper() {
+    local system=$1
+    local scrape_module=$2
 
-    [[ -z "$system" ]] && return
+    local params=()
+    local flags
 
     iniConfig " = " '"' "$configdir/all/skyscraper.cfg"
     eval $(_load_config_skyscraper)
 
-    local -a params=(-p "$system")
-    local flags="unattend,skipped,"
+    [[ "$system" != "<platform>" ]] && system=\"$system\"
+
+    params+=(-p "$system")
+    flags="unattend,skipped,"
 
     [[ "$download_videos" -eq 1 ]] && flags+="videos,"
 
@@ -330,7 +334,7 @@ function _scrape_skyscraper() {
 
     # If 2nd parameter is unset, use the configured scraping source, otherwise scrape from cache.
     # Scraping from cache means we can omit '-s' from the parameter list.
-    if [[ -z "$2" ]]; then
+    if [[ -z "$scrape_module" ]]; then
         params+=(-s "$scrape_source")
     fi
 
@@ -340,11 +344,24 @@ function _scrape_skyscraper() {
     flags=${flags::-1}
 
     params+=(--flags "$flags")
+    echo "${params[@]}"
+}
 
+
+# Scrape one system, passed as parameter
+function _scrape_skyscraper() {
+    local system="$1"
+    local scrape_module="$2"
+
+    [[ -z "$system" ]] && return
+
+    local params
+    params=$(_get_clioptions_skyscraper "$system" "$scrape_module")
+    declare -a "params_arr=($params)"
     # trap ctrl+c and return if pressed (rather than exiting retropie-setup etc)
     trap 'trap 2; return 1' INT
-        sudo -u "$user" stdbuf -o0  "$md_inst/Skyscraper" "${params[@]}"
-        echo -e "\nCOMMAND LINE USED:\n $md_inst/Skyscraper" "${params[@]}"
+        sudo -u "$user" stdbuf -o0 "$md_inst/Skyscraper" "${params_arr[@]}"
+        echo -e "\nCOMMAND LINE USED:\n $md_inst/Skyscraper" "${params}"
         sleep 2
     trap 2
 }
@@ -377,14 +394,24 @@ function _scrape_chosen_skyscraper() {
     [[ ${#choices[@]} -eq 0 || $? -eq 1 ]] && return 1
 
     # Confirm with the user that scraping can start
-    dialog --clear --colors --yes-label "Proceed" --no-label "Abort" --yesno "This will start the gathering process, which can take a long time if you have a large game collection.\n\nYou can interrupt this process anytime by pressing \ZbCtrl+C\Zn.\nProceed ?" 12 70 2>&1 >/dev/tty
+    local cli=("$md_inst/Skyscraper ")
+    cli+=$(_get_clioptions_skyscraper "<platform>" "")
+
+    local sky_cmd
+    sky_cmd=$(echo "${cli[@]}" | sed 's/ -/ \\\\n -/g')
+
+    local msg="This will start the gathering process, which can take a long time if you have a large game collection.\n\n"
+    msg+="You can interrupt this process anytime by pressing \ZbCtrl+C\Zn.\n\n"
+    msg+="For each selected <platform> Skyscraper is run with these commandline options:\n\n$sky_cmd"
+
+    dialog --clear --colors --yes-label "Proceed" --no-label "Abort" --yesno "$msg" 20 70 2>&1 >/dev/tty
     [[ ! $? -eq 0 ]] && return 1
 
     local choice
 
     for choice in "${choices[@]}"; do
         choice="${options[choice*3-2]}"
-        _scrape_skyscraper "$choice" "$@"
+        _scrape_skyscraper "$choice" ""
     done
 }
 
@@ -417,7 +444,7 @@ function _generate_chosen_skyscraper() {
 
     for choice in "${choices[@]}"; do
         choice="${options[choice*3-2]}"
-        _scrape_skyscraper "$choice" "cache" "$@"
+        _scrape_skyscraper "$choice" "cache"
     done
 }
 
@@ -520,8 +547,10 @@ function gui_skyscraper() {
         [1]=screenscraper
         [2]=arcadedb
         [3]=thegamesdb
-        [4]=openretro
-        [5]=worldofspectrum
+        [4]=mobygames
+        [5]=openretro
+        [6]=igdb
+        [7]=worldofspectrum
     )
     s_source+=(
         [10]=esgamelist
@@ -532,8 +561,10 @@ function gui_skyscraper() {
         [1]=ScreenScraper
         [2]=ArcadeDB
         [3]=TheGamesDB
-        [4]=OpenRetro
-        [5]="World of Spectrum"
+        [4]=MobyGames
+        [5]=OpenRetro
+        [6]="Internet Game Database"
+        [7]="World of Spectrum"
     )
     s_source_names+=(
         [10]="EmulationStation Gamelist"


### PR DESCRIPTION
This goes back to the forum discussion a while ago: Within the scriptmodule there can be options persisted (cf. `Skyscraper.cfg`) which then get applied to the command line, which overrun settings in Skyscraper's `config.ini`. 

To add more visibility about the applied options (and to avoid confusion about different behaviour of Skyscraper from scriptmodule vs. Skyscraper CLI usage) the user gets the actual command echoed before the scraping starts.

Tested it well on my side and did not notice a regression.

Also, for some reasons two already present scraping modules did not made it into the scriptmodule.