### PR TITLE
retroarch: fix build with FFmpeg 7+ (libavcodec >= 61.3.100)

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -35,6 +35,10 @@ function depends_retroarch() {
 
 function sources_retroarch() {
     gitPullOrClone
+    # Fix build with FFmpeg 7+ (libavcodec >= 61.3.100): avcodec_close() and
+    # AV_INPUT_BUFFER_MIN_SIZE were removed. Affects Ubuntu 26.04 and other
+    # distros shipping FFmpeg 7.x.
+    applyPatch "$md_data/01-ffmpeg7-api-compat.diff"
 }
 
 function build_retroarch() {

--- a/scriptmodules/emulators/retroarch/01-ffmpeg7-api-compat.diff
+++ b/scriptmodules/emulators/retroarch/01-ffmpeg7-api-compat.diff
@@ -1,0 +1,73 @@
+diff --git a/cores/libretro-ffmpeg/ffmpeg_core.c b/cores/libretro-ffmpeg/ffmpeg_core.c
+index 08bee25..b5edd49 100644
+--- a/cores/libretro-ffmpeg/ffmpeg_core.c
++++ b/cores/libretro-ffmpeg/ffmpeg_core.c
+@@ -2088,19 +2088,28 @@ void CORE_PREFIX(retro_unload_game)(void)
+ 
+    for (i = 0; i < MAX_STREAMS; i++)
+    {
++#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 3, 100)
++      avcodec_free_context(&sctx[i]);
++      avcodec_free_context(&actx[i]);
++#else
+       if (sctx[i])
+          avcodec_close(sctx[i]);
+       if (actx[i])
+          avcodec_close(actx[i]);
+       sctx[i] = NULL;
+       actx[i] = NULL;
++#endif
+    }
+ 
++#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 3, 100)
++   avcodec_free_context(&vctx);
++#else
+    if (vctx)
+    {
+       avcodec_close(vctx);
+       vctx = NULL;
+    }
++#endif
+ 
+    if (fctx)
+    {
+diff --git a/record/drivers/record_ffmpeg.c b/record/drivers/record_ffmpeg.c
+index 0af5499..36c566a 100644
+--- a/record/drivers/record_ffmpeg.c
++++ b/record/drivers/record_ffmpeg.c
+@@ -71,6 +71,10 @@ extern "C" {
+ 
+ #define FFMPEG3 (LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 10, 100))
+ #define HAVE_CH_LAYOUT (LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 28, 100))
++/* AV_INPUT_BUFFER_MIN_SIZE removed in FFmpeg 7.0 (libavcodec 61.3.100) */
++#ifndef AV_INPUT_BUFFER_MIN_SIZE
++#define AV_INPUT_BUFFER_MIN_SIZE 16384
++#endif
+ 
+ struct ff_video_info
+ {
+@@ -949,16 +953,24 @@ static void ffmpeg_free(void *data)
+ 
+    if (handle->audio.codec)
+    {
++#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 3, 100)
++      avcodec_free_context(&handle->audio.codec);
++#else
+       avcodec_close(handle->audio.codec);
+       av_free(handle->audio.codec);
++#endif
+    }
+ 
+    av_free(handle->audio.buffer);
+ 
+    if (handle->video.codec)
+    {
++#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 3, 100)
++      avcodec_free_context(&handle->video.codec);
++#else
+       avcodec_close(handle->video.codec);
+       av_free(handle->video.codec);
++#endif
+    }
+ 
+    av_frame_free(&handle->video.conv_frame);


### PR DESCRIPTION
## Summary

Fixes #4189

RetroArch fails to build on systems with FFmpeg 7.0+ (e.g. Ubuntu 26.04, released 2026-04-23, which ships libavcodec 62.11.100). Two previously deprecated symbols were fully removed in FFmpeg 7.0 (libavcodec 61.3.100):

- `AV_INPUT_BUFFER_MIN_SIZE` — removed from `<libavcodec/avcodec.h>`
- `avcodec_close()` — replaced by `avcodec_free_context()`

## Changes

- **`scriptmodules/emulators/retroarch/01-ffmpeg7-api-compat.diff`** — patch applied to the RetroArch source during `sources_retroarch()`:
  - `record/drivers/record_ffmpeg.c`: adds `#ifndef AV_INPUT_BUFFER_MIN_SIZE` fallback (`16384`) and replaces `avcodec_close() + av_free()` with `avcodec_free_context()`
  - `cores/libretro-ffmpeg/ffmpeg_core.c`: replaces all `avcodec_close()` calls with `avcodec_free_context()`
- **`scriptmodules/emulators/retroarch.sh`**: calls `applyPatch` in `sources_retroarch()` to apply the above patch

All changes are guarded by `LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 3, 100)` so older FFmpeg versions (Raspberry Pi OS, Debian Bullseye/Bookworm, etc.) are **not affected**.

## Test plan

- [x] Built successfully on Ubuntu 26.04 with libavcodec 62.11.100 (`make -j$(nproc)` completes without errors)
- [ ] Verify no regression on Raspberry Pi OS (Debian Bookworm, FFmpeg 5.x/6.x)
- [ ] Verify `applyPatch` skip logic works correctly on re-runs (`.applied` marker file)

## Environment tested

| Field | Value |
|-------|-------|
| OS | Ubuntu 26.04 LTS (released 2026-04-23) |
| libavcodec | 62.11.100 |
| RetroArch | retropie-v1.19.0 |
| GCC | system default |

🤖 Generated with [Claude Code](https://claude.com/claude-code)