### PR TITLE
dosbox-sdl2: fix build with SDL 2.x

### DIFF
--- a/scriptmodules/emulators/dosbox-sdl2.sh
+++ b/scriptmodules/emulators/dosbox-sdl2.sh
@@ -27,6 +27,8 @@ function sources_dosbox-sdl2() {
     # use custom config filename & path to allow coexistence with regular dosbox
     sed -i "src/misc/cross.cpp" -e 's/~\/.dosbox/~\/.'$md_id'/g' \
        -e 's/DEFAULT_CONFIG_FILE "dosbox-"/DEFAULT_CONFIG_FILE "'$md_id'-"/g'
+    # patch the SDL2 detection to remove the strict 2.0.x version check
+    applyPatch "$md_data/001-sd2.0-check-remove.diff"
 }
 
 function build_dosbox-sdl2() {

--- a/scriptmodules/emulators/dosbox-sdl2/001-sd2.0-check-remove.diff
+++ b/scriptmodules/emulators/dosbox-sdl2/001-sd2.0-check-remove.diff
@@ -1,0 +1,25 @@
+diff --git a/configure.ac b/configure.ac
+index 407d553..731d960 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -31,20 +31,6 @@ EXULT_CHECK_SDL(:,AC_MSG_ERROR([[*** SDL not found!]]))
+ LIBS="$LIBS $SDL_LIBS"
+ CPPFLAGS="$CPPFLAGS $SDL_CFLAGS"
+ 
+-dnl Check if SDL is 2.0.x
+-AC_MSG_CHECKING([for SDL version being 2.0.x])
+-AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+-#include "SDL.h"
+-void blah(){
+-#if !((SDL_MAJOR_VERSION == 2) && (SDL_MINOR_VERSION == 0))
+-#error "Only SDL 2.0 supported"
+-#endif
+-;
+-}
+-])],AC_MSG_RESULT([yes]),[
+- AC_MSG_RESULT([no]) 
+- AC_MSG_ERROR([Only libSDL 2.0.x supported])])
+-
+ dnl Checks for header files.
+ 
+ dnl Checks for typedefs, structures, and compiler characteristics.


### PR DESCRIPTION
The configure script checks for SDL 2, but the test program run afterwards checks only for 2.0.x. Removed the check to allow compilation with any SDL2 version.

NB: while this fixes the compilation, the emulator gets stuck on exit on RaspiOS Bookworm and the SDL KMS video driver.

Fixes #4062 