### PR TITLE
helpers: fix PolicyKit version mapping for Ubuntu

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -300,7 +300,9 @@ function _mapPackage() {
             [[ "$__os_debian_ver" -gt 10 ]] || compareVersions "$__os_ubuntu_ver" gt 23.04 && pkg="libfreetype-dev"
             ;;
         polkitd)
-            [[ "$__os_debian_ver" -lt 13 ]] || compareVersions "$_os_ubuntu_ver" lt 24.04 && pkg="policykit-1"
+            [[ "$__os_debian_ver" -lt 13 ]] && pkg="policykit-1"
+            [[ -n "$__os_ubuntu_ver" ]] && compareVersions "$__os_ubuntu_ver" lt 24.04 && pkg="policykit-1"
+            ;;
     esac
     echo "$pkg"
 }


### PR DESCRIPTION
Fixed the typo in the variable and separated the test since `compareVersions` with a `lt` comparison would succeed even on Debian.