### PR TITLE
mupen64plus - use full commit hash for pinning GLideN64

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -66,7 +66,7 @@ function _get_repos_mupen64plus() {
         commit="8a9d52b41b33d853445f0779dd2b9f5ec4ecdda8"
     fi
     # avoid a GLideN64 regression introduced in 1a0621d
-    isPlatform "gles" && commit="5bbf55df"
+    isPlatform "gles" && commit="5bbf55df8c61ab86b5e41a97906bc99ce9b00a36"
     repos+=("gonetz GLideN64 master $commit")
 
     local repo


### PR DESCRIPTION
The mupen64plus package will contain an md5sum of all the mupen64plus repos last git commit.

As it will get a full hash for each repo, but the update check will compare using any hashes stored in the repos variable, it will mismatch and think there has been an update.