### PR TITLE
lr-virtualjaguar: add NEON buld flags

### DIFF
--- a/scriptmodules/libretrocores/lr-virtualjaguar.sh
+++ b/scriptmodules/libretrocores/lr-virtualjaguar.sh
@@ -22,8 +22,10 @@ function sources_lr-virtualjaguar() {
 }
 
 function build_lr-virtualjaguar() {
+    local build_args
     make clean
-    make
+    isPlatform "neon" && build_flags+=" HAVE_NEON=1"
+    make $build_flags
     md_ret_require="$md_build/virtualjaguar_libretro.so"
 }
 


### PR DESCRIPTION
There have been a few recent additions to the core, one of them is the SIMD optimized blitters supporting SSE2 (for PC) and NEON (for ARM). While for ARM64 the NEON blitter path is built automatically, for 32bit platforms is not, so enable it on the supporting platforms.