### PR TITLE
system: add 'gpg' as essential package

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -331,7 +331,7 @@ function get_os_version() {
 }
 
 function get_retropie_depends() {
-    local depends=(git subversion dialog curl gcc g++ build-essential unzip xmlstarlet python3-pyudev ca-certificates dirmngr)
+    local depends=(git gpg subversion dialog curl gcc g++ build-essential unzip xmlstarlet python3-pyudev ca-certificates dirmngr)
     # on RaspiOS, install an extra package for X11 support on Pi5
     if isPlatform "rpi5" && [[ "$__os_id" == "Raspbian" ]]; then
         depends+=(gldriver-test)


### PR DESCRIPTION
`gpg` is called during system setup, but it's not installed by default on Debian. Package signature verification by `apt` depends on `gpgv or - more recently - `sqv`, so the full `gpg` package is not used on a bare/minimal system.