### PR TITLE
xroar: update to version 1.8.x

### DIFF
--- a/scriptmodules/emulators/xroar.sh
+++ b/scriptmodules/emulators/xroar.sh
@@ -11,9 +11,9 @@
 
 rp_module_id="xroar"
 rp_module_desc="Dragon / CoCo emulator XRoar"
-rp_module_help="ROM Extensions: .cas .wav .bas .asc .dmk .jvc .os9 .dsk .vdk .rom .ccc .sna\n\nCopy your Dragon roms to $romdir/dragon32\n\nCopy your CoCo games to $romdir/coco\n\nCopy the required BIOS files d32.rom (Dragon 32), bas13.rom (CoCo), coco3.rom/coco3p.rom (CoCo3) to $biosdir"
+rp_module_help="ROM Extensions: .bin .cas .wav .bas .asc .dmk .jvc .os9 .dsk .vdk .rom .ccc .sna\n\nCopy your Dragon roms to $romdir/dragon32\n\nCopy your CoCo games to $romdir/coco\n\nCopy the required BIOS files d32.rom (Dragon 32), bas13.rom (CoCo), coco3.rom/coco3p.rom (CoCo3) to $biosdir"
 rp_module_licence="GPL3 http://www.6809.org.uk/xroar/"
-rp_module_repo="git http://www.6809.org.uk/git/xroar.git 1.6.6"
+rp_module_repo="git http://www.6809.org.uk/git/xroar.git fixes-1.8"
 rp_module_section="opt"
 rp_module_flags=""
 


### PR DESCRIPTION
Added also the new `.bin` extension to the help text for the emulator.

New in version 1.8 (full change log at https://www.6809.org.uk/xroar/doc/ChangeLog):

* Fix mouse virtual joystick on resize in SDL builds
* New manual and automatic configuration saving from GUI
* Manage HD mounting from drive control dialog
* New MCX128 cartridge support for MC-10
* Fix some of the compatibility modes in GIME emulation
* Assert monitor detect line on CoCo 3 when RGB output selected
* Reduce write latency using Becker port

New in version 1.7:

* Avoid X11 keyboard init when SDL not build with X11 support
* SDL joystick module supports hotplug where possible
* Support reading a SDL gamepad DB file for non-SDL joystick modules
* New -joy-db-file option specifies SDL-compatible gamepad DB file
* New Linux evdev joystick module (hotplug, internal SDL DB, L/R profiles)
* Large changes to underlying UI mechanisms