### PR TITLE
coco/dragon32: add .bin extension

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -46,7 +46,7 @@ c64_fullname="Commodore 64"
 channelf_exts=".bin .rom .zip .7z"
 channelf_fullname="Fairchild ChannelF"
 
-coco_exts=".cas .wav .bas .asc .dmk .jvc .os9 .dsk .vdk .rom .ccc .sna"
+coco_exts=".bin .cas .wav .bas .asc .dmk .jvc .os9 .dsk .vdk .rom .ccc .sna"
 coco_fullname="TRS-80 Color Computer"
 
 coleco_exts=".bin .col .rom .zip"
@@ -60,7 +60,7 @@ crvision_fullname="CreatiVision"
 daphne_exts=".daphne .ogv"
 daphne_fullname="Daphne"
 
-dragon32_exts=".cas .wav .bas .asc .dmk .jvc .os9 .dsk .vdk .rom .ccc .sna"
+dragon32_exts=".bin .cas .wav .bas .asc .dmk .jvc .os9 .dsk .vdk .rom .ccc .sna"
 dragon32_fullname="Dragon 32"
 
 dreamcast_exts=".cdi .chd .cue .gdi .sh .zip .m3u"


### PR DESCRIPTION
According to the docs:

> a `.bin` is a DragonDOS or RS-DOS binary file. XRoar will determine which type it is from the header and load it into RAM, then tell the CPU to jump to its start (EXEC) address.