### PR TITLE
xpad: force version on kernel module

### DIFF
--- a/scriptmodules/supplementary/xpad.sh
+++ b/scriptmodules/supplementary/xpad.sh
@@ -34,6 +34,11 @@ function sources_xpad() {
     applyPatch "$md_data/01_enable_leds_and_trigmapping.diff"
     # Tell 'dkms' to use the 'updates' kernel module folder to store the module
     applyPatch "$md_data/02_dkms_updates_folder.diff"
+
+    # Force a module version, otherwise 'dkms' refuses to override the built-in module
+    if ! grep -q MODULE_VERSION xpad.c; then
+        applyPatch "$md_data/03_xpad_add_version.diff"
+    fi
 }
 
 function build_xpad() {

--- a/scriptmodules/supplementary/xpad/03_xpad_add_version.diff
+++ b/scriptmodules/supplementary/xpad/03_xpad_add_version.diff
@@ -1,0 +1,7 @@
+diff --git a/xpad.c b/xpad.c
+index 43985dd..8ea2991 100644
+@@ -2497,3 +2500,4 @@ module_usb_driver(xpad_driver);
+ MODULE_AUTHOR("Marko Friedemann <mfr@bmx-chemnitz.de>");
+ MODULE_DESCRIPTION("X-Box pad driver");
+ MODULE_LICENSE("GPL");
++MODULE_VERSION("0.4");


### PR DESCRIPTION
DKMS in Bookworm has a bug[1] where the autoinstall function on kernel updates fails due to a miscalculated version comparison, thinking always that the kernel version is newer than the custom version and skipping the installation. The message shown during upgrades is:

    xpad.ko.xz:
    Running module version sanity check.
    Module version  for xpad.ko.xz exactly matches what is already found in kernel
    DKMS will not replace this module.
    You may override by specifying --force.

Added a module version (copied from the `dkms.conf`'s package version) to have 'dkms' always install the out-of-tree version.

[1] https://github.com/dell/dkms/issues/296, fixed by https://github.com/dell/dkms/pull/297