### PR TITLE
system: fix platforms specification for 64bit ARM

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -361,7 +361,7 @@ function get_rpi_video() {
 
     if [[ "$__has_kms" -eq 1 ]]; then
         __platform_flags+=(mesa kms)
-        if ! isPlatform "aarm64" && [[ -z "$__has_dispmanx" ]]; then
+        if ! isPlatform "aarch64" && [[ -z "$__has_dispmanx" ]]; then
             if [[ "$__chroot" -eq 1 ]]; then
                 # in a chroot default to fkms (supporting dispmanx) when debian is older than 11 (bullseye)
                 [[ "$__os_debian_ver" -lt 11 ]] && __has_dispmanx=1
@@ -373,7 +373,7 @@ function get_rpi_video() {
         [[ "$__has_dispmanx" -eq 1 ]] && __platform_flags+=(dispmanx)
     else
         __platform_flags+=(videocore)
-        if ! isPlatform "aarm64"; then
+        if ! isPlatform "aarch64"; then
             __platform_flags+=(dispmanx)
         fi
     fi


### PR DESCRIPTION
The 64bit ARM has primarily the 'aarch64' Linux arch designation, I think there's been a typo in the original commit.