### PR TITLE
dbar4gun: fix installation and add version selection

### DIFF
--- a/scriptmodules/supplementary/dbar4gun.sh
+++ b/scriptmodules/supplementary/dbar4gun.sh
@@ -25,7 +25,7 @@ function sources_dbar4gun() {
 }
 
 function install_dbar4gun() {
-    virtualenv -p python3 "$md_inst"
+    python3 -m venv "$md_inst"
     source "$md_inst/bin/activate"
     pip3 install .
     deactivate


### PR DESCRIPTION
On Buster, there's no `virtualenv` command in the `python3-virtualenv` package, so use an alternate syntax to create the virtual environment. On RaspiOS Buster the version of Python is 3.7, while the calibration code added in 0.14.0 needs 3.8, so choose an older version when Buster is detected.

@lowlevel-1989 - does this seem ok ?