### PR TITLE
xpad: fix building on Buster kernels

### DIFF
--- a/scriptmodules/supplementary/xpad.sh
+++ b/scriptmodules/supplementary/xpad.sh
@@ -39,6 +39,11 @@ function sources_xpad() {
     if ! grep -q MODULE_VERSION xpad.c; then
         applyPatch "$md_data/03_xpad_add_version.diff"
     fi
+
+    # Fix building Buster, which has an older kernel
+    if [[ "$__os_debian_ver" -le 10 ]];  then
+        applyPatch "$md_data/04_fix_build_with_buster.diff"
+    fi
 }
 
 function build_xpad() {

--- a/scriptmodules/supplementary/xpad/04_fix_build_with_buster.diff
+++ b/scriptmodules/supplementary/xpad/04_fix_build_with_buster.diff
@@ -1,0 +1,14 @@
+diff --git a/xpad.c b/xpad.c
+index 9e0bd01..6e8231a 100644
+--- a/xpad.c
++++ b/xpad.c
+@@ -72,6 +72,9 @@
+ #include <linux/usb/quirks.h>
+
+ #define XPAD_PKT_LEN 64
++#ifndef ABS_PROFILE
++#define ABS_PROFILE 0x21
++#endif
+
+ /*
+  * xbox d-pads should map to buttons, as is required for DDR pads


### PR DESCRIPTION
Due to a recent merge of upstream code, the module no longer builds on Linux kernel 5.10, included in Raspberry Pi OS 'buster'. The change needed to compile is minimal, it's caused by a missing event code from 'input-event-codes.h', part of the kernel's UAPI headers.

I've opened an issue at https://github.com/paroj/xpad/issues/291, but in the mean time we can add a small patch for older OSes to fix updating/building the module.