### PR TITLE
Yamagi Quake 2 version 8.50 overhaul

### DIFF
--- a/scriptmodules/ports/yquake2.sh
+++ b/scriptmodules/ports/yquake2.sh
@@ -96,24 +96,30 @@ function game_data_yquake2() {
 
 
 function configure_yquake2() {
-    local params=()
-
-    if isPlatform "gl3"; then
-        params+=("+set vid_renderer gl3")
-    elif isPlatform "gles"; then
-        params+=("+set vid_renderer gles1")
-    elif isPlatform "gl" || isPlatform "mesa"; then
-        params+=("+set vid_renderer gl1")
-    else
-        params+=("+set vid_renderer soft")
-    fi
+    local config="$md_conf_root/quake2/yquake2/baseq2/yq2.cfg"
+    local renderer="soft"
 
     mkRomDir "ports/quake2"
 
     moveConfigDir "$home/.yq2" "$md_conf_root/quake2/yquake2"
     mkUserDir "$md_conf_root/quake2/yquake2/baseq2"
-    copyDefaultConfig "$md_data/yq2.cfg" "$md_conf_root/quake2/yquake2/baseq2/yq2.cfg"
+
+    copyDefaultConfig "$md_data/yq2.cfg" "$config"
+    iniConfig " " '"' "$config"
+
+    if isPlatform "gl3"; then
+        renderer="gl3"
+    elif isPlatform "gles3"; then
+        renderer="gles3"
+    elif isPlatform "gles" && [[ "$__os_debian_ver" -lt 11 ]]; then
+        renderer="gles1"
+        iniSet "set gl1_pointparameters" "1"
+    elif isPlatform "gl" || isPlatform "mesa"; then
+        renderer="gl1"
+    fi
+
+    iniSet "set vid_renderer" "$renderer"
 
     [[ "$md_mode" == "install" ]] && game_data_yquake2
-    add_games_yquake2 "$md_inst/quake2 -datadir $romdir/ports/quake2 ${params[*]} +set game %ROM%"
+    add_games_yquake2 "$md_inst/quake2 -datadir $romdir/ports/quake2 +set game %ROM%"
 }

--- a/scriptmodules/ports/yquake2.sh
+++ b/scriptmodules/ports/yquake2.sh
@@ -34,10 +34,18 @@ function sources_yquake2() {
 }
 
 function build_yquake2() {
-    make clean
-    make with_gles1
-    # build the add-ons source
+    local params=(config client game ref_soft)
     local repo
+
+    isPlatform "gl" || isPlatform "mesa" && params+=(ref_gl1)
+    isPlatform "gl3" && params+=(ref_gl3)
+    isPlatform "gles" && [[ "$__os_debian_ver" -lt 12 ]] && params+=(ref_gles1)
+    isPlatform "gles3" && params+=(ref_gles3)
+
+    make clean
+    make ${params[@]}
+
+    # build the add-ons source
     for repo in 'xatrix' 'rogue'; do
         make -C "$repo" clean
         make -C "$repo"
@@ -50,18 +58,18 @@ function build_yquake2() {
 function install_yquake2() {
     md_ret_files=(
         'release/baseq2'
-        'release/q2ded'
         'release/quake2'
-        'release/ref_gl1.so'
-        'release/ref_gl3.so'
-        'release/ref_gles1.so'
-        'release/ref_gles3.so'
         'release/ref_soft.so'
         'LICENSE'
         'README.md'
         'xatrix/xatrix'
         'rogue/rogue'
     )
+
+    isPlatform "gl" || isPlatform "mesa" && md_ret_files+=('release/ref_gl1.so')
+    isPlatform "gl3" && md_ret_files+=('release/ref_gl3.so')
+    isPlatform "gles" && [[ "$__os_debian_ver" -lt 12 ]] && md_ret_files+=('release/ref_gles1.so')
+    isPlatform "gles3" && md_ret_files+=('release/ref_gles3.so')
 }
 
 function add_games_yquake2() {

--- a/scriptmodules/ports/yquake2/hotkey_exit.diff
+++ b/scriptmodules/ports/yquake2/hotkey_exit.diff
@@ -1,0 +1,91 @@
+diff --git a/src/client/input/sdl2.c b/src/client/input/sdl2.c
+index 7ea263a4..4e16892e 100644
+--- a/src/client/input/sdl2.c
++++ b/src/client/input/sdl2.c
+@@ -79,11 +79,12 @@ typedef enum
+ // IN_Update() called at the beginning of a frame to the
+ // actual movement functions called at a later time.
+ static float mouse_x, mouse_y;
+-static unsigned char joy_escbutton = SDL_CONTROLLER_BUTTON_START;
+ static int joystick_left_x, joystick_left_y, joystick_right_x, joystick_right_y;
+ static float gyro_yaw, gyro_pitch;
+ static qboolean mlooking;
+ 
++static qboolean hotkey_back = false;	// RetroPie Hotkey is Back instead of Guide
++
+ // The last time input events were processed.
+ // Used throughout the client.
+ int sys_frame_time;
+@@ -652,6 +653,7 @@ IN_Update(void)
+ 	static qboolean left_trigger = false;
+ 	static qboolean right_trigger = false;
+ 	static qboolean left_stick[4] = {false, false, false, false};   // left, right, up, down virtual keys
++	static qboolean hotkey_pressed = false;	// is Hotkey in RetroPie pressed
+ 
+ 	static int consoleKeyCode = 0;
+ 
+@@ -852,9 +854,22 @@ IN_Update(void)
+ 				qboolean down = (event.type == SDL_CONTROLLERBUTTONDOWN);
+ 				unsigned char btn = event.cbutton.button;
+ 
+-				// Handle Esc button first, to override its original key
+-				Key_Event( (btn == joy_escbutton)? K_ESCAPE : K_JOY_FIRST_BTN + btn,
+-					down, true );
++				switch (btn)
++				{
++					case SDL_CONTROLLER_BUTTON_START:
++						if (hotkey_pressed && down)
++							Cbuf_AddText("quit");
++						else
++							Key_Event( K_ESCAPE, down, true );
++						break;
++
++					case SDL_CONTROLLER_BUTTON_BACK:
++						if (hotkey_back)
++					case SDL_CONTROLLER_BUTTON_GUIDE:
++							hotkey_pressed = down;
++					default:
++						Key_Event( K_JOY_FIRST_BTN + btn, down, true );
++				}
+ 				break;
+ 			}
+ 
+@@ -2204,22 +2219,6 @@ IN_Controller_Init(qboolean notify_user)
+ 	SDL_Joystick *joystick = NULL;
+ 	SDL_bool is_controller = SDL_FALSE;
+ 
+-	cvar = Cvar_Get("joy_escbutton", "0", CVAR_ARCHIVE);
+-	if (cvar)
+-	{
+-		switch ((int)cvar->value)
+-		{
+-			case 1:
+-				joy_escbutton = SDL_CONTROLLER_BUTTON_BACK;
+-				break;
+-			case 2:
+-				joy_escbutton = SDL_CONTROLLER_BUTTON_GUIDE;
+-				break;
+-			default:
+-				joy_escbutton = SDL_CONTROLLER_BUTTON_START;
+-		}
+-	}
+-
+ 	cvar = Cvar_Get("in_initjoy", "1", CVAR_NOSET);
+ 	if (!cvar->value)
+ 	{
+@@ -2365,6 +2364,7 @@ IN_Controller_Init(qboolean notify_user)
+ 
+ 			show_gamepad = true;
+ 			Com_Printf("Enabled as Game Controller, settings:\n%s\n", SDL_GameControllerMapping(controller));
++			hotkey_back = ( !strstr(SDL_GameControllerMapping(controller), "guide:") );
+ 
+ #ifndef NO_SDL_GYRO
+ 
+@@ -2540,6 +2540,7 @@ IN_Controller_Shutdown(qboolean notify_user)
+ 	show_gamepad = show_gyro = show_haptic = false;
+ 	joystick_left_x = joystick_left_y = joystick_right_x = joystick_right_y = 0;
+ 	gyro_yaw = gyro_pitch = 0;
++	hotkey_back = false;
+ 
+ #ifdef NO_SDL_GYRO
+ 	if (imu_joystick)

--- a/scriptmodules/ports/yquake2/sdl2_joylabels.diff
+++ b/scriptmodules/ports/yquake2/sdl2_joylabels.diff
@@ -1,0 +1,49 @@
+diff --git a/src/client/cl_keyboard.c b/src/client/cl_keyboard.c
+index 20ba3fcc..c9b24c41 100644
+--- a/src/client/cl_keyboard.c
++++ b/src/client/cl_keyboard.c
+@@ -216,10 +216,10 @@ static char *gamepadbtns[] =
+ 	// It is imperative that this list of buttons follow EXACTLY the order they
+ 	// appear in QKEYS enum in keyboard.h, which in turn is the same order as
+ 	// they appear in SDL_GamepadButton / SDL_GameControllerButton enum.
+-	"BTN_SOUTH",
+-	"BTN_EAST",
+-	"BTN_WEST",
+-	"BTN_NORTH",
++	"BTN_A",
++	"BTN_B",
++	"BTN_X",
++	"BTN_Y",
+ 	"BTN_BACK",
+ 	"BTN_GUIDE",
+ 	"BTN_START",
+@@ -245,10 +245,10 @@ static char *gamepadbtns[] =
+ 	"TRIG_LEFT",
+ 	"TRIG_RIGHT",
+ 	// Same with _ALT buttons ( button + 'alt modifier' pressed )
+-	"BTN_SOUTH_ALT",
+-	"BTN_EAST_ALT",
+-	"BTN_WEST_ALT",
+-	"BTN_NORTH_ALT",
++	"BTN_A_ALT",
++	"BTN_B_ALT",
++	"BTN_X_ALT",
++	"BTN_Y_ALT",
+ 	"BTN_BACK_ALT",
+ 	"BTN_GUIDE_ALT",
+ 	"BTN_START_ALT",
+diff --git a/src/client/input/sdl2.c b/src/client/input/sdl2.c
+index a4fa5e25..8a4fa52f 100644
+--- a/src/client/input/sdl2.c
++++ b/src/client/input/sdl2.c
+@@ -2467,8 +2467,8 @@ IN_Init(void)
+ 	joy_forwardsensitivity = Cvar_Get("joy_forwardsensitivity", "1.0", CVAR_ARCHIVE);
+ 	joy_sidesensitivity = Cvar_Get("joy_sidesensitivity", "1.0", CVAR_ARCHIVE);
+ 
+-	joy_labels = Cvar_Get("joy_labels", "-1", CVAR_ARCHIVE);
+-	joy_confirm = Cvar_Get("joy_confirm", "-1", CVAR_ARCHIVE);
++	joy_labels = Cvar_Get("joy_labels", "0", CVAR_ARCHIVE);
++	joy_confirm = Cvar_Get("joy_confirm", "0", CVAR_ARCHIVE);
+ 	joy_layout = Cvar_Get("joy_layout", "0", CVAR_ARCHIVE);
+ 	joy_left_expo = Cvar_Get("joy_left_expo", "2.0", CVAR_ARCHIVE);
+ 	joy_left_snapaxis = Cvar_Get("joy_left_snapaxis", "0.15", CVAR_ARCHIVE);

--- a/scriptmodules/ports/yquake2/yq2.cfg
+++ b/scriptmodules/ports/yquake2/yq2.cfg
@@ -37,6 +37,8 @@ set s_openal "0"
 set ogg_ignoretrack0 "1"
 
 // Video options
+set vid_renderer "soft"
 set gl1_discardfb "1"
 set gl1_lightmapcopies "1"
+set gl1_pointparameters "0"
 set r_mode "-2"

--- a/scriptmodules/ports/yquake2/yq2.cfg
+++ b/scriptmodules/ports/yquake2/yq2.cfg
@@ -1,0 +1,42 @@
+// Default gamepad controls
+bind SHOULDR_LEFT "+movedown"
+bind TRIG_LEFT "+moveup"
+bind SHOULDR_RIGHT "+joyaltselector"
+bind TRIG_RIGHT "+attack"
+
+bind BTN_A "+movedown"
+bind BTN_B "+moveup"
+bind BTN_X "weapprev"
+bind BTN_Y "weapnext"
+bind BTN_BACK "cmd help"
+bind BTN_GUIDE "+joyaltselector"
+bind STICK_LEFT "+gyroaction"
+bind STICK_RIGHT "centerview"
+bind DP_UP "cycleweap weapon_plasmabeam weapon_boomer weapon_chaingun weapon_etf_rifle weapon_machinegun weapon_blaster"
+bind DP_DOWN "cycleweap weapon_supershotgun weapon_shotgun weapon_chainfist"
+bind DP_LEFT "cycleweap weapon_phalanx weapon_rocketlauncher weapon_proxlauncher weapon_grenadelauncher ammo_grenades"
+bind DP_RIGHT "cycleweap weapon_bfg weapon_disintegrator weapon_railgun weapon_hyperblaster ammo_tesla ammo_trap"
+
+bind BTN_X_ALT "invdrop"
+bind BTN_Y_ALT "invuse"
+bind BTN_BACK_ALT "inven"
+bind DP_UP_ALT "invprev"
+bind DP_DOWN_ALT "invnext"
+bind DP_LEFT_ALT "invprev"
+bind DP_RIGHT_ALT "invnext"
+
+// Gameplay options, check YQ2 documentation
+set cl_run "1"
+set aimfix "1"
+set g_machinegun_norecoil "1"
+set g_quick_weap "1"
+set g_swap_speed "2"
+
+// Audio options
+set s_openal "0"
+set ogg_ignoretrack0 "1"
+
+// Video options
+set gl1_discardfb "1"
+set gl1_lightmapcopies "1"
+set r_mode "-2"


### PR DESCRIPTION
Changelog: https://github.com/yquake2/yquake2/blob/QUAKE2_8_50/CHANGELOG

Most relevant addition for RetroPie is a new **OpenGL ES 1.0** renderer, which provides excellent performance under _Buster_ for basically all Pis that are supported in this OS.
Works on _Bullseye_, but requires a little fiddling to run the Legacy driver there:
https://github.com/yquake2/yquake2/pull/1128#issuecomment-2265372663 (point 2).
Note that, even if you don't use GLES1, its new options for optimization in mobile / embedded GPUs (`gl1_discardfb` and `gl1_lightmapcopies`)  are also available in GL1, so all SBCs and their OSs are benefitted from it.

This PR includes:

- A patch that enables the "_Exit shortcut_", RetroArch style, in YQ2. Meaning, _Hotkey_ + _Start_ immediately quits the game and returns to EmulationStation. In terms of SDL buttons, "_Guide_" is the one used as Hotkey; if that doesn't exist, "_Back_" ("_Select_") is used.

- Another patch, which applies a "fake revert" of the SDL3 gamepad buttons PR of YQ2 (https://github.com/yquake2/yquake2/pull/1183), so it doesn't conflict with the SDL2 configuration applied by `runcommand` on RetroPie. The reasoning behind this is detailed in point 3 of this comment:
https://github.com/RetroPie/RetroPie-Setup/pull/4035#issuecomment-2706846361

- A new default configuration file to install for the game. This includes predefined gamepad buttons (that can be reassigned in options menu), gameplay changes for a smoother experience with controller, and most importantly, enables the mentioned optimization options for embedded GPUs.

- Changed name of the game expansions to properly order them by release date (instead of the second being shown first).

Something that I wanted to do, but it's not my call, is to change the module section from "**experimental**" to "**optional**". Please evaluate this after seeing this PR in action, in every platform, including Pi 1.