### PR TITLE
dxx-rebirth: fix installation with latest version

### DIFF
--- a/scriptmodules/ports/dxx-rebirth.sh
+++ b/scriptmodules/ports/dxx-rebirth.sh
@@ -72,9 +72,14 @@ function build_dxx-rebirth() {
 
 function install_dxx-rebirth() {
     # Rename generic files
-    mv -f "$md_build/d1x-rebirth/INSTALL.txt" "$md_build/d1x-rebirth/D1X-INSTALL.txt"
+    # install file(s) location moved in latest version
+    if [[ "$(_get_commit_dxx-rebirth)" == "" ]]; then
+        mv -f "$md_build/INSTALL.markdown" "$md_build/INSTALL.md";
+    else
+        mv -f "$md_build/d1x-rebirth/INSTALL.txt" "$md_build/d1x-rebirth/D1X-INSTALL.txt"
+        mv -f "$md_build/d2x-rebirth/INSTALL.txt" "$md_build/d2x-rebirth/D2X-INSTALL.txt"
+    fi
     mv -f "$md_build/d1x-rebirth/RELEASE-NOTES.txt" "$md_build/d1x-rebirth/D1X-RELEASE-NOTES.txt"
-    mv -f "$md_build/d2x-rebirth/INSTALL.txt" "$md_build/d2x-rebirth/D2X-INSTALL.txt"
     mv -f "$md_build/d2x-rebirth/RELEASE-NOTES.txt" "$md_build/d2x-rebirth/D2X-RELEASE-NOTES.txt"
 
     local build_path="$(_get_build_path_dxx-rebirth)"
@@ -85,13 +90,19 @@ function install_dxx-rebirth() {
         'd1x-rebirth/README.RPi'
         "$build_path/d1x-rebirth/d1x-rebirth"
         'd1x-rebirth/d1x.ini'
-        'd1x-rebirth/D1X-INSTALL.txt'
         'd1x-rebirth/D1X-RELEASE-NOTES.txt'
         "$build_path/d2x-rebirth/d2x-rebirth"
         'd2x-rebirth/d2x.ini'
-        'd2x-rebirth/D2X-INSTALL.txt'
         'd2x-rebirth/D2X-RELEASE-NOTES.txt'
     )
+    if [ -f "$md_build/INSTALL.md" ]; then
+        md_ret_files+=("INSTALL.md")
+    else
+        md_ret_files+=(
+            "d1x-rebirth/D1X-INSTALL.txt"
+            "d2x-rebirth/D2X-INSTALL.txt"
+        )
+    fi
 }
 
 function game_data_dxx-rebirth() {


### PR DESCRIPTION
Upstream project consolidated the installation instructions into a single filel, so the installation fails due to the missing removed `install.txt`. Modified the `install`-ed files to change depending on the commit used.