### PR TITLE
dsda-doom: buildfix for missing 'fluidsynth'

### DIFF
--- a/scriptmodules/ports/dsda-doom.sh
+++ b/scriptmodules/ports/dsda-doom.sh
@@ -19,7 +19,7 @@ rp_module_flags="sdl2"
 function depends_dsda-doom() {
     local depends=(cmake libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libogg-dev libmad0-dev libvorbis-dev libzip-dev zlib1g-dev zipcmp zipmerge ziptool)
     # we need Fluidsynth 2+, check whether the platform has the older libfluidsynth1
-    [[ -z "$(dpkg-query -W -f '${Version}' libfluidsynth1)" ]] && depends+=(libfluidsynth-dev)
+    [[ -z "$(dpkg-query -W -f '${Version}' libfluidsynth1)" ]] && depends+=(libfluidsynth-dev fluidsynth)
 
     getDepends "${depends[@]}"
 }


### PR DESCRIPTION
The build fails if it cannot find the 'fluidsynth' executable, so install the binary if we're building with Fluidsynth support.