### PR TITLE
image - Update Raspberry Pi lite images for rpios-bookworm/bookworm-64

### DIFF
--- a/scriptmodules/admin/image/dists/rpios-bookworm-64.ini
+++ b/scriptmodules/admin/image/dists/rpios-bookworm-64.ini
@@ -1,6 +1,6 @@
 name="bookworm-64"
 version="12"
-url="https://downloads.raspberrypi.com/raspios_oldstable_arm64/images/raspios_oldstable_arm64-2025-10-02/2025-10-01-raspios-bookworm-arm64.img.xz"
+url="https://downloads.raspberrypi.com/raspios_oldstable_lite_arm64/images/raspios_oldstable_lite_arm64-2025-11-24/2025-11-24-raspios-bookworm-arm64-lite.img.xz"
 format="xz"
 platforms="rpi3 rpi4 rpi5"
 file_rpi3="rpi3"

--- a/scriptmodules/admin/image/dists/rpios-bookworm.ini
+++ b/scriptmodules/admin/image/dists/rpios-bookworm.ini
@@ -1,6 +1,6 @@
 name="bookworm"
 version="12"
-url="https://downloads.raspberrypi.org/raspios_oldstable_lite_armhf/images/raspios_oldstable_lite_armhf-2025-10-02/2025-10-01-raspios-bookworm-armhf-lite.img.xz"
+url="https://downloads.raspberrypi.com/raspios_oldstable_lite_armhf/images/raspios_oldstable_lite_armhf-2025-11-24/2025-11-24-raspios-bookworm-armhf-lite.img.xz"
 format="xz"
 platforms="rpi1 rpi2 rpi3 rpi4 rpi5"
 file_rpi1="rpi1_zero"


### PR DESCRIPTION
Fix incorrect use of non lite image ini rpios-bookworm-64.ini