### PR TITLE
lr-flycast: fix implicit POSIX function declarations for glibc >= 2.40

### DIFF
--- a/scriptmodules/libretrocores/lr-flycast.sh
+++ b/scriptmodules/libretrocores/lr-flycast.sh
@@ -33,6 +33,9 @@ function sources_lr-flycast() {
     gitPullOrClone
     # don't override our C/CXXFLAGS and set LDFLAGS to CFLAGS to avoid warnings on linking
     applyPatch "$md_data/01_flags_fix.diff"
+    # glibc >= 2.40 (Ubuntu 26.04+) requires explicit unistd.h for POSIX functions
+    applyPatch "$md_data/02_getpid_fix.diff"
+    applyPatch "$md_data/03_zip_close_fix.diff"
 }
 
 function build_lr-flycast() {

--- a/scriptmodules/libretrocores/lr-flycast/02_getpid_fix.diff
+++ b/scriptmodules/libretrocores/lr-flycast/02_getpid_fix.diff
@@ -1,0 +1,10 @@
+--- a/core/deps/libzip/mkstemp.c
++++ b/core/deps/libzip/mkstemp.c
+@@ -43,7 +43,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+
+-#if defined(__APPLE__) || defined(__SWITCH__)
++#if defined(__APPLE__) || defined(__SWITCH__) || defined(__linux__)
+ #include <unistd.h>
+ #endif

--- a/scriptmodules/libretrocores/lr-flycast/03_zip_close_fix.diff
+++ b/scriptmodules/libretrocores/lr-flycast/03_zip_close_fix.diff
@@ -1,0 +1,10 @@
+--- a/core/deps/libzip/zip_close.c
++++ b/core/deps/libzip/zip_close.c
+@@ -42,7 +42,7 @@
+
+ #include "zipint.h"
+
+-#if defined(__APPLE__) || defined(__SWITCH__)
++#if defined(__APPLE__) || defined(__SWITCH__) || defined(__linux__)
+ #include <unistd.h>
+ #endif


### PR DESCRIPTION
## Summary

glibc 2.40 (Ubuntu 24.10+) no longer accepts implicit declarations of POSIX functions; they now require an explicit `#include <unistd.h>`. The bundled libzip in `core/deps/libzip/` guards this include only for `__APPLE__` and `__SWITCH__`, causing two build errors on Linux:

```
core/deps/libzip/mkstemp.c:70:15: error: implicit declaration of function 'getpid'
core/deps/libzip/zip_close.c:666:9: error: implicit declaration of function 'close'
```

## Fix

Add `defined(__linux__)` to the existing platform guard in the two affected files:

- `core/deps/libzip/mkstemp.c` — `getpid()`
- `core/deps/libzip/zip_close.c` — `close()`

`<unistd.h>` has always been available on Linux; this is a no-op on older distributions where glibc was more permissive.

## Test

Verified on Ubuntu 26.04 / glibc 2.41 / kernel 7.0.0-14-generic.