### PR TITLE
dependencies: update PolicyKit package name

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -299,6 +299,8 @@ function _mapPackage() {
         libfreetype6-dev)
             [[ "$__os_debian_ver" -gt 10 ]] || compareVersions "$__os_ubuntu_ver" gt 23.04 && pkg="libfreetype-dev"
             ;;
+        polkitd)
+            [[ "$__os_debian_ver" -lt 13 ]] || compareVersions "$_os_ubuntu_ver" lt 24.04 && pkg="policykit-1"
     esac
     echo "$pkg"
 }

--- a/scriptmodules/ports/kodi.sh
+++ b/scriptmodules/ports/kodi.sh
@@ -56,7 +56,7 @@ function depends_kodi() {
     fi
 
     # required for reboot/shutdown options. Don't try and remove if removing dependencies
-    [[ "$md_mode" == "install" ]] && getDepends policykit-1
+    [[ "$md_mode" == "install" ]] && getDepends polkitd
 
     addUdevInputRules
 }

--- a/scriptmodules/supplementary/pegasus-fe-dev.sh
+++ b/scriptmodules/supplementary/pegasus-fe-dev.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="pegasus-fe-dev"
 rp_module_desc="Pegasus: A cross platform, customizable graphical frontend (lastest master)"
-rp_module_help="Pegasus is a cross platform, customizable graphical frontend for launching emulators and managing your game collection.\nThis package provides source installation on platforms not covered by the upstream project pre-built binaries (i.e. ARM 64bit)."
+rp_module_help="Pegasus is a cross platform, customizable graphical frontend for launching emulators and managing your game collection.\nThis package provides source installation on platforms not covered by the upstream project pre-built binaries (i.e. ARM 64bit, Ubuntu 22.04 or later, Debian 11 or later)."
 rp_module_licence="GPL3 https://raw.githubusercontent.com/mmatyas/pegasus-frontend/master/LICENSE.md"
 rp_module_section="exp"
 rp_module_repo="git https://github.com/mmatyas/pegasus-frontend master"
@@ -36,7 +36,7 @@ function depends_pegasus-fe-dev() {
         libqt5multimedia5-plugins
         libsdl2-dev
         pkg-config
-        policykit-1
+        polkitd
         qml-module-qtgraphicaleffects qml-module-qtmultimedia qml-module-qtqml
         qml-module-qtqml-models2
         qml-module-qtquick-controls qml-module-qtquick-controls2

--- a/scriptmodules/supplementary/pegasus-fe.sh
+++ b/scriptmodules/supplementary/pegasus-fe.sh
@@ -24,7 +24,7 @@ function depends_pegasus-fe() {
         gstreamer1.0-plugins-good
         jq
         libsdl2-dev
-        policykit-1
+        polkitd
     )
     # show an error on 64bit ARMs, since there are no pre-built packages for it
     if isPlatform "arm" && hasFlag "64bit"; then


### PR DESCRIPTION
Use the new PolicyKit package name and adjust the name for the older distros. This fixes the installation of Kodi and Pegasus.