### PR TITLE
lr-scummvm: build with OpenGL(ES) context support

### DIFF
--- a/scriptmodules/libretrocores/lr-scummvm.sh
+++ b/scriptmodules/libretrocores/lr-scummvm.sh
@@ -25,9 +25,11 @@ function sources_lr-scummvm() {
 }
 
 function build_lr-scummvm() {
+    local gl_platform=OPENGL
+    isPlatform "gles" && gl_platform=OPENGLES2
     cd backends/platform/libretro
     make clean
-    make USE_MT32EMU=1
+    make USE_MT32EMU=1 FORCE_${gl_platform}=1
     make datafiles
     md_ret_require="$md_build/backends/platform/libretro/scummvm_libretro.so"
 }


### PR DESCRIPTION
Upstream has added support for using an OpenGL(ES2) context for 3D games and HW rendering. The core will request a HW GL context from RetroArch when starting. Added the necessary parameters to the build to support the GL context for the platform where RetroArch is running.