### PR TITLE
lr-mupen64plus - Fix building on rpi5 on bookworm (32bit)

### DIFF
--- a/scriptmodules/libretrocores/lr-mupen64plus.sh
+++ b/scriptmodules/libretrocores/lr-mupen64plus.sh
@@ -63,10 +63,12 @@ function build_lr-mupen64plus() {
         params+=(platform="$__platform-mesa")
     elif isPlatform "mali"; then
         params+=(platform="odroid")
-    else
-        isPlatform "arm" && params+=(WITH_DYNAREC=arm)
-        isPlatform "neon" && params+=(HAVE_NEON=1)
     fi
+
+    # set these ourselves, to fix missing platforms in the Makefile (eg. rpi5)
+    isPlatform "arm" && params+=(WITH_DYNAREC=arm)
+    isPlatform "neon" && params+=(HAVE_NEON=1)
+
     if isPlatform "gles3"; then
         params+=(FORCE_GLES3=1)
     elif isPlatform "gles"; then


### PR DESCRIPTION
The Makefile doesn't include a section for the rpi5 for 32bit. Setting WITH_DYNAREC/HAVE_NEON manually based on platform flags resolves this.