### PR TITLE
gzdoom - fix build with gcc 12 for armv8 on aarch64 kernel

### DIFF
--- a/scriptmodules/ports/gzdoom.sh
+++ b/scriptmodules/ports/gzdoom.sh
@@ -43,6 +43,8 @@ function sources_gzdoom() {
     sed -i 's/IMPORTED_TARGET libw/IMPORTED_TARGET GLOBAL libw/' CMakeLists.txt
     # lzma assumes hardware crc support on arm which breaks when building on armv7
     isPlatform "armv7" && applyPatch "$md_data/lzma_armv7_crc.diff"
+    # fix build with gcc 12 for armv8 on aarch64 kernel due to -ffast-math options
+    isPlatform "armv8" && [[ "$__gcc_version" -eq 12 ]] && applyPatch "$md_data/armv8_gcc12_fix.diff"
 }
 
 function build_gzdoom() {

--- a/scriptmodules/ports/gzdoom/armv8_gcc12_fix.diff
+++ b/scriptmodules/ports/gzdoom/armv8_gcc12_fix.diff
@@ -1,0 +1,22 @@
+ Fails to build with gcc 12 for armv8 on aarch64 kernel due to -ffast-math options. Enabling -fmath-errno resolves it.
+
+ Fixes:
+ /usr/lib/gcc/arm-linux-gnueabihf/12/include/arm_neon.h: In function ‘float16x8_t vmulq_n_f16(float16x8_t, float16_t)’:
+ /usr/lib/gcc/arm-linux-gnueabihf/12/include/arm_neon.h:17784:14: error: conversion of scalar ‘float’ to vector ‘float16x8_t’ involves truncation
+ 17784 |   return __a * __b;
+       |          ~~~~^~~~~
+ make[2]: *** [src/CMakeFiles/zdoom.dir/build.make:685: src/CMakeFiles/zdoom.dir/common/rendering/gles/gles_renderer.cpp.o] Error 1
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c6ba69a..b4ef587 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -158,7 +158,7 @@ endif()
+ # Fast math flags, required by some subprojects
+ set( ZD_FASTMATH_FLAG "" )
+ if( DEM_CMAKE_COMPILER_IS_GNUCXX_COMPATIBLE )
+-	set( ZD_FASTMATH_FLAG "-ffast-math -ffp-contract=fast" )
++	set( ZD_FASTMATH_FLAG "-ffast-math -ffp-contract=fast -fmath-errno" )
+ elseif( MSVC )
+ 	set( ZD_FASTMATH_FLAG "/fp:fast" )
+ endif()


### PR DESCRIPTION
When compiling with armv8 with gcc12 and an aarch64 kernel, the build fails with

    /usr/lib/gcc/arm-linux-gnueabihf/12/include/arm_neon.h: In function ‘float16x8_t vmulq_n_f16(float16x8_t, float16_t)’:
    /usr/lib/gcc/arm-linux-gnueabihf/12/include/arm_neon.h:17784:14: error: conversion of scalar ‘float’ to vector ‘float16x8_t’ involves truncation
    17784 |   return __a * __b;
          |          ~~~~^~~~~
    make[2]: *** [src/CMakeFiles/zdoom.dir/build.make:685: src/CMakeFiles/zdoom.dir/common/rendering/gles/gles_renderer.cpp.o] Error 1

Enabling -fmath-errno resolves the build error. This may be a gcc bug - not sure.