### PR TITLE
Additions to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# C/C++ Artifacts
+*.so
+
 # Virtual Environments
 venv/
 env/

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ ENV/
 *.7z
 *.lha
 *.cpio
+*.shar
 *.gz
 *.bz2
 *.xz

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,24 @@ env/
 ENV/
 .env/
 .venv/
+
+# Binary Archives
+*.tar
+*.zip
+*.rar
+*.7z
+*.lha
+*.cpio
+*.gz
+*.bz2
+*.xz
+*.lz
+*.tar.gz
+*.tar.bz2
+*.tar.xz
+*.tar.lz
+*.tgz
+*.tbz2
+*.txz
+*.tpxz
+*.tlz

--- a/.gitignore
+++ b/.gitignore
@@ -61,12 +61,15 @@ ENV/
 *.bz2
 *.xz
 *.lz
+*.lrz
 *.tar.gz
 *.tar.bz2
 *.tar.xz
 *.tar.lz
+*.tar.lrz
 *.tgz
 *.tbz2
 *.txz
 *.tpxz
 *.tlz
+*.tlrz

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,24 @@ Icon?
 ehthumbs.db
 Thumbs.db
 
+# Editor Artifacts & Configuration
+
+## PyCharm
+.idea/
+*.iml
+
+## VS Code
+.vscode/
+*.code-workspace
+
+## Spyder
+.spyderproject
+.spyproject
+
+## Sublime Text
+*.sublime-project
+*.sublime-workspace
+
 # Generated Files
 logs/
 tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,10 @@ ext/*
 __pycache__/
 *.py[cod]
 *$py.class
+
+# Virtual Environments
+venv/
+env/
+ENV/
+.env/
+.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ tmp/
 
 # 3rd Party Repos
 ext/*
+
+# Python Artifacts
+__pycache__/
+*.py[cod]
+*$py.class

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# OS generated files #
+# OS Generated Files #
 ######################
 .DS_Store
 .DS_Store?
@@ -9,7 +9,7 @@ Icon?
 ehthumbs.db
 Thumbs.db
 
-# Generated files
+# Generated Files
 logs/
 tmp/
 


### PR DESCRIPTION
# Improvements to .gitignore

This change adds several new elements to the `.gitignore` file in the hopes of streamlining development and reducing the potential for adding files that shouldn't be tracked to the project by mistake.

This should simplify things for new contributors as well as maintainers reviewing pull requests, who may have to reject changes where such files have been added unintentionally.

I've had to retroactively purge compressed archives from a repository before, and it was a total pain. Now I add files like this to `.gitignore` all the time in my own projects.
 
## Added File Types

The following types of files and directories will be ignored with the inclusion of these changes:

- Editor & IDE Artifacts
  - Files created by the following editors are now ignored:
    - PyCharm
    - VS Code
    - Spyder
    - Sublime Text
- Interpreter & Compiler Artifacts
  - Python bytecode and runtime files
  - C/C++ object files
- Virtual Environment Configurations
- Binary Archive Files
  - Common PC Archive Files
    - `*.zip, *.rar, *.7z, *.lha`
  - UNIX/Linux Archives
    - `*.tar, *.cpio, *.shar`
  - UNIX/Linux compressed files
    - `*.gz, *.bz2, *.xz, *.lz, *.lrz`
  - UNIX/Linux compressed archives  


### A Final Note

Thank you for reviewing my pull request! This is my first PR, so I hope I haven't overlooked something.

I welcome feedback as I learn more about contributing, both to RetroPie and to open source projects in general. 