### PR TITLE
Hypseus: Simplify multigame zipped ROM +  add dependencies for (v2.11.4)

### DIFF
--- a/scriptmodules/emulators/hypseus.sh
+++ b/scriptmodules/emulators/hypseus.sh
@@ -52,7 +52,7 @@ function configure_hypseus() {
     mkRomDir "daphne/roms"
 
     addEmulator 0 "$md_id" "daphne" "$md_inst/hypseus.sh %ROM%"
-    addSystem "daphne"
+    addSystem "daphne" "Hypseus" ".zlua"
 
     [[ "$md_mode" == "remove" ]] && return
 
@@ -78,17 +78,27 @@ function configure_hypseus() {
     cat >"$md_inst/hypseus.sh" <<_EOF_
 #!/bin/bash
 dir="\$1"
-name="\${dir##*/}"
-name="\${name%.*}"
+path=\$(dirname "\$dir")
+name=\$(basename "\${dir%.*}")
+ext="\${dir##*.}"
 
-if [[ -f "\$dir/\$name.commands" ]]; then
-    params=\$(<"\$dir/\$name.commands")
+if [[ "\$ext" == "zlua" ]]; then
+    parent=\$(awk '{\$1=\$1; print}' < "\$1")
+    dir="\$path/\$parent"
+    parent="\${parent##*/}"
+    params="-usealt \$name"
+else
+    parent="\$name"
 fi
 
-if [[ -f "\$dir/\$name.singe" ]]; then
-    singerom="\$dir/\$name.singe"
-elif [[ -f "\$dir/\$name.zip" ]]; then
-    singerom="\$dir/\$name.zip"
+if [[ -f "\$dir/\$name.commands" ]]; then
+    params="\${params:+\$params }\$(<"\$dir/\$name.commands")"
+fi
+
+if [[ -f "\$dir/\$parent.singe" ]]; then
+    singerom="\$dir/\$parent.singe"
+elif [[ -f "\$dir/\$parent.zip" ]]; then
+    singerom="\$dir/\$parent.zip"
 fi
 
 if [[ -n "\$singerom" ]]; then

--- a/scriptmodules/emulators/hypseus.sh
+++ b/scriptmodules/emulators/hypseus.sh
@@ -18,7 +18,7 @@ rp_module_section="exp"
 rp_module_flags="sdl2"
 
 function depends_hypseus() {
-    getDepends libvorbis-dev libogg-dev zlib1g-dev libzip-dev libmpeg2-4-dev libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev cmake
+    getDepends libvorbis-dev libogg-dev zlib1g-dev libzip-dev libmpeg2-4-dev libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev cmake
 }
 
 function sources_hypseus() {
@@ -40,6 +40,7 @@ function build_hypseus() {
 function install_hypseus() {
     md_ret_files=(
         'sound'
+        'midi'
         'pics'
         'fonts'
         'hypseus.bin'


### PR DESCRIPTION
This addition allows the new multi-game (zip) ROM's to be used without the need for symlinking.

This will aide: **actionmax**, **captainpower** and _SEGA_ **videodriver** multi games, to now:

 ``` 
roms
|-- daphne
|    |
|    |-- cpower1.zlua (single line containing parent zipname "captainpower")
|    |
|    |-- captainpower
|    |    |
|    |    |-- captainpower.zip [Main zipped LUA package]
|    |    |-- cpower1.commands (Optional)
|    |    |-- cpower1.txt      [Video Framefiles]
|    |    |-- cpower2.txt
|    |    |-- ...
|    |    |-- video
|    |
|    |
|    |
|    |-- 38ambushalley.zlua (single line containing parent zipname "actionmax")
|    |
|    |-- actionmax
|    |    |
|    |    |-- actionmax.zip          [Main zipped LUA package]
|    |    |-- 38ambushalley.commands (Optional)
|    |    |-- 38ambushalley.txt      [Video Framefiles]
|    |    |-- bluethunder.txt
|    |    |-- ...
|    |    |-- video_actionmaxintro.m2v
|    |    |-- video_actionmaxintro.ogg
|    |    |-- video_menu.m2v
|    |    |-- video_menu.ogg
|    |    |-- <game video subfolders>
```

Note: `-texturetarget` will also be required to be added to the .commands file for:

    actionmax
    captainpower

 (_It's currently negated, with `-texturestream`, by the **current** scriptmodule due to the old SDL version used._)

_Further Note:_

RetroPie v4.8 will not allow actionmax and captainpower to work, due to the outdated _SDL2 (2.0.10)_.
Debian Bookworm based installations work correctly (Pi4 and Pi5 tested).

A binary build of v2.11.3 should probably be provided to cover the new `-usealt` argument. Although it would only be called using the new `.zlua` extension.

Not certain, how, or indeed when, you would wish to merge in the RetroPie update process due to the later SDL versions required for the new game types.

_Footnote:_ `.zlua` is the acronym for Zipped LUA ROM introduced in the _2.11.x_ Hypseus versions.