### PR TITLE
Fix openmsx keymapping: F1 & F2 are swapped

### DIFF
--- a/scriptmodules/supplementary/emulationstation/configscripts/openmsx.sh
+++ b/scriptmodules/supplementary/emulationstation/configscripts/openmsx.sh
@@ -104,10 +104,10 @@ function map_openmsx_joystick() {
             msx_key="RIGHT"
             ;;
         x)
-            emu_key="keymatrixdown 6 0x40" # F1
+            emu_key="keymatrixdown 6 0x20" # F1
             ;;
         y)
-            emu_key="keymatrixdown 6 0x20" # F2
+            emu_key="keymatrixdown 6 0x40" # F2
             ;;
         lefttop|leftshoulder|pageup)
             emu_key="keymatrixdown 6 0x80" # F3


### PR DESCRIPTION
Fix openmsx keymapping: F1 & F2 are swapped. 

The MSX key matrix at https://map.grauw.nl/articles/keymatrix.php documents that bit 5 & 6 map to F1 and F2, respectively.

This PR maps "x" (host controller) to F1 (MSX) and "y" (host controller) to F2 (MSX).