### PR TITLE
lr-stella - fix building on GCC v8 (on buster)

### DIFF
--- a/scriptmodules/libretrocores/lr-stella.sh
+++ b/scriptmodules/libretrocores/lr-stella.sh
@@ -17,9 +17,9 @@ rp_module_repo="git https://github.com/stella-emu/stella.git master :_get_commit
 rp_module_section="exp"
 
 function _get_commit_lr-stella() {
-    # GCC 11 is required after fd35ce62
+    # GCC 11 is required after 2d57f9e0
     if [[ "$__gcc_version" -lt 11 ]]; then
-        echo "fd35ce62"
+        echo "2d57f9e0"
     fi
 }
 


### PR DESCRIPTION
C++20 changes were added in 7a85faef which broke compatibility with GCC 8.

GCC 10 compatibility was removed a few commits later in a8a23f61

Fix to commit 2d57f9e0 (last building on GCC 8) on GCC < 11