### PR TITLE
xpadneo: update to v0.9.7

### DIFF
--- a/scriptmodules/supplementary/xpadneo.sh
+++ b/scriptmodules/supplementary/xpadneo.sh
@@ -12,7 +12,7 @@
 rp_module_id="xpadneo"
 rp_module_desc="Advanced Linux driver for Xbox One wireless gamepads"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/atar-axis/xpadneo/master/LICENSE"
-rp_module_repo="git https://github.com/atar-axis/xpadneo.git v0.9.6"
+rp_module_repo="git https://github.com/atar-axis/xpadneo.git v0.9.7"
 rp_module_section="driver"
 rp_module_flags="nobin"
 


### PR DESCRIPTION
Most likely the last v0.9.x release, followed by v0.10.x which will probably not use `dkms` for build/install.

Headlines:

  * core, quirks: Add GameSir T4 Nova Lite support
  * core, quirks: Add GuliKit KK3 MAX quirks
  * core, quirks: Add heuristics to detect GameSir Nova controllers
  * hid-xpadneo: Actually allow building with kernel 6.12
  * hid-xpadneo: Allow building with kernel 6.12
  * xpadneo, core: Add configuration for disabling Xbox logo shift-mode
  * xpadneo, core: Fix coding style
  * xpadneo, hidraw: Fixup previous commit to properly work with DKMS
  * xpadneo, hidraw: Work around other software messing with our udev rules
  * xpadneo, quirks: Let another Microsoft OUI bypass heuristics
  * xpadneo, quirks: Prevent applying heuristics for some known vendors