### PR TITLE
openblok - Switch to v0.8.7 and fix building on Debian 10/11

### DIFF
--- a/scriptmodules/ports/openblok.sh
+++ b/scriptmodules/ports/openblok.sh
@@ -12,7 +12,7 @@
 rp_module_id="openblok"
 rp_module_desc="OpenBlok: A Block Dropping Game"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/mmatyas/openblok/master/LICENSE.md"
-rp_module_repo="git https://github.com/mmatyas/openblok.git master"
+rp_module_repo="git https://github.com/mmatyas/openblok.git v0.8.7"
 rp_module_section="exp"
 rp_module_flags=""
 


### PR DESCRIPTION
 * Current master branch requires cmake 3.20 which is newer than available on Debian 10/11.
 * Prefer to lock to a tag/release to avoid unplanned build issues (0.8.7 is the latest tagged version).
 * When the next version is released we can stick with v0.8.7 for the older OS versions.