### PR TITLE
wikidocs: simplify dependencies for build

### DIFF
--- a/scriptmodules/admin/wikidocs.sh
+++ b/scriptmodules/admin/wikidocs.sh
@@ -24,7 +24,7 @@ function sources_wikidocs() {
 function build_wikidocs() {
     python3 -m venv "$md_inst"
     source "$md_inst/bin/activate"
-    pip3 install --upgrade mkdocs mkdocs-material mdx_truly_sane_lists git+https://github.com/cmitu/mkdocs-altlink-plugin
+    pip3 install --upgrade mkdocs-material mdx_truly_sane_lists git+https://github.com/cmitu/mkdocs-altlink-plugin
     mkdocs build
     deactivate
 }


### PR DESCRIPTION
The `mkdocs` module is already a dependency of `mkdocs-material`, so don't install it manually. Since the upcoming (projected) Mkdocs 2.0 will not be compatible with `mkdocs-material` (and any existing plugins for that matter), let's have the transitive depdency install the right `mkdocs` (v1.x) version when building the doc site.

For further context: https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/