### PR TITLE
retroarch: updated to v1.19.1

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -12,7 +12,7 @@
 rp_module_id="retroarch"
 rp_module_desc="RetroArch - frontend to the libretro emulator cores - required by all lr-* emulators"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/RetroArch/master/COPYING"
-rp_module_repo="git https://github.com/retropie/RetroArch.git retropie-v1.18.0"
+rp_module_repo="git https://github.com/retropie/RetroArch.git retropie-v1.19.0"
 rp_module_section="core"
 
 function depends_retroarch() {


### PR DESCRIPTION
Version 1.19.1 is a patch for 1.19.0 with just fixes for issues noticed after 1.19.0. Here's the changelog (full changes at https://www.libretro.com/index.php/retroarch-1-19-0-release/) for 1.19.0. Most changes are related to iOS/macOS, now that RetroArch is published in Apple's AppStore.

**NB** please pull from https://github.com/cmitu/RetroArch/tree/retropie-v1.19.0 to get the latest code. No new asssets seem necessary (XMB monochrome has a new icon/icons, but they're only used for playlist), though maybe it's time to refresh the archive.

* General
   - Add compatibility with FFMPEG 7.0
   - Fix for scanning PSP ISOs (and probably few others)
   - Fix save new config name when core loaded
   - Fix core config saving
   - (XMB) New theme: FlatUX, designed to merge FlatUI and Retroactive themes into a single, unified design
   - Set compute fps stats logging to debug level

* Cheevos
   - Update to rcheevos 11.3
   - Fix hardcore acting as if it’s enabled when it isn’t
   - Revert AI translation to previous version (fix for translation not working with HW rendered cores)
   - Build a default RetroAchievements memory map when no RetroAchievements game is loaded

* Input
   - Add support for multimedia keys – Extended RETROK_ values with 18 new items, commonly found on “multimedia” keyboards. Mapping added for SDL, X11, Wayland, dinput, winraw keymaps.

* Video
   - Fix reinitialization of the threaded gl drivers
   - Fix crash when using threaded video – for Mesa 23.2 and later
   - Add support for A2R10G10B10 HDR format in Vulkan
   - Implement HDR readback – screenshot support - for Vulkan