### PR TITLE
amiberry: fix 'campsimg' plugin installation

### DIFF
--- a/scriptmodules/emulators/amiberry.sh
+++ b/scriptmodules/emulators/amiberry.sh
@@ -83,14 +83,14 @@ function sources_amiberry() {
 
 function build_amiberry() {
     local platform=$(_get_platform_amiberry)
+    make clean
     cd external/capsimg
     ./bootstrap
     ./configure
     make clean
     make
-    cp "*capsimg.so" "$md_build/plugins"
+    cp capsimg.so "$md_build/plugins"
     cd "$md_build"
-    make clean
     make PLATFORM="$platform" CPUFLAGS="$__cpu_flags"
     md_ret_require="$md_build/amiberry"
 }


### PR DESCRIPTION
The 'capsimg.so' wasn't properly copied after build to the plugins folder, making Amiberry unable to load IPF files. Also fixes - apparently - a double free crash on the Pi4 build.