### PR TITLE
ppsspp: fix build for v1.16.6 with new SDL_TTF

### DIFF
--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -54,8 +54,10 @@ function sources_ppsspp() {
     sed -n -i "p; s/^set(CMAKE_EXE_LINKER_FLAGS/set(CMAKE_SHARED_LINKER_FLAGS/p" cmake/Toolchains/raspberry.armv?.cmake
 
     # fix missing defines on opengles2 on v1.16.6 lr-ppsspp/ppsspp
+    # fix building with recent SDL_TTF on v1.16.6 for ppsspp
     if [[ "$md_id" == "ppsspp" && "$(_get_release_ppsspp)" == "v1.16.6" ]]; then
         applyPatch "${__mod_info[ppsspp/path]%/*}/ppsspp/gles2_fix.diff"
+        applyPatch "${__mod_info[ppsspp/path]%/*}/ppsspp/sdl_ttf_fix_before_1.19.diff"
     fi
 
     if hasPackage cmake 3.6 lt; then

--- a/scriptmodules/emulators/ppsspp/sdl_ttf_fix_before_1.19.diff
+++ b/scriptmodules/emulators/ppsspp/sdl_ttf_fix_before_1.19.diff
@@ -1,0 +1,43 @@
+diff --git a/Common/Render/Text/draw_text_sdl.h b/Common/Render/Text/draw_text_sdl.h
+index 87c543a..bfd3842 100644
+--- a/Common/Render/Text/draw_text_sdl.h
++++ b/Common/Render/Text/draw_text_sdl.h
+@@ -5,13 +5,15 @@
+ #include <map>
+ #include "Common/Render/Text/draw_text.h"
+ 
++#if defined(USE_SDL2_TTF)
++
++#include "SDL2/SDL.h"
++#include "SDL2/SDL_ttf.h"
++
+ #if defined(USE_SDL2_TTF_FONTCONFIG)
+ #include <fontconfig/fontconfig.h>
+ #endif
+ 
+-// SDL2_ttf's TTF_Font is a typedef of _TTF_Font.
+-struct _TTF_Font;
+-
+ class TextDrawerSDL : public TextDrawer {
+ public:
+ 	TextDrawerSDL(Draw::DrawContext *draw);
+@@ -33,15 +35,17 @@ class TextDrawerSDL : public TextDrawer {
+ 	bool FindFallbackFonts(uint32_t missingGlyph, int ptSize);
+ 
+ 	uint32_t fontHash_;
+-	std::map<uint32_t, _TTF_Font *> fontMap_;
++	std::map<uint32_t, TTF_Font *> fontMap_;
+ 
+ 	std::map<CacheKey, std::unique_ptr<TextStringEntry>> cache_;
+ 	std::map<CacheKey, std::unique_ptr<TextMeasureEntry>> sizeCache_;
+ 
+-	std::vector<_TTF_Font *> fallbackFonts_;
++	std::vector<TTF_Font *> fallbackFonts_;
+ 	std::vector<std::pair<std::string, int>> fallbackFontPaths_; // path and font face index
+ 
+ #if defined(USE_SDL2_TTF_FONTCONFIG)
+ 	FcConfig *config;
+ #endif
+ };
++
++#endif


### PR DESCRIPTION
SDL_TTF 2.40 and newer removed an internal structure that PPSSPP was (mis)using. This was fixed in recent PPSSPP (1.19.x) versions, backport the fix for the 1.16.6 version we use. This should fix building with recent Debian/Ubuntu versions (Debian Trixie, Ubuntu 25.10).