### PR TITLE
zesarux: update to version 11

### DIFF
--- a/scriptmodules/emulators/zesarux.sh
+++ b/scriptmodules/emulators/zesarux.sh
@@ -13,7 +13,7 @@ rp_module_id="zesarux"
 rp_module_desc="ZX Spectrum emulator ZEsarUX"
 rp_module_help="ROM Extensions: .sna .szx .z80 .tap .tzx .gz .udi .mgt .img .trd .scl .dsk .zip\n\nCopy your ZX Spectrum games to $romdir/zxspectrum"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/chernandezba/zesarux/master/src/LICENSE"
-rp_module_repo="git https://github.com/chernandezba/zesarux.git ZEsarUX-X"
+rp_module_repo="git https://github.com/chernandezba/zesarux.git ZEsarUX-11.0"
 rp_module_section="opt"
 rp_module_flags="sdl2 sdl1-videocore"
 


### PR DESCRIPTION
Full changelog at https://github.com/chernandezba/zesarux/releases/tag/ZEsarUX-11.0

Besides bug fixes, new and improved features:

* New additions:
   - Added loading audio from external audio source
   - Audio Spectrum Analyzer
   - Added ZENG Online feature, which allows you to play to any emulated game on a multiplayer way using a central server
   - Added ZENG support on all emulated machines
   - Added save screenAdded ZENG support on curses driver
   - Added save screen to .txt or .stl files
   - Added save support for ZX80 & ZX81 .Z81 snapshots
   - Added TempleOS GUI Style,  QNX GUI Style
   - Added .zmenu type files to generate launcher menus
   - Added more vintage Spectrum programs/games from me
   - Added PCW Video mode 1 palette selector
   - Added setting to force CHR$ 128 mode on ZX81

* Improvements
   - Allow to load Next .nex/.snx/.sna snapshots with additional files
   - Allow to pause playing on AY Player
   - Improved Keyboard Help: now you can press keys by clicking mouse
   - Allow to send ZENG snapshots more frequently (even every 20 ms)
   - Allow autorewind setting for real tape too
   - Allow to disable Spectrum colours on real video mode too
   - Remember last path used on output tape
   - Allow to load 48kB MSX cartridges
   - Allow to load MSX cartridges with memory mapper Ascii 8kb, Ascii 16kb, Konami without SCC, Konami with SCC, R-Type
   - Allow to set +2e/+3e rom from Custom rom menu item
   - Improve Hexadecimal editor on ZX80 and ZX81: show inverse characters
   - RCP Improvements
      * Added menu function to sync local snapshot to remote using ZRCP
      * Added ZRCP commands open-menu, print-error, get-text-overlay, cpu-history get extended     
      * Support MMU restore state on ZRCP command "cpu-history restore" for Spectrum 128k/+2/+2a/+3
   - Improved QL emulation
   - Improved file selector
   - Improved ZX Vision
   - Improved ZX Desktop