### PR TITLE
Add Amiberry for x86 platforms as well (fixes #3937)

### DIFF
--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -15,7 +15,7 @@ rp_module_help="ROM Extension: .adf .chd .ipf .lha .zip\n\nCopy your Amiga games
 rp_module_licence="GPL3 https://raw.githubusercontent.com/BlitterStudio/amiberry/master/LICENSE"
 rp_module_repo="git https://github.com/BlitterStudio/amiberry :_get_branch_amiberry"
 rp_module_section="opt"
-rp_module_flags=""
+rp_module_flags="!all arm rpi3 rpi4 rpi5 x86"
 
 function _update_hook_amiberry() {
     local rom
@@ -31,6 +31,8 @@ function _update_hook_amiberry() {
 function _get_branch_amiberry() {
     if isPlatform "dispmanx"; then
         echo "v5.7.1"
+    elif isPlatform "x86"; then
+        echo "v6.3.3"
     else
         echo "v5.7.2"
     fi

--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -15,7 +15,7 @@ rp_module_help="ROM Extension: .adf .chd .ipf .lha .zip\n\nCopy your Amiga games
 rp_module_licence="GPL3 https://raw.githubusercontent.com/BlitterStudio/amiberry/master/LICENSE"
 rp_module_repo="git https://github.com/BlitterStudio/amiberry :_get_branch_amiberry"
 rp_module_section="opt"
-rp_module_flags="!all arm rpi3 rpi4 rpi5"
+rp_module_flags=""
 
 function _update_hook_amiberry() {
     local rom
@@ -50,6 +50,8 @@ function _get_platform_amiberry() {
         platform="tinker"
     elif isPlatform "vero4k"; then
         platform="vero4k"
+    elif isPlatform "x86"; then
+        platform="x86-64"
     fi
     echo "$platform"
 }


### PR DESCRIPTION
Did a quick test and this seems to work, but there might be more changes you want to make.

I've only added `x86-64` as the platform, as there's no 32-bit version for x86 available.
I've also taken away the platform restrictions, but you know best on how to use those (perhaps just add that `x86` is permitted instead).