### PR TITLE
Update retronetplay.sh with IP4v Address

### DIFF
--- a/scriptmodules/supplementary/retronetplay.sh
+++ b/scriptmodules/supplementary/retronetplay.sh
@@ -86,7 +86,7 @@ function gui_retronetplay() {
     rps_retronet_loadconfig
 
     local ip_int=$(ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
-    local ip_ext=$(download http://ipecho.net/plain -)
+    local ip_ext=$(curl -4 http://ipecho.net/plain)
 
     while true; do
         cmd=(dialog --backtitle "$__backtitle" --cancel-label "Exit" --menu "Configure RetroArch Netplay.\nInternal IP: $ip_int External IP: $ip_ext" 22 76 16)


### PR DESCRIPTION
Ensure that we specify ipecho.net reports back an IP4v address, instead of IP6v. This way it's easier for the User to provide their Host IP Address to the Client player