### PR TITLE
various: don't depend on 'libraspberrypi'

### DIFF
--- a/scriptmodules/emulators/atari800.sh
+++ b/scriptmodules/emulators/atari800.sh
@@ -19,7 +19,7 @@ rp_module_flags="sdl1"
 
 function depends_atari800() {
     local depends=(libsdl1.2-dev autoconf automake zlib1g-dev libpng-dev)
-    isPlatform "rpi" && depends+=(libraspberrypi-dev)
+    isPlatform "dispmanx" && depends+=(libraspberrypi-dev)
     getDepends "${depends[@]}"
 }
 
@@ -33,7 +33,7 @@ function sources_atari800() {
 function build_atari800() {
     local params=()
     ./autogen.sh
-    isPlatform "videocore" && params+=(--target=rpi)
+    isPlatform "dispmanx" && params+=(--target=rpi)
     ./configure --prefix="$md_inst" ${params[@]}
     make clean
     make

--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -17,7 +17,7 @@ rp_module_section="core"
 
 function depends_retroarch() {
     local depends=(libudev-dev libxkbcommon-dev libsdl2-dev libasound2-dev libusb-1.0-0-dev)
-    isPlatform "rpi" && depends+=(libraspberrypi-dev)
+    isPlatform "dispmanx" && depends+=(libraspberrypi-dev)
     isPlatform "gles" && ! isPlatform "vero4k" && depends+=(libgles2-mesa-dev)
     isPlatform "mesa" && depends+=(libx11-xcb-dev)
     isPlatform "mali" && depends+=(mali-fbdev)

--- a/scriptmodules/ports/cannonball.sh
+++ b/scriptmodules/ports/cannonball.sh
@@ -18,7 +18,7 @@ rp_module_section="opt"
 
 function depends_cannonball() {
     local depends=(cmake libsdl2-dev libboost-dev)
-    isPlatform "rpi" && depends+=(libraspberrypi-dev)
+    isPlatform "dispmanx" && depends+=(libraspberrypi-dev)
     isPlatform "mesa" && depends+=(libgles2-mesa-dev)
     getDepends "${depends[@]}"
 }

--- a/scriptmodules/supplementary/controlblock.sh
+++ b/scriptmodules/supplementary/controlblock.sh
@@ -19,7 +19,7 @@ rp_module_flags="noinstclean !all rpi"
 
 function depends_controlblock() {
     local depends=(cmake doxygen gpiod libgpiod-dev)
-    isPlatform "rpi" && depends+=(libraspberrypi-dev)
+    isPlatform "videocore" && depends+=(libraspberrypi-dev)
 
     getDepends "${depends[@]}"
 }

--- a/scriptmodules/supplementary/moonlight.sh
+++ b/scriptmodules/supplementary/moonlight.sh
@@ -71,7 +71,7 @@ function depends_moonlight() {
     depends+=(avahi-daemon libnss-mdns)
 
     # platform-specific dependencies
-    isPlatform "rpi" && depends+=(libraspberrypi-dev)
+    isPlatform "dispmanx" && depends+=(libraspberrypi-dev)
     isPlatform "osmc" && depends+=(rbp-userland-dev-osmc)
     isPlatform "vero4k" && depends+=(vero3-userland-dev-osmc)
 

--- a/scriptmodules/supplementary/powerblock.sh
+++ b/scriptmodules/supplementary/powerblock.sh
@@ -18,7 +18,7 @@ rp_module_flags="noinstclean !all rpi"
 
 function depends_powerblock() {
     local depends=(cmake doxygen)
-    isPlatform "rpi" && depends+=(libraspberrypi-dev)
+    isPlatform "videocore" && depends+=(libraspberrypi-dev)
 
     getDepends "${depends[@]}"
 }

--- a/scriptmodules/supplementary/sdl1.sh
+++ b/scriptmodules/supplementary/sdl1.sh
@@ -13,7 +13,7 @@ rp_module_id="sdl1"
 rp_module_desc="SDL 1.2.15 with rpi fixes and dispmanx"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/libsdl-org/SDL-1.2/main/COPYING"
 rp_module_section="depends"
-rp_module_flags="!all rpi dispmanx"
+rp_module_flags="!all dispmanx"
 
 function get_pkg_ver_sdl1() {
     local basever

--- a/scriptmodules/supplementary/sdl2.sh
+++ b/scriptmodules/supplementary/sdl2.sh
@@ -58,7 +58,7 @@ function depends_sdl2() {
     local depends=(devscripts debhelper dh-autoreconf)
 
     isPlatform "mali" && depends+=(mali-fbdev)
-    isPlatform "rpi" && depends+=(libraspberrypi-dev)
+    isPlatform "dispmanx" && depends+=(libraspberrypi-dev)
     isPlatform "vero4k" && depends+=(vero3-userland-dev-osmc)
 
     getDepends $(_list_depends_sdl2) "${depends[@]}"
@@ -88,7 +88,7 @@ function build_sdl2() {
     fi
     isPlatform "vulkan" && conf_flags+=("--enable-video-vulkan") || conf_flags+=("--disable-video-vulkan")
     isPlatform "mali" && conf_flags+=("--enable-video-mali" "--disable-video-opengl")
-    isPlatform "rpi" && conf_flags+=("--enable-video-rpi")
+    isPlatform "dispmanx" && conf_flags+=("--enable-video-rpi") || conf_flags+=("--disable-video-rpi")
     isPlatform "kms" || isPlatform "rpi" && conf_flags+=("--enable-video-kmsdrm")
 
     # format debian package dependencies into comma-separated list


### PR DESCRIPTION
Remove the dependency on `libraspberrypi` packages for new RaspiOS Bookworm installations, since they're not useful anymore. 

To do this, make the installation/usage in various scriptmodules depend on the `dispmanx` system flag instead of the `rpi` system flag. `dispmanx` is not set/used on RaspiOS Bookworm/Bullseye, but will still be set/used on Buster as before for Pi 0-4 platforms.