### PR TITLE
Update snesdev.sh

### DIFF
--- a/scriptmodules/supplementary/snesdev.sh
+++ b/scriptmodules/supplementary/snesdev.sh
@@ -12,8 +12,8 @@
 rp_module_id="snesdev"
 rp_module_desc="SNESDev (Driver for the RetroPie GPIO-Adapter)"
 rp_module_section="driver"
-rp_module_repo="git https://github.com/petrockblog/SNESDev-RPi.git master"
-rp_module_flags="noinstclean !all rpi !rpi5"
+rp_module_repo="git https://github.com/MonsterJoysticks/SNESDev-RPi-Wiring-Pi.git master"
+rp_module_flags="noinstclean !all rpi"
 
 function sources_snesdev() {
     gitPullOrClone "$md_inst"


### PR DESCRIPTION
Point to an updated driver repository that uses the WiringPi library for compatibility with all Respberry Pi Versions.