### PR TITLE
lzdoom: fix building with newer GCC

### DIFF
--- a/scriptmodules/ports/lzdoom.sh
+++ b/scriptmodules/ports/lzdoom.sh
@@ -39,7 +39,7 @@ function build_lzdoom() {
     rm -rf release
     mkdir -p release
     cd release
-    local params=(-DCMAKE_INSTALL_PREFIX="$md_inst" -DPK3_QUIET_ZIPDIR=ON -DCMAKE_BUILD_TYPE=Release)
+    local params=(-DNO_GTK=On -DCMAKE_INSTALL_PREFIX="$md_inst" -DPK3_QUIET_ZIPDIR=ON -DCMAKE_BUILD_TYPE=Release)
     # Note: `-funsafe-math-optimizations` should be avoided, see: https://forum.zdoom.org/viewtopic.php?f=7&t=57781
     cmake "${params[@]}" ..
     make


### PR DESCRIPTION
LZDoom build fails using a recent GCC (14.x), due to C++ (new) dialect changes.

As a workaround, disable the GTK launcher from build to avoid the compilation errors. We don't use it and it's only built of GTK3 dev libraries are detected, but disable it so the compilation is not attempted even when the GTK3 dev libraries are installed.