### PR TITLE
skyscraper: add flag for smaller Skyscraper build on Raspberry Pi

### DIFF
--- a/scriptmodules/supplementary/skyscraper.sh
+++ b/scriptmodules/supplementary/skyscraper.sh
@@ -35,11 +35,16 @@ function sources_skyscraper() {
 
 function build_skyscraper() {
     rm --force .qmake.stash
+    params=()
+    # make smaller Skyscraper binary on RetroPie
+    hasFlag "rpi" && params+=(RPI_BUILD=1)
     if [[ "$__os_debian_ver" -ge 12 ]]; then
-        qmake6
+        params+=(qmake6)
     else
-        QT_SELECT=5 qmake
+        params+=(QT_SELECT=5)
+        params+=(qmake)
     fi
+    eval "${params[*]}"
     make
     md_ret_require="$md_build/Skyscraper"
 }


### PR DESCRIPTION
When the flag is set for Skyscraper's build process it will exclude a bundle of configuration files (Qt Resources) within the Skyscraper binary. However, these configuration files are also deployed via the install target of the scriptmodules, thus it makes no sense to keep them twice.