### PR TITLE
Update Yamagi Quake 2 to version 8.51

### DIFF
--- a/scriptmodules/ports/yquake2.sh
+++ b/scriptmodules/ports/yquake2.sh
@@ -12,7 +12,7 @@
 rp_module_id="yquake2"
 rp_module_desc="yquake2 - The Yamagi Quake II client"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/yquake2/yquake2/master/LICENSE"
-rp_module_repo="git https://github.com/yquake2/yquake2.git QUAKE2_8_50"
+rp_module_repo="git https://github.com/yquake2/yquake2.git QUAKE2_8_51"
 rp_module_section="exp"
 rp_module_flags="sdl2"
 
@@ -25,8 +25,8 @@ function depends_yquake2() {
 function sources_yquake2() {
     gitPullOrClone
     # get the add-ons sources
-    gitPullOrClone "$md_build/xatrix" "https://github.com/yquake2/xatrix" "XATRIX_2_14"
-    gitPullOrClone "$md_build/rogue" "https://github.com/yquake2/rogue" "ROGUE_2_13"
+    gitPullOrClone "$md_build/xatrix" "https://github.com/yquake2/xatrix" "XATRIX_2_15"
+    gitPullOrClone "$md_build/rogue" "https://github.com/yquake2/rogue" "ROGUE_2_14"
 
     # 1st enables Guide+Start to quit. 2nd restores buttons to SDL2 style (from SDL3).
     applyPatch "$md_data/hotkey_exit.diff"
@@ -115,6 +115,14 @@ function configure_yquake2() {
     copyDefaultConfig "$md_data/yq2.cfg" "$config"
     iniConfig " " '"' "$config"
 
+    # Don't apply GL1 mobile optimizations to x86
+    if isPlatform "x86"; then
+        iniSet "set gl1_discardfb" "0"
+        iniSet "set gl1_lightmapcopies" "0"
+        iniSet "set gl1_pointparameters" "1"
+    fi
+
+    # Select most efficient renderer as default
     if isPlatform "gl3"; then
         renderer="gl3"
     elif isPlatform "gles3"; then

--- a/scriptmodules/ports/yquake2/sdl2_joylabels.diff
+++ b/scriptmodules/ports/yquake2/sdl2_joylabels.diff
@@ -33,10 +33,20 @@ index 20ba3fcc..c9b24c41 100644
  	"BTN_GUIDE_ALT",
  	"BTN_START_ALT",
 diff --git a/src/client/input/sdl2.c b/src/client/input/sdl2.c
-index a4fa5e25..8a4fa52f 100644
+index a4fa5e25..ac14e768 100644
 --- a/src/client/input/sdl2.c
 +++ b/src/client/input/sdl2.c
-@@ -2467,8 +2467,8 @@ IN_Init(void)
+@@ -2239,9 +2239,6 @@ IN_Controller_Init(qboolean notify_user)
+ #ifdef SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE
+ 		SDL_SetHint( SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE, "1" );
+ #endif
+-#ifdef SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS	// use button positions instead of labels, like SDL3
+-		SDL_SetHint( SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS, "0" );
+-#endif
+ 
+ 		if (SDL_Init(SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC) == -1)
+ 		{
+@@ -2467,8 +2464,8 @@ IN_Init(void)
  	joy_forwardsensitivity = Cvar_Get("joy_forwardsensitivity", "1.0", CVAR_ARCHIVE);
  	joy_sidesensitivity = Cvar_Get("joy_sidesensitivity", "1.0", CVAR_ARCHIVE);
  


### PR DESCRIPTION
Hotfix release, intended to fix compilation in C23 mode and a small memory leak in mod selection menu ([Changelog](https://github.com/yquake2/yquake2/blob/QUAKE2_8_51/CHANGELOG)). 

For RetroPie, added a new feature to the patch that "downgrades" from SDL3 to SDL2 controller handling: game no longer disables `SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS`, restoring the classic SDL2 behavior of forcing labels to buttons, and not positions like SDL3. This will help Nintendo-style gamepads to respect the button labels when detected by SDL2.
Also, _x86_ installations no longer apply optimizations meant for mobile platforms.