### PR TITLE
customhidsony: fix DKMS build failures on kernel >= 6.12

### DIFF
--- a/scriptmodules/supplementary/customhidsony.sh
+++ b/scriptmodules/supplementary/customhidsony.sh
@@ -29,6 +29,8 @@ function sources_customhidsony() {
 
     cat > "Makefile" << _EOF_
 obj-m := drivers/hid/hid-sony.o
+# kernel >= 6.x changed report_fixup return type to const u8*; suppress the pointer-type error
+ccflags-y += -Wno-error=incompatible-pointer-types
 _EOF_
 
     cat > "dkms.conf" << _EOF_
@@ -48,6 +50,13 @@ mkdir -p "drivers/hid/" "patches"
 curl -s https://raw.githubusercontent.com/raspberrypi/linux/"\$rpi_kernel_ver"/drivers/hid/hid-sony.c -o "drivers/hid/hid-sony.c"
 curl -s https://raw.githubusercontent.com/raspberrypi/linux/"\$rpi_kernel_ver"/drivers/hid/hid-ids.h -o "drivers/hid/hid-ids.h"
 patch -p1 <"patches/0001-hidsony-gasiafix.diff"
+# kernel >= 6.12 removed asm/unaligned.h; replaced by linux/unaligned.h
+KVER="\${kernelver:-\$(uname -r)}"
+KMAJ=\$(echo "\$KVER" | cut -d. -f1)
+KMIN=\$(echo "\$KVER" | cut -d. -f2 | cut -d- -f1)
+if [ "\$KMAJ" -gt 6 ] || { [ "\$KMAJ" -eq 6 ] && [ "\$KMIN" -ge 12 ]; }; then
+    sed -i 's|#include <asm/unaligned.h>|#include <linux/unaligned.h>|g' drivers/hid/hid-sony.c
+fi
 _EOF_
     chmod +x "hidsony_source.sh"
 


### PR DESCRIPTION
## Summary

Two kernel API changes break the hid-sony DKMS module when building against kernel >= 6.12 (Ubuntu 24.10+):

**1. `asm/unaligned.h` removed (kernel >= 6.12)**

The hid-sony source downloaded from `rpi-5.10.y` includes `<asm/unaligned.h>`, which was removed in kernel 6.12 in favour of `<linux/unaligned.h>`. Build error:

```
drivers/hid/hid-sony.c:38:10: fatal error: asm/unaligned.h: No such file or directory
```

Fix: detect the kernel version in the DKMS `PRE_BUILD` script and replace the include via `sed` when `kernel >= 6.12`.

**2. `hid_driver.report_fixup` return type changed to `const u8 *` (kernel >= 6.2)**

The old source has `sony_report_fixup` returning `u8 *`, but newer kernel headers expect `const u8 *`, causing `-Werror=incompatible-pointer-types` to abort the build:

```
hid-sony.c:3053:29: error: initialization of 'const __u8 *...' from incompatible pointer type 'u8 *...'
```

Fix: add `ccflags-y += -Wno-error=incompatible-pointer-types` to the DKMS `Makefile`. Promoting `u8 *` to `const u8 *` is always safe. On older kernels the flag is a no-op.

## Backwards compatibility

- `asm/unaligned.h` replacement: guarded by kernel version check, no change on kernel < 6.12
- `ccflags-y` flag: no-op on kernels where the type already matches

## Test

Verified on Ubuntu 26.04 / kernel 7.0.0-14-generic and kernel 6.17.0-22-generic.