### PR TITLE
raspbiantools: disable the 'fluidsynth' service

### DIFF
--- a/scriptmodules/supplementary/raspbiantools.sh
+++ b/scriptmodules/supplementary/raspbiantools.sh
@@ -29,6 +29,11 @@ function apt_upgrade_raspbiantools() {
         sdl1_replace_raspbiantools
     fi
 
+    # on RaspiOS Trixie, disable the 'fluidsynth' user service starting automatically
+    if isPlatform "rpi" && [[ "$__os_debian_ver" -eq 13 ]]; then
+        fluidsynth_service_raspbiantools off
+    fi
+
     aptUpdate
     apt-get -y dist-upgrade --allow-downgrades
 }
@@ -200,6 +205,20 @@ function disable_zram_raspbiantools() {
     fi
 }
 
+function fluidsynth_service_raspbiantools() {
+    # use the 1st parameter as service state
+    local state=${1:-on}
+
+    if [[ "$state" == "on" ]]; then
+        rm "${home}/.config/systemd/user/fluidsynth.service"
+    fi
+
+    if [[ "$state" == "off" ]]; then
+       mkdir -p "${home}/.config/systemd/user"
+       ln -sf /dev/null "${home}/.config/systemd/user/fluidsynth.service"
+       chown -R "$__user":"$__group" "${home}/.config/systemd/user"
+    fi
+}
 function gui_raspbiantools() {
     while true; do
         local zram_status="Enable"


### PR DESCRIPTION
On Trixie, the 'fluidsynth' service starts automatically after the package is installed. On a RPI using ALSA, this will lock the HDMI audio output device since the HDMI card doesn't supports the DMIX plugin. This breaks audio for users that don't rely on a sound server (PulseAudio/Pipewire) since other programs started laster on will not be able to open the audio output device.

Note that even if the 'fluidsynth' package is not installed explicitely, it's a hard dependency for the accompanying `-dev` library package (explicitely added in Debian as a result of the CMake file included in the `-dev` package). So if the user installs a package needing the Fluidsynth libraries, the 'fluidsynth' package gets installed and thus the user service starts automatically.

The upstream Debian package will have this changed in Forky [1], so for now prevent the user service starting automatically by manually masking the user service.

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1110912