### PR TITLE
lr-scummvm: disable GL(ES) context creation with legacy drivers

### DIFF
--- a/scriptmodules/libretrocores/lr-scummvm.sh
+++ b/scriptmodules/libretrocores/lr-scummvm.sh
@@ -72,6 +72,9 @@ function configure_lr-scummvm() {
     # enable speed hack core option if running in arm platform
     isPlatform "arm" && setRetroArchCoreOption "scummvm_speed_hack" "enabled"
 
+    # on videocore platforms, disable the HW GL context since it leads to a crash
+    isPlatform "videocore" && setRetroArchCoreOption "scummvm_video_hw_acceleration" "disabled"
+
     # create retroarch launcher for lr-scummvm with support for rom directories
     # containing svm files inside (for direct game directory launching in ES)
     cat > "$md_inst/romdir-launcher.sh" << _EOF_


### PR DESCRIPTION
Due to the old EGL version implemented by the old BRCM GLES drivers, the core cannot obtain a (HW) GL context to be used for accelerated video output. Disable this feature on systems using the old/legacy GLES(2) driver.

See https://github.com/libretro/scummvm/issues/59 for context.