### PR TITLE
Flag comparisons

### DIFF
--- a/scriptmodules/emulators/dolphin.sh
+++ b/scriptmodules/emulators/dolphin.sh
@@ -15,7 +15,7 @@ rp_module_help="ROM Extensions: .gcm .iso .wbfs .ciso .gcz .rvz .wad .wbfs\n\nCo
 rp_module_licence="GPL2 https://raw.githubusercontent.com/dolphin-emu/dolphin/master/COPYING"
 rp_module_repo="git https://github.com/dolphin-emu/dolphin.git master :_get_commit_dolphin"
 rp_module_section="exp"
-rp_module_flags="!all 64bit"
+rp_module_flags="!all 64bit !:\$__gcc_version:-lt:8"
 
 function _get_commit_dolphin() {
     local commit
@@ -31,10 +31,6 @@ function _get_commit_dolphin() {
 
 function depends_dolphin() {
     local depends=(cmake gettext pkg-config libao-dev libasound2-dev libavcodec-dev libavformat-dev libbluetooth-dev libenet-dev liblzo2-dev libminiupnpc-dev libopenal-dev libpulse-dev libreadline-dev libsfml-dev libsoil-dev libsoundtouch-dev libswscale-dev libusb-1.0-0-dev libxext-dev libxi-dev libxrandr-dev portaudio19-dev zlib1g-dev libudev-dev libevdev-dev libmbedtls-dev libcurl4-openssl-dev libegl1-mesa-dev liblzma-dev)
-    if [[ "$__gcc_version" -lt 8 ]]; then
-        md_ret_errors+=("Sorry, you need an OS with gcc 8 or newer to compile $md_id")
-        return 1
-    fi
     # check if qt6 is available, otherwise use qt5
     local has_qt6=$(apt-cache -qq madison qt6-base-private-dev | cut -d'|' -f1)
     if [[ -n "$has_qt6" ]]; then

--- a/scriptmodules/emulators/mame.sh
+++ b/scriptmodules/emulators/mame.sh
@@ -15,7 +15,7 @@ rp_module_help="ROM Extensions: .zip .7z\n\nCopy your MAME roms to either $romdi
 rp_module_licence="GPL2 https://raw.githubusercontent.com/mamedev/mame/master/COPYING"
 rp_module_repo="git https://github.com/mamedev/mame.git :_get_branch_mame"
 rp_module_section="exp"
-rp_module_flags="!mali !armv6"
+rp_module_flags="!mali !armv6 !:\$__gcc_version:-lt:7"
 
 function _get_branch_mame() {
     # starting with 0.265, GCC 10.3 or later is required for full C++17 support
@@ -27,11 +27,6 @@ function _get_branch_mame() {
 }
 
 function depends_mame() {
-    if [[ "$__gcc_version" -lt 7 ]]; then
-        md_ret_errors+=("Sorry, you need an OS with gcc 7.2 or newer to compile $md_id")
-        return 1
-    fi
-
     # Install required libraries required for compilation and running
     # Note: libxi-dev is required as of v0.210, because of flag changes for XInput
     local depends=(libfontconfig1-dev libsdl2-ttf-dev libflac-dev libxinerama-dev libxi-dev libpulse-dev)

--- a/scriptmodules/emulators/ti99sim.sh
+++ b/scriptmodules/emulators/ti99sim.sh
@@ -15,13 +15,9 @@ rp_module_help="ROM Extension: .ctg\n\nCopy your TI-99 games to $romdir/ti99\n\n
 rp_module_licence="GPL2 https://www.mrousseau.org/programs/ti99sim"
 rp_module_repo="file $__archive_url/ti99sim-0.16.0.src.tar.gz"
 rp_module_section="exp"
-rp_module_flags=""
+rp_module_flags="!:\$__gcc_version:-lt:8"
 
 function depends_ti99sim() {
-    if [[ "$__gcc_version" -lt 8 ]]; then
-        md_ret_errors+=("Sorry, you need an OS with gcc 8 or newer to compile $md_id")
-        return 1
-    fi
     getDepends libsdl2-dev libssl-dev
 }
 

--- a/scriptmodules/libretrocores/lr-bsnes.sh
+++ b/scriptmodules/libretrocores/lr-bsnes.sh
@@ -15,14 +15,7 @@ rp_module_help="ROM Extensions: .bml .smc .sfc .zip\n\nCopy your SNES roms to $r
 rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/bsnes/master/LICENSE.txt"
 rp_module_repo="git https://github.com/libretro/bsnes.git master"
 rp_module_section="opt"
-rp_module_flags="!armv6"
-
-function depends_lr-bsnes() {
-    if [[ "$__gcc_version" -lt 7 ]]; then
-        md_ret_errors+=("You need an OS with gcc 7 or newer to compile $md_id")
-        return 1
-    fi
-}
+rp_module_flags="!armv6 !:\$__gcc_version:-lt:7"
 
 function sources_lr-bsnes() {
     gitPullOrClone

--- a/scriptmodules/libretrocores/lr-flycast-dev.sh
+++ b/scriptmodules/libretrocores/lr-flycast-dev.sh
@@ -15,13 +15,9 @@ rp_module_help="Dreamcast ROM Extensions: .cdi .gdi .chd .m3u, Naomi/Atomiswave 
 rp_module_licence="GPL2 https://raw.githubusercontent.com/flyinghead/flycast/master/LICENSE"
 rp_module_repo="git https://github.com/flyinghead/flycast.git master"
 rp_module_section="exp"
-rp_module_flags="!armv6 !videocore"
+rp_module_flags="!armv6 !videocore !:\$__gcc_version:-lt:9"
 
 function depends_lr-flycast-dev() {
-    if [[ "$__gcc_version" -lt 9 ]]; then
-        md_ret_errors+=("Sorry, you need an OS with gcc 9 or newer to compile $md_id")
-        return 1
-    fi
     local depends=(zlib1g-dev libgl-dev cmake)
     getDepends "${depends[@]}"
 }

--- a/scriptmodules/libretrocores/lr-mame.sh
+++ b/scriptmodules/libretrocores/lr-mame.sh
@@ -15,7 +15,7 @@ rp_module_help="ROM Extension: .zip\n\nCopy your MAME roms to either $romdir/mam
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame/master/COPYING"
 rp_module_repo="git https://github.com/libretro/mame.git master :_get_version_lr-mame"
 rp_module_section="exp"
-rp_module_flags=""
+rp_module_flags="!:\$__gcc_version:-lt:7"
 
 function _get_version_lr-mame() {
     local tagname
@@ -31,10 +31,6 @@ function _get_params_lr-mame() {
 }
 
 function depends_lr-mame() {
-    if [[ "$__gcc_version" -lt 7 ]]; then
-        md_ret_errors+=("Sorry, you need an OS with gcc 7 or newer to compile $md_id")
-        return 1
-    fi
     local depends=(libasound2-dev)
     isPlatform "gles" && depends+=(libgles2-mesa-dev)
     isPlatform "gl" && depends+=(libglu1-mesa-dev)

--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -949,6 +949,22 @@ function rp_registerModule() {
                 enabled=0
                 continue
             fi
+            # enable or disable based on a comparison in the format :\$var:cmp:val or !:\$var:cmp:val
+            # eg. :\$__gcc_version:-lt:7 would be evaluated as [[ $__gcc_version -lt 7 ]]
+            # this would enable a module if the comparison was true
+            # !:\$__gcc_version:-lt:7 would disable if the comparison was true
+
+            # match and extract the parameters
+            if [[ "$flag" =~ ^(\!?):([^:]+):([^:]+):(.+)$ ]]; then
+                # enable or disable based on the first parameter (!)
+                local e=1
+                [[ ${BASH_REMATCH[1]} == "!" ]] && e=0
+                # evaluate the comparison
+                if eval "[[ ${BASH_REMATCH[2]} ${BASH_REMATCH[3]} ${BASH_REMATCH[4]} ]]"; then
+                    enabled=$e
+                fi
+                continue
+            fi
         done
     fi
 

--- a/scriptmodules/ports/mysticmine.sh
+++ b/scriptmodules/ports/mysticmine.sh
@@ -14,6 +14,7 @@ rp_module_desc="Mystic Mine - Rail game for up to six players on one keyboard"
 rp_module_licence="MIT https://raw.githubusercontent.com/dewitters/MysticMine/master/LICENSE.txt"
 rp_module_repo="git https://github.com/dewitters/MysticMine.git master"
 rp_module_section="exp"
+rp_module_flags="!:\$__os_debian_ver:-gt:10"
 
 function depends_mysticmine() {
     getDepends python-pyrex python-numpy python-pygame


### PR DESCRIPTION
### packages - allow enabling/disabling a module with comparison flags

rp_module_flags can now contain a variable comparison to enable or disable a scriptmodule.
The comparison should be in the format :\$var:cmp:val or !:\$var:cmp:val

eg. :\$__gcc_version:-lt:7 would be evaluated as [[ $__gcc_version -lt 7 ]]

This would enable a module if the comparison was true or disable if !:\$__gcc_version:-lt:7 was used.
Only global variables set before modules are loaded (eg via system.sh) are supported.

$ is escaped so variables are not evaluated when the module is sourced.
It works without, but provides less useful information in the setup menus as the variable name will not be visible.

### Convert modules to using variable comparisons in flags

Replace GCC version checks in depends_* functions with variable comparisons in flags.

### mysticmine - Disable on Debian versions newer than 10 (buster)

The scriptmodule requires Python2 and python modules that are no longer packaged.

---

This is a rework of the functionality in the draft PR https://github.com/RetroPie/RetroPie-Setup/pull/3907 but using module flags over a hook function. 

It's more compact, and covers most cases we need. It also has the advantage of providing some information for disabled modules in the setup gui. 

@cmitu thoughts ?