### PR TITLE
Update platforms.cfg pc98 .cmd files

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -164,7 +164,7 @@ oric_fullname="Oric 1"
 pc88_exts=".d88 .cmt .m3u .t88"
 pc88_fullname="NEC PC-8801"
 
-pc98_exts=".d88 .d98 .88d .98d .fdi .fdd .xdf .hdm .dup .2hd .tfd .hdi .thd .nhd .hdd .zip .cmd"
+pc98_exts=".2hd .88d .98d .cmd .d88 .d98 .dup .fdi .fdd .hdd .hdi .hdm .nhd .thd .tfd .xdf .zip"
 pc98_fullname="NEC PC-9801"
 
 pc_exts=".bat .com .conf .cue .dosz .exe .ins .ima .img .iso .m3u .m3u8 .sh .vhd .zip"

--- a/platforms.cfg
+++ b/platforms.cfg
@@ -164,7 +164,7 @@ oric_fullname="Oric 1"
 pc88_exts=".d88 .cmt .m3u .t88"
 pc88_fullname="NEC PC-8801"
 
-pc98_exts=".d88 .d98 .88d .98d .fdi .fdd .xdf .hdm .dup .2hd .tfd .hdi .thd .nhd .hdd .zip"
+pc98_exts=".d88 .d98 .88d .98d .fdi .fdd .xdf .hdm .dup .2hd .tfd .hdi .thd .nhd .hdd .zip .cmd"
 pc98_fullname="NEC PC-9801"
 
 pc_exts=".bat .com .conf .cue .dosz .exe .ins .ima .img .iso .m3u .m3u8 .sh .vhd .zip"


### PR DESCRIPTION
For certain CD ROM based games (e.g Policenauts), you need to create a .cmd so you can run the system disk, user disk and CD