### PR TITLE
lr-mame: fix the build for 2016 repository

### DIFF
--- a/scriptmodules/libretrocores/lr-mame.sh
+++ b/scriptmodules/libretrocores/lr-mame.sh
@@ -25,7 +25,7 @@ function _get_version_lr-mame() {
     echo "$tagname"
 }
 function _get_params_lr-mame() {
-    local params=(OSD=retro RETRO=1 NOWERROR=1 OS=linux OPTIMIZE=2 TARGETOS=linux CONFIG=libretro NO_USE_MIDI=1 NO_USE_PORTAUDIO=1 TARGET=mame)
+    local params=(OSD=retro RETRO=1 PYTHON_EXECUTABLE=python3 NOWERROR=1 OS=linux OPTIMIZE=2 TARGETOS=linux CONFIG=libretro NO_USE_MIDI=1 NO_USE_PORTAUDIO=1 TARGET=mame)
     isPlatform "64bit" && params+=(PTR64=1)
     echo "${params[@]}"
 }


### PR DESCRIPTION
We removed the `python3` parameter setup in commit 2a95dd076a00ea7975d14a0cde7f29eff5bb68f0, but the build parameters are also used by Mame/Mess 2016. Mame2016/Mess2016 have python2 still as default, so re-add the `PYTHON_EXECUTABLE` ~~configuration~~ parameter.