### PR TITLE
dkms: amend removal of module for newer DKMS

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -1645,7 +1645,7 @@ function dkmsManager() {
             fi
             ;;
         remove)
-            for ver in $(dkms status "$module_name" | cut -d"," -f2 | cut -d":" -f1); do
+            for ver in $(dkms status "$module_name" | awk -F'[/,:]' '{print $2}'); do
                 dkms remove -m "$module_name" -v "$ver" --all
                 rm -f "/usr/src/${module_name}-${ver}"
             done


### PR DESCRIPTION
The `status` command returns `module/ver` in the first column, so amend the parsing to correctly extract the module version. Since the listing in newer version is a mix of `/` and `,` as separators, use `awk` to parse the line.

Should fix the uninstallation of drivers in recent latest RaspiOS/Debian (Bookworm, 12).