### PR TITLE
amiberry: update to 5.7.1

### DIFF
--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -13,7 +13,7 @@ rp_module_id="amiberry"
 rp_module_desc="Amiga emulator with JIT support (forked from uae4arm)"
 rp_module_help="ROM Extension: .adf .chd .ipf .lha .zip\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir/amiga"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/BlitterStudio/amiberry/master/LICENSE"
-rp_module_repo="git https://github.com/BlitterStudio/amiberry v5.6.6"
+rp_module_repo="git https://github.com/BlitterStudio/amiberry v5.7.1"
 rp_module_section="opt"
 rp_module_flags="!all arm rpi3 rpi4 rpi5"
 

--- a/scriptmodules/emulators/amiberry/01_preserve_env.diff
+++ b/scriptmodules/emulators/amiberry/01_preserve_env.diff
@@ -1,18 +1,18 @@
-diff --git i/Makefile w/Makefile
-index cff286e2..40e3c05f 100644
---- i/Makefile
-+++ w/Makefile
+diff --git a/Makefile b/Makefile
+index 9747718..dcdfb2f 100644
+--- a/Makefile
++++ b/Makefile
 @@ -43,10 +43,10 @@ SDL_CONFIG ?= sdl2-config
  export SDL_CFLAGS := $(shell $(SDL_CONFIG) --cflags)
  export SDL_LDFLAGS := $(shell $(SDL_CONFIG) --libs)
  
--CPPFLAGS = -MD -MT $@ -MF $(@:%.o=%.d) $(SDL_CFLAGS) -Iexternal/libguisan/include -Isrc -Isrc/osdep -Isrc/threaddep -Isrc/include -Isrc/archivers -Isrc/floppybridge -Iexternal/mt32emu/src -D_FILE_OFFSET_BITS=64
+-CPPFLAGS = -MD -MT $@ -MF $(@:%.o=%.d) $(SDL_CFLAGS) -Iexternal/libguisan/include -Isrc -Isrc/osdep -Isrc/threaddep -Isrc/include -Isrc/archivers -Iexternal/floppybridge/src -Iexternal/mt32emu/src -D_FILE_OFFSET_BITS=64
 -CFLAGS=-pipe -Wno-shift-overflow -Wno-narrowing -fno-pie
-+CPPFLAGS += -MD -MT $@ -MF $(@:%.o=%.d) $(SDL_CFLAGS) -Iexternal/libguisan/include -Isrc -Isrc/osdep -Isrc/threaddep -Isrc/include -Isrc/archivers -Isrc/floppybridge -Iexternal/mt32emu/src -D_FILE_OFFSET_BITS=64
-+CFLAGS +=-pipe -Wno-shift-overflow -Wno-narrowing -fno-pie
- USE_LD ?= gold
++CPPFLAGS += -MD -MT $@ -MF $(@:%.o=%.d) $(SDL_CFLAGS) -Iexternal/libguisan/include -Isrc -Isrc/osdep -Isrc/threaddep -Isrc/include -Isrc/archivers -Iexternal/floppybridge/src -Iexternal/mt32emu/src -D_FILE_OFFSET_BITS=64
++CFLAGS += -pipe -Wno-shift-overflow -Wno-narrowing -fno-pie
+ 
 -LDFLAGS = $(SDL_LDFLAGS) -lSDL2_image -lSDL2_ttf -lserialport -lportmidi -lguisan -Lexternal/libguisan/lib -lmt32emu -Lexternal/mt32emu
 +LDFLAGS += $(SDL_LDFLAGS) -lSDL2_image -lSDL2_ttf -lserialport -lportmidi -lguisan -Lexternal/libguisan/lib -lmt32emu -Lexternal/mt32emu
- ifneq ($(strip $(USE_LD)),)
- 	LDFLAGS += -fuse-ld=$(USE_LD)
- endif
+ LDFLAGS += -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed -lpthread -lz -lpng -lrt -lFLAC -lmpg123 -ldl -lmpeg2convert -lmpeg2 -lstdc++fs -no-pie
+ 
+ ifdef USE_OPENGL


