### PR TITLE
stella: upgrade to 7.0

### DIFF
--- a/scriptmodules/emulators/stella.sh
+++ b/scriptmodules/emulators/stella.sh
@@ -13,9 +13,18 @@ rp_module_id="stella"
 rp_module_desc="Atari2600 emulator STELLA"
 rp_module_help="ROM Extensions: .a26 .bin .rom .zip .gz\n\nCopy your Atari 2600 roms to $romdir/atari2600"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/stella-emu/stella/master/License.txt"
-rp_module_repo="git https://github.com/stella-emu/stella.git 6.7"
+rp_module_repo="git https://github.com/stella-emu/stella.git :_get_version_stella"
 rp_module_section="opt"
 rp_module_flags=""
+
+function _get_version_stella() {
+    if [[ "$__gcc_version" -lt 11 ]]; then
+        echo "6.7"
+    else
+        # latest version needs C++-20 support
+        echo "7.0"
+    fi
+}
 
 function depends_stella() {
     getDepends libsdl2-dev libpng-dev zlib1g-dev


### PR DESCRIPTION
Full changelog is at https://stella-emu.github.io/changelog.html, some highlights:

 * Added automatically enabled phosphor modes.
 * Enhanced Game Properties dialog for multigame ROMs.
 * Added 2nd UI theme and hotkey for toggling UI theme.
 * Added bezel support (incl. Sinden Lightgun).
 * Added optional type format detection based on colors used.
 * Added Joy2B+ controller support.
 * Added auto detection for QuadTari attached controllers.
 * Enhanced Kid Vid support to play tape audio.
 * Added port selection, used for controller default mapping.
 * Added missing PlusROM support for E7 bankswitching.
 * Enhanced movie cart (MVC) support.
 * Accelerated emulation up to ~15% (ARM) (!!)
 * Added limited GameLine Master Module bankswitching support.
 * Added 03E0 bankswitching for Brazilian Parker Bros ROMs.
 * Added WF8 bankswitching used by some certain Coleco white carts.
 * Added JANE bankswitching used by Coleco's Tarzan prototype.
 * Added ELF mapper for Mattress Monkeys.
 * Added BUS bankswitching support for some older demos.
 * Fixed broken 7800 pause key support.

**NOTE**: since 7.0 requires a C++20 capable compiler, enable this version on GCC 11 or later. Added a version chooser function to pick the correct release tag based on the detected GCC version.