### PR TITLE
Crosscomp bookworm 64

### DIFF
--- a/scriptmodules/admin/crosscomp.sh
+++ b/scriptmodules/admin/crosscomp.sh
@@ -20,7 +20,7 @@ function _default_dist_crosscomp() {
 }
 
 function depends_crosscomp() {
-    getDepends distcc
+    getDepends distcc texinfo bison
 }
 
 function sources_crosscomp() {


### PR DESCRIPTION
Add support for aarch64 cross compiler for bookworm

Remove stretch from setup_all (no longer supported)

Fix systemctl enabling / starting of distcc-$dist services

Add missing dependencies