### PR TITLE
scummvm: update to version 2026.1.0

### DIFF
--- a/scriptmodules/emulators/scummvm-sdl1.sh
+++ b/scriptmodules/emulators/scummvm-sdl1.sh
@@ -13,7 +13,7 @@ rp_module_id="scummvm-sdl1"
 rp_module_desc="ScummVM - built with legacy SDL1 support."
 rp_module_help="Copy your ScummVM games to $romdir/scummvm"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/scummvm/scummvm/master/COPYING"
-rp_module_repo="git https://github.com/scummvm/scummvm.git v2.9.1"
+rp_module_repo="git https://github.com/scummvm/scummvm.git v2026.1.0"
 rp_module_section="opt"
 rp_module_flags="sdl1 !mali !x11 !kms"
 

--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -13,13 +13,13 @@ rp_module_id="scummvm"
 rp_module_desc="ScummVM"
 rp_module_help="Copy your ScummVM games to $romdir/scummvm"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/scummvm/scummvm/master/COPYING"
-rp_module_repo="git https://github.com/scummvm/scummvm.git v2.9.1"
+rp_module_repo="git https://github.com/scummvm/scummvm.git v2026.1.0"
 rp_module_section="opt"
 rp_module_flags="sdl2"
 
 function depends_scummvm() {
     local depends=(
-        liba52-0.7.4-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libgif-dev libmad0-dev libpng-dev
+        liba52-0.7.4-dev libmpeg2-4-dev libogg-dev libvorbis-dev libenet-dev libflac-dev libgif-dev libmad0-dev libpng-dev
         libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev
         libjpeg-dev libasound2-dev libcurl4-openssl-dev libmikmod-dev libvpx-dev
     )
@@ -44,17 +44,12 @@ function build_scummvm() {
         --prefix="$md_inst"
         --enable-release --enable-vkeybd
         --disable-debug --disable-eventrecorder --disable-sonivox
+        --disable-updates --disable-discord --disable-imgui --disable-gtk
     )
-    isPlatform "rpi" && isPlatform "32bit" && params+=(--host=raspberrypi)
     isPlatform "rpi" && [[ "$md_id" == "scummvm-sdl1" ]] && params+=(--opengl-mode=none)
-    # stop scummvm using arm-linux-gnueabihf-g++ which is v4.6 on
-    # wheezy and doesn't like rpi2 cpu flags
-    if isPlatform "rpi"; then
-        if [[ "$md_id" == "scummvm-sdl1" ]]; then
-            SDL_CONFIG=sdl-config CC="gcc" CXX="g++" ./configure "${params[@]}"
-        else
-            CC="gcc" CXX="g++" ./configure "${params[@]}"
-        fi
+
+    if [[ "$md_id" == "scummvm-sdl1" ]]; then
+        SDL_CONFIG=sdl-config ./configure "${params[@]}"
     else
         ./configure "${params[@]}"
     fi


### PR DESCRIPTION
Scriptmodule updates:

 * removed the `host` parameter for the build configuration since it's only useful for cross-compiling to the RPI. It alse presets SDL2 to be used, but we're using that anyway
 * removed the workarounds for 'wheezy' for CC/CPP, they're not longer needed with the current versions of GCC.
 * added a few more features excluded from the build which are not useful for our use case
 * added an extra depdendency to `libenev-dev`, used by a few platforms

ScummVM added 12 new engines and quite a few new games, most notable being:

 * Dark Seed
 * God of Thunder
 * The Adventures of Willy Beamish
 * Heart of China
 * Nancy Drew: Secret of the Scarlet Hand
 * Nancy Drew: Ghost Dogs of Moon Lake
 * Ripley's Believe It or Not!: The Riddle of Master Lu
 * Little Longnose
 * Pilot Brothers 3: Back Side of the Earth
 * Pilot Brothers 3D. The Case of Garden Pests
 * Pilot Brothers 3D-2. Kennel Club Secrets
 * Features of National Fishing
 * Mom Don't Worry
 * Dog-n-cat: In the Footsteps of Unprecedented Beasts
 * Dog-n-cat: Island of Dr Ratiarty
 * Out of this World (Another World)
 * SLUDGE-based games
 * Adibou 2: Nature & Sciences
 * WAGE-based games
 * Penumbra: Overture
 * Tex Murphy: Martian Memorandum
 * Mort&Phil: A Movie Adventure (Special Edition)
 * Trick or Treat
 * Hodj 'n' Podj
 * The Last Express

Release announcement: https://www.scummvm.org/news/20260131/
Full changelog: https://downloads.scummvm.org/frs/scummvm/2026.1.0/ReleaseNotes.html