### PR TITLE
Add Sega Model3: supermodel

### DIFF
--- a/scriptmodules/emulators/supermodel3.sh
+++ b/scriptmodules/emulators/supermodel3.sh
@@ -74,7 +74,7 @@ function configure_supermodel3() {
 
     # launch the emulator with an X11 backend, has better scaling and mouse/lightgun support
     isPlatform "kms" && setBackend "$md_id" "x11"
-    isPlatform "lms" && setBackend "$md_id-scaled" "x11"
+    isPlatform "kms" && setBackend "$md_id-scaled" "x11"
 
     # on upgrades keep the local config, but overwrite the game configs
     copyDefaultConfig "$md_inst/Config/Supermodel.ini" "$conf_dir/Config/Supermodel.ini"

--- a/scriptmodules/emulators/supermodel3.sh
+++ b/scriptmodules/emulators/supermodel3.sh
@@ -56,9 +56,13 @@ function configure_supermodel3() {
     mkRomDir "arcade"
     addSystem "arcade"
 
-    local game_args="-fullscreen -vsync"
-    addEmulator 0 "$md_id" "arcade" "$md_inst/supermodel.sh %ROM% $game_args"
-    addEmulator 0 "$md_id-scaled" "arcade" "$md_inst/supermodel.sh %ROM% $game_args -res=%XRES%,%YRES%"
+    local game_args="-vsync"
+    local launch_prefix=""
+    # launch the emulator with an X11 backend, has better scaling and mouse/lightgun support
+    isPlatform "kms" && launch_prefix="XINIT:"
+
+    addEmulator 0 "$md_id" "arcade" "${launch_prefix}$md_inst/supermodel.sh %ROM% $game_args"
+    addEmulator 0 "$md_id-scaled" "arcade" "${launch_prefix}$md_inst/supermodel.sh %ROM% $game_args -res=%XRES%,%YRES%"
     if isPlatform "x86"; then
         # add a legacy3d entry for less powerful PC systems
         addEmulator 0 "$md_id-legacy3d" "arcade" "$md_inst/supermodel.sh %ROM% -legacy3d $game_args"
@@ -71,10 +75,6 @@ function configure_supermodel3() {
     mkUserDir "$conf_dir/NVRAM"
     mkUserDir "$conf_dir/Saves"
     mkUserDir "$conf_dir/Config"
-
-    # launch the emulator with an X11 backend, has better scaling and mouse/lightgun support
-    isPlatform "kms" && setBackend "$md_id" "x11"
-    isPlatform "kms" && setBackend "$md_id-scaled" "x11"
 
     # on upgrades keep the local config, but overwrite the game configs
     copyDefaultConfig "$md_inst/Config/Supermodel.ini" "$conf_dir/Config/Supermodel.ini"

--- a/scriptmodules/emulators/supermodel3.sh
+++ b/scriptmodules/emulators/supermodel3.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+ 
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="supermodel3"
+rp_module_desc="Super Model 3 Emulator"
+rp_module_help="ROM Addition: Copy your roms to $romdir/arcade"
+rp_module_licence="GPL3 https://raw.githubusercontent.com/DirtBagXon/model3emu-code-sinden/main/Docs/LICENSE.txt"
+rp_module_repo="git https://github.com/DirtBagXon/model3emu-code-sinden.git arm"
+rp_module_section="exp"
+rp_module_flags="sdl2"
+
+function depends_supermodel3() {
+
+    getDepends xinit libsdl2-dev libsdl2-net-dev libsdl2-net-2.0-0 x11-xserver-utils xserver-xorg
+
+    aptRemove xserver-xorg-legacy
+
+    if [[ "$__os_debian_ver" -eq 12 ]]; then
+        getDepends gldriver-test
+    fi
+}
+
+function sources_supermodel3() {
+    gitPullOrClone
+}
+
+function build_supermodel3() {
+    cp Makefiles/Makefile.UNIX Makefile
+    make clean
+    make NET_BOARD=1
+    cp Docs/LICENSE.txt LICENSE
+    cp bin/supermodel supermodel3
+    md_ret_require="supermodel3"
+}
+
+function install_supermodel3() {
+    md_ret_files=(
+        'supermodel3'
+        'Config'
+        'LICENSE'
+    )
+}
+
+function configure_supermodel3() {
+
+    mkRomDir "arcade"
+    
+    addEmulator 0 "$md_id" "arcade" "XINIT:$md_inst/supermodel3.sh %ROM%"
+    addSystem "arcade"
+
+    [[ "$md_mode" == "remove" ]] && return
+
+    mkUserDir "$md_conf_root/$md_id"
+    mkUserDir "$md_conf_root/$md_id/Saves"
+    mkUserDir "$md_conf_root/$md_id/NVRAM"
+
+    ln -snf "$md_conf_root/$md_id/NVRAM" "$md_inst/NVRAM"
+    ln -snf "$md_conf_root/$md_id/NVRAM" "$home/NVRAM"
+    ln -snf "$md_conf_root/$md_id/Saves" "$md_inst/Saves"
+    ln -snf "$md_conf_root/$md_id/Saves" "$home/Saves"
+    ln -snf "$md_conf_root/$md_id" "$home/Config"
+    ln -snf "$md_conf_root/$md_id" "$md_inst/LocalConfig"
+    ln -snf "$md_conf_root/$md_id" "$home/LocalConfig"
+
+    copyDefaultConfig "$md_inst/Config/Supermodel.ini" "$md_conf_root/$md_id/Supermodel.ini"
+    copyDefaultConfig "$md_inst/Config/Games.xml" "$md_conf_root/$md_id/Games.xml"
+
+    rm -rf "$md_inst/Config"
+    chown -R $user:$user "$md_inst"
+    chown -R $user:$user "$md_conf_root/$md_id"
+
+    cat >"$md_inst/supermodel3.sh" <<_EOF_
+#!/bin/bash
+
+commands="\${1%.*}.commands"
+
+if [[ -f "\$commands" ]]; then
+	params=\$(<"\$commands" tr -d '\r' | tr '\n' ' ')
+fi
+
+$md_inst/supermodel3 \$params \$1
+_EOF_
+    chmod +x "$md_inst/supermodel3.sh"
+}


### PR DESCRIPTION
Just pushing this to see if there is any interest. Feel free to close if it's considered too problematic, I am aware it can require lots of tweaking per install.

This is the ARM optimised code, as used from Exarkuniv's "_RetroPie-Extra_", based on _mechafatnick_'s original arm mods.

This branch has received tweaking, from the _Sinden_ Pi guys, to _Supermodel.ini_ and _Games.xml_ for some time and is maintained.

It also has the following additions to the arm optimizations:
```
'Absolute' Mouse Input for light guns in Linux
Multiple Mouse Support : Allowing 2 players in lightgun games
Support for selecting a clone from within merged ROM set
Per game .commands file for individual game configuration
Log based Framerate Monitoring
Built-in Sinden border
```

The repo branch is here for reference: https://github.com/DirtBagXon/model3emu-code-sinden/tree/arm

I have made this `rp_module_id="supermodel3"`  to avoid existing unofficial installs which seem to be just `supermodel`

It's now using a `.commands` file, based on game, to alter arguments.  
With the addition of `-game` to select a clone within a MAME style merged ROM set, this has become particularly useful.

```
/opt/retropie/emulators/supermodel3/supermodel3 /home/pi/RetroPie/roms/arcade/scud.zip -game=scuddxo
```

It will run on a Pi4 and P5, without too many issues, on many games, so perhaps there should be a restriction in the scriptmodule for those model - looking for feedback or disinterest. Either is fine.
