### PR TITLE
mupen64pluus: workaround the GLES GlideN64 regression

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -65,6 +65,8 @@ function _get_repos_mupen64plus() {
     if compareVersions "$cmake_ver" lt 3.9; then
         commit="8a9d52b41b33d853445f0779dd2b9f5ec4ecdda8"
     fi
+    # avoid a GLideN64 regression introduced in 1a0621d
+    isPlatform "gles" && commit="5bbf55df"
     repos+=("gonetz GLideN64 master $commit")
 
     local repo


### PR DESCRIPTION
Upstream GlideN64 has a regression due to a recent shader related change, which breaks the video output on GLES devices/platforms. Until this issue is fixed in the upstream GlideN64, build the plugin from a commit before the changes that cause the regression.

The problem was reported in the forums [1] and I reported it upstream [2] and though there is a fix for it, it hasn't been added to the main GlidedN64 repository.

[1] https://retropie.org.uk/forum/topic/35444/
[2] https://github.com/gonetz/GLideN64/issues/2837