### PR TITLE
image: switch to LZMA for compression

### DIFF
--- a/scriptmodules/admin/image.sh
+++ b/scriptmodules/admin/image.sh
@@ -364,15 +364,15 @@ function platform_image() {
     [[ "$make_bb" -eq 1 ]] && rp_callModule image create_bb "$dest/${image_base}-berryboot.img256"
 
     printMsgs "console" "Compressing ${image_name} ..."
-    gzip -c "$image_file" > "${image_file}.gz"
+    xz -v --compress --stdout "$image_file" > "${image_file}.xz"
 
     printMsgs "console" "Generating JSON data for rpi-imager ..."
     local template
     template="$(<"$md_data/template.json")"
-    template="${template/IMG_PATH/$__version\/${image_name}.gz}"
+    template="${template/IMG_PATH/$__version\/${image_name}.xz}"
     template="${template/IMG_EXTRACT_SIZE/$(stat -c %s $image_file)}"
     template="${template/IMG_SHA256/$(sha256sum $image_file | cut -d" " -f1)}"
-    template="${template/IMG_DOWNLOAD_SIZE/$(stat -c %s ${image_file}.gz)}"
+    template="${template/IMG_DOWNLOAD_SIZE/$(stat -c %s ${image_file}.xz)}"
     template="${template/IMG_VERSION/$__version}"
     template="${template/IMG_PLATFORM/$image_title}"
     template="${template/IMG_DATE/$(date '+%Y-%m-%d')}"


### PR DESCRIPTION
Using LZMA (xz) for compression instead LZ77 (gzip) reduces the image size by approx 30% more. Image writing utilities with compressed image support (RPI Imager, Balena Etcher) already support it and the RaspiOS or Armbian images are already distributed as `.xz` files.

Changed our image compression format from `.gz` to `.xz` and thus reduce the download size for all images.