### PR TITLE
image - Fix up buster repositories in image building

### DIFF
--- a/scriptmodules/admin/image.sh
+++ b/scriptmodules/admin/image.sh
@@ -183,6 +183,12 @@ function install_rp_image() {
 
     [[ -z "$__chroot_repo" ]] && __chroot_repo="https://github.com/RetroPie/RetroPie-Setup.git"
     [[ -z "$__chroot_branch" ]] && __chroot_branch="master"
+
+    # fix up raspberry pi repos for buster image building (see buster_fix_apt_raspbiantools in raspbiantools.sh scriptmodule)
+    if [[ "$dist" == "rpios-buster" ]]; then
+        sed -i "s/raspbian\.raspberrypi\.org/legacy.raspbian.org/" "$chroot/etc/apt/sources.list"
+    fi
+
     cat > "$chroot/home/pi/install.sh" <<_EOF_
 #!/bin/bash
 cd


### PR DESCRIPTION
RaspiOS Buster repository has been moved to the legacy site, modify `apt` list of sources accordingly.

See 25d6527a (which fixes it for existing installs).