### PR TITLE
gzdoom: update to 4.12, fix installation

### DIFF
--- a/scriptmodules/ports/gzdoom.sh
+++ b/scriptmodules/ports/gzdoom.sh
@@ -18,7 +18,7 @@ rp_module_flags="sdl2 !armv6"
 
 function _get_version_gzdoom() {
     # default GZDoom version
-    local gzdoom_version="g4.11.3"
+    local gzdoom_version="g4.12.2"
 
     # 32 bit is no longer supported since g4.8.1
     isPlatform "32bit" && gzdoom_version="g4.8.0"
@@ -74,7 +74,7 @@ function install_gzdoom() {
         'release/game_widescreen_gfx.pk3'
         'release/soundfonts'
         "release/zmusic/lib/libzmusic.so.1"
-        "release/zmusic/lib/libzmusic.so.1.1.12"
+        "release/zmusic/lib/libzmusic.so.1.1.13"
         'README.md'
     )
 }


### PR DESCRIPTION
Fixed installation error due to ZMusic changing it's SO version. Upgraded GZDoom to 4.12.2. Changes in 4.12 (full changes at https://github.com/ZDoom/gzdoom/releases)

* 4.12.2
  * network fixes, including prediction and interpolation
  * added emulation of Final Doom's teleporter z glitch and activate it for Saturnia MAP10
  * Reworked clientside lerping
  * fix issues with GCC 14

* 4.12.1
  * Added pistol start gameplay option
  * Restored Windows 7 support

* 4.12
  * set default backend to Vulkan, if Vulkan fails go GLES not OpenGL
  * Update LZMA SDK to 23.01
  * do not print all GL extensions to the log for the GLES renderer.
  * fix map WAD check for savegame validation.
  * Allow setting the colormap from mapinfo (dsda-doom)
  * added per-sector sky UDMF properties.
  * added DSDA's thrust properties for UDMF
  * added rudimentary support for DSDA's COMPLVL lump.
  * allow defining zero gravity through MAPINFO
  * fix GL ES switch appearing as 'Unknown' in the menu sometimes
  * Fixed console rendering crash on wide consoles
  * Added friction and colormap related properties from DSDA.
  * hooked up the per-level colormaps with the hardware renderer.
  * always save the map WAD in a savegame's metadata, even if it is from the IWAD
  * fix UMAPINFO's intermusic being used at the summary screen.

Closed #3935 