### PR TITLE
Fix es input missing triggers

### DIFF
--- a/scriptmodules/supplementary/emulationstation/configscripts/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/emulationstation.sh
@@ -54,7 +54,7 @@ function map_emulationstation_joystick() {
         rightbottom|rightshoulder)
             key="pagedown"
             ;;
-        up|right|down|left|start|select|x|y|leftanalogup|leftanalogright|leftanalogdown|leftanalogleft|rightanalogup|rightanalogright|rightanalogdown|rightanalogleft)
+        up|right|down|left|start|select|x|y|leftanalogup|leftanalogright|leftanalogdown|leftanalogleft|rightanalogup|rightanalogright|rightanalogdown|rightanalogleft|lefttrigger|righttrigger|leftthumb|rightthumb|hotkeyenable)
             key="$input_name"
             ;;
         a)


### PR DESCRIPTION
The map_emulationstation_joystick function was silently dropping lefttrigger, righttrigger, leftthumb and rightthumb inputs — they fell through to the *) return case despite being documented as supported. Add them to the passthrough case so they get written to es_input.cfg.

What's happening is that when a controller is configured with the 'wizard', these inputs are not copied in and then these inputs can't be used in ES .Right now most (if not all) are unused, but during development i noticed that these buttons were not being responsive and then i noticed they were missing the in the es_input.cfg. Adding them in manually showed that it made ES responsive, and this script was the one that generated that file.