### PR TITLE
retropiemenu: remove tty redirection

### DIFF
--- a/scriptmodules/supplementary/retropiemenu.sh
+++ b/scriptmodules/supplementary/retropiemenu.sh
@@ -91,7 +91,12 @@ function configure_retropiemenu()
         'Connect to or disconnect from a WiFi network and configure WiFi settings.'
     )
 
-    setESSystem "RetroPie" "retropie" "$rpdir" ".rp .sh" "sudo $scriptdir/retropie_packages.sh retropiemenu launch %ROM% </dev/tty >/dev/tty" "" "retropie"
+    # 'legacy' joy2key uses direct tty I/O and needs the extra redirection arguments
+    iniConfig " = " '"' "$configdir/all/runcommand.cfg"
+    iniGet "legacy_joy2key"
+    local tty_args
+    [[ "$ini_value" == "1" ]] && tty_args=" </dev/tty >/dev/tty"
+    setESSystem "RetroPie" "retropie" "$rpdir" ".rp .sh" "sudo $scriptdir/retropie_packages.sh retropiemenu launch %ROM% $tty_args" "" "retropie"
 
     local file
     local name

--- a/scriptmodules/supplementary/runcommand.sh
+++ b/scriptmodules/supplementary/runcommand.sh
@@ -21,7 +21,7 @@ function _update_hook_runcommand() {
         [[ -f "$md_inst/joy2key.py" ]] && rp_callModule "joy2key"
         install_bin_runcommand
     fi
-    if hasFlag "armv6"; then
+    if hasFlag "armv6" && [[ "$__os_debian_ver" -le 12 ]]; then
         iniConfig " = " '"' "$configdir/all/runcommand.cfg"
         iniSet "legacy_joy2key" "1"
     fi


### PR DESCRIPTION
Debian 13 trixie and Ubuntu 24.x have an issue when redirecting the I/O of the tty for scripts to read/write. This results in the 'dialog' window exiting when called from EmulationStation, but no from CLI. It's been reported in the forums [1],[2].

However, the current `joy2key` version doesn't need any tty access since d417e06978bea82, since we're now using `uinput` to produce keyboard events while using `sdl2` for input reading.

The changes added here remove the `/dev/tty` redirection when `legacy_joy2key` is not set and also update the `runcommand` update hook to set `legacy_joy2key` only for older OSes, where it's still supported.

[1] https://retropie.org.uk/forum/topic/35798/retropie-setup-menu-runcommand-crashing-in-es-on-ubuntu/18
[2] https://retropie.org.uk/forum/topic/37226/any-timeline-for-trixie-support/19
[3] https://github.com/RetroPie/RetroPie-Setup/commit/d417e06978bea82751cecc7bda90267723f5f31b