### PR TITLE
lr-ppsspp: fix builds with trixie

### DIFF
--- a/scriptmodules/libretrocores/lr-ppsspp.sh
+++ b/scriptmodules/libretrocores/lr-ppsspp.sh
@@ -24,9 +24,10 @@ function depends_lr-ppsspp() {
 function sources_lr-ppsspp() {
     sources_ppsspp
 
-    # fix missing defines on opengles2 on v1.16.6 lr-ppsspp
+    # fix missing defines on opengles2 and include on v1.16.6 lr-ppsspp
     if [[ "$(_get_release_ppsspp)" == "v1.16.6" ]]; then
         applyPatch "${__mod_info[ppsspp/path]%/*}/ppsspp/gles2_fix.diff"
+        applyPatch "$md_data/v16-clamp-include.diff"
     fi
 
     # fix missing exported symbol for libretro on v1.13.2

--- a/scriptmodules/libretrocores/lr-ppsspp/v16-clamp-include.diff
+++ b/scriptmodules/libretrocores/lr-ppsspp/v16-clamp-include.diff
@@ -1,0 +1,12 @@
+diff --git a/libretro/libretro.cpp b/libretro/libretro.cpp
+index 5a2f9104f1..5eabd5e54e 100644
+--- a/libretro/libretro.cpp
++++ b/libretro/libretro.cpp
+@@ -6,6 +6,7 @@
+ #include <vector>
+ #include <cstdlib>
+ #include <mutex>
++#include <algorithm>
+ 
+ #include "Common/CPUDetect.h"
+ #include "Common/Log.h"


### PR DESCRIPTION
There is an error (and others of the same) when compiling lr-ppsspp
ppsspp/libretro/libretro.cpp:1423:18: error: ‘clamp’ is not a member of ‘std’
 1423 |    x_left = std::clamp(x_left / norm * mappedNorm, -1.0f, 1.0f);

This is likely working earlier to some earlier versions of libraries were including the `<algorithm>` 'somehow'. This now explicitly includes <algorithm> with this patch.

I am running trixie and a rpi5 when building