### PR TITLE
xroar: update to 1.6.6

### DIFF
--- a/scriptmodules/emulators/xroar.sh
+++ b/scriptmodules/emulators/xroar.sh
@@ -13,7 +13,7 @@ rp_module_id="xroar"
 rp_module_desc="Dragon / CoCo emulator XRoar"
 rp_module_help="ROM Extensions: .cas .wav .bas .asc .dmk .jvc .os9 .dsk .vdk .rom .ccc .sna\n\nCopy your Dragon roms to $romdir/dragon32\n\nCopy your CoCo games to $romdir/coco\n\nCopy the required BIOS files d32.rom (Dragon 32), bas13.rom (CoCo), coco3.rom/coco3p.rom (CoCo3) to $biosdir"
 rp_module_licence="GPL3 http://www.6809.org.uk/xroar/"
-rp_module_repo="git http://www.6809.org.uk/git/xroar.git 1.5.3"
+rp_module_repo="git http://www.6809.org.uk/git/xroar.git 1.6.6"
 rp_module_section="opt"
 rp_module_flags=""
 


### PR DESCRIPTION
New in version 1.6:

 *  New machine Dragon Professional (Alpha), 'dragonpro'
 *  New machine Tandy Deluxe Colour Computer, 'deluxecoco'
 *  New -ram-org option to specify RAM addressing
 *  New -ram-init option to specify initial RAM state
 *  6309 DIVD behaviour fixed against Tim Lindner’s fuzzing tool
 *  6309 DIVD timing fixed according to David Banks’s behaviour notes
 *  6309 DIVQ behaviour & timing adjusted similarly, though untested
 *  More accurate observed NTSC CoCo 3 GIME composite video behaviour
 *  New GTK+ 3 UI
 *  New printer control dialog (GTK+ 3, Windows) or menu options (Mac OS X+)
 *  More keyboard virtual joystick profiles included by default
 *  All physical joysticks selectable from menus by default