### PR TITLE
srb2: update to 2.2.15

### DIFF
--- a/scriptmodules/ports/srb2.sh
+++ b/scriptmodules/ports/srb2.sh
@@ -11,42 +11,49 @@
 
 rp_module_id="srb2"
 rp_module_desc="Sonic Robo Blast 2 - 3D Sonic the Hedgehog fan-game built using a modified version of the Doom Legacy source port of Doom"
-rp_module_licence="GPL2 https://raw.githubusercontent.com/STJr/SRB2/master/LICENSE"
-rp_module_repo="git https://github.com/STJr/SRB2.git SRB2_release_2.2.9"
+rp_module_licence="GPL2 https://git.do.srb2.org/STJr/SRB2/-/raw/next/LICENSE?ref_type=heads"
+rp_module_repo="git https://git.do.srb2.org/STJr/SRB2 :_get_branch_srb2"
 rp_module_section="exp"
 
+function _version_srb2() {
+    echo "2.2.15"
+}
+
+function _get_branch_srb2() {
+    echo "SRB2_release_$(_version_srb2)"
+}
+
 function depends_srb2() {
-    local depends=(cmake libsdl2-dev libsdl2-mixer-dev libgme-dev libpng-dev libcurl4-openssl-dev)
-    [[ "$__os_debian_ver" -gt 9 ]] && depends+=(libopenmpt-dev)
-    getDepends "${depends[@]}"
+    getDepends cmake libsdl2-dev libsdl2-mixer-dev libgme-dev libpng-dev libcurl4-openssl-dev libopenmpt-dev
 }
 
 function sources_srb2() {
     gitPullOrClone
-    downloadAndExtract "$__archive_url/srb2-assets.tar.gz" "$md_build"
+    local ver="$(_version_srb2)"
+    ver=${ver//\./}
+    downloadAndExtract "https://github.com/STJr/SRB2/releases/download/SRB2_release_$(_version_srb2)/SRB2-v${ver}-Full.zip" "$md_build/assets"
+    # patch detection for CMake < 3.18
+    if hasPackage cmake 3.18 lt; then
+        applyPatch "$md_data/001-cmake-libfind.diff"
+    fi
 }
 
 function build_srb2() {
-    mkdir build
+    rm -fr build && mkdir build
     cd build
 
-    # Disable OpenMPT on Debian Stretch and old, its version is too old
-    local extra
-    [[ "$__os_debian_ver" -lt 10 ]] && extra="-DSRB2_CONFIG_HAVE_OPENMPT=Off"
-    cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$md_inst" $extra
+    cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$md_inst" -DSRB2_SDL2_EXE_NAME=srb2
     make
-    md_ret_require="$md_build/build/bin/lsdlsrb2"
+    md_ret_require="$md_build/build/bin/srb2"
 }
 
 function install_srb2() {
-    # copy and dereference, so we get a srb2 binary rather than a symlink to lsdlsrb2-version
-    cp -L 'build/bin/lsdlsrb2' "$md_inst/srb2"
     md_ret_files=(
-        'assets/installer/music.dta'
-        'assets/installer/player.dta'
-        'assets/installer/zones.pk3'
-        'assets/installer/srb2.pk3'
-        'assets/installer/patch.pk3'
+        'build/bin/srb2'
+        'assets/characters.pk3'
+        'assets/srb2.pk3'
+        'assets/music.pk3'
+        'assets/zones.pk3'
         'assets/README.txt'
         'assets/LICENSE.txt'
     )

--- a/scriptmodules/ports/srb2/001-cmake-libfind.diff
+++ b/scriptmodules/ports/srb2/001-cmake-libfind.diff
@@ -1,0 +1,26 @@
+diff --git a/cmake/Modules/Findlibopenmpt.cmake b/cmake/Modules/Findlibopenmpt.cmake
+index 96cc310..d509c25 100644
+--- a/cmake/Modules/Findlibopenmpt.cmake
++++ b/cmake/Modules/Findlibopenmpt.cmake
+@@ -26,7 +26,7 @@ FIND_PACKAGE_HANDLE_STANDARD_ARGS(libopenmpt
+     REQUIRED_VARS libopenmpt_LIBRARY libopenmpt_INCLUDE_DIR)
+ 
+ if(libopenmpt_FOUND AND NOT TARGET openmpt)
+-	add_library(openmpt UNKNOWN IMPORTED)
++	add_library(openmpt UNKNOWN IMPORTED GLOBAL)
+ 	set_target_properties(
+ 		openmpt
+ 		PROPERTIES
+diff --git a/cmake/Modules/Findminiupnpc.cmake b/cmake/Modules/Findminiupnpc.cmake
+index f4931ad..eb12927 100644
+--- a/cmake/Modules/Findminiupnpc.cmake
++++ b/cmake/Modules/Findminiupnpc.cmake
+@@ -26,7 +26,7 @@ FIND_PACKAGE_HANDLE_STANDARD_ARGS(miniupnpc
+     REQUIRED_VARS libminiupnpc_LIBRARY libminiupnpc_INCLUDE_DIR)
+ 
+ if(miniupnpc_FOUND AND NOT TARGET miniupnpc)
+-	add_library(miniupnpc UNKNOWN IMPORTED)
++	add_library(miniupnpc UNKNOWN IMPORTED GLOBAL)
+ 	set_target_properties(
+ 		miniupnpc
+ 		PROPERTIES


### PR DESCRIPTION
* changed the upstream Git repository from Github to their own server
* updated the SRB2 scripmodule to install the latest vesion (2.2.15)
* removed support for older Debian versions where OpenMPT had issues
* changed the build/installation to download the assets directly from the SRB2 releases and adjusted the included assets
* patched CMake detection for a couple of libraries due to a bug in CMake < 3.18 (i.e. Debian Buster)

EDIT: Supersedes #3497