### PR TITLE
Drop readme.txt for PCSX ReARMed install (no longer present upstream)

### DIFF
--- a/scriptmodules/emulators/pcsx-rearmed.sh
+++ b/scriptmodules/emulators/pcsx-rearmed.sh
@@ -44,7 +44,6 @@ function install_pcsx-rearmed() {
         'ChangeLog.df'
         'NEWS'
         'README.md'
-        'readme.txt'
         'pcsx'
     )
     mkdir "$md_inst/plugins"

--- a/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
+++ b/scriptmodules/libretrocores/lr-pcsx-rearmed.sh
@@ -53,7 +53,6 @@ function install_lr-pcsx-rearmed() {
         'pcsx_rearmed_libretro.so'
         'NEWS'
         'README.md'
-        'readme.txt'
     )
 }
 


### PR DESCRIPTION
Tried to update `lr-pcsx-rearmed` today and it failed due to a missing `readme.txt`. Turns out this file was recently removed  upstream (actually, moved away from the repository root as being pandora-specific) in these commits:

- https://github.com/notaz/pcsx_rearmed/commit/9fed432cc7a98f4fbe8c7f0f3a82c608f5fb016e
- https://github.com/libretro/pcsx_rearmed/commit/9fed432cc7a98f4fbe8c7f0f3a82c608f5fb016e
