### PR TITLE
mame: add GCC requirements for version 0.265

### DIFF
--- a/scriptmodules/emulators/mame.sh
+++ b/scriptmodules/emulators/mame.sh
@@ -18,6 +18,11 @@ rp_module_section="exp"
 rp_module_flags="!mali !armv6"
 
 function _get_branch_mame() {
+    # starting with 0.265, GCC 10.3 or later is required for full C++17 support
+    if [[ "$__gcc_version" -lt 10 ]]; then
+        echo "mame0264"
+        return
+    fi
     download https://api.github.com/repos/mamedev/mame/releases/latest - | grep -m 1 tag_name | cut -d\" -f4
 }
 

--- a/scriptmodules/libretrocores/lr-mame.sh
+++ b/scriptmodules/libretrocores/lr-mame.sh
@@ -13,10 +13,17 @@ rp_module_id="lr-mame"
 rp_module_desc="MAME emulator - MAME (current) port for libretro"
 rp_module_help="ROM Extension: .zip\n\nCopy your MAME roms to either $romdir/mame-libretro or\n$romdir/arcade"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame/master/COPYING"
-rp_module_repo="git https://github.com/libretro/mame.git master"
+rp_module_repo="git https://github.com/libretro/mame.git master :_get_version_lr-mame"
 rp_module_section="exp"
 rp_module_flags=""
 
+function _get_version_lr-mame() {
+    local tagname
+    if [[ "$__gcc_version" -lt 10 ]]; then
+        tagname="lrmame0264"
+    fi
+    echo "$tagname"
+}
 function _get_params_lr-mame() {
     local params=(OSD=retro RETRO=1 NOWERROR=1 OS=linux OPTIMIZE=2 TARGETOS=linux CONFIG=libretro NO_USE_MIDI=1 NO_USE_PORTAUDIO=1 TARGET=mame)
     isPlatform "64bit" && params+=(PTR64=1)

--- a/scriptmodules/libretrocores/lr-mess.sh
+++ b/scriptmodules/libretrocores/lr-mess.sh
@@ -13,7 +13,7 @@ rp_module_id="lr-mess"
 rp_module_desc="MESS emulator - MESS Port for libretro"
 rp_module_help="see wiki for detailed explanation"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame/master/COPYING"
-rp_module_repo="git https://github.com/libretro/mame.git master"
+rp_module_repo="git https://github.com/libretro/mame.git master :_get_version_lr-mame"
 rp_module_section="exp"
 rp_module_flags=""
 


### PR DESCRIPTION
Starting with version 0.265 (April 2024), GCC 10.3 is required for building MAME. Enforce this requirement when building the emulator and libretro cores, Debian Buster will be getting 0.264 as the last version.