### PR TITLE
wikidocs: use a python venv for build requirements

### DIFF
--- a/scriptmodules/admin/wikidocs.sh
+++ b/scriptmodules/admin/wikidocs.sh
@@ -14,8 +14,7 @@ rp_module_desc="Generate mkdocs documentation from wiki"
 rp_module_section=""
 
 function depends_wikidocs() {
-    getDepends python3 python3-pip libyaml-dev python3-setuptools python3-wheel
-    pip3 install --upgrade mkdocs mkdocs-material mdx_truly_sane_lists git+https://github.com/cmitu/mkdocs-altlink-plugin
+    getDepends python3 python3-pip libyaml-dev python3-setuptools python3-wheel python3-virtualenv
 }
 
 function sources_wikidocs() {
@@ -23,7 +22,11 @@ function sources_wikidocs() {
 }
 
 function build_wikidocs() {
+    python3 -m venv "$md_inst"
+    source "$md_inst/bin/activate"
+    pip3 install --upgrade mkdocs mkdocs-material mdx_truly_sane_lists git+https://github.com/cmitu/mkdocs-altlink-plugin
     mkdocs build
+    deactivate
 }
 
 function install_wikidocs() {


### PR DESCRIPTION
Since Debian 12 (bookworm) `pip` can no longer install - by default - install system-wide packages. Instead, a virtual environment (venv) is preferred so adjust our build process to create a venv in `$md_inst` for any python3 modules required by `mkdocs` & friends.