### PR TITLE
tyrquake - switch to RetroPie github mirror

### DIFF
--- a/scriptmodules/ports/tyrquake.sh
+++ b/scriptmodules/ports/tyrquake.sh
@@ -12,7 +12,7 @@
 rp_module_id="tyrquake"
 rp_module_desc="Quake 1 engine - TyrQuake port"
 rp_module_licence="GPL2 https://disenchant.net/git/tyrquake.git/plain/gnu.txt"
-rp_module_repo="git git://disenchant.net/tyrquake master"
+rp_module_repo="git https://github.com/RetroPie/tyrquake.git master"
 rp_module_section="opt"
 
 function depends_tyrquake() {


### PR DESCRIPTION
The upstream repo git://disenchant.net/tyrquake is currently not working. Cloning via https://disenchant.net/git/tyrquake.git works, but is slow.

Switch to the updated RetroPie mirror at https://github.com/RetroPie/tyrquake.git