### PR TITLE
joy2key: use 'uinput' for emitting keyboard events

### DIFF
--- a/scriptmodules/admin/joy2key.sh
+++ b/scriptmodules/admin/joy2key.sh
@@ -19,7 +19,7 @@ function _update_hook_joy2key() {
 }
 
 function depends_joy2key() {
-    local depends=(python3-urwid)
+    local depends=(python3-urwid python3-uinput)
     # 'python3-sdl2' might not be available
     # it's packaged in Debian starting with version 11 (Bullseye)
     local p_ver
@@ -78,7 +78,10 @@ esac
 exit 0
 _EOF_
     chmod +x "$wrapper"
-
+    if ! grep -q "uinput" /etc/modules; then
+        addLineToFile "uinput" "/etc/modules"
+    fi
+    modprobe uinput
     joy2keyStart
 }
 

--- a/scriptmodules/admin/joy2key/joy2key_sdl.py
+++ b/scriptmodules/admin/joy2key/joy2key_sdl.py
@@ -12,29 +12,26 @@ Command line joystick to keyboard translator, using SDL2 for event handling
 Example usage:
  <script> kcub1 kcuf1 kcuu1 kcud1 0x0a 0x20 0x1b 0x00 kpp knp [--debug|-d]
 See https://pubs.opengroup.org/onlinepubs/7908799/xcurses/terminfo.html for termcap codes
