### PR TITLE
sdl2 - update to 2.30.8

### DIFF
--- a/scriptmodules/supplementary/sdl2.sh
+++ b/scriptmodules/supplementary/sdl2.sh
@@ -17,7 +17,7 @@ rp_module_flags=""
 
 function get_ver_sdl2() {
     if [[ "$__os_debian_ver" -ge 11 ]]; then
-        echo "2.26.3"
+        echo "2.30.8"
     else
         echo "2.0.10"
     fi


### PR DESCRIPTION
Binaries for bullseye are available.

Replaces #3856
