### PR TITLE
dxx-rebirth game data

### DIFF
--- a/scriptmodules/ports/dxx-rebirth.sh
+++ b/scriptmodules/ports/dxx-rebirth.sh
@@ -124,7 +124,7 @@ function game_data_dxx-rebirth() {
     fi
 
     # Download / unpack / install Descent 2 shareware files
-    if [[ ! -f "$dest_d2/D2DEMO.HOG" ]]; then
+    if [[ ! -f "$dest_d2/D2DEMO.HOG" && ! -f "$dest_d2/DESCENT2.HOG" ]]; then
         downloadAndExtract "$D2X_SHARE_URL" "$dest_d2"
     fi
 

--- a/scriptmodules/ports/dxx-rebirth.sh
+++ b/scriptmodules/ports/dxx-rebirth.sh
@@ -109,7 +109,7 @@ function game_data_dxx-rebirth() {
     mkUserDir "$dest_d2"
 
     # Download / unpack / install Descent shareware files
-    if [[ ! -f "$dest_d1/descent.hog" ]]; then
+    if [[ -z "$(find "$dest_d1" -maxdepth 1 -iname descent.hog)" ]]; then
         downloadAndExtract "$D1X_SHARE_URL" "$dest_d1"
     fi
 
@@ -124,7 +124,7 @@ function game_data_dxx-rebirth() {
     fi
 
     # Download / unpack / install Descent 2 shareware files
-    if [[ ! -f "$dest_d2/D2DEMO.HOG" && ! -f "$dest_d2/DESCENT2.HOG" ]]; then
+    if [[ -z "$(find "$dest_d2" -maxdepth 1 \( -iname D2DEMO.HOG -o -iname DESCENT2.HOG \))" ]]; then
         downloadAndExtract "$D2X_SHARE_URL" "$dest_d2"
     fi
 


### PR DESCRIPTION
Don't download D2 shareware data if registered version files exist.

Ignore case - don't download D1/D2 shareware whether user-provided data files in **ALL CAPS** (DOS) or **lowercase** (Steam).

Shareware and add-on files no longer available from dxx-rebirth.com - switch to self-hosted files at `$__archive_url` (I don't know how to actually put them there, though. Someone else will have to do that part, or show me how.)