### PR TITLE
zesarux: update to version 12 - Bubble Bobble edition

### DIFF
--- a/scriptmodules/emulators/zesarux.sh
+++ b/scriptmodules/emulators/zesarux.sh
@@ -13,7 +13,7 @@ rp_module_id="zesarux"
 rp_module_desc="ZX Spectrum emulator ZEsarUX"
 rp_module_help="ROM Extensions: .sna .szx .z80 .tap .tzx .gz .udi .mgt .img .trd .scl .dsk .zip\n\nCopy your ZX Spectrum games to $romdir/zxspectrum"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/chernandezba/zesarux/master/src/LICENSE"
-rp_module_repo="git https://github.com/chernandezba/zesarux.git ZEsarUX-11.0"
+rp_module_repo="git https://github.com/chernandezba/zesarux.git ZEsarUX-12.0"
 rp_module_section="opt"
 rp_module_flags="sdl2 sdl1-videocore"
 


### PR DESCRIPTION
Highlights for the new 12.0 release (full changelog at https://github.com/chernandezba/zesarux/releases/tag/ZEsarUX-12.0):

* Added ZX Microdrive emulation on ZX Spectrum
* Added machines Czerweny CZ 1000, CZ 1500, CZ 1000 Plus, CZ 1500 Plus, CZ 2000, CZ Spectrum, CZ Spectrum Plus
* Added LEC memory extension emulation
* Added Memory Cheat feature: useful to find counters of energy, bombs, ammo or any other cheat in a game
* Added Quicksave screen function
* Added CPC Additional ROMS emulation
* Added setting "--simplemenus" to have a very simple main menu
* Added Visual Cassette Tape window
* Improved ZX Improved Spectrum Next emulation
* Various improvements to emulation and in specific areas (Hilow Datadrive emulation, Debugging, ZX Vision, ZX Desktop)
* Lots of fixes and QoL modifications for emulation and configuration/menus.