### PR TITLE
yabasanshiro: fix building on ARM64

### DIFF
--- a/scriptmodules/emulators/yabasanshiro.sh
+++ b/scriptmodules/emulators/yabasanshiro.sh
@@ -27,10 +27,16 @@ function sources_yabasanshiro() {
 }
 
 function build_yabasanshiro() {
-    mkdir build
+    local params=(-DGIT_EXECUTABLE=/usr/bin/git -DUSE_EGL=ON -DYAB_PORTS=retro_arena -DYAB_WANT_DYNAREC_DEVMIYAX=ON -DYAB_WANT_ARM7=ON -DYAB_WANT_OPENAL=OFF -DCMAKE_INSTALL_PREFIX="$md_inst")
+    isPlatform "32bit" && params+=(-DCMAKE_SYSTEM_PROCESSOR=armv7-a)
+    isPlatform "64bit" && params+=(-DCMAKE_SYSTEM_PROCESSOR=aarch64)
+
+    export CFLAGS="$CFLAGS -D_POSIX_C_SOURCE=199309L -D__PI4__ -D__RETORO_ARENA__"
+    export CXXFLAGS="$CXXFLAGS -D__PI4__ -D__RETORO_ARENA_"
+
+    rm -fr build && mkdir -p build
     cd build
-    cmake ../yabause/ -DGIT_EXECUTABLE=/usr/bin/git -DYAB_PORTS=retro_arena -DYAB_WANT_DYNAREC_DEVMIYAX=ON -DYAB_WANT_ARM7=ON -DCMAKE_TOOLCHAIN_FILE=../yabause/src/retro_arena/pi4.cmake -DYAB_WANT_OPENAL=OFF -DCMAKE_INSTALL_PREFIX="$md_inst"
-    make clean
+    cmake ../yabause/ "${params[@]}"
     make
     md_ret_require="$md_build/build/src/retro_arena/yabasanshiro"
 }


### PR DESCRIPTION
The previous build method on the Pi4 uses a CMake toolchain file which assumes a 32bit ARM system. To make it compile on ARM64, remove the toolchain file usage and add the appropriate defines/options from it to the CMake invocation.

NB: with these changes, we can probably try to install from the main/master branch (which doesn't have the Pi4 CMake toolchain file), but I'll not add it to this PR.