### PR TITLE
amiberry: upgrade to 5.7.2; handle dispmanx deprecation

### DIFF
--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -13,7 +13,7 @@ rp_module_id="amiberry"
 rp_module_desc="Amiga emulator with JIT support (forked from uae4arm)"
 rp_module_help="ROM Extension: .adf .chd .ipf .lha .zip\n\nCopy your Amiga games to $romdir/amiga\n\nCopy the required BIOS files\nkick13.rom\nkick20.rom\nkick31.rom\nto $biosdir/amiga"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/BlitterStudio/amiberry/master/LICENSE"
-rp_module_repo="git https://github.com/BlitterStudio/amiberry v5.7.1"
+rp_module_repo="git https://github.com/BlitterStudio/amiberry :_get_branch_amiberry"
 rp_module_section="opt"
 rp_module_flags="!all arm rpi3 rpi4 rpi5"
 
@@ -26,6 +26,14 @@ function _update_hook_amiberry() {
             moveConfigFile "$biosdir/$rom" "$biosdir/amiga/$rom"
         fi
     done
+}
+
+function _get_branch_amiberry() {
+    if isPlatform "dispmanx"; then
+        echo "v5.7.1"
+    else
+        echo "v5.7.2"
+    fi
 }
 
 function _get_platform_amiberry() {
@@ -58,6 +66,11 @@ function depends_amiberry() {
 function sources_amiberry() {
     gitPullOrClone
     applyPatch "$md_data/01_preserve_env.diff"
+    # Dispmanx is locked on v5.7.1, apply some critical fixes on top of it
+    if isPlatform "dispmanx"; then
+        applyPatch "$md_data/02_fix_uae_config_load.diff"
+        applyPatch "$md_data/03_fix_crash_saving.diff"
+    fi
     # use our default optimisation level
     sed -i "/CFLAGS += -O3/d" "$md_build/Makefile"
 }

--- a/scriptmodules/emulators/amiberry/02_fix_uae_config_load.diff
+++ b/scriptmodules/emulators/amiberry/02_fix_uae_config_load.diff
@@ -1,0 +1,68 @@
+diff --git a/src/osdep/amiberry_whdbooter.cpp b/src/osdep/amiberry_whdbooter.cpp
+index 8a03e732..939b26b8 100644
+--- a/src/osdep/amiberry_whdbooter.cpp
++++ b/src/osdep/amiberry_whdbooter.cpp
+@@ -1180,6 +1180,7 @@ void set_booter_drives(uae_prefs* prefs, const char* filepath)
+ 
+ void whdload_auto_prefs(uae_prefs* prefs, const char* filepath)
+ {
++	bool custom_config_loaded = false;
+ 	write_log("WHDBooter Launched\n");
+ 
+ 	if (lstAvailableROMs.empty())
+@@ -1207,18 +1208,7 @@ void whdload_auto_prefs(uae_prefs* prefs, const char* filepath)
+ 	const std::string filename_no_extension = get_game_filename(filepath);
+ 	whdload_prefs.filename = filename_no_extension;
+ 
+-	// LOAD GAME SPECIFICS FOR EXISTING .UAE - USE SHA1 IF AVAILABLE
+-	//  CONFIG LOAD IF .UAE IS IN CONFIG PATH
+-	build_uae_config_filename(whdload_prefs.filename);
+-
+-	// If we have a config file, we use that first
+-	if (std::filesystem::exists(uae_config))
+-	{
+-		write_log("WHDBooter -  %s found. Loading Config for WHDLoad options.\n", uae_config.c_str());
+-		target_cfgfile_load(prefs, uae_config.c_str(), CONFIG_TYPE_DEFAULT, 0);
+-	}
+-
+-	// setups for tmp folder.
++	// setup for tmp folder.
+ 	std::filesystem::create_directories("/tmp/amiberry/s");
+ 	std::filesystem::create_directories("/tmp/amiberry/c");
+ 	std::filesystem::create_directories("/tmp/amiberry/devs");
+@@ -1234,7 +1224,6 @@ void whdload_auto_prefs(uae_prefs* prefs, const char* filepath)
+ 	// LOAD GAME SPECIFICS
+ 	whd_path = whdbooter_path / "game-data";
+ 	game_hardware_options game_detail;
+-
+ 	whd_config = whd_path / "whdload_db.xml";
+ 
+ 	if (std::filesystem::exists(whd_config))
+@@ -1243,7 +1232,17 @@ void whdload_auto_prefs(uae_prefs* prefs, const char* filepath)
+ 	}
+ 	else
+ 	{
+-		write_log("WHDBooter -  Could not load whdload_db.xml - does not exist?\n");
++		write_log("WHDBooter - Could not load whdload_db.xml - does not exist?\n");
++	}
++
++	// LOAD CUSTOM CONFIG
++	build_uae_config_filename(whdload_prefs.filename);
++	// If we have a config file, we will load that on top of the XML settings
++	if (std::filesystem::exists(uae_config))
++	{
++		write_log("WHDBooter - %s found. Loading Config for WHDLoad options.\n", uae_config.c_str());
++		target_cfgfile_load(prefs, uae_config.c_str(), CONFIG_TYPE_DEFAULT, 0);
++		custom_config_loaded = true;
+ 	}
+ 
+ 	// If we have a slave, create a startup-sequence
+@@ -1308,7 +1307,7 @@ void whdload_auto_prefs(uae_prefs* prefs, const char* filepath)
+ #endif
+ 
+ 	// if we already loaded a .uae config, we don't need to do the below manual setup for hardware
+-	if (std::filesystem::exists(uae_config))
++	if (custom_config_loaded)
+ 	{
+ 		write_log("WHDBooter - %s found; ignoring WHD Quickstart setup.\n", uae_config.c_str());
+ 		return;

--- a/scriptmodules/emulators/amiberry/03_fix_crash_saving.diff
+++ b/scriptmodules/emulators/amiberry/03_fix_crash_saving.diff
@@ -1,0 +1,13 @@
+diff --git a/src/cfgfile.cpp b/src/cfgfile.cpp
+index f96ee0d9..24bd58cb 100644
+--- a/src/cfgfile.cpp
++++ b/src/cfgfile.cpp
+@@ -2243,7 +2243,7 @@ void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
+ #ifdef AMIBERRY
+ 		std::string mode;
+ 		std::string buffer;
+-		didata* did = &di_joystick[jp->id];
++		didata* did = &di_joystick[jp->id - JSEM_JOYS];
+ 
+ 		// custom options SAVING
+ 		for (int m = 0; m < 2; ++m)


### PR DESCRIPTION
The 5.7.1 version has a couple of regresions (one is a crash), fixed in version 5.7.2. However, DispmanX support was dropped starting with 5.7.2 so just bumping the version would break Buster based Pi installation.

Therefore the module was changed so that:
 - for DispmanX platforms cherry pick the post 5.7.2 fixes manually and lock the version to 5.7.1
 - for every other platform build the 5.7.2 version