### PR TITLE
cgenius: bump verson to 3.6.1 and promote to optional

### DIFF
--- a/scriptmodules/ports/cgenius.sh
+++ b/scriptmodules/ports/cgenius.sh
@@ -12,11 +12,11 @@
 rp_module_id="cgenius"
 rp_module_desc="Commander Genius - Modern Interpreter for the Commander Keen Games (Vorticon and Galaxy Games)"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/gerstrong/Commander-Genius/master/COPYRIGHT"
-rp_module_repo="git https://gitlab.com/Dringgstein/Commander-Genius.git v3.3.0"
-rp_module_section="exp"
+rp_module_repo="git https://gitlab.com/Dringgstein/Commander-Genius.git v3.6.1"
+rp_module_section="opt"
 
 function depends_cgenius() {
-    getDepends cmake libcurl4-openssl-dev libvorbis-dev libogg-dev libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev
+    getDepends cmake libcurl4-openssl-dev libvorbis-dev libogg-dev libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev zlib1g-dev
 }
 
 function sources_cgenius() {
@@ -24,7 +24,9 @@ function sources_cgenius() {
 }
 
 function build_cgenius() {
-    rmdir -fr build
+    # gcc8 mistakenly warns on certain conversion alignments, don't promote the warnings to errors
+    sed -i 's/-Werror=cast-align//' src/CMakeLists.txt
+    rm -fr build
     mkdir -p build && cd build
     cmake -DBUILD_COSMOS=1 -DNOTYPESAVE=on ..
     make


### PR DESCRIPTION
* New version solves building on Trixie
* Fixed build folder not being removed before build
* Remove a spurious error-turned-warning with GCC 8 that prevents building on Buster. The same code gets build fine with newer GCC, so it's just a false positive with older version of the compiler