### PR TITLE
emulationstation: fixes for the SDL2 gamecontrollerdb

### DIFF
--- a/scriptmodules/supplementary/emulationstation/configscripts/sdl2.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/sdl2.sh
@@ -87,14 +87,19 @@ function map_sdl2_joystick() {
 
     case "$input_type" in
        axis)
-           if [[ "$input_value" == "-1" ]]; then
-               echo "$sdl2_mapped_input:-a${input_id}" >> "$input_temp_map"
-           else
-               echo "$sdl2_mapped_input:+a${input_id}" >> "$input_temp_map"
-           fi
+           # add the direction for D-Pads only
+           if [[ "$sdl2_mapped_input" == "dp"* ]]; then
+               if [[ "$input_value" == "-1" ]]; then
+                   echo "$sdl2_mapped_input:-a${input_id}" >> "$input_temp_map"
+               else
+                   echo "$sdl2_mapped_input:+a${input_id}" >> "$input_temp_map"
+               fi
+            else
+                 echo "$sdl2_mapped_input:a${input_id}" >> "$input_temp_map"
+            fi
            ;;
        hat)
-           echo "$sdl2_mapped_input:hat${input_id}.${input_value}" >> "$input_temp_map"
+           echo "$sdl2_mapped_input:h${input_id}.${input_value}" >> "$input_temp_map"
            ;;
        button)
            echo "$sdl2_mapped_input:b${input_id}" >> "$input_temp_map"


### PR DESCRIPTION
Based on the feedback from @protocultor:

 - add the correct Hat mapping value ('h' and not 'hat')
 - don't add automatically direction signs for axis mappings since they're only necessary in certain configurations. However the info from the ES file is not enough to determine those configurations, though they seem to be an exception rather than the norm. One case where the signs are needed seems to be when the D-Pad is mapped using axis, so that was left implemented.