### PR TITLE
Install libconfuse-dev in build_snesdev function

### DIFF
--- a/scriptmodules/supplementary/snesdev.sh
+++ b/scriptmodules/supplementary/snesdev.sh
@@ -30,6 +30,8 @@ function sources_snesdev() {
 }
 
 function build_snesdev() {
+    aptInstall libconfuse-dev
+
     local wiringpi_version
     wiringpi_version="$(dpkg-query -f='${Version} ${Status}' -W wiringpi 2>/dev/null | grep installed | cut -f1)"
 


### PR DESCRIPTION
Added installation of libconfuse-dev for build process, otherwise build and install fails.