### PR TITLE
lr-mame: branch name should not be empty

### DIFF
--- a/scriptmodules/libretrocores/lr-mame.sh
+++ b/scriptmodules/libretrocores/lr-mame.sh
@@ -20,6 +20,8 @@ rp_module_flags="!:\$__gcc_version:-lt:7"
 function _get_version_lr-mame() {
     if compareVersions "$(gcc -dumpfullversion)" lt 10.3.0; then
         echo "lrmame0264"
+    else
+        echo "master"
     fi
 }
 function _get_params_lr-mame() {


### PR DESCRIPTION
... otherwise the update/install will pass an empty string to `git ls-remote` and the operation fails, leading to:

 - `git ls-remote` failing in the background because it checks for and empty branch (with an additional 'are you connected to the internet' message added)
 - the update dialog showing 'no install options available' and leaving only the removal or the package as an option.

NB: the empty branch propagates to `retropie.pkg`, which may also have a say in the erroneous update check from `rp_getRemoteRepoHash`.

Should fix #4204 