### PR TITLE
mame/lr-mame - fix building on bullseye

### DIFF
--- a/scriptmodules/emulators/mame.sh
+++ b/scriptmodules/emulators/mame.sh
@@ -19,7 +19,7 @@ rp_module_flags="!mali !armv6 !:\$__gcc_version:-lt:7"
 
 function _get_branch_mame() {
     # starting with 0.265, GCC 10.3 or later is required for full C++17 support
-    if [[ "$__gcc_version" -lt 10 ]]; then
+    if compareVersions "$(gcc -dumpfullversion)" lt 10.3.0; then
         echo "mame0264"
         return
     fi

--- a/scriptmodules/libretrocores/lr-mame.sh
+++ b/scriptmodules/libretrocores/lr-mame.sh
@@ -13,16 +13,14 @@ rp_module_id="lr-mame"
 rp_module_desc="MAME emulator - MAME (current) port for libretro"
 rp_module_help="ROM Extension: .zip\n\nCopy your MAME roms to either $romdir/mame-libretro or\n$romdir/arcade"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/mame/master/COPYING"
-rp_module_repo="git https://github.com/libretro/mame.git master :_get_version_lr-mame"
+rp_module_repo="git https://github.com/libretro/mame.git :_get_version_lr-mame"
 rp_module_section="exp"
 rp_module_flags="!:\$__gcc_version:-lt:7"
 
 function _get_version_lr-mame() {
-    local tagname
-    if [[ "$__gcc_version" -lt 10 ]]; then
-        tagname="lrmame0264"
+    if compareVersions "$(gcc -dumpfullversion)" lt 10.3.0; then
+        echo "lrmame0264"
     fi
-    echo "$tagname"
 }
 function _get_params_lr-mame() {
     local params=(OSD=retro RETRO=1 PYTHON_EXECUTABLE=python3 NOWERROR=1 OS=linux OPTIMIZE=2 TARGETOS=linux CONFIG=libretro NO_USE_MIDI=1 NO_USE_PORTAUDIO=1 TARGET=mame)


### PR DESCRIPTION
 * MAME specifically checks for GCC 10.3 so we need to compare with the full GCC version as bullseye has 10.2.
 * lr-mame - Remove "master" branch from rp_module_repo so the _get_version tag is passed as a branch to checkout
 * lr-mame - Simplify _get_version_lr-mame as the tagname variable was only used once