### PR TITLE
xpad: fix build for older kernels

### DIFF
--- a/scriptmodules/supplementary/xpad.sh
+++ b/scriptmodules/supplementary/xpad.sh
@@ -13,7 +13,7 @@ rp_module_id="xpad"
 rp_module_desc="Updated Xpad Linux Kernel driver"
 rp_module_help="This is the latest Xpad driver from https://github.com/paroj/xpad\n\nThe driver has been patched to allow the triggers to map to buttons for any controller and this has been enabled by default.\n\nThis fixes mapping the triggers in Emulation Station.\n\nIf you want the previous trigger behaviour please edit /etc/modprobe.d/xpad.conf and set triggers_to_buttons=0"
 rp_module_licence="GPL2 https://www.kernel.org/pub/linux/kernel/COPYING"
-rp_module_repo="git https://github.com/paroj/xpad.git master"
+rp_module_repo="git https://github.com/paroj/xpad.git master af6ff9b"
 rp_module_section="driver"
 rp_module_flags="noinstclean !mali"
 
@@ -39,6 +39,9 @@ function sources_xpad() {
     if ! grep -q MODULE_VERSION xpad.c; then
         applyPatch "$md_data/03_xpad_add_version.diff"
     fi
+
+    # Revert an upstream (6.5+) modification for the locking mechanism
+    applyPatch "$md_data/04-revert-guard-usage.diff"
 }
 
 function build_xpad() {

--- a/scriptmodules/supplementary/xpad/04-revert-guard-usage.diff
+++ b/scriptmodules/supplementary/xpad/04-revert-guard-usage.diff
@@ -1,0 +1,251 @@
+diff --git a/xpad.c b/xpad.c
+index 7eafbb4..1d9d2a8 100644
+--- a/xpad.c
++++ b/xpad.c
+@@ -1470,8 +1470,9 @@ static void xpad_irq_out(struct urb *urb)
+ 	struct device *dev = &xpad->intf->dev;
+ 	int status = urb->status;
+ 	int error;
++	unsigned long flags;
+ 
+-	guard(spinlock_irqsave)(&xpad->odata_lock);
++	spin_lock_irqsave(&xpad->odata_lock, flags);
+ 
+ 	switch (status) {
+ 	case 0:
+@@ -1505,6 +1506,8 @@ static void xpad_irq_out(struct urb *urb)
+ 			xpad->irq_out_active = false;
+ 		}
+ 	}
++
++	spin_unlock_irqrestore(&xpad->odata_lock, flags);
+ }
+ 
+ static int xpad_init_output(struct usb_interface *intf, struct usb_xpad *xpad,
+@@ -1569,8 +1572,10 @@ static int xpad_inquiry_pad_presence(struct usb_xpad *xpad)
+ {
+ 	struct xpad_output_packet *packet =
+ 			&xpad->out_packets[XPAD_OUT_CMD_IDX];
++	unsigned long flags;
++	int retval;
+ 
+-	guard(spinlock_irqsave)(&xpad->odata_lock);
++	spin_lock_irqsave(&xpad->odata_lock, flags);
+ 
+ 	packet->data[0] = 0x08;
+ 	packet->data[1] = 0x00;
+@@ -1589,12 +1594,17 @@ static int xpad_inquiry_pad_presence(struct usb_xpad *xpad)
+ 
+ 	/* Reset the sequence so we send out presence first */
+ 	xpad->last_out_packet = -1;
+-	return xpad_try_sending_next_out_packet(xpad);
++	retval = xpad_try_sending_next_out_packet(xpad);
++
++	spin_unlock_irqrestore(&xpad->odata_lock, flags);
++
++	return retval;
+ }
+ 
+ static int xpad_start_xbox_one(struct usb_xpad *xpad)
+ {
+-	int error;
++	unsigned long flags;
++	int retval;
+ 
+ 	if (usb_ifnum_to_if(xpad->udev, GIP_WIRED_INTF_AUDIO)) {
+ 		/*
+@@ -1603,15 +1613,15 @@ static int xpad_start_xbox_one(struct usb_xpad *xpad)
+ 		 * Controller for Series X|S (0x20d6:0x200e) to report the
+ 		 * guide button.
+ 		 */
+-		error = usb_set_interface(xpad->udev,
+-					  GIP_WIRED_INTF_AUDIO, 0);
+-		if (error)
++		retval = usb_set_interface(xpad->udev,
++					   GIP_WIRED_INTF_AUDIO, 0);
++		if (retval)
+ 			dev_warn(&xpad->dev->dev,
+ 				 "unable to disable audio interface: %d\n",
+-				 error);
++				 retval);
+ 	}
+ 
+-	guard(spinlock_irqsave)(&xpad->odata_lock);
++	spin_lock_irqsave(&xpad->odata_lock, flags);
+ 
+ 	/*
+ 	 * Begin the init sequence by attempting to send a packet.
+@@ -1619,7 +1629,11 @@ static int xpad_start_xbox_one(struct usb_xpad *xpad)
+ 	 * sending any packets from the output ring.
+ 	 */
+ 	xpad->init_seq = 0;
+-	return xpad_try_sending_next_out_packet(xpad);
++	retval = xpad_try_sending_next_out_packet(xpad);
++
++	spin_unlock_irqrestore(&xpad->odata_lock, flags);
++
++	return retval;
+ }
+ 
+ static int xpad_start_xbox_360(struct usb_xpad *xpad)
+@@ -1716,6 +1730,7 @@ err_free_ctrl_data:
+ 
+ static void xpadone_ack_mode_report(struct usb_xpad *xpad, u8 seq_num)
+ {
++	unsigned long flags;
+ 	struct xpad_output_packet *packet =
+ 			&xpad->out_packets[XPAD_OUT_CMD_IDX];
+ 	static const u8 mode_report_ack[] = {
+@@ -1723,7 +1738,7 @@ static void xpadone_ack_mode_report(struct usb_xpad *xpad, u8 seq_num)
+ 		0x00, GIP_CMD_VIRTUAL_KEY, GIP_OPT_INTERNAL, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00
+ 	};
+ 
+-	guard(spinlock_irqsave)(&xpad->odata_lock);
++	spin_lock_irqsave(&xpad->odata_lock, flags);
+ 
+ 	packet->len = sizeof(mode_report_ack);
+ 	memcpy(packet->data, mode_report_ack, packet->len);
+@@ -1733,6 +1748,8 @@ static void xpadone_ack_mode_report(struct usb_xpad *xpad, u8 seq_num)
+ 	/* Reset the sequence so we send out the ack now */
+ 	xpad->last_out_packet = -1;
+ 	xpad_try_sending_next_out_packet(xpad);
++
++	spin_unlock_irqrestore(&xpad->odata_lock, flags);
+ }
+ 
+ #ifdef CONFIG_JOYSTICK_XPAD_FF
+@@ -1742,6 +1759,8 @@ static int xpad_play_effect(struct input_dev *dev, void *data, struct ff_effect
+ 	struct xpad_output_packet *packet = &xpad->out_packets[XPAD_OUT_FF_IDX];
+ 	__u16 strong;
+ 	__u16 weak;
++	int retval;
++	unsigned long flags;
+ 
+ 	if (effect->type != FF_RUMBLE)
+ 		return 0;
+@@ -1749,7 +1768,7 @@ static int xpad_play_effect(struct input_dev *dev, void *data, struct ff_effect
+ 	strong = effect->u.rumble.strong_magnitude;
+ 	weak = effect->u.rumble.weak_magnitude;
+ 
+-	guard(spinlock_irqsave)(&xpad->odata_lock);
++	spin_lock_irqsave(&xpad->odata_lock, flags);
+ 
+ 	switch (xpad->xtype) {
+ 	case XTYPE_XBOX:
+@@ -1815,10 +1834,15 @@ static int xpad_play_effect(struct input_dev *dev, void *data, struct ff_effect
+ 		dev_dbg(&xpad->dev->dev,
+ 			"%s - rumble command sent to unsupported xpad type: %d\n",
+ 			__func__, xpad->xtype);
+-		return -EINVAL;
++		retval = -EINVAL;
++		goto out;
+ 	}
+ 
+-	return xpad_try_sending_next_out_packet(xpad);
++	retval = xpad_try_sending_next_out_packet(xpad);
++
++out:
++	spin_unlock_irqrestore(&xpad->odata_lock, flags);
++	return retval;
+ }
+ 
+ static int xpad_init_ff(struct usb_xpad *xpad)
+@@ -1871,10 +1895,11 @@ static void xpad_send_led_command(struct usb_xpad *xpad, int command)
+ {
+ 	struct xpad_output_packet *packet =
+ 			&xpad->out_packets[XPAD_OUT_LED_IDX];
++	unsigned long flags;
+ 
+ 	command %= 16;
+ 
+-	guard(spinlock_irqsave)(&xpad->odata_lock);
++	spin_lock_irqsave(&xpad->odata_lock, flags);
+ 
+ 	switch (xpad->xtype) {
+ 	case XTYPE_XBOX360:
+@@ -1904,6 +1929,8 @@ static void xpad_send_led_command(struct usb_xpad *xpad, int command)
+ 	}
+ 
+ 	xpad_try_sending_next_out_packet(xpad);
++
++	spin_unlock_irqrestore(&xpad->odata_lock, flags);
+ }
+ 
+ /*
+@@ -2034,10 +2061,11 @@ static void xpad_stop_input(struct usb_xpad *xpad)
+ 
+ static void xpad360w_poweroff_controller(struct usb_xpad *xpad)
+ {
++	unsigned long flags;
+ 	struct xpad_output_packet *packet =
+ 			&xpad->out_packets[XPAD_OUT_CMD_IDX];
+ 
+-	guard(spinlock_irqsave)(&xpad->odata_lock);
++	spin_lock_irqsave(&xpad->odata_lock, flags);
+ 
+ 	packet->data[0] = 0x00;
+ 	packet->data[1] = 0x00;
+@@ -2057,6 +2085,8 @@ static void xpad360w_poweroff_controller(struct usb_xpad *xpad)
+ 	/* Reset the sequence so we send out poweroff now */
+ 	xpad->last_out_packet = -1;
+ 	xpad_try_sending_next_out_packet(xpad);
++
++	spin_unlock_irqrestore(&xpad->odata_lock, flags);
+ }
+ 
+ static int xpad360w_start_input(struct usb_xpad *xpad)
+@@ -2519,9 +2549,10 @@ static int xpad_suspend(struct usb_interface *intf, pm_message_t message)
+ 		if (auto_poweroff && xpad->pad_present)
+ 			xpad360w_poweroff_controller(xpad);
+ 	} else {
+-		guard(mutex)(&input->mutex);
++		mutex_lock(&input->mutex);
+ 		if (input->users)
+ 			xpad_stop_input(xpad);
++		mutex_unlock(&input->mutex);
+ 	}
+ 
+ 	xpad_stop_output(xpad);
+@@ -2533,25 +2564,26 @@ static int xpad_resume(struct usb_interface *intf)
+ {
+ 	struct usb_xpad *xpad = usb_get_intfdata(intf);
+ 	struct input_dev *input = xpad->dev;
++	int retval = 0;
+ 
+-	if (xpad->xtype == XTYPE_XBOX360W)
+-		return xpad360w_start_input(xpad);
+-
+-	guard(mutex)(&input->mutex);
+-
+-	if (input_device_enabled(input))
+-		return xpad_start_input(xpad);
+-
+-	if (xpad->xtype == XTYPE_XBOXONE) {
+-		/*
+-		 * Even if there are no users, we'll send Xbox One pads
+-		 * the startup sequence so they don't sit there and
+-		 * blink until somebody opens the input device again.
+-		 */
+-		return xpad_start_xbox_one(xpad);
++	if (xpad->xtype == XTYPE_XBOX360W) {
++		retval = xpad360w_start_input(xpad);
++	} else {
++		mutex_lock(&input->mutex);
++		if (input->users) {
++			retval = xpad_start_input(xpad);
++		} else if (xpad->xtype == XTYPE_XBOXONE) {
++			/*
++			 * Even if there are no users, we'll send Xbox One pads
++			 * the startup sequence so they don't sit there and
++			 * blink until somebody opens the input device again.
++			 */
++			retval = xpad_start_xbox_one(xpad);
++		}
++		mutex_unlock(&input->mutex);
+ 	}
+ 
+-	return 0;
++	return retval;
+ }
+ 
+ static struct usb_driver xpad_driver = {


### PR DESCRIPTION
The recent rebasing of the `xpad` driver onto the latest upstream version has added a new feature present only on 6.5+ kernels. Back out that change so that we can still use the driver on older kernels and also pin the source to a repo commit, just to prevent a build failure in case upstream reverts also the offending changes.

NB: This should be just a temporary workaround until upstream fixes the compatibility, which may take some time.