### PR TITLE
Update for Skyscraper v3.15.0

### DIFF
--- a/scriptmodules/supplementary/skyscraper.sh
+++ b/scriptmodules/supplementary/skyscraper.sh
@@ -28,6 +28,7 @@ function sources_skyscraper() {
 }
 
 function build_skyscraper() {
+    rm --force .qmake.stash
     QT_SELECT=5 qmake
     make
     md_ret_require="$md_build/Skyscraper"
@@ -43,6 +44,7 @@ function install_skyscraper() {
         'Skyscraper'
         'supplementary/scraperdata/check_screenscraper_json_to_idmap.py'
         'supplementary/scraperdata/convert_platforms_json.py'
+        'supplementary/scraperdata/deepdiff_peas_jsonfiles.py'
         'supplementary/scraperdata/peas_and_idmap_verify.py'
     )
     md_ret_files+=("${config_files[@]}")
@@ -220,13 +222,14 @@ function configure_skyscraper() {
 
     _init_config_skyscraper
     chown -R "$__user":"$__group" "$configdir/all/skyscraper"
+    chmod a+x "$md_inst"/*.py
 }
 
 function _init_config_skyscraper() {
     local config_files=($(_config_files_skyscraper))
 
-    # assume new(er) install
     mkdir -p .pristine_cfgs
+    # assume new(er) install
     for cf in "${config_files[@]}"; do
         bn=${cf##*/} # cut off all folders
         if [[ -e "$md_inst/$bn" ]]; then
@@ -237,7 +240,7 @@ function _init_config_skyscraper() {
 
     local scraper_conf_dir="$configdir/all/skyscraper"
 
-    # Make sure the `artwork.xml` and other conf file(s) are present, but don't overwrite them on upgrades
+    # Make sure the 'artwork.xml' and other conf file(s) are present, but don't overwrite them on upgrades
     local f_conf
     for f_conf in artwork.xml aliasMap.csv peas.json platforms_idmap.csv; do
         copyDefaultConfig "$md_inst/.pristine_cfgs/$f_conf" "$scraper_conf_dir/$f_conf"


### PR DESCRIPTION
In essence the `deepdiff_peas_jsonfiles.py` should be installed by the scriptmodule with the [release 3.15.0](https://github.com/Gemba/skyscraper/releases/tag/3.15.0) to ease the maintenance of [local changes](https://gemba.github.io/skyscraper/PLATFORMS/#step-1-transfer-platform-information-peas-to-local-file) to the platform configuration.

The change related to the topic in the forum: https://retropie.org.uk/forum/post/301718

I did not put python3-deepdiff to the scriptmodules dependencies as the platform configuration maintenance is an advanced use-case and not a base requirement to run/build Skyscraper.

The remainder of changes in here are cosmetic.
Thanks.