### PR TITLE
joy2key: ensure the install user is part of 'input' group

### DIFF
--- a/scriptmodules/admin/joy2key.sh
+++ b/scriptmodules/admin/joy2key.sh
@@ -82,6 +82,10 @@ _EOF_
         addLineToFile "uinput" "/etc/modules"
     fi
     modprobe uinput
+
+    # make sure the install user is part of 'input' group
+    usermod -a -G input "$__user"
+
     joy2keyStart
 }
 


### PR DESCRIPTION
On RaspiOS, the install user is part of the `input` group by default, but on Ubuntu is not. Add it during install so that `joy2key` can work as regular user (i.e. as part of `runcommand`).