### PR TITLE
ppsspp/lr-ppsspp - fix building on arm userland with aarch64 kernel

### DIFF
--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -83,7 +83,8 @@ function build_ffmpeg_ppsspp() {
     elif isPlatform "aarch64"; then
         arch="aarch64"
     fi
-    isPlatform "vero4k" && local extra_params='--arch=arm'
+    # force to arm arch on arm - fixes building on 32bit arm userland with aarch64 kernel
+    isPlatform "arm" && local extra_params='--arch=arm'
 
     local MODULES
     local VIDEO_DECODERS
@@ -148,6 +149,14 @@ function build_ppsspp() {
         fi
     elif isPlatform "mesa"; then
         params+=(-DUSING_GLES2=ON -DUSING_EGL=OFF)
+        # force arm target on arm platforms to fix building on arm 32bit userland with aarch64 kernel
+        if isPlatform "arm"; then
+            if isPlatform "armv6"; then
+                params+=(-DFORCED_CPU=armv6)
+            else
+                params+=(-DFORCED_CPU=armv7)
+            fi
+        fi
     elif isPlatform "mali"; then
         params+=(-DUSING_GLES2=ON -DUSING_FBDEV=ON)
         # remove -DGL_GLEXT_PROTOTYPES on odroid-xu/tinker to avoid errors due to header prototype differences


### PR DESCRIPTION
Force --arch=arm on arm platforms to fix building on 32bit arm userland with aarch64 kernel

Set cmake FORCED_CPU=armv7 on armv8