+NB: not all capabilities are supported, but more can be added to the TERM_EVENTS below
 
 SDL2 event handling is based on EmulationStation's event handling, see
 https://github.com/RetroPie/EmulationStation/blob/62fd08c26d2f757259b7d890c98c0d7e212f6f84/es-core/src/InputManager.cpp#L205
 EmulationStation is authored by Alec "Aloshi" Lofquist (http://www.aloshi.com,http://www.emulationstation.org)
 
-This script uses the PySDL2 python module from https://github.com/marcusva/py-sdl2.
-Install it before running the script with:
- pip3 install -U git+https://github.com/marcusva/py-sdl2.git
+This script uses the PySDL2 module from https://github.com/py-sdl/py-sdl2
+This script uses the Python-uinput module from https://github.com/tuomasjjrasanen/python-uinput
 """
 
 import logging
-import fcntl
 import sys
-import curses
-import termios
 import signal
-import os.path
 import re
+import os
+import uinput
 
 from argparse import ArgumentParser
 from ctypes import create_string_buffer, byref
 from configparser import ConfigParser
-from pwd import getpwnam
 from sdl2 import joystick, events, version, \
     SDL_WasInit, SDL_Init, SDL_QuitSubSystem, SDL_GetError, \
     SDL_INIT_JOYSTICK, version_info, \
@@ -74,6 +71,43 @@ JS_HAT_VALUES = {
     "left": SDL_HAT_LEFT,
     "right": SDL_HAT_RIGHT
 }
+
+# Map termios capabilitu codes to Linux (uinput) event ids, for backwards compatibility
+# List of possible event IDs:
+# https://github.com/tuomasjjrasanen/python-uinput/blob/master/src/ev.py
+TERM_EVENTS = {
+    "kcub1": 105, # left
+    "kcuf1": 106, # right
+    "kcud1": 108, # down
+    "kcuu1": 103, # up
+    "khome": 102, # home
+    "kbs"  : 14,  # backspace
+    "kend" : 107, # end
+    "knp"  : 109, # page-up
+    "kpp"  : 104, # page-down
+    "kent" : 28,  # enter
+    "kf1"  : 59,  # F1
+    "kf2"  : 60,  # F2
+    "kf3"  : 61,  # F3
+    "kf4"  : 62,  # F4
+    "kf5"  : 63,  # F5
+    "kf6"  : 64,  # F6
+    "kf7"  : 65,  # F7
+    "kf8"  : 66,  # F8
+    "kf9"  : 67,  # F9
+    "kf10" : 68   # F10
+}
+
+# A charmap with 'ascii_code': 'event_id', needed to translate hex valued parameters
+# Copy the one defined in 'uinput', so we can extend it since it's missing some entries
+CHAR_MAP = { ord(x):y[1] for (x,y) in uinput._CHAR_MAP.items() }
+# add our entries to the map, so we can translate them
+CHAR_MAP[27]  = 1   # Escape 
+CHAR_MAP[61]  = 13  # Equals (=)
+CHAR_MAP[43]  = 12  # Minus (-)
+CHAR_MAP[91]  = 26  # Left bracket ([)
+CHAR_MAP[93]  = 27  # Right bracket (])
+CHAR_MAP[127] = 111 # Delete
 
 # RetroPie configurations directory
 CONFIG_DIR = '/opt/retropie/configs'
@@ -275,7 +309,7 @@ Remove all queued events for a device
 def remove_events_for_device(event_queue: dict, dev_index: int):
     return { key:value for (key,value) in event_queue.items() if not key.startswith(f"{dev_index}_")}
 
-def event_loop(configs, joy_map, tty_fd):
+def event_loop(configs, joy_map):
     event = SDL_Event()
 
     # keep of dict of active joystick devices as a dict of
@@ -293,6 +327,11 @@ def event_loop(configs, joy_map, tty_fd):
 
     # keep track of axis previous values
     axis_prev_values = {}
+
+    # instantiate a keyboard device with uinput to send the translated joypad inputs as keys
+    keyboard_events = [ (0x1,code) for code in joy_map.values() ]
+    LOG.debug(f'Creating uinput keyboard devices with events: {keyboard_events}')
+    kbd = uinput.Device(events=keyboard_events, name="Joy2Key Keyboard")
 
     def handle_new_input(e: SDL_Event, axis_norm_value: int = 0) -> bool:
         """
@@ -401,12 +440,13 @@ def event_loop(configs, joy_map, tty_fd):
         if len(event_queue):
             emitted_events = filter_active_events(event_queue)
             if len(emitted_events):
-                LOG.debug(f'Events emitted: {emitted_events}')
+                LOG.debug(f'Events to emit: {emitted_events}')
             # send the events mapped key code(s) to the terminal
             for k in emitted_events:
                 if k in joy_map:
-                    for c in joy_map[k]:
-                        fcntl.ioctl(tty_fd, termios.TIOCSTI, c)
+                    c = joy_map[k]
+                    LOG.debug(f'Emitting input code {c}')
+                    kbd.emit_click( (0x1,c) )
 
         SDL_Delay(JS_POLL_DELAY)
 
@@ -443,18 +483,34 @@ def ra_btn_swap_config():
 
     return menu_swap
 
+def get_uinput_event(key_str: str):
+    """
+    For a Termios control string or an ASCII hex code, return the Linux scancode (integer)
+    See https://github.com/tuomasjjrasanen/python-uinput/blob/master/src/ev.py for an enumeratin of scancodes
 
-def get_hex_chars(key_str: str):
+    If 'key_str' starts with '0x', it's assumed to be a hexadecimal value of an ASCII char,
+    otherwise it's presumed to be a termios control string tied to the terminal's capabilities
+    """
     try:
-        if key_str.startswith('0x'):
-            out = bytes.fromhex(key_str[2:])
-        else:
-            out = curses.tigetstr(key_str)
-        return out.decode('utf-8')
-    except Exception as e:
-        LOG.debug(f'Cannot get hex chars from {key_str}, value ignored')
-        return None
+        if key_str.startswith('/'):
+            # ignore any device name - they're not part of our assignment
+            return None
 
+        if key_str.startswith('0x'):
+            out = int(key_str,0)
+            # hex numbers are considered ASCII codes for keyboard keys
+            # we need to translate them to Linux input scancodes
+            out = CHAR_MAP[out]
+        else:
+            if (key_str in TERM_EVENTS.keys()):
+                out = TERM_EVENTS[key_str]
+            else:
+                LOG.warning(f'Unsupported termios control code "{key_str}", value ignored')
+                return 0
+        return out
+    except Exception as e:
+        LOG.debug(f'Cannot determine input code for "{key_str}", value ignored')
+        return 0
 
 def _SDL_JoystickGetGUIDString(guid, pszGUID, cbGUID):
     """
@@ -478,8 +534,7 @@ def main():
     def signal_handler(signum, frame):
         signal.signal(signal.SIGINT, signal.SIG_IGN)
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        if tty_fd:
-            os.close(tty_fd)
+
         if SDL_WasInit(SDL_INIT_JOYSTICK) == SDL_INIT_JOYSTICK:
             SDL_QuitSubSystem(SDL_INIT_JOYSTICK)
         SDL_Quit()
@@ -492,19 +547,14 @@ def main():
 
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
-    # daemonize after signal handlers are registered
-    if os.fork():
-        os._exit(0)
+    # when running with no debugging, daemonize after signal handlers are registered
+    if not debug_flag:
+        if os.fork():
+            os._exit(0)
+    else:
+        LOG.debug(f'Debugging enabled, running in foreground')
 
-    try:
-        tty_fd = os.open('/dev/tty', os.O_WRONLY)
-    except IOError:
-        LOG.error('Unable to open /dev/tty', file=sys.stderr)
-        sys.exit(1)
-
-    curses.setupterm()
-    mapped_chars = [get_hex_chars(code) for code in hex_chars if get_hex_chars(code) is not None]
-
+    mapped_chars = [get_uinput_event(code) for code in hex_chars if get_uinput_event(code) is not None]
     def_buttons = ['left', 'right', 'up', 'down', 'a', 'b', 'x', 'y', 'pageup', 'pagedown']
     joy_map = {}
     # add for each button the mapped keycode, based on the arguments received
@@ -512,6 +562,7 @@ def main():
         if i < len(mapped_chars):
             joy_map[btn] = mapped_chars[i]
 
+    LOG.debug(f'Joy map:\n {joy_map}')
     menu_swap = ra_btn_swap_config()
     # if button A is <enter> and menu_swap_ok_cancel_buttons is true, swap buttons A and B functions
     if menu_swap \
@@ -546,7 +597,7 @@ def main():
     if joystick.SDL_NumJoysticks() < 1:
         LOG.debug(f'No available joystick devices found on startup')
 
-    event_loop(configs, joy_map, tty_fd)
+    event_loop(configs, joy_map)
 
     SDL_QuitSubSystem(SDL_INIT_JOYSTICK)
     SDL_Quit()


### PR DESCRIPTION
Recent Linux kernels (6.2+) have the ability to disable the 'TIOCSTI' ioctl, thus rendering unusable the method of sending keyboard events to the controlling terminal via `fcntl.ioctl` [1]. Not all distributions have left it enabled currently, but Ubuntu 24.04 has it enabled, affecting the `runcommand` ability to generate keyboard events for a joystick.

Use the `python-uinput` module to create a virtual keyboard and send the proper events through it, without relying on the 'curses' or 'fcntl' modules. Now, since the new module doesn't know about Termios codes, which were used previously, I've added a translation table to accomodate scripts using those capability codes. The `python-uinput` uses the Linux event codes [2].

The new method needs the `uinput` Linux kernel module to be loaded beforehand - so add the module to be automatically loaded. The user also needs to be part of the 'input' group, otherwise they won't be able to use the `uinput` interface -  RetroPie doesn't automate that, but assumes the installation user belongs to that group.

We also don't need the `termios`/`fnctl` calls, so the terminal handling part has been removed, simpplifying a bit the code.

OTHER changes:
 - the device path (/dev/jsX) is now ignored. It hasn't been working since the switch to SDL2 for input processing, but was still parsed for compatibility with the old version.
 - when invoking with the debug (--debug|-d) parameter, the script now runs in the foreground, instead of forking and running in the background. It's easier when running it to diagnose issues; running with debugging enabled should not be used for regular usage.

== PR notes

 This change adds a new dependency for `joy2key`, but `python-uinput` is already shipped in Debian/Ubuntu so it shouldn't be an issue. Ubuntu adds `uinput` support into the kernel, so there's no need to load the module.

 It doesn't seem that the new dependency and the `uinput` initialization in Python adds any noticeable overhead (tested on Pi3/Pi4 with sdcard), but it could be impacting very slow systems (slow storage ?).
 
[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=83efeeeb3d04b22aaed1df99bc70a48fe9d22c4d
[2] https://github.com/tuomasjjrasanen/python-uinput/blob/master/src/ev.py