### PR TITLE
ppsspp: fix build with trixie gcc14

### DIFF
--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -53,9 +53,10 @@ function sources_ppsspp() {
     # ensure Pi vendor libraries are available for linking of shared library
     sed -n -i "p; s/^set(CMAKE_EXE_LINKER_FLAGS/set(CMAKE_SHARED_LINKER_FLAGS/p" cmake/Toolchains/raspberry.armv?.cmake
 
-    # fix missing defines on opengles2 on v1.16.6 lr-ppsspp/ppsspp
+    # fix missing defines on opengles2 and gcc14 ttf_font on v1.16.6 lr-ppsspp/ppsspp
     if [[ "$md_id" == "ppsspp" && "$(_get_release_ppsspp)" == "v1.16.6" ]]; then
         applyPatch "${__mod_info[ppsspp/path]%/*}/ppsspp/gles2_fix.diff"
+        applyPatch "${__mod_info[ppsspp/path]%/*}/ppsspp/gcc14_sdl_fix.diff"
     fi
 
     if hasPackage cmake 3.6 lt; then

--- a/scriptmodules/emulators/ppsspp/gcc14_sdl_fix.diff
+++ b/scriptmodules/emulators/ppsspp/gcc14_sdl_fix.diff
@@ -1,0 +1,28 @@
+diff --git a/Common/Render/Text/draw_text_sdl.h b/Common/Render/Text/draw_text_sdl.h
+index 87c543a..810392f 100644
+--- a/Common/Render/Text/draw_text_sdl.h
++++ b/Common/Render/Text/draw_text_sdl.h
+@@ -10,7 +10,7 @@
+ #endif
+ 
+ // SDL2_ttf's TTF_Font is a typedef of _TTF_Font.
+-struct _TTF_Font;
++#include <SDL2/SDL_ttf.h>
+ 
+ class TextDrawerSDL : public TextDrawer {
+ public:
+@@ -33,12 +33,12 @@ class TextDrawerSDL : public TextDrawer {
+ 	bool FindFallbackFonts(uint32_t missingGlyph, int ptSize);
+ 
+ 	uint32_t fontHash_;
+-	std::map<uint32_t, _TTF_Font *> fontMap_;
++	std::map<uint32_t, TTF_Font *> fontMap_;
+ 
+ 	std::map<CacheKey, std::unique_ptr<TextStringEntry>> cache_;
+ 	std::map<CacheKey, std::unique_ptr<TextMeasureEntry>> sizeCache_;
+ 
+-	std::vector<_TTF_Font *> fallbackFonts_;
++	std::vector<TTF_Font *> fallbackFonts_;
+ 	std::vector<std::pair<std::string, int>> fallbackFontPaths_; // path and font face index
+ 
+ #if defined(USE_SDL2_TTF_FONTCONFIG)


### PR DESCRIPTION
The current implementation of draw_text_sdl.h uses a forward declaration of the internal `_TTF_Font` struct. In recent versions of SDL_ttf and stricter C++ environments (GCC 14), this leads to type mismatch errors and "incomplete type" errors.