### PR TITLE
lr-flycast: fix build failures on GCC 14

### DIFF
--- a/scriptmodules/libretrocores/lr-flycast.sh
+++ b/scriptmodules/libretrocores/lr-flycast.sh
@@ -33,6 +33,8 @@ function sources_lr-flycast() {
     gitPullOrClone
     # don't override our C/CXXFLAGS and set LDFLAGS to CFLAGS to avoid warnings on linking
     applyPatch "$md_data/01_flags_fix.diff"
+    applyPatch "$md_data/02_gcc14_unistd_fix.diff"
+    applyPatch "$md_data/03_gcc14_glsm_fix.diff"
 }
 
 function build_lr-flycast() {

--- a/scriptmodules/libretrocores/lr-flycast/02_gcc14_unistd_fix.diff
+++ b/scriptmodules/libretrocores/lr-flycast/02_gcc14_unistd_fix.diff
@@ -1,0 +1,15 @@
+diff --git a/core/deps/libzip/zip_close.c b/core/deps/libzip/zip_close.c
+index e901915..6790b1f 100644
+--- a/core/deps/libzip/zip_close.c
++++ b/core/deps/libzip/zip_close.c
+@@ -42,9 +42,9 @@
+ 
+ #include "zipint.h"
+ 
+-#if defined(__APPLE__) || defined(__SWITCH__)
++#if !defined(_MSC_VER)
+ #include <unistd.h>
+ #endif
+ 
+ static int add_data(struct zip *, struct zip_source *, struct zip_dirent *,
+ 		    FILE *);

--- a/scriptmodules/libretrocores/lr-flycast/03_gcc14_glsm_fix.diff
+++ b/scriptmodules/libretrocores/lr-flycast/03_gcc14_glsm_fix.diff
@@ -1,0 +1,33 @@
+diff --git a/core/libretro-common/glsm/glsm.c b/core/libretro-common/glsm/glsm.c
+index 289bca7..6f731c2 100644
+--- a/core/libretro-common/glsm/glsm.c
++++ b/core/libretro-common/glsm/glsm.c
+@@ -2746,15 +2746,15 @@ static void glsm_state_setup(void)
+    gl_state.colorlogicop                = GL_COPY;
+ #endif
+ 
+ #ifdef CORE
+-   glGenVertexArrays(1, &gl_state.vao);
++   rglGenVertexArrays(1, &gl_state.vao);
+ #endif
+ }
+ 
+ static void glsm_state_bind(void)
+ {
+    unsigned i;
+ #ifdef CORE
+-   glBindVertexArray(gl_state.vao);
++   rglBindVertexArray(gl_state.vao);
+ #endif
+    glBindBuffer(GL_ARRAY_BUFFER, gl_state.array_buffer);
+@@ -2870,9 +2870,9 @@ static void glsm_state_unbind(void)
+ static void glsm_state_unbind(void)
+ {
+    unsigned i;
+ #ifdef CORE
+-   glBindVertexArray(0);
++   rglBindVertexArray(0);
+ #endif
+    for (i = 0; i < SGL_CAP_MAX; i ++)
+    {
+       if (gl_state.cap_state[i])


### PR DESCRIPTION
Add patches to resolve implicit function declaration errors under GCC 14:
- 02_gcc14_unistd_fix.diff: include <unistd.h> in core/deps/libzip/zip_close.c for POSIX platforms (fixes close() implicit declaration)
- 03_gcc14_glsm_fix.diff: use rgl* wrappers in core/libretro-common/glsm/glsm.c (fixes glGenVertexArrays and glBindVertexArray implicit declarations)