### PR TITLE
mame/lr-mame - fix building on aarch64 kernel with 32bit arm userland

### DIFF
--- a/scriptmodules/emulators/mame.sh
+++ b/scriptmodules/emulators/mame.sh
@@ -58,6 +58,9 @@ function build_mame() {
     # tell the linker to remove debugging info
     LDFLAGS+=" -s"
 
+    # force arm on arm platform - fixes building mame on when using 32bit arm userland with aarch64 kernel
+    isPlatform "arm" && params+=(PLATFORM=arm)
+
     # workaround for linker crash on bullseye (use gold linker)
     if [[ "$__os_debian_ver" -eq 11 ]] && isPlatform "arm"; then
         LDFLAGS+=" -fuse-ld=gold -Wl,--long-plt" make "${params[@]}"

--- a/scriptmodules/libretrocores/lr-mame.sh
+++ b/scriptmodules/libretrocores/lr-mame.sh
@@ -25,6 +25,8 @@ function _get_version_lr-mame() {
 function _get_params_lr-mame() {
     local params=(OSD=retro RETRO=1 PYTHON_EXECUTABLE=python3 NOWERROR=1 OS=linux OPTIMIZE=2 TARGETOS=linux CONFIG=libretro NO_USE_MIDI=1 NO_USE_PORTAUDIO=1 TARGET=mame)
     isPlatform "64bit" && params+=(PTR64=1)
+    # force arm on arm platform - fixes building mame on when using 32bit arm userland with aarch64 kernel
+    isPlatform "arm" && params+=(PLATFORM=arm)
     echo "${params[@]}"
 }
 


### PR DESCRIPTION
Force PLATFORM=arm on arm systems. Without this mame builds for aarch64 and sets PTR64=1 erroring out with:

    static_assert(sizeof(void *) == 8, "PTR64 flag enabled, but was compiled for 32-bit target\n");

This also fixes building of lr-mame2016