### PR TITLE
ioquake3: Switch to CMake for building

### DIFF
--- a/scriptmodules/ports/ioquake3.sh
+++ b/scriptmodules/ports/ioquake3.sh
@@ -12,9 +12,18 @@
 rp_module_id="ioquake3"
 rp_module_desc="Quake 3 source port"
 rp_module_licence="GPL2 https://github.com/ioquake/ioq3/blob/master/COPYING.txt"
-rp_module_repo="git https://github.com/ioquake/ioq3 main"
+rp_module_repo="git https://github.com/ioquake/ioq3 main :_get_commit_ioquake3"
 rp_module_section="opt"
 rp_module_flags="!videocore"
+
+function _get_commit_ioquake3() {
+    # On Buster and Bullseye we have to build using make (an old method) instead of cmake.
+    # This is because ioquake3 requires CMake 3.25 or higher which is satisfied only on Bookworm.
+    if [[ "$__os_debian_ver" -lt 12 ]]; then
+        # This is the latest commit before the Makefile was removed.
+        echo 7ac92951f2da597611ab4525023979df2f92047a
+    fi
+}
 
 function depends_ioquake3() {
     getDepends cmake libsdl2-dev libgl1-mesa-dev
@@ -25,17 +34,32 @@ function sources_ioquake3() {
 }
 
 function build_ioquake3() {
-    cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-    cmake --build build --clean-first
-    md_ret_require="$md_build/build/Release/ioquake3"
+    if [[ "$__os_debian_ver" -lt 12 ]]; then
+        make clean
+        I_ACKNOWLEDGE_THE_MAKEFILE_IS_DEPRECATED=1 make
+    else
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+        cmake --build build --clean-first
+    fi
+    md_ret_require="$md_build/$(_release_dir)/ioquake3"
+}
+
+function _release_dir() {
+    if [[ "$__os_debian_ver" -lt 12 ]]; then
+        # exact parsing from Makefile
+        local arch_ioquake3="$(uname -m | sed -e 's/i.86/x86/' | sed -e 's/^arm.*/arm/' | sed -e 's/aarch64/arm64/')"
+        echo "build/release-linux-${arch_ioquake3}"
+    else
+        echo "build/Release"
+    fi
 }
 
 function install_ioquake3() {
     md_ret_files=(
-        "build/Release/ioq3ded"
-        "build/Release/ioquake3"
-        "build/Release/renderer_opengl1.so"
-        "build/Release/renderer_opengl2.so"
+        "$(_release_dir)/ioq3ded"
+        "$(_release_dir)/ioquake3"
+        "$(_release_dir)/renderer_opengl1.so"
+        "$(_release_dir)/renderer_opengl2.so"
     )
 }
 


### PR DESCRIPTION
ioquake3 `Makefile` is gonna be deprecated by November 6, 2025.

See:
 - https://github.com/ioquake/ioq3/pull/750
 - https://github.com/ioquake/ioq3/commit/2c893f2fc2a5792c835ae415c090be681b634495
