### PR TITLE
supermodel3: add the Assets folder in x86

### DIFF
--- a/scriptmodules/emulators/supermodel3.sh
+++ b/scriptmodules/emulators/supermodel3.sh
@@ -49,6 +49,7 @@ function install_supermodel3() {
         'Docs/LICENSE.txt'
         'Docs/README.txt'
     )
+    isPlatform "x86" && md_ret_files+=("Assets")
 }
 
 function configure_supermodel3() {
@@ -75,10 +76,12 @@ function configure_supermodel3() {
     mkUserDir "$conf_dir/NVRAM"
     mkUserDir "$conf_dir/Saves"
     mkUserDir "$conf_dir/Config"
+    isPlatform "x86" && mkUserDir "$conf_dir/Assets"
 
     # on upgrades keep the local config, but overwrite the game configs
     copyDefaultConfig "$md_inst/Config/Supermodel.ini" "$conf_dir/Config/Supermodel.ini"
     cp -f "$md_inst/Config/Games.xml" "$conf_dir/Config/"
+    isPlatform "x86" && cp -fr "$md_inst/Assets" "$conf_dir"
     chown -R "$user:$user" "$conf_dir"
 
     cat >"$md_inst/supermodel.sh" <<_EOF_


### PR DESCRIPTION
The folder contains the crosshairs bitmaps used in the `main` branch, installed only `x86`.

Should replace https://github.com/RetroPie/RetroPie-Setup/pull/3961.