### PR TITLE
Fix building lr-mupen64plus-next on 32bit arm RPIOS Bookworm

### DIFF
--- a/scriptmodules/libretrocores/lr-mupen64plus-next.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus-next.sh
@@ -56,16 +56,19 @@ function build_lr-mupen64plus-next() {
     # force ARCH=armv7 on arm platforms to fix building with 32bit arm userland on aarch64 kernel
     isPlatform "arm" && params+=(ARCH=armv7l)
 
+    local add_cflags=()
+
+    # workaround for linkage_arm.S including some armv7 instructions without this
+    isPlatform "armv6" && add_cflags+=(-DARMv5_ONLY)
+
+    # fix building on armv8.2 (rpi5) on 32bit arm bookworm.
+    isPlatform "armv8" && add_cflags+=(-mfp16-format=ieee)
+
     # use a custom core name to avoid core option name clashes with lr-mupen64plus
     params+=(CORE_NAME=mupen64plus-next)
     make "${params[@]}" clean
 
-    # workaround for linkage_arm.S including some armv7 instructions without this
-    if isPlatform "armv6"; then
-        CFLAGS="$CFLAGS -DARMv5_ONLY" make "${params[@]}"
-    else
-        make "${params[@]}"
-    fi
+    CFLAGS="$CFLAGS ${add_cflags[*]}" make "${params[@]}"
 
     md_ret_require="$md_build/mupen64plus_next_libretro.so"
 }

--- a/scriptmodules/libretrocores/lr-mupen64plus-next.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus-next.sh
@@ -53,6 +53,9 @@ function build_lr-mupen64plus-next() {
         params+=(FORCE_GLES=1)
     fi
 
+    # force ARCH=armv7 on arm platforms to fix building with 32bit arm userland on aarch64 kernel
+    isPlatform "arm" && params+=(ARCH=armv7l)
+
     # use a custom core name to avoid core option name clashes with lr-mupen64plus
     params+=(CORE_NAME=mupen64plus-next)
     make "${params[@]}" clean


### PR DESCRIPTION
**lr-mupen64plus-next - fix building on aarch64 kernel with arm userland**

**lr-mupen64plus-next - fix building on rpi5 on 32bit arm bookworm**

On the rpi5 on 32bit arm rpios bookworm, building failed with


    /usr/lib/gcc/arm-linux-gnueabihf/12/include/arm_neon.h:18284:34: error: unknown type name ‘float16x4_t’; did you mean ‘bfloat16x4_t’?
    18284 | vfmlal_low_f16 (float32x2_t __r, float16x4_t __a, float16x4_t __b)
          |                                  ^~~~~~~~~~~
          |                                  bfloat16x4_t

Add the option -mfp16-format=ieee which fixes this.

Use an array add_clags to handle the additional CFLAGS changes and use for the linkage_arm.S workaround.