### PR TITLE
xroar: update to 1.11

### DIFF
--- a/scriptmodules/emulators/xroar.sh
+++ b/scriptmodules/emulators/xroar.sh
@@ -13,7 +13,7 @@ rp_module_id="xroar"
 rp_module_desc="Dragon / CoCo emulator XRoar"
 rp_module_help="ROM Extensions: .bin .cas .wav .bas .asc .dmk .jvc .os9 .dsk .vdk .rom .ccc .sna\n\nCopy your Dragon roms to $romdir/dragon32\n\nCopy your CoCo games to $romdir/coco\n\nCopy the required BIOS files d32.rom (Dragon 32), bas13.rom (CoCo), coco3.rom/coco3p.rom (CoCo3) to $biosdir"
 rp_module_licence="GPL3 http://www.6809.org.uk/xroar/"
-rp_module_repo="git http://www.6809.org.uk/git/xroar.git 1.10"
+rp_module_repo="git http://www.6809.org.uk/git/xroar.git 1.11"
 rp_module_section="opt"
 rp_module_flags=""
 


### PR DESCRIPTION
Notable changes in 1.11:

* S19 records supported, recognised by the .s19 file extension.
* 74LS785 SAM support, and new `-machine-opt sam=type` option.
* Initial iMMUnity support has been contributed by Jim Brain. Specify `-machine-opt immunity` for a Dragon or CoCo 1/2 to use.
* New option `-trap-trace-n n` turns on trace mode for specified number of instructions when a trap is matched.