### PR TITLE
snesdev: update to new version

### DIFF
--- a/scriptmodules/supplementary/snesdev/001-wiringpi-static.diff
+++ b/scriptmodules/supplementary/snesdev/001-wiringpi-static.diff
@@ -1,0 +1,24 @@
+diff --git a/wiringPi/Makefile b/wiringPi/Makefile
+index 88fc48e..ee5dc9f 100644
+--- a/wiringPi/Makefile
++++ b/wiringPi/Makefile
+@@ -78,6 +78,10 @@ $(DYNAMIC):	$(OBJ)
+ 	$Q echo "[Link (Dynamic)]"
+ 	$Q $(CC) -shared -Wl,-soname,libwiringPi.so$(WIRINGPI_SONAME_SUFFIX) -o libwiringPi.so.$(VERSION) $(OBJ) $(LIBS)
+ 
++$(STATIC):	$(OBJ)
++	$Q echo "[Link (Static)]"
++	$Q $(AR) -rcs $(STATIC) $(OBJ)
++
+ .c.o:
+ 	$Q echo [Compile] $<
+ 	$Q $(CC) -c $(CFLAGS) $< -o $@
+@@ -86,7 +90,7 @@ $(DYNAMIC):	$(OBJ)
+ .PHONY:	clean
+ clean:
+ 	$Q echo "[Clean]"
+-	$Q rm -f $(OBJ) $(OBJ_I2C) *~ core tags Makefile.bak libwiringPi.*
++	$Q rm -f $(OBJ) $(OBJ_I2C) *~ core tags Makefile.bak libwiringPi.* $(STATIC)
+ 
+ .PHONY:	tags
+ tags:	$(SRC)


### PR DESCRIPTION
**NB**: should be merged after #4019.

New version of SNESDev needs WiringPi, but not the original version that got discontinued. There's an active fork of WiringPi which also provides `.deb` files, so check whether this new version is installed first before compiling locally a static version and using it.

Other modifications:

* modified the installation/build to use `$md_build` and handle the installation ourselves, instead of using the upstream `make` targets. This means the driver is copied to `/opt/retropie` (just like `xboxdrv`) instead of being located in `/usr/local`.
* added a `systemd` unit file to start the driver and don't rely on the upstream `rc.d` service scripts.