### PR TITLE
systems: improve Odroid XU detection

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -452,6 +452,9 @@ function get_platform() {
                         *raspberrypi*)
                             get_rpi_model
                             ;;
+                        *odroid-xu[3|4]*)
+                            __platform="odroid-xu"
+                            ;;
                         *tegra186*)
                             __platform="tegra-x2"
                             ;;


### PR DESCRIPTION
Add support for recognizing the XU3/4 boards through `/proc/device-tree/compatible`, seems like recent kernels (just like the RPI boards) have removed the board name from the CPU information
Possibly related file: <https://github.com/raspberrypi/linux/blob/rpi-6.6.y/Documentation/devicetree/bindings/arm/samsung/samsung-boards.yaml#L180-L186>