### PR TITLE
packages - fix install of modules with nonet flag when not connected

### DIFF
--- a/scriptmodules/packages.sh
+++ b/scriptmodules/packages.sh
@@ -150,7 +150,7 @@ function rp_callModule() {
             isConnected && has_net=1
 
             # for modules with nonet flag that don't need to download data, we force has_net to 1
-            hasFlag "${__mod_info[$id/flags]}" "nonet" && has_net=1
+            hasFlag "${__mod_info[$md_id/flags]}" "nonet" && has_net=1
 
             if [[ "$has_net" -eq 1 ]]; then
                 rp_hasBinary "$md_id"


### PR DESCRIPTION
This allows updating/reinstalling of modules with the nonet flag set (retropiemenu and runcommand) when no internet connection is available.

Incorrect variable was used in comparison ($id instead of $md_id), so the has_net wasn't forced to 1.