### PR TITLE
snesdev: fix build on Trixie/Buster

### DIFF
--- a/scriptmodules/supplementary/snesdev.sh
+++ b/scriptmodules/supplementary/snesdev.sh
@@ -25,15 +25,19 @@ function _wiringpi_snesdev() {
     popd
 }
 
+function depends_snesdev() {
+    getDepends libconfuse-dev
+}
+
 function sources_snesdev() {
     gitPullOrClone
 }
 
 function build_snesdev() {
     local wiringpi_version
-    wiringpi_version="$(dpkg-query -f='${Version} ${Status}' -W wiringpi 2>/dev/null | grep installed | cut -f1)"
+    wiringpi_version="$(dpkg-query -f='${Version} ${Status}' -W wiringpi 2>/dev/null | grep installed | cut -f1 -d' ')"
 
-    cd "$md_inst"
+    CFLAGS+=" -Wno-incompatible-pointer-types"
     if [[ -z "$wiringpi_version" ]] || compareVersions "$wiringpi_version" lt 3.14; then
         # when there's no WiringPi installed or there's an old version, build a static version and use it
         printMsgs console "Using locally built WiringPi library"


### PR DESCRIPTION
* Trixie needs the CFLAGS for pointer conversion checks to be relaxed in order to complete the compilation.
* Buster had an error with the WirinPi version detection step which resulted in the wrong WiringPi `.deb` being installed.
* Added `libconfuse-dev` as dependency, to avoid compiling the older vendored library included. The older (included) version doesn't compile on Trixie without specifying the `--build` parameter for `configure`, but the package is present on Buster also, so use it as a dependency.

Supercedes #4160