### PR TITLE
mupen64plus - fix building on rpi5 with aarch64 kernel + arm userland

### DIFF
--- a/scriptmodules/emulators/mupen64plus/remove_fast_math.diff
+++ b/scriptmodules/emulators/mupen64plus/remove_fast_math.diff
@@ -1,0 +1,66 @@
+--- a/mupen64plus-audio-sdl/projects/unix/Makefile
++++ b/mupen64plus-audio-sdl/projects/unix/Makefile
+@@ -99,7 +99,7 @@ OBJDIR = _obj$(POSTFIX)
+ # base CFLAGS, LDLIBS, and LDFLAGS
+ OPTFLAGS ?= -O3 -flto
+ WARNFLAGS ?= -Wall
+-CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -ffast-math -fvisibility=hidden -I$(SRCDIR)
++CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -fvisibility=hidden -I$(SRCDIR)
+ LDFLAGS += $(SHARED)
+ 
+ # Since we are building a shared library, we must compile with -fPIC on some architectures
+--- a/mupen64plus-input-sdl/projects/unix/Makefile
++++ b/mupen64plus-input-sdlprojects/unix/Makefile
+@@ -96,7 +96,7 @@ OBJDIR = _obj$(POSTFIX)
+ # base CFLAGS, LDLIBS, and LDFLAGS
+ OPTFLAGS ?= -O3 -flto
+ WARNFLAGS ?= -Wall
+-CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -ffast-math -fvisibility=hidden -I$(SRCDIR) -D_GNU_SOURCE=1
++CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -fvisibility=hidden -I$(SRCDIR) -D_GNU_SOURCE=1
+ LDFLAGS += $(SHARED)
+ LDLIBS += -lm
+ 
+--- a/mupen64plus-rsp-hle/projects/unix/Makefile
++++ b/mupen64plus-rsp-hle/projects/unix/Makefile
+@@ -147,7 +147,7 @@ OBJDIR = _obj$(POSTFIX)
+ # base CFLAGS, LDLIBS, and LDFLAGS
+ OPTFLAGS ?= -O3 -flto
+ WARNFLAGS ?= -Wall
+-CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -ffast-math -fvisibility=hidden -I$(SRCDIR)
++CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -fvisibility=hidden -I$(SRCDIR)
+ LDFLAGS += $(SHARED)
+ 
+ # Since we are building a shared library, we must compile with -fPIC on some architectures
+--- a/mupen64plus-ui-console/projects/unix/Makefile
++++ b/mupen64plus-ui-console/projects/unix/Makefile
+@@ -74,7 +74,7 @@ OBJDIR = _obj$(POSTFIX)
+ OPTFLAGS ?= -O3 -flto
+ WARNFLAGS ?= -Wall
+ 
+-CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -ffast-math -I$(SRCDIR)
++CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -I$(SRCDIR)
+ ifeq ($(OS), MINGW)
+   CFLAGS += -lpthread
+   LDLIBS += -lpthread
+--- a/mupen64plus-video-gles2n64/projects/unix/Makefile
++++ b/mupen64plus-video-gles2n64/projects/unix/Makefile
+@@ -132,7 +132,7 @@ endif
+ # base CFLAGS, LDLIBS, and LDFLAGS
+ OPTFLAGS ?= -O3 -flto
+ WARNFLAGS ?= -Wall
+-CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -ffast-math -fno-strict-aliasing -fvisibility=hidden -I../../src -DSDL_VIDEO_OPENGL_ES2=1 -DSDL_VIDEO_OPENGL=0     
++CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -fno-strict-aliasing -fvisibility=hidden -I../../src -DSDL_VIDEO_OPENGL_ES2=1 -DSDL_VIDEO_OPENGL=0     
+ CXXFLAGS += $(OPTFLAGS) -std=c++11 -fvisibility-inlines-hidden -DSDL_VIDEO_OPENGL_ES2=1 -DSDL_VIDEO_OPENGL=0    
+ LDFLAGS += $(SHARED)
+ 
+--- a/mupen64plus-video-gles2rice/projects/unix/Makefile
++++ b/mupen64plus-video-gles2rice/projects/unix/Makefile
+@@ -133,7 +133,7 @@ endif
+ # base CFLAGS, LDLIBS, and LDFLAGS
+ OPTFLAGS ?= -flto
+ WARNFLAGS ?= -Wall
+-CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -ffast-math -fsingle-precision-constant -fno-strict-aliasing -fvisibility=hidden -I../../src -DSDL_VIDEO_OPENGL_ES2=1 -DSDL_VIDEO_OPENGL=0
++CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -fsingle-precision-constant -fno-strict-aliasing -fvisibility=hidden -I../../src -DSDL_VIDEO_OPENGL_ES2=1 -DSDL_VIDEO_OPENGL=0
+ CXXFLAGS += -fvisibility-inlines-hidden -DSDL_VIDEO_OPENGL_ES2=1 -DSDL_VIDEO_OPENGL=0
+ LDFLAGS += $(SHARED)
+ 


### PR DESCRIPTION
These commits fix building on 32bit RPIOS Bookworm, with the RPI5. This patch may break if optimisation changes are made in the Makefiles. I was thinking to just "sed" them but can see how this goes. There may be a better fix also - but want to get this building for now. The de-duplication of the code is useful however.

**mupen64plus - de-duplicate make parameters** 

The make parameters are needed at the install stage and build stage so move them to a function.

Rename variable $source to $dir in the install loop - This matches the build function. An undefined variable $dir was used previously.

This also fixes some slight differences between them that were unnecessary:
  * isPlatform "rpi1" && params+=("VFP=1" "VFP_HARD=1") was missing from the install stage
  * install was missing isPlatform "armv8" && params+=("HOST_CPU=armv8") which is needed when building for the rpi5 with 64bit kernel and 32bit userland.
  
**mupen64plus - fix building on rpi5 with aarch64 kernel + arm userland**

Remove -ffast-math from makefiles on armv8. This option causes the following error when building on the rpi5 (armv8.2a):

    /usr/lib/gcc/arm-linux-gnueabihf/12/include/arm_neon.h: In function ‘float16x4_t vmul_n_f16(float16x4_t, float16_t)’:
    /usr/lib/gcc/arm-linux-gnueabihf/12/include/arm_neon.h:17755:14: error: conversion of scalar ‘float’ to vector ‘float16x4_t’ involves truncation

This also disables it for other armv8 platforms (that didn't have this problem), but the option does come with some risks and was added to code which I don't think will benefit such as mupen64plus-ui-console.

