### PR TITLE
retropiemenu: handle p7zip package rename on Ubuntu 24.04+

### DIFF
--- a/scriptmodules/supplementary/retropiemenu.sh
+++ b/scriptmodules/supplementary/retropiemenu.sh
@@ -24,7 +24,12 @@ function _update_hook_retropiemenu() {
 }
 
 function depends_retropiemenu() {
-    getDepends mc p7zip
+    local p7zip_pkg="p7zip"
+    # Ubuntu 26.04+ renamed p7zip to 7zip
+    if [[ "$__os_id" == "Ubuntu" ]] && compareVersions "$__os_ubuntu_ver" ge "26.04"; then
+        p7zip_pkg="7zip"
+    fi
+    getDepends mc "$p7zip_pkg"
 }
 
 function install_bin_retropiemenu() {


### PR DESCRIPTION
## Summary

Ubuntu 24.04 replaced the `p7zip` package with `7zip`. Running an update on Ubuntu 24.04+ produces:

```
Did not find needed dependencies: p7zip. Trying to install them now.
Could not install package(s): p7zip.
```

`7zip` is already installed on these systems (e.g. `7zip 26.00+dfsg-1`), but the dependency check requests the old package name and fails.

## Fix

Probe `apt-cache show p7zip` at install time. If `p7zip` is not available, fall back to `7zip`. Older distributions that still ship `p7zip` (Debian Bookworm, Ubuntu 22.04, Raspberry Pi OS) are unaffected.

## Test

Verified on Ubuntu 26.04 / kernel 7.0.0-14-generic.