### PR TITLE
Fix building MAME on rpi3 with 32bit arm userland and aarch64 kernel 

### DIFF
--- a/scriptmodules/emulators/mame.sh
+++ b/scriptmodules/emulators/mame.sh
@@ -15,7 +15,7 @@ rp_module_help="ROM Extensions: .zip .7z\n\nCopy your MAME roms to either $romdi
 rp_module_licence="GPL2 https://raw.githubusercontent.com/mamedev/mame/master/COPYING"
 rp_module_repo="git https://github.com/mamedev/mame.git :_get_branch_mame"
 rp_module_section="exp"
-rp_module_flags="!mali !armv6 !:\$__gcc_version:-lt:7"
+rp_module_flags="!mali !armv6 !:\$__gcc_version:-lt:7 nodistcc"
 
 function _get_branch_mame() {
     # starting with 0.265, GCC 10.3 or later is required for full C++17 support


### PR DESCRIPTION
**mame - fix rpi3 build on 32bit arm userland with aarch64 kernel** 

Workaround g++-12 compiler bug/compilation issue on 32bit arm userland with aarch64 kernel on the rpi3 (cortex-a53)

Disabling -ftree-slp-vectorize works around the issue:

    {standard input}: Assembler messages:
    {standard input}:4045: Error: co-processor offset out of range
    make[2]: *** [skeleton.make:2727: obj/Release/src/mame/skeleton/scopus.o] Error 1

Add arch_opts_cxx array to handle adding additional parameters to ARCHOPTS_CXX.

**mame - disable distcc**

Mame doesn't work with distcc - add the nodistcc flag.