### PR TITLE
ppsspp: update to version v1.20.x

### DIFF
--- a/platforms.cfg
+++ b/platforms.cfg
@@ -193,7 +193,7 @@ ports_platform="pc"
 ps2_exts=".iso .img .bin .mdf .z .z2 .bz2 .dump .cso .chd .ima .gz"
 ps2_fullname="PlayStation 2"
 
-psp_exts=".iso .pbp .cso"
+psp_exts=".chd .iso .pbp .cso"
 psp_fullname="PlayStation Portable"
 
 psx_exts=".cue .cbn .chd .img .iso .m3u .mdf .pbp .toc .z .znx"

--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -18,16 +18,24 @@ rp_module_section="opt"
 rp_module_flags=""
 
 function _get_release_ppsspp() {
-    local tagged_version="v1.16.6"
-    #  the V3D Mesa driver before 21.x has issues with v1.14 and later
-    if [[ "$__os_debian_ver" -lt 11 ]] && isPlatform "kms" && isPlatform "rpi"; then
-        tagged_version="v1.13.2"
+    local tagged_version="v1.20.1"
+    # buster and older can't compile recent PPSSPP
+    if [[ "$__os_debian_ver" -lt 11 ]]; then
+        #  the V3D Mesa driver before 21.x has issues with v1.14 and later
+        if isPlatform "kms" && isPlatform "rpi"; then
+            tagged_version="v1.13.2"
+        else
+            tagged_version="v1.16.6"
+        fi
     fi
     echo $tagged_version
 }
 
 function depends_ppsspp() {
-    local depends=(cmake libsdl2-dev libsnappy-dev libzip-dev zlib1g-dev)
+    local depends=(cmake libbrotli-dev libsnappy-dev libbz2-dev libzip-dev zlib1g-dev libzstd-dev libminiupnpc-dev)
+    [[ $md_id != "lr-ppsspp" ]] && depends+=(libsdl2-dev libsdl2-ttf-dev libfontconfig-dev)
+    [[ $md_id != "lr-ppsspp" ]] && isPlatform "x11" && depends+=(libx11-dev wayland-protocols libwayland-dev)
+    isPlatform "x86" && depends+=(nasm)
     isPlatform "videocore" && depends+=(libraspberrypi-dev)
     isPlatform "mesa" && depends+=(libgles2-mesa-dev)
     isPlatform "vero4k" && depends+=(vero3-userland-dev-osmc)
@@ -58,12 +66,6 @@ function sources_ppsspp() {
     if [[ "$md_id" == "ppsspp" && "$(_get_release_ppsspp)" == "v1.16.6" ]]; then
         applyPatch "${__mod_info[ppsspp/path]%/*}/ppsspp/gles2_fix.diff"
         applyPatch "${__mod_info[ppsspp/path]%/*}/ppsspp/sdl_ttf_fix_before_1.19.diff"
-    fi
-
-    if hasPackage cmake 3.6 lt; then
-        cd ..
-        mkdir -p cmake
-        downloadAndExtract "$__archive_url/cmake-3.6.2.tar.gz" "$md_build/cmake" --strip-components 1
     fi
 }
 
@@ -122,26 +124,16 @@ function build_ffmpeg_ppsspp() {
     make install
 }
 
-function build_cmake_ppsspp() {
-    cd "$md_build/cmake"
-    ./bootstrap
-    make
-}
-
 function build_ppsspp() {
     local ppsspp_binary="PPSSPPSDL"
-    local cmake="cmake"
-    if hasPackage cmake 3.6 lt; then
-        build_cmake_ppsspp
-        cmake="$md_build/cmake/bin/cmake"
-    fi
 
     # build ffmpeg
     build_ffmpeg_ppsspp "$md_build/ppsspp/ffmpeg"
 
     # build ppsspp
     cd "$md_build/ppsspp"
-    rm -rf CMakeCache.txt CMakeFiles
+    rm -fr "build" && mkdir "build"
+    cd "build"
     local params=()
     if isPlatform "videocore"; then
         if isPlatform "armv6"; then
@@ -171,21 +163,29 @@ function build_ppsspp() {
     if isPlatform "arm" && ! isPlatform "vulkan"; then
         params+=(-DARM_NO_VULKAN=ON)
     fi
+    if isPlatform "vulkan"; then
+        params+=(-DUSE_VULKAN_DISPLAY_KHR=ON)
+    fi
+    if isPlatform "x11"; then
+        params+=(-DUSE_WAYLAND_WSI=ON -DUSING_X11_VULKAN=ON)
+    fi
     if [[ "$md_id" == "lr-ppsspp" ]]; then
         params+=(-DLIBRETRO=On)
         ppsspp_binary="lib/ppsspp_libretro.so"
     fi
-    "$cmake" "${params[@]}" .
+    params+=(-DUSE_SYSTEM_SNAPPY=ON -DUSE_SYSTEM_ZSTD=ON -DUSE_SYSTEM_LIBZIP=ON -DUSE_SYSTEM_LIBSDL2=ON -DUSE_SYSTEM_ZSTD=ON -DUSE_SYSTEM_MINIUPNPC=ON)
+    params+=(-DUSE_DISCORD=OFF)
+    cmake "${params[@]}" ..
     make clean
     make
 
-    md_ret_require="$md_build/ppsspp/$ppsspp_binary"
+    md_ret_require="$md_build/ppsspp/build/$ppsspp_binary"
 }
 
 function install_ppsspp() {
     md_ret_files=(
-        'ppsspp/assets'
-        'ppsspp/PPSSPPSDL'
+        'ppsspp/build/assets'
+        'ppsspp/build/PPSSPPSDL'
     )
 }
 

--- a/scriptmodules/libretrocores/lr-ppsspp.sh
+++ b/scriptmodules/libretrocores/lr-ppsspp.sh
@@ -42,8 +42,8 @@ function build_lr-ppsspp() {
 
 function install_lr-ppsspp() {
     md_ret_files=(
-        'ppsspp/lib/ppsspp_libretro.so'
-        'ppsspp/assets'
+        'ppsspp/build/lib/ppsspp_libretro.so'
+        'ppsspp/build/assets'
     )
 }
 


### PR DESCRIPTION
Update our version to the latest release. Too many versions/changes to include here, links to the release announcements:

* Release 1.20 (Feb 2026) - https://www.ppsspp.org/news/release-1.20/
* Release 1.19 (June 2025) - https://www.ppsspp.org/news/release-1.19/
* Release 1.18 (November 2024) - https://www.ppsspp.org/news/release-1.18/
* Release 1.17 (January 2024) - https://www.ppsspp.org/news/release-1.17/

 New version has RetroAchievements support and now supports CHD as a storage media.

Module changes:

 - 1.20.x is enabled only for Bullseye and later, since it needs GCC 9 at least. For now, we keep the local patches we have for 1.13 and 1.16.
 - revised the list of dependencies and added them selectively based on the platform/module used.
 - removed the `cmake` local build, it's not needed on the platforms we support. Minimum requirement is 3.16 (on the latest version) and Buster included 3.18 (at lease on Raspbian) so I think this wasn't needed for quite some time.
 - changed some of the build options to force the system libraries, disable Discord and enable the Vulkan KHR fullscreen extension.
 - the `cmake` build needs to be done out-of-tree, so the build and binary/assets paths have been adjusted