### PR TITLE
Dxx rebirth update

### DIFF
--- a/scriptmodules/ports/dxx-rebirth.sh
+++ b/scriptmodules/ports/dxx-rebirth.sh
@@ -17,7 +17,12 @@ rp_module_section="opt"
 rp_module_flags="!mali"
 
 function _get_commit_dxx-rebirth() {
-    local commit="15bd145d"
+    local commit=""
+    # last version to build on gcc 10
+    [[ "$__gcc_version" -le 10 ]] && commit="ec41384d"
+    # last version to build on Debian Buster due to pkg-config issue with physfs
+    # newer versions also have incompatible scons changes
+    [[ "$__os_debian_ver" -le 10 ]] && commit="15bd145d"
     # latest code requires gcc 7+
     [[ "$__gcc_version" -lt 7 ]] && commit="a1b3a86c"
     echo "$commit"

--- a/scriptmodules/ports/dxx-rebirth.sh
+++ b/scriptmodules/ports/dxx-rebirth.sh
@@ -43,6 +43,11 @@ function sources_dxx-rebirth() {
     gitPullOrClone
 }
 
+function _get_build_path_dxx-rebirth() {
+    # later versions use a build subfolder
+    [[ -d "$md_build/build" ]] && echo "build"
+}
+
 function build_dxx-rebirth() {
     local params=()
     isPlatform "arm" && params+=("words_need_alignment=1")
@@ -57,9 +62,11 @@ function build_dxx-rebirth() {
 
     scons -c
     scons "${params[@]}" -j$__jobs
+
+    local build_path="$md_build/$(_get_build_path_dxx-rebirth)"
     md_ret_require=(
-        "$md_build/d1x-rebirth/d1x-rebirth"
-        "$md_build/d2x-rebirth/d2x-rebirth"
+        "$build_path/d1x-rebirth/d1x-rebirth"
+        "$build_path/d2x-rebirth/d2x-rebirth"
     )
 }
 
@@ -70,15 +77,17 @@ function install_dxx-rebirth() {
     mv -f "$md_build/d2x-rebirth/INSTALL.txt" "$md_build/d2x-rebirth/D2X-INSTALL.txt"
     mv -f "$md_build/d2x-rebirth/RELEASE-NOTES.txt" "$md_build/d2x-rebirth/D2X-RELEASE-NOTES.txt"
 
+    local build_path="$(_get_build_path_dxx-rebirth)"
+
     md_ret_files=(
         'COPYING.txt'
         'GPL-3.txt'
         'd1x-rebirth/README.RPi'
-        'd1x-rebirth/d1x-rebirth'
+        "$build_path/d1x-rebirth/d1x-rebirth"
         'd1x-rebirth/d1x.ini'
         'd1x-rebirth/D1X-INSTALL.txt'
         'd1x-rebirth/D1X-RELEASE-NOTES.txt'
-        'd2x-rebirth/d2x-rebirth'
+        "$build_path/d2x-rebirth/d2x-rebirth"
         'd2x-rebirth/d2x.ini'
         'd2x-rebirth/D2X-INSTALL.txt'
         'd2x-rebirth/D2X-RELEASE-NOTES.txt'

--- a/scriptmodules/ports/dxx-rebirth.sh
+++ b/scriptmodules/ports/dxx-rebirth.sh
@@ -95,11 +95,12 @@ function install_dxx-rebirth() {
 }
 
 function game_data_dxx-rebirth() {
-    local D1X_SHARE_URL='https://www.dxx-rebirth.com/download/dxx/content/descent-pc-shareware.zip'
-    local D2X_SHARE_URL='https://www.dxx-rebirth.com/download/dxx/content/descent2-pc-demo.zip'
-    local D1X_HIGH_TEXTURE_URL='https://www.dxx-rebirth.com/download/dxx/res/d1xr-hires.dxa'
-    local D1X_OGG_URL='https://www.dxx-rebirth.com/download/dxx/res/d1xr-sc55-music.dxa'
-    local D2X_OGG_URL='https://www.dxx-rebirth.com/download/dxx/res/d2xr-sc55-music.dxa'
+    local base_url="$__archive_url/descent"
+    local D1X_SHARE_URL="$base_url/descent-pc-shareware.zip"
+    local D2X_SHARE_URL="$base_url/descent2-pc-demo.zip"
+    local D1X_HIGH_TEXTURE_URL="$base_url/d1xr-hires.dxa"
+    local D1X_OGG_URL="$base_url/d1xr-sc55-music.dxa"
+    local D2X_OGG_URL="$base_url/d2xr-sc55-music.dxa"
 
     local dest_d1="$romdir/ports/descent1"
     local dest_d2="$romdir/ports/descent2"


### PR DESCRIPTION
### dxx-rebirth - fix building on newer distros

In https://github.com/RetroPie/RetroPie-Setup/commit/77bb4c16d8a4f74ec755541404dbe6c03fc6158b the code was locked to an older commit due to incompatibilities with Raspberry Pi OS Buster, but this version doesn't build with newer GCC.

Switch to using the latest code by default but lock to older versions for Buster and GCC 10 and lower

Tested to build correctly on Raspberry Pi OS Buster, Bullseye and Bookworm.

### dxx-rebirth - fix build path on recent dxx-rebirth

Newer dxx-rebirth uses a build/ subfolder.

### dxx-rebirth - use self hosted shareware game data

The official site no longer hosts the files.