### PR TITLE
sdl2: upgrade to the latest 2.x version

### DIFF
--- a/scriptmodules/supplementary/sdl2.sh
+++ b/scriptmodules/supplementary/sdl2.sh
@@ -17,7 +17,7 @@ rp_module_flags=""
 
 function get_ver_sdl2() {
     if [[ "$__os_debian_ver" -ge 11 ]]; then
-        echo "2.30.8"
+        echo "2.32.10"
     else
         echo "2.0.10"
     fi


### PR DESCRIPTION
It needs https://github.com/cmitu/SDL/tree/retropie-2.32.10 to be pulled into https://github.com/RetroPie/SDL.

Needed for Trixie (and possibly recent Ubuntus on SBCs) support, since the current version is behind Debian/Ubuntu's stable editions.