### PR TITLE
issues: new issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,0 @@
-Please start a topic on the RetroPie forum before opening an issue - https://retropie.org.uk/forum/
-
-Once a problem has been verified on the forum, an issue can be opened here.
-
-Please remove this text before posting.

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,23 @@
+name: Create Issue
+description: |
+ Report a bug with RetroPie-Setup scripts
+body:
+
+  - type: markdown
+    id: info
+    attributes:
+     value: |
+       #### Important
+       Only RetroPie-Setup **bugs** should be reported here as an Issue.
+       For general support questions, games troubleshooting and enhancement requests please use the [RetroPie Forums](https://retropie.org.uk/forum).
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      placeholder: describe the problem/bug in RetroPie's scripts
+    validations:
+      required: true
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: RetroPie Forums
+    url: https://retropie.org.uk/forum
+    about: Community for discussion and support
+  
+  - name: Documentation
+    url: https://retropie.org.uk/docs
+    about: Official RetroPie Documentation


### PR DESCRIPTION
Leverage the new Github features for issues by adding an extra stop to point users to forums/docs when attempting to open an issue. The new issue template was modified to include the previous note, but now formatted with Markdown.


The current ISSUE_TEMPLATE.md is no longer used, since it's been deprecated since March 2025 [1], and users will not see the advice to use the forums for anythings that's not a bug.

[1] https://github.blog/changelog/2025-02-18-github-issues-projects-february-18th-update/#%f0%9f%8c%85-single-issue-templates-issue_template-md-will-be-retired

For a preview of what this looks like, try opening an issue on https://github.com/cmitu/RetroPie-Setup (ignore the emojis on the 1st page, they're not included in this PR).