### PR TITLE
doom: update Freedoom to 0.13.0

### DIFF
--- a/scriptmodules/libretrocores/lr-prboom.sh
+++ b/scriptmodules/libretrocores/lr-prboom.sh
@@ -40,9 +40,9 @@ function game_data_lr-prboom() {
         download "$__archive_url/doom1.wad" "$dest/doom1.wad"
     fi
 
-    if ! echo "e9bf428b73a04423ea7a0e9f4408f71df85ab175 $romdir/ports/doom/freedoom1.wad" | sha1sum -c &>/dev/null; then
+    if ! echo "97bb88094a51457a8dcad98c58be22a2d0fa9a37 $romdir/ports/doom/freedoom1.wad" | sha1sum -c &>/dev/null; then
         # download (or update) freedoom
-        downloadAndExtract "https://github.com/freedoom/freedoom/releases/download/v0.12.1/freedoom-0.12.1.zip" "$dest" -j -LL
+        downloadAndExtract "https://github.com/freedoom/freedoom/releases/download/v0.13.0/freedoom-0.13.0.zip" "$dest" -j -LL
     fi
 
     mkUserDir "$dest/addon"


### PR DESCRIPTION
Changelog:

* General
  - Improved vanilla compatibility.
  - Boom features removed.
  - Hall of mirrors greatly reduced.
  - Visplane overflows fixed.
  - Savegame buffer overflow errors remain.

* Levels
  - New levels E1M9, E2M2, E2M3, E2M4, E2M7, E2M8, E3M5, MAP07, MAP21 and MAP27.
  - Numerous vanilla fixes and aesthetic modernizations.
  - Fixed and standardized secret exits.

* Monsters
  - New minigunner
  - The hatchling, which replaces the deadflare.
  - The matribite, which replaces the summoner.

* Music
  - Lots of new music including most of FreeDM music.

* Sounds
  - New boss brain sounds.

* Visuals
  - Colorblind-friendly keys and key indicators.
  - Various revisions to sprites and textures.
  - Improved kerning for menu text.

* Weapons
  - Improved weapon sprites generally.
  - SSG replacement restored to updated take on older version.
  - Double-barreled shotgun flash timing bug fixed in built-in DeHackEd.

* Textures
   - Esa Repo (Espi)'s old STAR* textures are now included under ESPI*.
   - A STARBR1 texture is now included as a counterpart to STARBR2.
   - Numerous additional grey and METAL2-based textures also available.
   - Boss brain wall found to have Hexen resources and was re-done.
   - Wolfenstein replacements completely redone, designed to work as seamlessly with other textures as possible. A few are also added.