### PR TITLE
jzintv: Avoid sdl2-config error on multiarch systems by using pkg-config (https://retropie.org.uk/forum/post/306212)

### DIFF
--- a/scriptmodules/emulators/jzintv.sh
+++ b/scriptmodules/emulators/jzintv.sh
@@ -32,6 +32,7 @@ function sources_jzintv() {
         applyPatch "$md_data/01_rpi_hide_cursor_sdl2.patch"
         applyPatch "$md_data/01_rpi_pillar_boxing_black_background_sdl2.patch"
     fi
+    applyPatch "$md_data/02_Makefile_multiarch_pkg_config.patch"
 
     # Add source release date information to build
     mv buildcfg/90-svn.mak buildcfg/90-svn.mak.txt

--- a/scriptmodules/emulators/jzintv/02_Makefile_multiarch_pkg_config.patch
+++ b/scriptmodules/emulators/jzintv/02_Makefile_multiarch_pkg_config.patch
@@ -1,0 +1,14 @@
+--- a/Makefile
++++ a/Makefile
+@@ -39,8 +39,8 @@
+ GNU_READLINE ?= 1
+ 
+ # Get SDL2 related build flags.
+-SDL2_CFLAGS := $(shell sdl2-config --cflags) -DUSE_SDL2
+-SDL2_LFLAGS := $(shell sdl2-config --static-libs || sdl2-config --libs)
++SDL2_CFLAGS := $(shell pkg-config --cflags sdl2) -DUSE_SDL2
++SDL2_LFLAGS := $(shell pkg-config --libs --static --keep-system-libs sdl2 || pkg-config --libs sdl2)
+ 
+ # Override these in a .mak file. See buidlcfg/00-compiler*.txt for examples.
+ #
+


### PR DESCRIPTION
cf. https://retropie.org.uk/forum/post/306212