### PR DESCRIPTION
Changes in 5.7.1 (https://github.com/BlitterStudio/amiberry/releases/tag/v5.7.1)

* Bugfixes (since 5.6.6):
   - improve CD32 default mapping
   - fix base color for Radiobuttons in SaveStates panel
   - fix KMSDRM video regression
   - fixed background color for SaveStates panel checkboxes
   - when saving a new config in the GUI, it should be selected after the refresh
   - when loading config from the command line and opening the GUI, the settings were reset to defaults
   - always clear the text fields when deleting a config
   - fullscreen toggle didn't quite work
   - quickstart - enabling 2nd floppy drive did not refresh panel
   - make guisan widgets active/inactive status more visible
   - fixed textbox background color in Create hardfile dialog
   - the floppy dropdown wasn't updated properly after a selection
   - fixed CD dropdown did not refresh properly
   - ensure keyboard keys are released when pressing Alt-Tab
   - ignore alt-tab if used to release focus
   - GUI Hardware sprite checkbox wouldn't enable when needed
   - some RTG options were not changed on-the-fly
   - fix mouse drift when using RTG hardware sprite
   - mouse - when using SuperHighRes or Single line modes, the movement scaling was incorrect
   - fix offset for button indicators in ControllerMap GUI
   - mouse: RTG modes can use the positioning directly, but they were affected by the single/double line mode setting, fix absolute positioning
   - fixed crash when using Restart after previous updates
   - Ensure changes in virtual mouse and magic mouse are applied immediately
   - datapath wasn't parsed in WHDBooter
   - bugfix: aspect ratio option was not respected in autocrop
   - bugfix: return empty string when cancelling file/folder dialog
   - fixed select file/folder dialogs briefly showing a scrollbar on startup
   - enter would no longer trigger a KEYDOWN event in guisan
   - fix memory leak when closing filesys unit
   - fixed parsing of ROMs in the GUI
   - don't crash if no kickstarts are found on startup
   - controller hotkey mapping was broken after recent updates
   - fixed navigation in Floppy GUI panel
   - fix all A600 quickstart configs would always incorrectly add Fast RAM
   - start in Quickstart checkbox would not change status
   - virtual Keyboard did not respect Auto-Crop
   - listbox selection color was hardcoded when inactive
   - if Cancel was used in a file/folder dialog, the path would be emptied on return

* Enhancements:
   - Implemented GUI foreground color option for themes
   - Updated floppybridge library to latest version
   - Added button to Create new folder in the dialogs
   - All plugins (floppybridge, capsimg) now live in a separate directory, named "plugins"
   - Added option to log to console
   - Set config name automatically for CD images as well
   - Config panel double-click time reduced to 500ms
   - Improve help text in Config panel,Misc panel,Sound Panel
   - Add console logging details in GUI helptex
   - Added new custom events for Disk Swapper. Two new events were added, Insert Next/Previous disk swapper slot.These allow you to select the next/previous slot and also insert it into DF0: in one step.
   - Added default path for LHA archives. This allows you to set a default path that will be used to load WHDLoad .lha files, for use with the WHDBooter.
   - Added default Floppy, CD-ROM and Hard Drive paths
   - Added option to use "System Default" audio device.This new checkbox in the GUI (Sound panel) will not choose a specific audio device, and instead tell SDL2 to pick the system default one. This helps with systems that may have sound devices that are not listed in the dropdown.
   - Added new WHDLoad panel in GUI. This panel exposes the options that the WHDBooter uses, and allows changes to the slave options before launching a title. The Custom Fields can also be customized from this area. All information is parsed from the same XML that Amiberry uses to match the WHDLoad titles.
   - Added new "Save Mapping" button in Custom Controls.This allows you to save the current mapping for the selected controller as the default, which will be automatically loaded on startup (if the controller is connected).
   - Detect WHDLoad, CD and floppy disk images as parameters in the command line. As a fall back, you can now pass the path to a supported image filename, and it will be loaded automatically. This makes it possible to set Amiberry as the default handler for such files (e.g. .lha, .adf, .adz, .ipf, .cue, .iso, etc.). WHDLoad and CD images trigger the autoloader, while floppy disk images will be loaded into DF0:
   - If a config file that matches the inserted disk image exists, it will be loaded automatically. Otherwise the default one will be used instead. This also makes it easy to save a config after you've loaded a disk image, since the panel will be populated with the right name already.
   - Added support for custom font colors in the GUI theme