### PR TITLE
lr-flycast-dev: fix build for GLES2 systems

### DIFF
--- a/scriptmodules/libretrocores/lr-flycast-dev.sh
+++ b/scriptmodules/libretrocores/lr-flycast-dev.sh
@@ -31,7 +31,7 @@ function build_lr-flycast-dev() {
 
     if isPlatform "gles3"; then
             params+=("-DUSE_GLES=ON")
-    elif isPlatform "gles2"; then
+    elif isPlatform "gles"; then
             params+=("-DUSE_GLES2=ON")
     fi
     isPlatform "vulkan" && params+=("-DUSE_VULKAN=ON") || params+=("-DUSE_VULKAN=OFF")
@@ -48,6 +48,7 @@ function install_lr-flycast-dev() {
     md_ret_files=(
         'build/flycast_libretro.so'
         'LICENSE'
+        'README.md'
     )
 }
 


### PR DESCRIPTION
There's no 'gles2' flag, use 'gles' to detect GLES2 only systems and add the GLES build options (e.g. Pi3). Added the project's README.md file to the installation.