### PR TITLE
solarus: enable for arm64

### DIFF
--- a/scriptmodules/ports/solarus.sh
+++ b/scriptmodules/ports/solarus.sh
@@ -12,10 +12,9 @@
 rp_module_id="solarus"
 rp_module_desc="Solarus - A lightweight, free and open-source game engine for Action-RPGs"
 rp_module_help="Copy your Solarus quests (games) to $romdir/solarus"
-rp_module_licence="GPL3 https://gitlab.com/solarus-games/solarus/raw/dev/license.txt"
+rp_module_licence="GPL3 https://gitlab.com/solarus-games/solarus/-/raw/dev/license"
 rp_module_repo="git https://gitlab.com/solarus-games/solarus.git master"
 rp_module_section="opt"
-rp_module_flags="!aarch64"
 
 function _options_cfg_file_solarus() {
     echo "$configdir/solarus/options.cfg"


### PR DESCRIPTION
Fixed the licence link and removed the arm64 restriction.

The restriction was added in [1] for Odroid-C2, when `libluajit-5.1-dev` was not available. But that was in 2016 and I think the Ubuntu 20.04 image that's available now for C2 (or a current Armbian release based on Debian/Ubuntu) does have it [2].

[1] https://github.com/RetroPie/RetroPie-Setup/commit/acba46e0953ac74055a085b40e6e4f2b9eb67a65
[2] https://packages.ubuntu.com/noble/arm64/libluajit-5.1-dev/download