### PR TITLE
zesarux: update to version 12.1

### DIFF
--- a/scriptmodules/emulators/zesarux.sh
+++ b/scriptmodules/emulators/zesarux.sh
@@ -13,7 +13,7 @@ rp_module_id="zesarux"
 rp_module_desc="ZX Spectrum emulator ZEsarUX"
 rp_module_help="ROM Extensions: .sna .szx .z80 .tap .tzx .gz .udi .mgt .img .trd .scl .dsk .zip\n\nCopy your ZX Spectrum games to $romdir/zxspectrum"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/chernandezba/zesarux/master/src/LICENSE"
-rp_module_repo="git https://github.com/chernandezba/zesarux.git ZEsarUX-12.0"
+rp_module_repo="git https://github.com/chernandezba/zesarux.git ZEsarUX-12.1"
 rp_module_section="opt"
 rp_module_flags="sdl2 sdl1-videocore"
 


### PR DESCRIPTION
New version 12.1 (Night Shift Edition). Full changelog (too large) is at:

https://github.com/chernandezba/zesarux/releases/tag/ZEsarUX-12.1