### PR TITLE
joy2key: allow selecting the non-SDL version

### DIFF
--- a/scriptmodules/admin/joy2key.sh
+++ b/scriptmodules/admin/joy2key.sh
@@ -60,7 +60,7 @@ if [[ "\${#params[@]}" -eq 0 ]]; then
 fi
 
 script="joy2key_sdl.py"
-! python3 -c "import sdl2" 2>/dev/null && script="joy2key.py"
+grep --basic-regexp --quiet --no-messages '^legacy_joy2key[[:space:]]*=[[:space:]]*"\?1"\?' $configdir/all/runcommand.cfg && script="joy2key.py"
 
 case "\$mode" in
     start)

--- a/scriptmodules/supplementary/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand.sh
@@ -21,6 +21,10 @@ function _update_hook_runcommand() {
         [[ -f "$md_inst/joy2key.py" ]] && rp_callModule "joy2key"
         install_bin_runcommand
     fi
+    if hasFlag "armv6"; then
+        iniConfig " = " '"' "$configdir/all/runcommand.cfg"
+        iniSet "legacy_joy2key" "1"
+    fi
 }
 
 function depends_runcommand() {
@@ -43,6 +47,8 @@ function install_bin_runcommand() {
         iniSet "governor" ""
         iniSet "disable_menu" "0"
         iniSet "image_delay" "2"
+        # weaker systems should use the old Joy2Key version
+        hasFlag "armv6" && iniSet "legacy_joy2key" "1"
         chown "$__user":"$__group" "$configdir/all/runcommand.cfg"
     fi
     if [[ ! -f "$configdir/all/runcommand-launch-dialog.cfg" ]]; then
@@ -110,9 +116,11 @@ function gui_runcommand() {
             'disable_joystick=0' \
             'image_delay=2' \
             'governor=' \
+            'legacy_joy2key=' \
         )"
 
         [[ -z "$governor" ]] && governor="Default: don't change"
+        [[ -z "$legacy_joy2key" ]] && legacy_joy2key="0"
 
         cmd=(dialog --backtitle "$__backtitle" --cancel-label "Exit" --default-item "$default" --menu "Choose an option." 22 86 16)
         options=()
@@ -138,6 +146,12 @@ function gui_runcommand() {
         options+=(4 "Launch image delay in seconds (currently $image_delay)")
         options+=(5 "CPU governor configuration (currently: $governor)")
 
+        if [[ "$legacy_joy2key" -eq 1 ]]; then
+            options+=(6 "Use old Joy2Key for joystick control (currently: Enabled)")
+        else
+            options+=(6 "Use old Joy2Key for joystick control (currently: Disabled)")
+        fi
+
         local choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
         [[ -z "$choice" ]] && break
         default="$choice"
@@ -158,6 +172,9 @@ function gui_runcommand() {
                 ;;
             5)
                 governor_runcommand
+                ;;
+            6)
+                iniSet "legacy_joy2key" "$((legacy_joy2key ^ 1))"
                 ;;
         esac
     done

--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -124,6 +124,9 @@ function get_config() {
         iniGet "image_delay"
         IMAGE_DELAY="$ini_value"
         [[ -z "$IMAGE_DELAY" ]] && IMAGE_DELAY=2
+        iniGet "legacy_joy2key"
+        LEGACY_JOY2KEY="$ini_value"
+        [[ -z "$LEGACY_JOY2KEY" ]] && LEGACY_JOY2KEY=0
     fi
 
     if [[ -n "$DISPLAY" ]] && $XRANDR &>/dev/null; then
@@ -1260,6 +1263,9 @@ function show_launch() {
             feh -F -N -Z -Y -q "$image" & &>/dev/null
             IMG_PID=$!
             sleep "$IMAGE_DELAY"
+            # if we're not using the old Joy2Key script, we need feh to stop after the delay
+            # otherwise the menu will not be triggered due to terminal being out of focus
+            [[ "$LEGACY_JOY2KEY" -eq 0 && "DISABLE_MENU" -ne 1 ]] && kill -SIGINT "$IMG_PID"
         else
             fbi -1 -t "$IMAGE_DELAY" -noverbose -a "$image" </dev/tty &>/dev/null
         fi


### PR DESCRIPTION
There are 2 (uinput) related changes here:

* The SDL2/Uinput based Joy2Key is too slow for Pi1/0 devices, so allow the user to choose the older version. The older version is simpler since it doesn't need or load SDL2/Uinput, thus faster to load on those systems. By default, on ARMv6 devices the old version will be configured.

* The Uinput based event generation of keyboard events is not able to trigger the `runcommand` menu when launching images splash is done via `feh`, since the image display will get always have focus and thus the keybord events will not reach the `runcommand` terminal. So, in order for the `runcommand` menu to work after the splash image, make sure we stop `feh` before launch, just like `fbi` is stopped on non-desktop systems.