### PR TITLE
joy2key: add udev rule for /dev/uinput permissions

### DIFF
--- a/scriptmodules/admin/joy2key.sh
+++ b/scriptmodules/admin/joy2key.sh
@@ -81,6 +81,10 @@ _EOF_
     if ! grep -q "uinput" /etc/modules; then
         addLineToFile "uinput" "/etc/modules"
     fi
+    # add an udev rule to give 'input' group write access to `/dev/uinput`
+    echo 'KERNEL=="uinput", MODE="0660", GROUP="input"' > /etc/udev/rules.d/80-rpi-uinput.rules
+    udevadm control --reload
+
     modprobe uinput
 
     # make sure the install user is part of 'input' group


### PR DESCRIPTION
Add an udev rule to give the `input` group write access to `/dev/uinput` in order for the python uinput device(s) can be created.

I didn't notice this since I had a similar rule added from the `steamcontroller` package installation on my systems and the `/dev/uinput` device had the correct (`root:input`) Uid/Gid.