### PR TITLE
sdl2: update dependencies and version

### DIFF
--- a/scriptmodules/supplementary/sdl2.sh
+++ b/scriptmodules/supplementary/sdl2.sh
@@ -17,7 +17,7 @@ rp_module_flags=""
 
 function get_ver_sdl2() {
     if [[ "$__os_debian_ver" -ge 11 ]]; then
-        echo "2.32.10"
+        echo "2.32.11"
     else
         echo "2.0.10"
     fi
@@ -42,13 +42,14 @@ function get_arch_sdl2() {
 function _list_depends_sdl2() {
     # Dependencies from the debian package control + additional dependencies for the pi (some are excluded like dpkg-dev as they are
     # already covered by the build-essential package retropie relies on.
-    local depends=(libasound2-dev libudev-dev libibus-1.0-dev libdbus-1-dev fcitx-libs-dev libsndio-dev libsamplerate0-dev)
+    local depends=(libasound2-dev libudev-dev libibus-1.0-dev libdbus-1-dev libsndio-dev libsamplerate0-dev)
     # these were removed by a PR for vero4k support (cannot test). Needed though at least for for RPI and X11
     ! isPlatform "vero4k" && depends+=(libx11-dev libxcursor-dev libxext-dev libxi-dev libxinerama-dev libxkbcommon-dev libxrandr-dev libxss-dev libxt-dev libxv-dev libxxf86vm-dev libgl1-mesa-dev)
     isPlatform "gles" || isPlatform "gl" && depends+=(libegl1-mesa-dev libgles2-mesa-dev)
     isPlatform "gl" || isPlatform "rpi" && depends+=(libgl1-mesa-dev libglu1-mesa-dev)
     isPlatform "kms" || isPlatform "rpi" && depends+=(libdrm-dev libgbm-dev)
     isPlatform "x11" && depends+=(libpulse-dev libwayland-dev)
+    [[ "$__os_debian_ver" -lt 11 ]] && depends+=(fcitx-libs-dev)
 
     echo "${depends[@]}"
 }


### PR DESCRIPTION
This is a re-do of https://github.com/RetroPie/RetroPie-Setup/pull/4220 (from @TheRetroMars), slightly modified to prevent build errors because of our Debian package requiring `fcitx-libs-dev` (i.e. package [control](https://github.com/RetroPie/SDL/blob/retropie-2.32.10/debian/control) file).

From https://github.com/RetroPie/RetroPie-Setup/pull/4220:

Remove `fcitx-libs-dev` on recent Debian/Ubuntu versions, since `fcitx-libs-dev` is for Fcitx 4 and on Debian 12+ or Ubuntu 24.04+ the default input method is fcitx5. Since `fcitx-libs-dev` conflicts with `fcitx5`, `apt` will remove `fcitx5` if SDL2 is build. Also, official Debian 12+ packages for SDL2 no longer use fcitx-libs-dev.

**NOTE**: this needs https://github.com/cmitu/SDL/tree/retropie-2.32.11 to be included in https://github.com/RetroPie/SDL. The branch incorporated the latest fixes from the upstream project `2.32.x` branch as it may not get any version bumps in the near future (see <https://discourse.libsdl.org/t/sdl-2-0-future-support/68372>)