### PR TITLE
runcommand: clear launch banner before starting

### DIFF
--- a/scriptmodules/supplementary/runcommand/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand/runcommand.sh
@@ -1403,6 +1403,7 @@ function runcommand() {
     fi
 
     local ret
+    clear
     launch_command
     ret=$?
 


### PR DESCRIPTION
The runcommand launch info screen will stay 'resident' under the emulator/port/etc. launched. While most of the time is not visible, it can show up when the launched program doesn't start full screen.

Note: this was reported in and https://github.com/RetroPie/RetroPie-Setup/issues/3563 attempted a fix in https://github.com/RetroPie/RetroPie-Setup/pull/3564.