### PR TITLE
lr-parallel-n64: fix build with gcc 15

### DIFF
--- a/scriptmodules/libretrocores/lr-parallel-n64.sh
+++ b/scriptmodules/libretrocores/lr-parallel-n64.sh
@@ -26,6 +26,8 @@ function depends_lr-parallel-n64() {
 
 function sources_lr-parallel-n64() {
     gitPullOrClone
+    # fix building with gcc 15
+    applyPatch "$md_data/01-fix-fsqrt-conflicts.diff"
 }
 
 function build_lr-parallel-n64() {

--- a/scriptmodules/libretrocores/lr-parallel-n64/01-fix-fsqrt-conflicts.diff
+++ b/scriptmodules/libretrocores/lr-parallel-n64/01-fix-fsqrt-conflicts.diff
@@ -1,0 +1,49 @@
+diff --git a/mupen64plus-core/src/r4300/hacktarux_dynarec/assemble.h b/mupen64plus-core/src/r4300/hacktarux_dynarec/assemble.h
+index 8161292..31f21b1 100644
+--- a/mupen64plus-core/src/r4300/hacktarux_dynarec/assemble.h
++++ b/mupen64plus-core/src/r4300/hacktarux_dynarec/assemble.h
+@@ -1650,7 +1650,7 @@ static INLINE void fchs(void)
+ }
+ 
+ 
+-static INLINE void fsqrt(void)
++static INLINE void fsqrt_(void)
+ {
+    put8(0xD9);
+    put8(0xFA);
+diff --git a/mupen64plus-core/src/r4300/hacktarux_dynarec/hacktarux_dynarec.c b/mupen64plus-core/src/r4300/hacktarux_dynarec/hacktarux_dynarec.c
+index 89fb982..4f81f9d 100644
+--- a/mupen64plus-core/src/r4300/hacktarux_dynarec/hacktarux_dynarec.c
++++ b/mupen64plus-core/src/r4300/hacktarux_dynarec/hacktarux_dynarec.c
+@@ -6317,13 +6317,13 @@ void gensqrt_d(void)
+ #ifdef __x86_64__
+    mov_xreg64_m64rel(RAX, (uint64_t *)(&reg_cop1_double[dst->f.cf.fs]));
+    fld_preg64_qword(RAX);
+-   fsqrt();
++   fsqrt_();
+    mov_xreg64_m64rel(RAX, (uint64_t *)(&reg_cop1_double[dst->f.cf.fd]));
+    fstp_preg64_qword(RAX);
+ #else
+    mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fs]));
+    fld_preg32_qword(EAX);
+-   fsqrt();
++   fsqrt_();
+    mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fd]));
+    fstp_preg32_qword(EAX);
+ #endif
+@@ -7301,13 +7301,13 @@ void gensqrt_s(void)
+ #ifdef __x86_64__
+    mov_xreg64_m64rel(RAX, (uint64_t *)(&reg_cop1_simple[dst->f.cf.fs]));
+    fld_preg64_dword(RAX);
+-   fsqrt();
++   fsqrt_();
+    mov_xreg64_m64rel(RAX, (uint64_t *)(&reg_cop1_simple[dst->f.cf.fd]));
+    fstp_preg64_dword(RAX);
+ #else
+    mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+    fld_preg32_dword(EAX);
+-   fsqrt();
++   fsqrt_();
+    mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fd]));
+    fstp_preg32_dword(EAX);
+ #endif


### PR DESCRIPTION
Added a patch to fix the conflict between the new `fsqrt` added in `math.h` and the function defined by the program. Fixes building on Ubuntu 25.10, which includes gcc 15.2.