### PR TITLE
jzintv: simplify a bit the launcher

### DIFF
--- a/scriptmodules/emulators/jzintv.sh
+++ b/scriptmodules/emulators/jzintv.sh
@@ -90,17 +90,19 @@ disp_w=\$1; shift
 disp_h=\$1; shift
 
 ratio="4/3"
-do_pillarboxing='\$(python3 -c "print(\$disp_w / \$disp_h >= \$ratio)")'
-if [[ "\$do_pillarboxing" == "True" ]] ; then
-    # le/ri padding
-    intv_w=\$(python3 -c "print(round(\$disp_h * \$ratio))")
+read intv_w intv_h < <(python3 <<PYSCRIPT
+if (\$disp_w / \$disp_h >= \$ratio):
+    # left/right padding
+    intv_w=round(\$disp_h * \$ratio)
     intv_h=\$disp_h
-else
-    # top/btm padding (letterboxing; e.g., on 5:4 displays)
+else:
+    # top/bottom padding (letterboxing; e.g., on 5:4 displays)
     intv_w=\$disp_w
-    intv_h=\$(python3 -c "print(round(\$disp_w / (\$ratio)))")
-fi
+    intv_h=round(\$disp_w / (\$ratio))
 
+print(intv_w,intv_h)
+PYSCRIPT
+)
 # set --gfx-verbose instead of --quiet for verbose output
 options=(
     -f1 # fullscreen
@@ -111,10 +113,8 @@ options=(
     --voice=1
 )
 
-echo "Launching: \$jzintv_bin \${options[@]} \"\$@\"" >> /dev/shm/runcommand.log
-pushd "$romdir/intellivision" > /dev/null
+echo "Launching: \$jzintv_bin \${options[@]} \$@"
 \$jzintv_bin \${options[@]} "\$@"
-popd
 _EOF_
     chown $user:$user "$start_script"
     chmod u+x "$start_script"


### PR DESCRIPTION
As a follow-up to @joolswills's comment from https://github.com/RetroPie/RetroPie-Setup/pull/3507#issuecomment-3786067330. Bonus for scripting style - first script featuring nested heredocs. 

* Modified the launcher part that calculates the 4/3 width/height values to use just one `python3` invocation with an inline heredoc script.
* Removed the pushd/popd since they're not needed - `jzintv` receives the ROM full path from the `%ROM%` expansion. 
* Removed the explicit redirect to the log file since it's not needed, `runcommand` will capture the output anyway and save it to `/dev/shm/runcommand.log`.