### PR TITLE
Enable Enterprise 128 emulation via ep128emu libretro core.

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -66,6 +66,9 @@ dragon32_fullname="Dragon 32"
 dreamcast_exts=".cdi .chd .cue .gdi .sh .zip .m3u"
 dreamcast_fullname="Dreamcast"
 
+enterprise_exts=".img .dsk .tap .dtf .wav .bas .com .trn .128"
+enterprise_fullname="Enterprise 128"
+
 fba_exts=".7z .cue .fba .iso .zip"
 fba_fullname="Final Burn Alpha"
 fba_platform="arcade"

--- a/scriptmodules/libretrocores/lr-ep128emu.sh
+++ b/scriptmodules/libretrocores/lr-ep128emu.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-ep128emu"
+rp_module_desc="Enterprise 128 emulator"
+rp_module_help="ROM Extensions: .img .dsk .tap .dtf .wav .bas .com .trn .128\n\nCopy your Enterprise games to $romdir/enterprise"
+rp_module_licence="GPL2 https://raw.githubusercontent.com/libretro/ep128emu-core/refs/heads/core/COPYING"
+rp_module_repo="git https://github.com/libretro/ep128emu-core.git core"
+rp_module_section="exp"
+
+function sources_lr-ep128emu() {
+    gitPullOrClone
+}
+
+function build_lr-ep128emu() {
+    make clean
+    make
+    md_ret_require="$md_build/ep128emu_core_libretro.so"
+}
+
+function install_lr-ep128emu() {
+    md_ret_files=(
+        'ep128emu_core_libretro.so'
+    )
+}
+
+function configure_lr-ep128emu() {
+    mkRomDir "enterprise"
+    ensureSystemretroconfig "enterprise"
+
+    addEmulator 1 "$md_id" "enterprise" "$md_inst/ep128emu_core_libretro.so"
+    addSystem "enterprise"
+}


### PR DESCRIPTION
New system also added. Theme icon was recently submitted: https://github.com/RetroPie/es-theme-carbon-2021/pull/24

Added as experimental for now, but the libretro core has been in use since a while. Script based on lr-caprice32 and recent additions.

Tested on RPi 4, but core can be compiled for armv7, x86, x86_64 architectures so it is not restricted.