### PR TITLE
dosbox: fix dependency

### DIFF
--- a/scriptmodules/emulators/dosbox-sdl2.sh
+++ b/scriptmodules/emulators/dosbox-sdl2.sh
@@ -18,7 +18,7 @@ rp_module_section="exp"
 rp_module_flags="sdl2"
 
 function depends_dosbox-sdl2() {
-    local depends=(libsdl2-dev libsdl2-net-dev libfluidsynth-dev fluid-soundfont-gm libglew-dev)
+    local depends=(alsa-utils libsdl2-dev libsdl2-net-dev libfluidsynth-dev fluid-soundfont-gm libglew-dev)
     depends_dosbox "${depends[@]}"
 }
 

--- a/scriptmodules/emulators/dosbox.sh
+++ b/scriptmodules/emulators/dosbox.sh
@@ -18,7 +18,7 @@ rp_module_section="opt"
 rp_module_flags="sdl1 !mali"
 
 function depends_dosbox() {
-    local depends=(libasound2-dev libpng-dev automake autoconf zlib1g-dev "$@")
+    local depends=(alsa-utils libasound2-dev libpng-dev automake autoconf zlib1g-dev "$@")
     [[ "$md_id" == "dosbox" ]] && depends+=(libsdl1.2-dev libsdl-net1.2-dev libsdl-sound1.2-dev)
     isPlatform "rpi" && depends+=(timidity freepats)
     getDepends "${depends[@]}"


### PR DESCRIPTION
Included `alsa-utils` since it contains `aconnect` and recent desktop distros may not have it installed automatically.