### PR TITLE
FIX: fix readme code block for git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ sudo apt-get install git
 Then you can download the latest RetroPie setup script with:
 
 ```shell
-cd
 git clone --depth=1 https://github.com/RetroPie/RetroPie-Setup.git
 ```
 


### PR DESCRIPTION
Title: Remove cd command from code block for easier copy-paste

Description:
This pull request simplifies the code block by removing the unnecessary cd command. The change improves the user experience by making the code easier to copy and paste directly without requiring edits.

Updated Code Block:
```bash
git clone --depth=1 https://github.com/RetroPie/RetroPie-Setup.git
```
This small adjustment ensures a more streamlined process for users.