### PR TITLE
mupen64plus: fix ZSTD link errors on Ubuntu 24.04

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -155,6 +155,11 @@ function sources_mupen64plus() {
 
     # fix CMake detection for zstd
     sed -i 's/ZSTD REQUIRED/zstd REQUIRED/g' GLideN64/src/GLideNHQ/CMakeLists.txt
+    # on Ubuntu 24.04, link to the `zstd` shared libs instead of the static ones, because of LP#2086543
+    if [[ -n "$__os_ubuntu_ver" ]] && compareVersions "$__os_ubuntu_ver" eq 24.04; then
+        sed -i 's/zstd::libzstd_static/zstd::libzstd_shared/g' GLideN64/src/GLideNHQ/CMakeLists.txt
+    fi
+
     local config_version=$(grep -oP '(?<=CONFIG_VERSION_CURRENT ).+?(?=U)' GLideN64/src/Config.h)
     echo "$config_version" > "$md_build/GLideN64_config_version.ini"
 }


### PR DESCRIPTION
On Ubuntu 24.04, due to a bug on how the `zstd` static library was built, the GlideN64 build fails when linking with a message similar to the one reported in [1]. Modify the `cmake` build file to link `zstd` dynamically, so the build doesn't fail.

The link error is not present on Debian (13-Trixie) or later Ubuntus (25.10), so add this workaround just for the 24.04 LTS version.

[1] https://bugs.launchpad.net/ubuntu/+source/libzstd/+bug/2086543

Should fix the 2nd/latest build error reported in #4203.