### PR TITLE
retroarch: update to the 1.22+ version

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -12,16 +12,16 @@
 rp_module_id="retroarch"
 rp_module_desc="RetroArch - frontend to the libretro emulator cores - required by all lr-* emulators"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/libretro/RetroArch/master/COPYING"
-rp_module_repo="git https://github.com/retropie/RetroArch.git retropie-v1.19.0"
+rp_module_repo="git https://github.com/retropie/RetroArch.git retropie-v1.22.4"
 rp_module_section="core"
 
 function depends_retroarch() {
     local depends=(libudev-dev libxkbcommon-dev libsdl2-dev libasound2-dev libusb-1.0-0-dev)
-    isPlatform "rpi" && depends+=(libraspberrypi-dev)
+    isPlatform "dispmanx" && depends+=(libraspberrypi-dev)
     isPlatform "gles" && ! isPlatform "vero4k" && depends+=(libgles2-mesa-dev)
     isPlatform "mesa" && depends+=(libx11-xcb-dev)
     isPlatform "mali" && depends+=(mali-fbdev)
-    isPlatform "x11" && depends+=(libx11-xcb-dev libpulse-dev)
+    isPlatform "x11" && depends+=(libx11-xcb-dev libpulse-dev libpipewire-0.3-dev)
     isPlatform "vulkan" && depends+=(libvulkan-dev mesa-vulkan-drivers)
     isPlatform "vero4k" && depends+=(vero3-userland-dev-osmc zlib1g-dev libfreetype6-dev)
     isPlatform "kms" && depends+=(libgbm-dev)
@@ -40,7 +40,7 @@ function sources_retroarch() {
 function build_retroarch() {
     local params=(--disable-sdl --enable-sdl2 --disable-oss --disable-al --disable-jack --disable-qt)
     if ! isPlatform "x11"; then
-        params+=(--disable-pulse)
+        params+=(--disable-pulse --disable-pipewire)
         ! isPlatform "mesa" && params+=(--disable-x11)
     fi
     if [[ "$__os_debian_ver" -lt 9 ]]; then
@@ -48,7 +48,7 @@ function build_retroarch() {
     fi
     isPlatform "gles" && params+=(--enable-opengles)
     if isPlatform "gles3"; then
-        params+=(--enable-opengles3)
+        params+=(--enable-opengles3 --disable-opengl1)
         isPlatform "gles31" && params+=(--enable-opengles3_1)
         isPlatform "gles32" && params+=(--enable-opengles3_2)
     fi
@@ -230,18 +230,22 @@ function configure_retroarch() {
     iniSet "input_joypad_driver" "udev"
     iniSet "all_users_control_menu" "true"
     iniSet "remap_save_on_exit" "false"
+    # saves remaps under a gamepad-named folder
+    iniSet "input_remap_sort_by_controller_enable" "true"
 
-    # rgui by default
+    # use the RGUI menu by default
     iniSet "menu_driver" "rgui"
-    iniSet "rgui_aspect_ratio_lock" "2"
+    iniSet "rgui_border_filler_enable" "false" # disable the border
+    iniSet "rgui_aspect_ratio_lock" "2" # 4:3
+    iniSet "rgui_aspect_ratio" "11" # Auto
     iniSet "rgui_browser_directory" "$romdir"
     iniSet "rgui_switch_icons" "false"
     iniSet "menu_rgui_shadows" "true"
     iniSet "rgui_menu_color_theme" "29" # Tango Dark theme
+    iniSet "menu_linear_filter" "false" # disable linear scaling, looks bad on RGUI
 
-    # hide online updater menu options and the restart option
+    # hide online core updater menu options and the restart option
     iniSet "menu_show_core_updater" "false"
-    iniSet "menu_show_online_updater" "false"
     iniSet "menu_show_restart_retroarch" "false"
     # disable the search action
     iniSet "menu_disable_search_button" "true"
@@ -260,6 +264,11 @@ function configure_retroarch() {
     iniSet "core_info_cache_enable" "false"
     # disable game runtime logging
     iniSet "content_runtime_log" "false"
+    # disable history file
+    iniSet "history_list_enable" "false"
+    # .. and also favorites
+    iniSet "content_favorites_size" "0"
+    iniSet "content_show_favorites" "false"
 
     # disable unnecessary xmb menu tabs
     iniSet "xmb_show_add" "false"
@@ -276,8 +285,9 @@ function configure_retroarch() {
     # enable menu_unified_controls by default (see below for more info)
     iniSet "menu_unified_controls" "true"
 
-    # disable 'press twice to quit'
-    iniSet "quit_press_twice" "false"
+    # disable 'press twice to quit/reset'
+    iniSet "confirm_quit" "false"
+    iniSet "confirm_reset" "false"
 
     # enable video shaders
     iniSet "video_shader_enable" "true"
@@ -297,13 +307,16 @@ function configure_retroarch() {
 
     # set RGUI aspect ratio to "Integer Scaling" to prevent stretching
     _set_config_option_retroarch "rgui_aspect_ratio_lock" "2"
+    # disable linear filtering, looks bad for RGUI
+    _set_config_option_retroarch "menu_linear_filter" "false"
 
     # if no menu_unified_controls is set, force it on so that keyboard player 1 can control
     # the RGUI menu which is important for arcade sticks etc that map to keyboard inputs
     _set_config_option_retroarch "menu_unified_controls" "true"
 
-    # disable `quit_press_twice` on existing configs
-    _set_config_option_retroarch "quit_press_twice" "false"
+    # disable confirmation for quit/reset
+    _set_config_option_retroarch "confirm_quit" "false"
+    _set_config_option_retroarch "confirm_reset" "false"
 
     # enable video shaders on existing configs
     _set_config_option_retroarch "video_shader_enable" "true"

--- a/scriptmodules/supplementary/configedit.sh
+++ b/scriptmodules/supplementary/configedit.sh
@@ -223,7 +223,7 @@ function advanced_configedit() {
 
     local audio_opts="alsa alsathread sdl2"
     if isPlatform "x11"; then
-        audio_opts+=" pulse"
+        audio_opts+=" pulse pipewire"
     fi
 
     local ini_options=(


### PR DESCRIPTION
This bumps the RetroArch version to current RA master from 1.19.0. You can pull the rebased version from https://github.com/cmitu/RetroArch/tree/retropie-v1.22.4. Our patches have been re-based/modified to accomodate the current RetroArch master. There were some regressions in 1.22 that have been solved in current master and since there are no major releases since last November, I decided to rebased onto the current master.

~~The new version has a regression on KMS/DRM for RGUI, reported upstream, which is worked around by setting `rgui_aspect_ratio_lock` to `0` until (if) it's fixed. This will make the RGUI stretch/shrink to the current core provided resolution instead of staying the same.~~
The RGUI regression present in 1.22 has been fixed upstream.

The RetroPie module changed with:

  - RGUI border is removed in the default configuration.
  - New version enables a 'linear' interpolation on menus by default, which blurs the menu for RGUI, so disable it
  - Reset/Quit require confirmation now and their option names have been renamed, so make sure they're updated in existing configs and new default config.
  - Enable saving the remaps sorted by controller name in new default configs. Seems natural given that remaps use the underlying physical controller indexes for axis/buttons, which are controller dependant. See https://github.com/libretro/RetroArch/pull/16747 for details.
    NB: this is a breaking change from the existing/default behavior of RetroArch, but is not applied to existing configurations, just for new insallations.
  - Now the Pipewire is supported as audio server, add the dependencies to build with it on desktop. Add the driver to the configuration editor, so it can be selected.
  - Due to changes in the build scripts, when GLES(2) is enabled then OpenGL1 should be disabled.

Release announcements for the new versions:

 - 1.22 (Nov 2025) followed up by 1.22.1 and 1.22.2 in the same month. No release announcement on libretro.com.
 - 1.21 (April 2025) https://www.libretro.com/index.php/retroarch-1-21-0-release/
 - 1.20 (January 2025) https://www.libretro.com/index.php/retroarch-1-20-0-release/

Abbreviated changelog from 1.19.0, focused on features relevant to Linux/RetroPie:

  * AUTOCONF:
      - Enable alternative display name in autoconfig files (v1.21)
      - Make autoconfig failure messages optional (v1.21)
      - Extend autoconfig matching with a physical identifier (v1.22), see https://github.com/libretro/RetroArch/pull/18190
  * AUDIO:
      - Option to mute on rewind (v1.21)
      - PIPEWIRE
         - Fix app launch when pipewire service is stopped (v1.21)
         - Fix speedup with threaded video mode (v1.21)
         - Fix latency setting and microphone handling (v1.21)
         - Pass the new rate to the audio driver (v1.21)
      - audio handling in case of RARCH_NETPLAY_CTL_USE_CORE_PACKET_INTERFACE (v1.20)
      - Add PipeWire audio driver (v1.20)
      - Add PipeWire microphone driver (v1.20)

  * CHEEVOS
      - Add rarity and points to achievement unlock widget (v1.20)
      - Add rank to leaderboard submission notification (v1.20)
      - Update to rcheevos 11.6 (v1.20)
      - Show rcheevos game image in Discord rich presence (v1.20)
      - Use translated strings for achievement messages (v1.20)
      - Include achievement state in netplay states (v1.21)
      - Fix crash when entering achievements in quick menu while client is not present (v1.21)
      - Upgrade to rcheevos 12.1 (v1.22)
      - Hashing of RVZ files is now supported (v1.22)
      - Show additional message for unsupported achievements (v1.22)
      - Update to rcheevos 12.3 (1.22+)
      - Download badges on demand only (1.22+)
      - Fix for PS2/PSP CHD hashing with RetroAchievements (1.22+)

  * CRT/SWITCHRES: Update switchres to 2.2.1 (v1.20)

  * GENERAL:
      - Fix save state auto increment (v1.21)
      - Fix softpatching with periods/dots in the file name (v1.21)
      - Allow asset directory redefinition and other directory overrides via environment variables (v1.21)
      - Fix performance counter option not remembered between sessions (v1.21)
      - Use core fps instead of screen refresh for calculating dropped frames (v1.21)
      - Support for mbedtls v3 (v1.20)
      - Automatic Frame Delay refactor (v1.20)
      - Remove Frame Reset, obsoleted by Frame Delay refactor (v1.20)
      - Wrap around auto increment save state indexes when amount of states is limited (v1.20)
      - Enable auto save state when new content is loaded (v1.20)
      - Improve Preemptive Frames when pointing device is used (v1.20)
      - New network commands SAVE_STATE_SLOT N and GET_CONFIG_PARAM

  * INPUT:
      - Fix a crash when initializing illuminance sensor on Linux (v1.21)
      - Analog-to-digital refactor, fixing behavior when analogs are assigned to keys (v1.21)
      - Turbo fire overhaul. See https://github.com/libretro/RetroArch/pull/17633 (v1.21)
      - Allow to select a preferred/reserved device for each player (v1.20)
      - Enable Caps, Num, Scroll Lock modifiers on multiple platforms (v1.20)
      - Autoconfig extension with alternative name/vid/pid (v1.20)
      - Fix autoconfig profile saving when device is not in the default port (v1.20)
      - Change classic turbo mode to work independently of which key was pressed first (v1.20)
      - Pointer and lightgun handling sanitization on Windows and Linux desktop platforms. These input drivers will now report edge and offscreen positions in a harmonized way, and will not return 0 instead. (v1.20)
      - Sort and apply remaps based on the specific connected controller (v1.20)
      - (udev) Enable mouse buttons 4 and 5 (v1.20)
      - (Wayland) Enable horizontal scroll and mouse buttons 4 and 5 (v1.20)
      - (Wayland) Simulate lightgun input for cores (v1.20)
      - (Wayland) Support for cursor-shape-v1 and content-type-v1 protocol (v1.20)
      -  Enable mouse buttons 4 and 5 (v1.20)
      - Extend X11 input driver with XInput2 extensions for multi-mouse (v1.21)
      = Reset + Close content require confirmation (v1.22)
      - Turbo fire settings are saved to remaps and not overrides (v1.22)
      - Menu toggle and hotkey enable can now be assigned to the same key (v1.22)
      - Option to have hotkeys follow the port mapped first to the core (v1.22)
      - New analog-to-digital types: both stick, twin-stick (for pressing face buttons with analog stick). (v1.22+)
      - Fix for setups which have Game Focus and Hotkey Enable on the same key (v1.22+)
      - Autoconf profile load/save rework: saved profiles have now higher priority, several QoL improvements for saving (v1.22+)
      - Allow remap of gyro/accelerometer axes in autoconfig (v1.22+)
      - Unused RetroRating and performance level indications removed (v1.22+)
      - Saving menu is reorganized (v1.22+)
      - Refactor of bind/remap menu (v1.22+)
      - Rename Quick Menu Restart to Reset (v1.22+)
      - Add sublabels for built-in cores and show them in core manager list (v1.22+)

  * LIBRETRO:
     - Support RETRO_ENVIRONMENT_GET_FILE_BROWSER_START_DIRECTORY (v1.20)
     - Support “/” as a file extension for loading a directory as content (v1.20)

  * MENU
      - XMB:
         - Allow playlist icons to be individually customized, by looking for images in Named_Logos (v1.20)
         - Fix Light theme, font shadow (v1.21)
         - Appearance menu cleanup (v1.21)
         - Icon thumbnail can be any of the existing types (v1.21)
         - Cheat menu rework (v1.22+)
      - OZONE:
          - Add Selenium theme for Ozone (v1.20)
          - Touchscreen improvements (v1.20)
          - Add a touch-sensitive Resume button in the lower right corner (v1.20)
          - Fix messagebox background (v1.21)
      - Support local thumbnails in other image formats than png (jpg/jpeg, bmp, tga) (v1.20)
      - Delete also savestate thumbnails when savestates are garbage collected (v1.20)
      - Option to disable analog stick menu navigation (v1.20)
      - Fix pause toggle to not clear fast forward state (v1.20)
      - Fix search playlist index in XMB/Ozone (v1.20)
      - Fix renamed entry display (v1.20)
      - Filter unknown extensions also inside zip files (v1.20)
      - Add icons for present / missing firmware on core info page (v1.20)
      - Ignore other hotkeys when menu toggle is pressed (v1.20)
      - Fix menu jumping when using L3+R3 combo (v1.20)
      - System Information now only shows features relevant for the platform (v1.20)
      - Add warning to BFI and related menu items (v1.21)
      - Fix latency statistics when using runahead (v1.21)
      - Fix opening file inside archive with core selection (v1.21)
      - Main menu unified between different menu drivers (v1.21)
      - Visibility toggle for playlist tabs (v1.21)
      - Color the notification icon by message category (v1.21)
      - Gray Dark+Light theme adjustments (v1.21)
      - Random selection/shuffle function (v1.21)
      - Task widget improvements (v1.22+)
      - RGUI:
           - Cleanups of certain menu items (v1.21)
           - Thumbnail fixes (v1.21)
           - Clock format is now configurable and moved to top header (v1.22)
      - Update CRTSwitchRes menu options for future use (v1.22)
      - Move core options reset from Settings/Configuration to Main Menu / Configuration Files (v1.22)
      - Save As / Save Main options for configuration file (v1.22)
      - Less important widgets are now sized like task notifications (v1.22)
      - Configurable startup page (several options beside default Main Menu) (v1.22)
      - Shader menu rework, combined save/remove menus, save current, Y and Start hotkeys for shader parameters and background (v1.22)
      - Show keyboard overlay selection even if it is not loaded (v1.22+)
      - Do hard reset when pushing RetroPad Start on Restart menu item (v1.22+)
      - Widget default size adjusted (v1.22+)
      - Use RetroPad Y inside shader menu to toggle background opacity or reset shader passes (v1.22+)
      - Fix crash when closing content with runahead and remaps active (v1.22+)
      - Unused RetroRating and performance level indications removed (v1.22+)
      - Saving menu is reorganized (v1.22+)
      - Refactor of bind/remap menu (v1.22+)
      - Rename Quick Menu Restart to Reset (v1.22+)

  * MIDI:
      - Fix lingering notes on close in Alsa driver (v1.20)
      -  Add dropdown items for midi device selection (v1.21)

  * OVERLAY:
      - Add option to load overlay based on system name (v1.20)
      - Fix overlay lightgun, mouse & pointer (v1.21)
      - Preferred overlay loading is now default only on mobile platforms (v1.21)
      - Improve analog recentering when touching the area just outside the recentering zone (v1.21)

  * SAVESTATES: Reset state index when loading new content (v1.21)

  * VIDEO
      - Force fullscreen when KMS is used (v1.20)
      - (OPENGLES)
           - Improve version directive granularity (v1.20)
           - Fix FP/sRGB FBO support (v1.21)
      - SHADERS
           - Fix memory leak when shader parameter step is 0.0 (v1.20)
           - Add 2 uniforms, OriginalAspect and OriginalAspectRot. (v1.20)
           - Add CoreFPS and FrameTimeDelta uniforms. (v1.20)
           - Support optional includes (v1.20)
           - Allow exact refresh rate sync with shader subframes (v1.21)
           - Use shader path from CLI for shader cycling (v1.20)
           - FIX shader wildcards (v1.21)
           - Support for Cg and GLSL shaders in the GLCore video driver (v1.22)
           - Shader hold function, useful for some lightguns and shader comparison (v1.22)
           - Display on-screen error when preset load fails (v1.22+)
           - Add gyroscope / accelerometer uniforms for shaders (v1.22+)
           - Add aggressive shader caching to slang shader backend (v1.22+)
       - VULKAN:
           - Fix Vulkan window freezes when swapchain becomes suboptimal (v1.20)
           - Prefer IMMEDIATE mode without vsync (v1.20)
       - Support inhibit of Xss screensaver (v1.20)
       - Show and use exact refresh rate (3 decimals) and interlace/doublestrike where available (v1.20)
       - Allow setting viewport bias to offset viewport horizontally/vertically (v1.20)
       - Support viewport bias also with integer overscale and custom aspect ratios (v1.20)
       - Pixel perfect integer scaling improvements: axis options, smart mode (v1.20)
       - Use shader path from CLI for shader cycling (v1.20)
       - Add upscale 1.66x filter (v1.20)
       - Fix auto swap interval setup (v1.22)
       - Improvements for integer scale half scaling (v1.22)
       - Adjustments to smart integer scaling, considering title safe area (v1.22)
       - Fix viewport bias when using custom aspect ratio (v1.22)
       - Improve GLES version detection (v1.22)
       - Throttle framerate when VSync is enabled but window is not focused (v1.22+)
       - New video filters de-dither, pixel-art-AA, ntsc, crop-borders (v1.22+)
       -  Major HDR update. Inverse tone mapping uses RGB maxing instead of luminance, better full-spectrum remapping of SDR space to HDR, Contrast option remove. Performance improved. HDR menu settings exposed to shaders, fast HDR single-pass scanline simulation added. (v1.22+)
       - SDL2: Add hardware-accelerated support for widgets, XMB, Ozone
       - WAYLAND:
           - Support for xdg-toplevel-icon-v1
           - Fix segfault when relative pointer is not supported (v1.20)
           - Use reverse DNS name for desktop file and icon (v1.20)
           - Commit viewport resizes for more responsive display when resizing window (v1.20)