### PR TITLE
gzdoom: update to version 4.13.0

### DIFF
--- a/scriptmodules/ports/gzdoom.sh
+++ b/scriptmodules/ports/gzdoom.sh
@@ -18,7 +18,7 @@ rp_module_flags="sdl2 !armv6"
 
 function _get_version_gzdoom() {
     # default GZDoom version
-    local gzdoom_version="g4.12.2"
+    local gzdoom_version="g4.13.0"
 
     # 32 bit is no longer supported since g4.8.1
     isPlatform "32bit" && gzdoom_version="g4.8.0"
@@ -74,7 +74,7 @@ function install_gzdoom() {
         'release/game_widescreen_gfx.pk3'
         'release/soundfonts'
         "release/zmusic/lib/libzmusic.so.1"
-        "release/zmusic/lib/libzmusic.so.1.1.13"
+        "release/zmusic/lib/libzmusic.so.1.1.14"
         'README.md'
     )
 }


### PR DESCRIPTION
The new version has lots of bugfixes and adds support for the new Doom II add-on "Legacy of Rust" released by Bethesda with the Doom(+II) re-release.

New in version 4.13.0:

 * Added pistol start gameplay option
 * A few ID24 spec implementations, adds support for new Bethesda DOOM + DOOM II re-release and Legacy of Rust
 * Several multiplayer network fixes, especially with prediction
 * Some savegame fixes, should now be able to delete them on windows
 * Add Extra Parameters to iwad selection box
 * iwad selection box now always shows unless one of the following is true: it is disabled, -iwad is used from command line, or you load in a gameinfo that suggests an iwad
 * Add mbf21 and mbf21 (strict) compatibility presets
 * Particles and rollsprites are now square
 * ZMusic update, allows selecting a new module player
 * Forced-perspective sprite clipping (limited ability for sprites to render under the floor)
 * Support for Orthographic projection
 * Decoupled animation fixes
 * Able to now pass optional parameters in any order