### PR TITLE
Update Yamagi Quake 2 to version 8.41

### DIFF
--- a/scriptmodules/ports/yquake2.sh
+++ b/scriptmodules/ports/yquake2.sh
@@ -12,7 +12,7 @@
 rp_module_id="yquake2"
 rp_module_desc="yquake2 - The Yamagi Quake II client"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/yquake2/yquake2/master/LICENSE"
-rp_module_repo="git https://github.com/yquake2/yquake2.git QUAKE2_8_40"
+rp_module_repo="git https://github.com/yquake2/yquake2.git QUAKE2_8_41"
 rp_module_section="exp"
 rp_module_flags=""
 


### PR DESCRIPTION
This is a hotfix release, intended to amend [a small bug introduced by yours truly](https://github.com/yquake2/yquake2/pull/1133); it only affects the GL1 renderer.
Also fixes a SDL sound bug in Windows.