### PR TITLE
attractmode: fix build on RPI systems

### DIFF
--- a/scriptmodules/supplementary/attractmode.sh
+++ b/scriptmodules/supplementary/attractmode.sh
@@ -147,20 +147,21 @@ function sources_attractmode() {
 function build_attractmode() {
     if isPlatform "rpi"; then
         local params
-        cd sfml-pi
+        cd "$md_build/sfml-pi"
         isPlatform "videocore" && params="-DSFML_RPI=1 -DEGL_INCLUDE_DIR=/opt/vc/include -DEGL_LIBRARY=/opt/vc/lib/libbrcmEGL.so -DGLES_INCLUDE_DIR=/opt/vc/include -DGLES_LIBRARY=/opt/vc/lib/libbrcmGLESv2.so"
         isPlatform "kms" && params="-DSFML_DRM=1"
-        cmake . -DCMAKE_INSTALL_PREFIX="$md_inst/sfml" $params
+        cmake . -DCMAKE_INSTALL_PREFIX="$md_inst/sfml" -DSFML_INSTALL_PKGCONFIG_FILES=Yes $params
         make clean
         make
-        cd ..
+        make install
+        export PKG_CONFIG_PATH="$md_inst/sfml"
     fi
-    cd attract
+    cd "$md_build/attract"
     make clean
     local params=(prefix="$md_inst")
-    isPlatform "videocore" && params+=(USE_GLES=1 EXTRA_CXXFLAGS="$CFLAGS -I$md_build/sfml-pi/include -L$md_build/sfml-pi/lib")
-    isPlatform "kms" && params+=(USE_DRM=1 EXTRA_CXXFLAGS="$CFLAGS -I$md_build/sfml-pi/include -L$md_build/sfml-pi/lib")
-    isPlatform "rpi" && params+=(USE_MMAL=1)
+    isPlatform "videocore" && params+=(USE_MMAL=1)
+    isPlatform "kms" && params+=(USE_DRM=1)
+    isPlatform "gles" && params+=(USE_GLES=1)
     make "${params[@]}"
 
     # remove example configs


### PR DESCRIPTION
Due to a recent upstream change in the `Makefile`, the SFML custom installed libs on RPI systems are not found by `pkg-config` and since `pkg-config` throws an error, the build fails due to missing include files and missing library names/paths.

To fix this, run the install steps for the `sfml-pi` library in order for the `.pc` files needed by `pkg-config` to be generated and then reference them during the `attractmode` build through the `PKG_CONFIG_PATH` env var.