### PR TITLE
Update Yamagi Quake 2 to version 8.40

### DIFF
--- a/scriptmodules/ports/yquake2.sh
+++ b/scriptmodules/ports/yquake2.sh
@@ -12,7 +12,7 @@
 rp_module_id="yquake2"
 rp_module_desc="yquake2 - The Yamagi Quake II client"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/yquake2/yquake2/master/LICENSE"
-rp_module_repo="git https://github.com/yquake2/yquake2.git QUAKE2_8_30"
+rp_module_repo="git https://github.com/yquake2/yquake2.git QUAKE2_8_40"
 rp_module_section="exp"
 rp_module_flags=""
 
@@ -25,8 +25,8 @@ function depends_yquake2() {
 function sources_yquake2() {
     gitPullOrClone
     # get the add-ons sources
-    gitPullOrClone "$md_build/xatrix" "https://github.com/yquake2/xatrix" "XATRIX_2_12"
-    gitPullOrClone "$md_build/rogue" "https://github.com/yquake2/rogue" "ROGUE_2_11"
+    gitPullOrClone "$md_build/xatrix" "https://github.com/yquake2/xatrix" "XATRIX_2_13"
+    gitPullOrClone "$md_build/rogue" "https://github.com/yquake2/rogue" "ROGUE_2_12"
 }
 
 function build_yquake2() {


### PR DESCRIPTION
Released a few days ago, this version includes more practical weapon switching by repeteadly tapping "_next weapon_" or "_previous weapon_" buttons/keys, allowing you to skip over the list of guns. Also, cvars to set laser beams' transparency (`cl_laseralpha`) and show the player speed (`cl_showspeed`). Platforms that can use the GL1 renderer are the most benefitted, since there are a lot of optimizations for it.
Expansions / Mission Packs have been updated as well.