### PR TITLE
Update Yamagi Quake 2 to 8.70

### DIFF
--- a/scriptmodules/ports/yquake2.sh
+++ b/scriptmodules/ports/yquake2.sh
@@ -12,7 +12,7 @@
 rp_module_id="yquake2"
 rp_module_desc="yquake2 - The Yamagi Quake II client"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/yquake2/yquake2/master/LICENSE"
-rp_module_repo="git https://github.com/yquake2/yquake2.git QUAKE2_8_60"
+rp_module_repo="git https://github.com/yquake2/yquake2.git QUAKE2_8_70"
 rp_module_section="exp"
 rp_module_flags="sdl2"
 
@@ -25,8 +25,8 @@ function depends_yquake2() {
 function sources_yquake2() {
     gitPullOrClone
     # get the add-ons sources
-    gitPullOrClone "$md_build/xatrix" "https://github.com/yquake2/xatrix" "XATRIX_2_16"
-    gitPullOrClone "$md_build/rogue" "https://github.com/yquake2/rogue" "ROGUE_2_15"
+    gitPullOrClone "$md_build/xatrix" "https://github.com/yquake2/xatrix" "XATRIX_2_17"
+    gitPullOrClone "$md_build/rogue" "https://github.com/yquake2/rogue" "ROGUE_2_16"
 
     # 1st enables Guide+Start to quit. 2nd restores buttons to SDL2 style (from SDL3).
     applyPatch "$md_data/hotkey_exit.diff"
@@ -34,7 +34,7 @@ function sources_yquake2() {
 }
 
 function build_yquake2() {
-    local params=(config client game ref_soft)
+    local params=(WITH_SDL3=no WITH_XDG=no config client game ref_soft)
     local repo
 
     isPlatform "gl" || isPlatform "mesa" && params+=(ref_gl1)
@@ -42,7 +42,7 @@ function build_yquake2() {
     isPlatform "gles" && [[ "$__os_debian_ver" -lt 12 ]] && params+=(ref_gles1)
     isPlatform "gles3" && params+=(ref_gles3)
 
-    make clean
+    make clean WITH_SDL3=no
     make ${params[@]}
 
     # build the add-ons source

--- a/scriptmodules/ports/yquake2/hotkey_exit.diff
+++ b/scriptmodules/ports/yquake2/hotkey_exit.diff
@@ -1,12 +1,8 @@
 diff --git a/src/client/input/sdl2.c b/src/client/input/sdl2.c
-index 527e3f5c..1c693749 100644
+index c280a4f4..678fd7f1 100644
 --- a/src/client/input/sdl2.c
 +++ b/src/client/input/sdl2.c
-@@ -94,10 +94,11 @@ typedef enum
- // IN_Update() called at the beginning of a frame to the
- // actual movement functions called at a later time.
- static float mouse_x, mouse_y;
--static unsigned char joy_escbutton = SDL_CONTROLLER_BUTTON_START;
+@@ -96,6 +96,8 @@ static float mouse_x, mouse_y;
  static int joystick_left_x, joystick_left_y, joystick_right_x, joystick_right_y;
  static qboolean mlooking;
  
@@ -15,7 +11,7 @@ index 527e3f5c..1c693749 100644
  // The last time input events were processed.
  // Used throughout the client.
  int sys_frame_time;
-@@ -857,6 +858,7 @@ IN_Update(void)
+@@ -851,6 +853,7 @@ IN_Update(void)
  	static qboolean left_trigger = false;
  	static qboolean right_trigger = false;
  	static qboolean left_stick[4] = {false, false, false, false};   // left, right, up, down virtual keys
@@ -23,13 +19,14 @@ index 527e3f5c..1c693749 100644
  
  	static int consoleKeyCode = 0;
  
-@@ -1057,9 +1059,22 @@ IN_Update(void)
- 				qboolean down = (event.type == SDL_CONTROLLERBUTTONDOWN);
+@@ -1049,9 +1052,24 @@ IN_Update(void)
+ 			case SDL_CONTROLLERBUTTONDOWN:
+ 			{
  				unsigned char btn = event.cbutton.button;
++				qboolean down = (event.type == SDL_CONTROLLERBUTTONDOWN);
  
--				// Handle Esc button first, to override its original key
--				Key_Event( (btn == joy_escbutton)? K_ESCAPE : K_JOY_FIRST_BTN + btn,
--					down, true );
+-				Key_Event( (btn == SDL_CONTROLLER_BUTTON_START)? K_ESCAPE : K_JOY_FIRST_BTN + btn,
+-					(event.type == SDL_CONTROLLERBUTTONDOWN), true );
 +				switch (btn)
 +				{
 +					case SDL_CONTROLLER_BUTTON_START:
@@ -49,41 +46,18 @@ index 527e3f5c..1c693749 100644
  				break;
  			}
  
-@@ -2524,22 +2539,6 @@ IN_Controller_Init(qboolean notify_user)
- 	SDL_Joystick *joystick = NULL;
- 	SDL_bool is_controller = SDL_FALSE;
- 
--	cvar = Cvar_Get("joy_escbutton", "0", CVAR_ARCHIVE);
--	if (cvar)
--	{
--		switch ((int)cvar->value)
--		{
--			case 1:
--				joy_escbutton = SDL_CONTROLLER_BUTTON_BACK;
--				break;
--			case 2:
--				joy_escbutton = SDL_CONTROLLER_BUTTON_GUIDE;
--				break;
--			default:
--				joy_escbutton = SDL_CONTROLLER_BUTTON_START;
--		}
--	}
--
- 	cvar = Cvar_Get("in_initjoy", "1", CVAR_NOSET);
- 	if (!cvar->value)
- 	{
-@@ -2685,6 +2684,7 @@ IN_Controller_Init(qboolean notify_user)
+@@ -2754,6 +2772,7 @@ IN_Controller_Init(qboolean notify_user)
  
  			show_gamepad = true;
  			Com_Printf("Enabled as Game Controller, settings:\n%s\n", SDL_GameControllerMapping(controller));
 +			hotkey_back = ( !strstr(SDL_GameControllerMapping(controller), "guide:") );
+ 			IN_Gyro_and_LED_Enabling();
  
- #ifndef NO_SDL_GYRO
- 
-@@ -2960,6 +2960,7 @@ IN_Controller_Shutdown(qboolean notify_user)
+ 			joystick_haptic = SDL_HapticOpenFromJoystick(SDL_GameControllerGetJoystick(controller));
+@@ -2965,6 +2984,7 @@ IN_Controller_Shutdown(qboolean notify_user)
+ 	show_gamepad = show_gyro = show_haptic = gyro_active = gyro_enabled = false;
  	joystick_left_x = joystick_left_y = joystick_right_x = joystick_right_y = 0;
  	joy_active_layout = LAYOUT_NONE;
- 	gyro_enabled = false;
 +	hotkey_back = false;
  
  #ifdef NO_SDL_GYRO

--- a/scriptmodules/ports/yquake2/sdl2_joylabels.diff
+++ b/scriptmodules/ports/yquake2/sdl2_joylabels.diff
@@ -1,5 +1,5 @@
 diff --git a/src/client/cl_keyboard.c b/src/client/cl_keyboard.c
-index 20ba3fcc..c9b24c41 100644
+index 1a112cdb..47d9b7a2 100644
 --- a/src/client/cl_keyboard.c
 +++ b/src/client/cl_keyboard.c
 @@ -216,10 +216,10 @@ static char *gamepadbtns[] =
@@ -16,7 +16,7 @@ index 20ba3fcc..c9b24c41 100644
 +	"BTN_Y",
  	"BTN_BACK",
  	"BTN_GUIDE",
- 	"BTN_START",
+ 	"",	// START
 @@ -245,10 +245,10 @@ static char *gamepadbtns[] =
  	"TRIG_LEFT",
  	"TRIG_RIGHT",
@@ -31,12 +31,12 @@ index 20ba3fcc..c9b24c41 100644
 +	"BTN_Y_ALT",
  	"BTN_BACK_ALT",
  	"BTN_GUIDE_ALT",
- 	"BTN_START_ALT",
+ 	"",	// START ALT
 diff --git a/src/client/input/sdl2.c b/src/client/input/sdl2.c
-index 1c693749..2921a498 100644
+index 678fd7f1..74cb0c16 100644
 --- a/src/client/input/sdl2.c
 +++ b/src/client/input/sdl2.c
-@@ -2559,9 +2559,6 @@ IN_Controller_Init(qboolean notify_user)
+@@ -2689,9 +2689,6 @@ IN_Controller_Init(qboolean notify_user)
  #ifdef SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE
  		SDL_SetHint( SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE, "1" );
  #endif
@@ -46,7 +46,7 @@ index 1c693749..2921a498 100644
  
  		if (SDL_Init(SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC) == -1)
  		{
-@@ -2878,8 +2875,8 @@ IN_Init(void)
+@@ -2910,8 +2907,8 @@ IN_Init(void)
  	joy_forwardsensitivity = Cvar_Get("joy_forwardsensitivity", "1.0", CVAR_ARCHIVE);
  	joy_sidesensitivity = Cvar_Get("joy_sidesensitivity", "1.0", CVAR_ARCHIVE);
  


### PR DESCRIPTION
Changelog: https://github.com/yquake2/yquake2/blob/QUAKE2_8_70/CHANGELOG

I like the smoother laser lerping and the ability to change crosshair color.

Note that it now tries to compile using SDL3 instead of SDL2 by default. Support for the latter will not be discontinued in the foreseeable future, so I changed the corresponding parameters to continue using SDL2.