### PR TITLE
lr-atari800: patch sound regression locally

### DIFF
--- a/scriptmodules/libretrocores/lr-atari800.sh
+++ b/scriptmodules/libretrocores/lr-atari800.sh
@@ -18,6 +18,7 @@ rp_module_section="main"
 
 function sources_lr-atari800() {
     gitPullOrClone
+    applyPatch "$md_data/01_fix_audio_volume.diff"
 }
 
 function build_lr-atari800() {

--- a/scriptmodules/libretrocores/lr-atari800/01_fix_audio_volume.diff
+++ b/scriptmodules/libretrocores/lr-atari800/01_fix_audio_volume.diff
@@ -1,0 +1,35 @@
+diff --git a/libretro/core-mapper.c b/libretro/core-mapper.c
+index 66de339..44a8b0f 100644
+--- a/libretro/core-mapper.c
++++ b/libretro/core-mapper.c
+@@ -26,7 +26,7 @@ unsigned long  Ktime=0 , LastFPSTime=0;
+ #endif 
+ 
+ //SOUND
+-unsigned char SNDBUF[1024*2*2];
++short signed int SNDBUF[1024*2];
+ int snd_sampler_pal = 44100 / 50;
+ int snd_sampler_ntsc = 44100 / 60;
+ 
+@@ -155,7 +155,7 @@ void retro_sound_update(void)
+ 
+    if (! UI_is_active)
+    {
+-      Sound_Callback(SNDBUF, 1024*2*2);
++      Sound_Callback((UBYTE *)SNDBUF, 1024*2*2);
+       for(x=0;x<stop*2;x+=2)
+          retro_audio_cb(SNDBUF[x],SNDBUF[x+2]);
+ 
+diff --git a/libretro/libretro-core.c b/libretro/libretro-core.c
+index aa3fed8..d65f345 100644
+--- a/libretro/libretro-core.c
++++ b/libretro/libretro-core.c
+@@ -135,7 +135,7 @@ extern int ToggleTV;
+ extern int CURRENT_TV;
+ 
+ extern int SHIFTON, pauseg, SND;
+-extern unsigned char SNDBUF[];
++extern short signed int SNDBUF[1024 * 2];
+ 
+ char RPATH[512];
+ char RETRO_DIR[512];


### PR DESCRIPTION
A buildfix patch [1] has been commited recently, but it introduced a regression [2]. Use the patch from [3] to replace the buildfix patch, since it has no side effects, until the libretro repository patches the issue.

[1] https://github.com/libretro/libretro-atari800/pull/92
[2] https://github.com/libretro/libretro-atari800/issues/96, https://retropie.org.uk/forum/topic/35513/
[3] https://github.com/libretro/libretro-atari800/pull/95