### PR TITLE
packages: map the 7zip packages for newer distros

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -303,6 +303,9 @@ function _mapPackage() {
             [[ "$__os_debian_ver" -lt 13 ]] && pkg="policykit-1"
             [[ -n "$__os_ubuntu_ver" ]] && compareVersions "$__os_ubuntu_ver" lt 24.04 && pkg="policykit-1"
             ;;
+        p7zip|p7zip-full)
+            [[ -n "$__os_ubuntu_ver" ]] && compareVersions "$__os_ubuntu_ver" ge 26.04 && pkg="7zip"
+            [[ "$__os_debian_ver" -ge 13 ]] && pkg="7zip"
     esac
     echo "$pkg"
 }

--- a/scriptmodules/supplementary/retropiemenu.sh
+++ b/scriptmodules/supplementary/retropiemenu.sh
@@ -24,12 +24,7 @@ function _update_hook_retropiemenu() {
 }
 
 function depends_retropiemenu() {
-    local p7zip_pkg="p7zip"
-    # Ubuntu 26.04+ renamed p7zip to 7zip
-    if [[ "$__os_id" == "Ubuntu" ]] && compareVersions "$__os_ubuntu_ver" ge "26.04"; then
-        p7zip_pkg="7zip"
-    fi
-    getDepends mc "$p7zip_pkg"
+    getDepends mc p7zip
 }
 
 function install_bin_retropiemenu() {


### PR DESCRIPTION
Both `p7zip` and `p7zip-full` are replaced by `7zip` in recent (Trixie) Debian and Ubuntu (26.04). Map the packages in our helper since they're used in more than one place.