### PR TITLE
image: adjust file size and partition calculations

### DIFF
--- a/scriptmodules/admin/image.sh
+++ b/scriptmodules/admin/image.sh
@@ -311,10 +311,11 @@ function create_image() {
     # if not specified default the boot size partition to 512MiB
     [[ -z "$boot_size_mib" ]] && boot_size_mib=512
 
-    # get size of files in MiB
-    local chroot_size_mib=$(du -s -m "$chroot" 2>/dev/null | cut -f1)
-    # make image size 256MiB larger than contents of chroot and boot partition
-    local image_size_mib=$((boot_size_mib + chroot_size_mib + 256))
+    # Get file size in MiB: use --apparent-size to avoid underestimating
+    # file sizes on a compressed filesystem (e.g. ZFS + compression)
+    local chroot_size_mib=$(du -s -m --apparent-size "$chroot" 2>/dev/null | cut -f1)
+    # make image size 384MiB larger than contents of chroot and boot partition
+    local image_size_mib=$((boot_size_mib + chroot_size_mib + 384))
 
     # create image
     printMsgs "console" "Creating image $image ..."


### PR DESCRIPTION
When creating images on a build host with a compressed filesystem (e.g. ZFS + compression), du would report smaller file sizes causing the root partition to be undersized and failing.

Use --apparent-size to get the actual file sizes and increase the amount added to 384MiB to account for filesystem metadata.